### PR TITLE
Include the 64-bit kernel in 32-bit userland DTS

### DIFF
--- a/linux/linux.mk
+++ b/linux/linux.mk
@@ -224,6 +224,9 @@ ifeq ($(KERNEL_ARCH),i386)
 LINUX_ARCH_PATH = $(LINUX_DIR)/arch/x86
 else ifeq ($(KERNEL_ARCH),x86_64)
 LINUX_ARCH_PATH = $(LINUX_DIR)/arch/x86
+else ifeq ($(BR2_LINUX_X64_KERNEL_IN_X32_USER),y)
+# arm64 kernel when arch is arm
+LINUX_ARCH_PATH = $(LINUX_DIR)/arch/arm64
 else
 LINUX_ARCH_PATH = $(LINUX_DIR)/arch/$(KERNEL_ARCH)
 endif


### PR DESCRIPTION
When compiling 64bit for 32bit userland, the package needs to point to the arm64 folder for the dtb