### PR TITLE
fix xu4 /media

### DIFF
--- a/board/batocera/fsoverlay/etc/fstab
+++ b/board/batocera/fsoverlay/etc/fstab
@@ -7,4 +7,5 @@ tmpfs           /dev/shm       tmpfs    mode=0777         0      0
 tmpfs           /tmp           tmpfs    mode=1777         0      0
 tmpfs           /var           tmpfs    mode=1777         0      0
 tmpfs           /run           tmpfs    mode=1777         0      0
+tmpfs           /media         tmpfs    mode=1777         0      0 # to have it rw on xu4
 sysfs		/sys	       sysfs    defaults	  0	 0


### PR DESCRIPTION
on the xu4, there is no overlayfs, thus, no tmpfs over the squashfs.
so, at the end, /media is read only, preventing any device to be mounted.
so, to fix it, /media should be rw in any case. tmpfs is mounted on it.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>