### PR TITLE
fix pad orders

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -135,9 +135,8 @@ def generateHotkeys(playersControllers):
     }
 
     nplayer = 1
-    for playercontroller in playersControllers:
+    for playercontroller, pad in sorted(playersControllers.items()):
         if nplayer == 1:
-            pad = playersControllers[playercontroller]
             f.write("[Hotkeys1]" + "\n")
             f.write("Device = evdev/0/" + pad.realName + "\n")
 
@@ -177,9 +176,8 @@ def generateControllerConfig_any(playersControllers, filename, anyDefKey, anyMap
     # in case of two pads having the same name, dolphin wants a number to handle this
     double_pads = dict()
 
-    for playercontroller in playersControllers:
+    for playercontroller, pad in sorted(playersControllers.items()):
         # handle x pads having the same name
-        pad = playersControllers[playercontroller]
         if pad.configName in double_pads:
             nsamepad = double_pads[pad.configName]
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeControllers.py
@@ -30,8 +30,7 @@ def generateControllerConfig(system, playersControllers):
     if not os.path.exists(confDirectory):
         os.makedirs(confDirectory)
 
-    for playercontroller in playersControllers:
-        pad = playersControllers[playercontroller]
+    for playercontroller, pad in sorted(playersControllers.items()):
         configFileName = "{}/{}".format(recalboxFiles.fsuaeConfig, "Controllers/" + pad.guid + "_linux.conf")
         f = open(configFileName, "w")
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
@@ -96,9 +96,9 @@ class FsuaeGenerator(Generator):
 
         # controllers
         n = 0
-        for pad in playersControllers:
+        for playercontroller, pad in sorted(playersControllers.items()):
             if n <= 3:
-                commandArray.append("--joystick_port_" + str(n) + "=" + playersControllers[pad].realName + "")
+                commandArray.append("--joystick_port_" + str(n) + "=" + pad.realName + "")
                 n += 1
 
         if 'args' in system.config and system.config['args'] is not None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Controllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Controllers.py
@@ -48,9 +48,8 @@ def generateControllerConfig(system, playersControllers, rom):
     nplayer = 0
 
     # players with a controller
-    for playercontroller in playersControllers:
+    for playercontroller, pad in sorted(playersControllers.items()):
         if nplayer < 2:
-            pad = playersControllers[playercontroller]
             f.write("[{}][name] = {}\n".format(nplayer, pad.realName))
 
             for x in pcsx2Keys:


### PR DESCRIPTION
playersConfigurations in configgen is a dict of strings "1", "2", ...
it is a choice that makes it not easy to manipulate : a dict in python is unsorted
and finally, pad order can be false in emulators.
Ideally, this structure should be replaced by a classical tabular

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>