### PR TITLE
libretro-pscx update

### DIFF
--- a/package/batocera/libretro-pcsx/libretro-pcsx.mk
+++ b/package/batocera/libretro-pcsx/libretro-pcsx.mk
@@ -3,7 +3,7 @@
 # PCSXREARMED
 #
 ################################################################################
-LIBRETRO_PCSX_VERSION = 0a6520c3fee25dded241427f16df844cea79182f
+LIBRETRO_PCSX_VERSION = ea4f4384c24996e839106d515f000269b5cfc792
 LIBRETRO_PCSX_SITE = $(call github,libretro,pcsx_rearmed,$(LIBRETRO_PCSX_VERSION))
 
 define LIBRETRO_PCSX_BUILD_CMDS


### PR DESCRIPTION
Update from (Feb 11, 2017) to (Jan 28, 2018), tested on x86_64 and RPI3 platforms.