### PR TITLE
libretro-atari800: fix Atari System

### DIFF
--- a/package/batocera/libretro-atari800/0001-libretro-core.patch
+++ b/package/batocera/libretro-atari800/0001-libretro-core.patch
@@ -1,7 +1,16 @@
 diff --git a/libretro/libretro-core.c b/libretro/libretro-core.c
-index 96d9aa3..1bdb60c 100644
+index 96d9aa3..229cc9f 100644
 --- a/libretro/libretro-core.c
 +++ b/libretro/libretro-core.c
+@@ -85,7 +85,7 @@ void retro_set_environment(retro_environment_t cb)
+    struct retro_variable variables[] = {
+      {
+        "atari800_system",
+-       "Atari System; 400/800 (OS B)|800XL (64K)|130XE (128K)|5200",
++       "Atari System; 5200|400/800 (OS B)|800XL (64K)|130XE (128K)",
+      },
+      {
+        "atari800_ntscpal",
 @@ -562,7 +562,7 @@ void retro_get_system_info(struct retro_system_info *info)
  {
     memset(info, 0, sizeof(*info));


### PR DESCRIPTION
Changing the sequence and option "5200" will be the default choice.