### PR TITLE
rename rbxshare to userdata

### DIFF
--- a/board/batocera/batocera-patch-target.sh
+++ b/board/batocera/batocera-patch-target.sh
@@ -9,15 +9,15 @@
 
 BATOCERA_TARGET=$(grep -E "^BR2_PACKAGE_BATOCERA_TARGET_[A-Z_0-9]*=y$" "${BR2_CONFIG}" | sed -e s+'^BR2_PACKAGE_BATOCERA_TARGET_\([A-Z_0-9]*\)=y$'+'\1'+)
 
-sed -i "s|root:x:0:0:root:/root:/bin/sh|root:x:0:0:root:/recalbox/share/system:/bin/sh|g" "${TARGET_DIR}/etc/passwd" || exit 1
+sed -i "s|root:x:0:0:root:/root:/bin/sh|root:x:0:0:root:/userdata/system:/bin/sh|g" "${TARGET_DIR}/etc/passwd" || exit 1
 rm -rf "${TARGET_DIR}/etc/dropbear" || exit 1
-ln -sf "/recalbox/share/system/ssh" "${TARGET_DIR}/etc/dropbear" || exit 1
+ln -sf "/userdata/system/ssh" "${TARGET_DIR}/etc/dropbear" || exit 1
 
 mkdir -p ${TARGET_DIR}/etc/emulationstation || exit 1
 ln -sf "/recalbox/share_init/system/.emulationstation/es_systems.cfg" "${TARGET_DIR}/etc/emulationstation/es_systems.cfg" || exit 1
 ln -sf "/recalbox/share_init/system/.emulationstation/themes"         "${TARGET_DIR}/etc/emulationstation/themes"         || exit 1
 mkdir -p "${TARGET_DIR}/recalbox/share_init/cheats" || exit 1
-ln -sf "/recalbox/share/cheats"                                       "${TARGET_DIR}/recalbox/share_init/cheats/custom"   || exit 1
+ln -sf "/userdata/cheats"                                       "${TARGET_DIR}/recalbox/share_init/cheats/custom"   || exit 1
 
 # we don't want the kodi startup script
 rm -f "${TARGET_DIR}/etc/init.d/S50kodi" || exit 1

--- a/board/batocera/fsoverlay/etc/init.d/S03populate
+++ b/board/batocera/fsoverlay/etc/init.d/S03populate
@@ -11,7 +11,7 @@ cp /etc/sixad.profile /var/lib/sixad/profiles/default
 
 # custom network config
 mkdir -p "/var/lib/connman"
-ln -sf "/recalbox/share/system/network-connman.config" "/var/lib/connman/recalbox-custom.config"
+ln -sf "/userdata/system/network-connman.config" "/var/lib/connman/recalbox-custom.config"
 ln -sf "/boot/network-connman.config"                  "/var/lib/connman/recalbox-boot-custom.config"
 
 # bluetooth

--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -6,7 +6,7 @@ then
 fi
 
 IN=/recalbox/share_init
-OUT=/recalbox/share
+OUT=/userdata
 # force the creation of some directories
 for DIR in cheats \
            system/.cache \
@@ -67,33 +67,33 @@ do
 done
 
 # ssh : create the ssh key while the -R option of dropbear try a chown or an operation which is not permitted on fat32
-if mkdir -p /recalbox/share/system/ssh
+if mkdir -p /userdata/system/ssh
 then
-    test -e /recalbox/share/system/ssh/dropbear_ecdsa_host_key || dropbearkey -t ecdsa -f /recalbox/share/system/ssh/dropbear_ecdsa_host_key
-    test -e /recalbox/share/system/ssh/dropbear_rsa_host_key   || dropbearkey -t rsa   -f /recalbox/share/system/ssh/dropbear_rsa_host_key
-    test -e /recalbox/share/system/ssh/dropbear_dss_host_key   || dropbearkey -t dss   -f /recalbox/share/system/ssh/dropbear_dss_host_key
+    test -e /userdata/system/ssh/dropbear_ecdsa_host_key || dropbearkey -t ecdsa -f /userdata/system/ssh/dropbear_ecdsa_host_key
+    test -e /userdata/system/ssh/dropbear_rsa_host_key   || dropbearkey -t rsa   -f /userdata/system/ssh/dropbear_rsa_host_key
+    test -e /userdata/system/ssh/dropbear_dss_host_key   || dropbearkey -t dss   -f /userdata/system/ssh/dropbear_dss_host_key
 fi
 
 # bluetooth : now gotta tar/untar, the directory structure for bluez5 is more complex
 # once untar, delete the cache folder. The exclude tar option of busybox is dreadful
-btTar=/recalbox/share/system/bluetooth/bluetooth.tar
+btTar=/userdata/system/bluetooth/bluetooth.tar
 tar xvf "$btTar" -C / 2>/dev/null 
 
 # udev : create a link for rules persistance
-mkdir -p /recalbox/share/system/udev/rules.d
+mkdir -p /userdata/system/udev/rules.d
 rm -rf /run/udev/rules.d
-ln -s /recalbox/share/system/udev/rules.d/ /run/udev/
+ln -s /userdata/system/udev/rules.d/ /run/udev/
 
 ## if the system was upgraded, fixes some files
 # fixes
 XNEW=$(cat /recalbox/batocera.version)
-XCUR=$(cat /recalbox/share/system/data.version)
+XCUR=$(cat /userdata/system/data.version)
 XARCH=$(cat /recalbox/recalbox.arch)
 test "${XCUR}" = "${XNEW}" && exit 0
 
 # retroarchcustom.cfg
 retroarchcustom_fix_force_param() {
-    L_CFG="/recalbox/share/system/configs/retroarch/retroarchcustom.cfg"
+    L_CFG="/userdata/system/configs/retroarch/retroarchcustom.cfg"
     L_PARAM=$1
     L_VALUE=$2
 
@@ -108,7 +108,7 @@ retroarchcustom_fix_force_param() {
 }
 
 retroarchcustom_fix_remove_param_value() {
-    L_CFG="/recalbox/share/system/configs/retroarch/retroarchcustom.cfg"
+    L_CFG="/userdata/system/configs/retroarch/retroarchcustom.cfg"
     L_PARAM=$1
     L_VALUE=$2
 
@@ -117,7 +117,7 @@ retroarchcustom_fix_remove_param_value() {
 }
 
 recalboxconf_force_value() {
-    L_CFG="/recalbox/share/system/recalbox.conf"
+    L_CFG="/userdata/system/recalbox.conf"
     L_PARAM=$1
     L_VALUE=$2
 
@@ -164,7 +164,7 @@ then
 fi
 
 # save to avoid to redo that all the times
-cp /recalbox/batocera.version /recalbox/share/system/data.version || exit 1
+cp /recalbox/batocera.version /userdata/system/data.version || exit 1
 
 exit 0
 # END

--- a/board/batocera/fsoverlay/etc/init.d/S25lircd
+++ b/board/batocera/fsoverlay/etc/init.d/S25lircd
@@ -8,7 +8,7 @@
 start() {
 	echo -n "Starting lirc: "
 	mkdir -p /var/run/lirc
-	start-stop-daemon -b -S -q -m -p /var/run/lirc.pid --exec /usr/sbin/lircd -- -n --driver=default --device=/dev/lirc0 --output=/var/run/lirc/lircd --pidfile=/var/run/lirc/lircd-lirc0.pid /recalbox/share/system/.config/lirc/lircd.conf
+	start-stop-daemon -b -S -q -m -p /var/run/lirc.pid --exec /usr/sbin/lircd -- -n --driver=default --device=/dev/lirc0 --output=/var/run/lirc/lircd --pidfile=/var/run/lirc/lircd-lirc0.pid /userdata/system/.config/lirc/lircd.conf
 	echo "OK"
 }
 

--- a/board/batocera/fsoverlay/etc/init.d/S26recalboxsystem
+++ b/board/batocera/fsoverlay/etc/init.d/S26recalboxsystem
@@ -2,7 +2,7 @@
 
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
 config_script=/recalbox/scripts/recalbox-config.sh
-log="/recalbox/share/system/logs/recalbox.log"
+log="/userdata/system/logs/recalbox.log"
 
 rb_volume_configure() {
     settingsVolume="`$systemsetting -command load -key audio.volume`"
@@ -117,11 +117,11 @@ rb_xarcade2jstick() {
 
 # from https://batocera-linux.xorhub.com/forum/d/794-how-to-hdmi-sound-on-x86-builds
 rb_alsa_load() {
-    alsactl restore -f /recalbox/share/system/asound.state
+    alsactl restore -f /userdata/system/asound.state
 }
 
 rb_alsa_save() {
-    alsactl store -f /recalbox/share/system/asound.state
+    alsactl store -f /userdata/system/asound.state
 }
 
 case "$1" in
@@ -130,7 +130,7 @@ case "$1" in
 
 	# Dos carriage return characters
 	recallog "converting dos to unix carriage return characters"
-	sed -i 's/\r//g' /recalbox/share/system/recalbox.conf
+	sed -i 's/\r//g' /userdata/system/recalbox.conf
 	
 	# configure
 	rb_gpio_configure&    # 0.9 start by the gpio while it's the longer

--- a/board/batocera/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/fsoverlay/etc/init.d/S31emulationstation
@@ -2,7 +2,7 @@
 #
 #
 
-log=/recalbox/share/system/logs/recalbox.log
+log=/userdata/system/logs/recalbox.log
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
 
 case "$1" in
@@ -12,7 +12,7 @@ case "$1" in
                 batocera-resolution minTomaxResolution
 		settings_lang="`$systemsetting -command load -key system.language`"
         	recallog "starting emulationstation with lang = $settings_lang"
-                command="HOME=/recalbox/share/system LANG=\"${settings_lang}.UTF-8\" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
+                command="HOME=/userdata/system LANG=\"${settings_lang}.UTF-8\" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
         	recallog "Starting emulationstation with command : "
         	recallog "$command"
         	eval $command >> $log &

--- a/board/batocera/fsoverlay/etc/init.d/S32bluetooth
+++ b/board/batocera/fsoverlay/etc/init.d/S32bluetooth
@@ -4,7 +4,7 @@
 #
 
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
-btTar=/recalbox/share/system/bluetooth/bluetooth.tar
+btTar=/userdata/system/bluetooth/bluetooth.tar
 
 case "$1" in
   start)
@@ -25,7 +25,7 @@ case "$1" in
         	if [ "$settings_version" != "bluez" ]; then BLUETOOTHD_ARGS="--noplugin=sixaxis"; else  BLUETOOTHD_ARGS="--noplugin=sixaxispair"; fi
 		start-stop-daemon -S -q -m -p /var/run/bluetoothd.pid  --exec /usr/libexec/bluetooth/bluetoothd -- $BLUETOOTHD_ARGS &	
 		( /recalbox/scripts/bluetoothcontrollers.sh && \
-                  start-stop-daemon -S -q -m -p /var/run/btDaemon.pid  --exec /recalbox/scripts/bluetooth/btDaemon > /recalbox/share/system/logs/btDaemon.log 2>&1 ) &
+                  start-stop-daemon -S -q -m -p /var/run/btDaemon.pid  --exec /recalbox/scripts/bluetooth/btDaemon > /userdata/system/logs/btDaemon.log 2>&1 ) &
         fi
         ;;
   stop)

--- a/board/batocera/fsoverlay/etc/init.d/S99custom
+++ b/board/batocera/fsoverlay/etc/init.d/S99custom
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test -e "/recalbox/share/system/custom.sh" && /recalbox/share/system/custom.sh $1
+test -e "/userdata/system/custom.sh" && /userdata/system/custom.sh $1

--- a/board/batocera/fsoverlay/etc/samba/smb-secure.conf
+++ b/board/batocera/fsoverlay/etc/samba/smb-secure.conf
@@ -332,8 +332,8 @@ socket options = TCP_NODELAY
 ;   postexec = /bin/umount /cdrom
 
 [share]
-comment = Recalbox user data
-path = /recalbox/share
+comment = batocera.linux user data
+path = /userdata
 writeable = yes
 guest ok = no
 create mask = 0600

--- a/board/batocera/fsoverlay/etc/samba/smb.conf
+++ b/board/batocera/fsoverlay/etc/samba/smb.conf
@@ -337,8 +337,8 @@ socket options = TCP_NODELAY
 ;   postexec = /bin/umount /cdrom
 
 [share]
-comment = Recalbox user data
-path = /recalbox/share
+comment = batocera.linux user data
+path = /userdata
 writeable = yes
 guest ok = yes
 create mask = 0644

--- a/board/batocera/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/batocera/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -5,4 +5,4 @@ KEY_VOLUMEDOWN	2		/usr/bin/amixer set Master 5%-
 KEY_MUTE        1               /usr/bin/amixer sset Master toggle
 KEY_POWER       1               /sbin/shutdown -h now
 # display some information on X displays
-KEY_F5          1               /recalbox/scripts/recalbox-info.sh --short | HOME=/recalbox/share/system DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4
+KEY_F5          1               /recalbox/scripts/recalbox-info.sh --short | HOME=/userdata/system DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4

--- a/board/batocera/fsoverlay/recalbox/scripts/emulatorlauncher.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/emulatorlauncher.sh
@@ -105,7 +105,7 @@ fi
 
 if [[ "$emulator" == "gba" ]]; then
 	/recalbox/scripts/runcommand.sh 4 "$retroarchbin -L $retroarchcores/gpsp_libretro.so --config /recalbox/configs/retroarch/retroarchcustom.cfg \"$1\""
-#	/recalbox/scripts/runcommand.sh 4 "$gpspbin \"/recalbox/share/roms/gba/${fullfilename}\""
+#	/recalbox/scripts/runcommand.sh 4 "$gpspbin \"/userdata/roms/gba/${fullfilename}\""
 fi
 
 if [[ "$emulator" == "gbc" ]]; then
@@ -237,5 +237,5 @@ if [[ "$emulator" == "fbalibretro" ]]; then
 fi
 
 if [[ "$emulator" == "scummvm" ]]; then
-         /recalbox/scripts/runcommand.sh 2 "scummvm --joystick=0 --screenshotspath=/recalbox/share/screenshots --extrapath=/usr/share/scummvm --path=\"$dirName\" \"$filenameNoExt\""
+         /recalbox/scripts/runcommand.sh 2 "scummvm --joystick=0 --screenshotspath=/userdata/screenshots --extrapath=/usr/share/scummvm --path=\"$dirName\" \"$filenameNoExt\""
 fi

--- a/board/batocera/fsoverlay/recalbox/scripts/essetting.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/essetting.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-es_settings="/recalbox/share/system/.emulationstation/es_settings.cfg"
-log=/recalbox/share/system/logs/
+es_settings="/userdata/system/.emulationstation/es_settings.cfg"
+log=/userdata/system/logs/
 
 
 command="$1"

--- a/board/batocera/fsoverlay/recalbox/scripts/moonlight/Moonlight.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/moonlight/Moonlight.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # More options available here: https://github.com/irtimmer/moonlight-embedded/tree/master/docs
-#cd /recalbox/share/roms/moonlight/
+#cd /userdata/roms/moonlight/
 moonlight_dir=/recalbox/scripts/moonlight
-moonlight_config_dir=/recalbox/share/system/configs/moonlight
-moonlight_romsdir=/recalbox/share/roms/moonlight
+moonlight_config_dir=/userdata/system/configs/moonlight
+moonlight_romsdir=/userdata/roms/moonlight
 moonlight_ip=
 moonlight_screen="720"
 moonlight_fps="60"
@@ -35,8 +35,8 @@ findRealGameName () {
 
 scrape () {
   GDBURL="http://thegamesdb.net/api/GetGame.php?platform=pc&exactname="
-  GAMELIST=/recalbox/share/roms/moonlight/gamelist.xml
-  IMGPATH=/recalbox/share/roms/moonlight/downloaded_images
+  GAMELIST=/userdata/roms/moonlight/gamelist.xml
+  IMGPATH=/userdata/roms/moonlight/downloaded_images
 
   # Test if $GDBURL is online, and stop if it's offline
   dbdns=$(echo $GDBURL | awk -F/ '{print $3}')

--- a/board/batocera/fsoverlay/recalbox/scripts/powerswitch.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/powerswitch.sh
@@ -243,7 +243,7 @@ if [[ "$1" != "start" && $1 != "stop" ]]; then
     exit 1
 fi
 
-CONFFILE="/recalbox/share/system/recalbox.conf"
+CONFFILE="/userdata/system/recalbox.conf"
 CONFPARAM="system.power.switch" 
 CONFVALUE=
 if [ -e $CONFFILE ]; then

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-config.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-config.sh
@@ -22,7 +22,7 @@ postBootConfig() {
     mount -o remount,ro /boot
 }
 
-log=/recalbox/share/system/logs/recalbox.log
+log=/userdata/system/logs/recalbox.log
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
 
 echo "---- recalbox-config.sh ----" >> $log
@@ -168,13 +168,13 @@ if [ "$command" == "audio" ];then
 	# custom: don't touch the .asoundrc file
 	# any other, create the .asoundrd file
 	if [ "$mode" == "auto" ];then
-	    rm -rf /recalbox/share/system/.asoundrc || exit 1
+	    rm -rf /userdata/system/.asoundrc || exit 1
 	elif [ "$mode" != "custom" ];then
 	    if echo "${mode}" | grep -qE '^[0-9]*,[0-9]* '
 	    then
 		cardnb=$(echo "${mode}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)
 		devicenb=$(echo "${mode}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)
-		cat > /recalbox/share/system/.asoundrc <<EOF
+		cat > /userdata/system/.asoundrc <<EOF
 	    pcm.!default { type plug slave { pcm "hw:${cardnb},${devicenb}" } }
 	    ctl.!default { type hw card ${cardnb} }
 EOF
@@ -365,7 +365,7 @@ if [[ "$command" == "forgetBT" ]]; then
    /etc/init.d/S32bluetooth stop
    rm -rf /var/lib/bluetooth
    mkdir /var/lib/bluetooth
-   rm -f /recalbox/share/system/bluetooth/bluetooth.tar
+   rm -f /userdata/system/bluetooth/bluetooth.tar
    /etc/init.d/S32bluetooth start
    exit 0
 fi

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-install.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-install.sh
@@ -8,7 +8,7 @@ arch=$(cat /recalbox/recalbox.arch)
 updateurl=$($systemsetting -command load -key updates.url)
 test -n "${updateurl}" && recalboxupdateurl="${updateurl}"
 
-IMGFOLDER="/recalbox/share/system/installs"
+IMGFOLDER="/userdata/system/installs"
 ACTION=$1
 shift
 
@@ -34,7 +34,7 @@ determine_part_prefix() {
 }
 
 disks_to_keep() {
-    grep -E '^[^ ]* /boot |^[^ ]* /recalbox/share' /proc/mounts | sed -e s+"^\([^ ]*\) .*$"+'\1'+ |
+    grep -E '^[^ ]* /boot |^[^ ]* /userdata' /proc/mounts | sed -e s+"^\([^ ]*\) .*$"+'\1'+ |
 	while read X
 	do
 	    determine_part_prefix "${X}"
@@ -163,7 +163,7 @@ do_install() {
 	    echo "need to download ${size}mB"
 
 	    # check free space on fs
-	    for fs in /recalbox/share
+	    for fs in /userdata
 	    do
 		freespace=$(df -m "${fs}" | tail -1 | awk '{print $4}')
 		test $? -eq 0 || return 1

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-scraper.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-scraper.sh
@@ -46,7 +46,7 @@ do_scrap() {
 
 	for x in "mame" "fba" "fba_libretro" "neogeo"
 	do
-	    test "${LRDIR}" = "/recalbox/share/roms/${x}" && EXTRAOPT="-mame"
+	    test "${LRDIR}" = "/userdata/roms/${x}" && EXTRAOPT="-mame"
 	done
 
 	(cd "${LRDIR}" && sselph-scraper -console_src ss,gdb,ovgdb -lang "${sslang}" -console_img "${IMGSTYLE}" -workers 5 ${EXTRAOPT}) 2>&1
@@ -56,9 +56,9 @@ do_scrap() {
 # find system to scrape
 (if test -n "${DOSYS}"
  then
-     test -d "/recalbox/share/roms/${DOSYS}" && echo "/recalbox/share/roms/${DOSYS}"
+     test -d "/userdata/roms/${DOSYS}" && echo "/userdata/roms/${DOSYS}"
  else
-     find /recalbox/share/roms -maxdepth 1 -mindepth 1 -type d
+     find /userdata/roms -maxdepth 1 -mindepth 1 -type d
  fi) |
     while read RDIR1
     do

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-support.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-support.sh
@@ -2,7 +2,7 @@
 
 
 GTMP="/tmp"
-DHOME="/recalbox/share/system"
+DHOME="/userdata/system"
 
 # to be callable by any external tool
 if test $# -eq 1
@@ -11,7 +11,7 @@ then
     OUTPUTFILE=$1
 else
     REPORTNAME="batocera-support-"$(date +%Y%m%d%H%M%S)
-    OUTPUTFILE="/recalbox/share/saves/${REPORTNAME}.tar.gz"
+    OUTPUTFILE="/userdata/saves/${REPORTNAME}.tar.gz"
 fi
 
 TMPDIR="${GTMP}/${REPORTNAME}"
@@ -60,19 +60,19 @@ connmanctl services     > "${DSYSTEM}/connman-services.txt"
 f_cp /recalbox/batocera.version                               "${DSYSTEM}"
 f_cp /recalbox/recalbox.arch                                  "${DSYSTEM}"
 f_cp /boot/config.txt                                         "${DSYSTEM}"
-f_cp /recalbox/share/system/recalbox.conf                     "${DSYSTEM}"
-d_cp /recalbox/share/system/logs                              "${DSYSTEM}"
+f_cp /userdata/system/recalbox.conf                     "${DSYSTEM}"
+d_cp /userdata/system/logs                              "${DSYSTEM}"
 f_cp /var/log/messages                                        "${DSYSTEM}"
-f_cp /recalbox/share/system/.emulationstation/es_settings.cfg "${DSYSTEM}"
-f_cp /recalbox/share/system/.emulationstation/es_log.txt      "${DSYSTEM}"
-f_cp /recalbox/share/system/.emulationstation/es_input.cfg    "${DSYSTEM}"
-f_cp /recalbox/share/system/logs/es_launch_stdout.log         "${DSYSTEM}"
-f_cp /recalbox/share/system/logs/es_launch_stderr.log         "${DSYSTEM}"
+f_cp /userdata/system/.emulationstation/es_settings.cfg "${DSYSTEM}"
+f_cp /userdata/system/.emulationstation/es_log.txt      "${DSYSTEM}"
+f_cp /userdata/system/.emulationstation/es_input.cfg    "${DSYSTEM}"
+f_cp /userdata/system/logs/es_launch_stdout.log         "${DSYSTEM}"
+f_cp /userdata/system/logs/es_launch_stderr.log         "${DSYSTEM}"
 f_cp /boot/recalbox-boot.conf                                 "${DSYSTEM}"
 f_cp /var/log/Xorg.0.log                                      "${DSYSTEM}"
 
 # Emulators configs
-d_cp /recalbox/share/system/configs                           "${TMPDIR}/configs"
+d_cp /userdata/system/configs                           "${TMPDIR}/configs"
 
 # joysticks
 DJOYS="${TMPDIR}/joysticks"

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-sync.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-sync.sh
@@ -6,7 +6,7 @@ print_usage() {
 }
 
 rs_current() {
-    grep -E "^[^ ]* /recalbox/share " /proc/mounts | sed -e s+'^\([^ ]*\) .*$'+'\1'+
+    grep -E "^[^ ]* /userdata " /proc/mounts | sed -e s+'^\([^ ]*\) .*$'+'\1'+
 }
 
 # hum, i'm very carefull
@@ -59,7 +59,7 @@ rs_fix_min_dates() {
   # i won't force a fixed date while having the same date (at 2 seconds, means being the same content)
   # so, the touch to the current time is a way to randomize dates
   # keep this while some people could have some old files while the recalbox got date from 1970 before
-  find /recalbox/share ! -newer /tmp/min_timestamp | while read X; do touch "${X}"; done
+  find /userdata ! -newer /tmp/min_timestamp | while read X; do touch "${X}"; done
 }
 
 rs_sync() {
@@ -110,9 +110,9 @@ rs_sync() {
     if test "${FSTYPE}" = "vfat"
     then
 	RSYNCOPT="-rpt --exclude system/bluetooth" # exclude bluetooth while it contains : chars not supported on fat32
-        rs_fix_min_dates "/recalbox/share" # if fails, will take a longer time
+        rs_fix_min_dates "/userdata" # if fails, will take a longer time
     fi
-    if rsync $RSYNCOPT -v --modify-window=2 --delete-during "/recalbox/share/" "${MOUNTDIR}" 2>&1 # modify-window because all file system such as fat32 doesn't have the same time precision
+    if rsync $RSYNCOPT -v --modify-window=2 --delete-during "/userdata/" "${MOUNTDIR}" 2>&1 # modify-window because all file system such as fat32 doesn't have the same time precision
     then
 	EXITCODE=0
     fi

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-systems.py
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-systems.py
@@ -196,7 +196,7 @@ def createReadme(systems):
 
 if __name__ == '__main__':
     if len(sys.argv) == 1:
-        prefix = "/recalbox/share"
+        prefix = "/userdata"
         displayMissingBios(systems, checkBios(systems, prefix))
     elif sys.argv[1] == "--createReadme":
         createReadme(systems)

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-upgrade.sh
@@ -2,8 +2,8 @@
 
 do_clean() {
     test -n "${GETPERPID}" && kill -9 "${GETPERPID}"
-    rm -f "/recalbox/share/system/upgrade/boot.tar.xz"
-    rm -f "/recalbox/share/system/upgrade/boot.tar.xz.md5"
+    rm -f "/userdata/system/upgrade/boot.tar.xz"
+    rm -f "/userdata/system/upgrade/boot.tar.xz.md5"
 }
 trap do_clean EXIT
 
@@ -12,7 +12,7 @@ getPer() {
 
     while true
     do
-	CURVAL=$(stat "/recalbox/share/system/upgrade/boot.tar.xz" | grep -E '^[ ]*Size:' | sed -e s+'^[ ]*Size: \([0-9][0-9]*\) .*$'+'\1'+)
+	CURVAL=$(stat "/userdata/system/upgrade/boot.tar.xz" | grep -E '^[ ]*Size:' | sed -e s+'^[ ]*Size: \([0-9][0-9]*\) .*$'+'\1'+)
 	CURVAL=$((CURVAL / 1024 / 1024))
 	PER=$(expr ${CURVAL} '*' 100 / ${TARVAL})
 	echo "downloading >>> ${PER}%"
@@ -42,7 +42,7 @@ test -n "${updateurl}" && recalboxupdateurl="${updateurl}"
 test "${updatetype}" != "stable" -a "${updatetype}" != "unstable" -a "${updatetype}" != "beta" && updatetype="stable"
 
 # download directory
-mkdir -p /recalbox/share/system/upgrade || exit 1
+mkdir -p /userdata/system/upgrade || exit 1
 
 # custom the url directory
 DWD_HTTP_DIR="${recalboxupdateurl}/${arch}/${updatetype}/last"
@@ -63,7 +63,7 @@ test $? -eq 0 || exit 1
 echo "need to download ${size}mB"
 
 # check free space on fs
-for fs in /recalbox/share /boot
+for fs in /userdata /boot
 do
     freespace=$(df -m "${fs}" | tail -1 | awk '{print $4}')
     test $? -eq 0 || exit 1
@@ -77,20 +77,20 @@ done
 # downlaod
 url="${DWD_HTTP_DIR}/boot.tar.xz"
 
-touch "/recalbox/share/system/upgrade/boot.tar.xz"
+touch "/userdata/system/upgrade/boot.tar.xz"
 getPer "${size}" &
 GETPERPID=$!
-mkdir -p "/recalbox/share/system/upgrade" || exit 1
-curl -sfL "${url}" -o "/recalbox/share/system/upgrade/boot.tar.xz" || exit 1
+mkdir -p "/userdata/system/upgrade" || exit 1
+curl -sfL "${url}" -o "/userdata/system/upgrade/boot.tar.xz" || exit 1
 kill -9 "${GETPERPID}"
 GETPERPID=
 
 # try to download an md5 checksum
-curl -sfL "${url}.md5" -o "/recalbox/share/system/upgrade/boot.tar.xz.md5"
-if test -e "/recalbox/share/system/upgrade/boot.tar.xz.md5"
+curl -sfL "${url}.md5" -o "/userdata/system/upgrade/boot.tar.xz.md5"
+if test -e "/userdata/system/upgrade/boot.tar.xz.md5"
 then
-    DISTMD5=$(cat "/recalbox/share/system/upgrade/boot.tar.xz.md5")
-    CURRMD5=$(md5sum "/recalbox/share/system/upgrade/boot.tar.xz" | sed -e s+' .*$'++)
+    DISTMD5=$(cat "/userdata/system/upgrade/boot.tar.xz.md5")
+    CURRMD5=$(md5sum "/userdata/system/upgrade/boot.tar.xz" | sed -e s+' .*$'++)
     if test "${DISTMD5}" = "${CURRMD5}"
     then
 	echo "valid checksum."
@@ -127,7 +127,7 @@ done
 
 # extract file on /boot
 echo "extracting files"
-if ! (cd /boot && xz -dc < "/recalbox/share/system/upgrade/boot.tar.xz" | tar xvf -)
+if ! (cd /boot && xz -dc < "/userdata/system/upgrade/boot.tar.xz" | tar xvf -)
 then
     exit 1
 fi
@@ -153,8 +153,8 @@ then
 fi
 
 # a sync
-rm -f "/recalbox/share/system/upgrade/boot.tar.xz"
-rm -f "/recalbox/share/system/upgrade/boot.tar.xz.md5"
+rm -f "/userdata/system/upgrade/boot.tar.xz"
+rm -f "/userdata/system/upgrade/boot.tar.xz.md5"
 sync
 
 echo "done."

--- a/board/batocera/fsoverlay/recalbox/scripts/recalbox-usbmount.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/recalbox-usbmount.sh
@@ -3,7 +3,7 @@
 # the aim of this script
 # is to make things happend in this way :
 # udev
-# mounting /recalbox/share
+# mounting /userdata
 # mounting other devices
 #
 # because:
@@ -19,7 +19,7 @@ then
 fi
 
 # if not, delay the automounting by saving the context for later
-# it will be played by the S11share script after the mounting of /recalbox/share
+# it will be played by the S11share script after the mounting of /userdata
 if mkdir -p /var/run/usbmount.delay
 then
     N=$(ls /var/run/usbmount.delay | wc -l)

--- a/board/batocera/fsoverlay/recalbox/scripts/systemsetting.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/systemsetting.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-system_settings=/recalbox/share/system/recalbox.conf
+system_settings=/userdata/system/recalbox.conf
 
 command="$1"
 argsetting="$2"
-log=/recalbox/share/system/logs/recalbox.log
+log=/userdata/system/logs/recalbox.log
 
 if [[ "$command" == "get" ]];then
 	echo "`logtime` : systemsetting.sh - searching for $argsetting" >> $log

--- a/board/batocera/fsoverlay/recalbox/scripts/udev-sixpair.sh
+++ b/board/batocera/fsoverlay/recalbox/scripts/udev-sixpair.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-log=/recalbox/share/system/logs/controllers.log
+log=/userdata/system/logs/controllers.log
 "ps3 usb controller detected" >> $log
 sixpair >> $log
 if [[ "$?" != "0" ]];then

--- a/board/batocera/fsoverlay/recalbox/share_init/bios/keropi/config
+++ b/board/batocera/fsoverlay/recalbox/share_init/bios/keropi/config
@@ -1,2 +1,2 @@
 [WinX68k]
-StartDir=/recalbox/share/roms/x68000/
+StartDir=/userdata/roms/x68000/

--- a/board/batocera/fsoverlay/recalbox/share_init/system/.hatari/hatari.cfg
+++ b/board/batocera/fsoverlay/recalbox/share_init/system/.hatari/hatari.cfg
@@ -167,8 +167,8 @@ YmVolumeMixing = 2
 [Memory]
 nMemorySize = 1
 bAutoSave = FALSE
-szMemoryCaptureFileName = /recalbox/share/saves/atarist.sav
-szAutoSaveFileName = /recalbox/share/saves/autosave_atarist.sav
+szMemoryCaptureFileName = /userdata/saves/atarist.sav
+szAutoSaveFileName = /userdata/saves/autosave_atarist.sav
 
 [Floppy]
 bAutoInsertDiskB = TRUE
@@ -182,7 +182,7 @@ szDiskAZipPath =
 szDiskAFileName =
 szDiskBZipPath =
 szDiskBFileName =
-szDiskImageDirectory = /recalbox/share/roms/atarist
+szDiskImageDirectory = /userdata/roms/atarist
 
 [HardDisk]
 nHardDiskDrive = 0
@@ -199,7 +199,7 @@ szIdeMasterHardDiskImage = /
 szIdeSlaveHardDiskImage = /
 
 [ROM]
-szTosImageFileName = /recalbox/share/bios/tos.img
+szTosImageFileName = /userdata/bios/tos.img
 bPatchTos = TRUE
 szCartridgeImageFileName =
 

--- a/board/batocera/fsoverlay/recalbox/share_init/system/configs/advancemame/advmame.rc.origin
+++ b/board/batocera/fsoverlay/recalbox/share_init/system/configs/advancemame/advmame.rc.origin
@@ -1,10 +1,10 @@
-dir_hi /recalbox/share/bios/advance
-dir_image /recalbox/share/roms/image
-dir_memcard /recalbox/share/saves/advance/memcard
-dir_nvram /recalbox/share/saves/advance/nvram
-dir_rom /recalbox/share/roms/mame
-dir_sample /recalbox/share/bios/advance/samples
-dir_snap /recalbox/share/screenshots
+dir_hi /userdata/bios/advance
+dir_image /userdata/roms/image
+dir_memcard /userdata/saves/advance/memcard
+dir_nvram /userdata/saves/advance/nvram
+dir_rom /userdata/roms/mame
+dir_sample /userdata/bios/advance/samples
+dir_snap /userdata/screenshots
 device_video fb
 device_joystick auto
 misc_quiet yes

--- a/board/batocera/fsoverlay/recalbox/share_init/system/configs/moonlight/moonlight.conf
+++ b/board/batocera/fsoverlay/recalbox/share_init/system/configs/moonlight/moonlight.conf
@@ -50,7 +50,7 @@ sops = true
 
 ## Directory to store encryption keys
 ## By default keys are stored in $XDG_CACHE_DIR/moonlight or ~/.cache/moonlight
-keydir = /recalbox/share/system/configs/moonlight/keydir
+keydir = /userdata/system/configs/moonlight/keydir
 
 ## Load additional configuration files
 #config = /path/to/config

--- a/board/batocera/fsoverlay/recalbox/share_init/system/configs/mupen64/mupen64plus.cfg
+++ b/board/batocera/fsoverlay/recalbox/share_init/system/configs/mupen64/mupen64plus.cfg
@@ -66,11 +66,11 @@ EnableDebugger = False
 # Save state slot (0-9) to use when saving/loading the emulator state
 CurrentStateSlot = 0
 # Path to directory where screenshots are saved. If this is blank, the default value of ${UserConfigPath}/screenshot will be used
-ScreenshotPath = "/recalbox/share/screenshots/"
+ScreenshotPath = "/userdata/screenshots/"
 # Path to directory where emulator save states (snapshots) are saved. If this is blank, the default value of ${UserConfigPath}/save will be used
-SaveStatePath = "/recalbox/share/saves/n64/"
+SaveStatePath = "/userdata/saves/n64/"
 # Path to directory where SRAM/EEPROM data (in-game saves) are stored. If this is blank, the default value of ${UserConfigPath}/save will be used
-SaveSRAMPath = "/recalbox/share/saves/n64/"
+SaveSRAMPath = "/userdata/saves/n64/"
 # Path to a directory to search when looking for shared data files
 SharedDataPath = "/recalbox/configs/mupen64/"
 # Delay interrupt after DMA SI read/write

--- a/board/batocera/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
+++ b/board/batocera/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
@@ -1,6 +1,6 @@
-core_options_path = /recalbox/share/system/configs/retroarch/cores/retroarch-core-options.cfg
+core_options_path = /userdata/system/configs/retroarch/cores/retroarch-core-options.cfg
 
-system_directory = /recalbox/share/bios/
+system_directory = /userdata/bios/
 
 config_save_on_exit = false
 
@@ -22,17 +22,17 @@ savestate_auto_save = false
 savestate_auto_load = false
 
 video_shader_dir = /recalbox/share_init/shaders/
-screenshot_directory = /recalbox/share/screenshots/
-savestate_directory = /recalbox/share/saves/
-savefile_directory = /recalbox/share/saves/
-extraction_directory = /recalbox/share/extractions/
+screenshot_directory = /userdata/screenshots/
+savestate_directory = /userdata/saves/
+savefile_directory = /userdata/saves/
+extraction_directory = /userdata/extractions/
 cheat_database_path = /recalbox/share_init/cheats/cht/
-cheat_settings_path = /recalbox/share/cheats/saves/
+cheat_settings_path = /userdata/cheats/saves/
 
 fastforward_ratio = -1.0
 input_autodetect_enable = false
 
-joypad_autoconfig_dir = /recalbox/share/system/configs/retroarch/inputs/
+joypad_autoconfig_dir = /userdata/system/configs/retroarch/inputs/
 
 input_joypad_driver = "sdl2"
 

--- a/board/batocera/fsoverlay/usr/bin/recallog
+++ b/board/batocera/fsoverlay/usr/bin/recallog
@@ -1,5 +1,5 @@
 #!/bin/sh
-log="/recalbox/share/system/logs/recalbox.log"
+log="/userdata/system/logs/recalbox.log"
 if [[ "$1" == "-e" ]];then
   shift
   echo "`logtime` : $@" >> $log

--- a/board/batocera/patches/libfm/001-libfm-fancymounts.patch
+++ b/board/batocera/patches/libfm/001-libfm-fancymounts.patch
@@ -31,25 +31,25 @@ index 104f988..45fd463 100644
 -        path = fm_path_get_home();
 -        new_path_item(model, &it, path, FM_PLACES_ID_HOME,
 -                      _("Home Folder"), "user-home", job);
-+      path = fm_path_new_for_str("/recalbox/share");
++      path = fm_path_new_for_str("/userdata");
 +      new_path_item(model, &it, path, FM_PLACES_ID_BATOCERA_SHARE,
 +		    _("Share"), "share", job);
 +    }
 +
 +    {
-+      path = fm_path_new_for_str("/recalbox/share/roms");
++      path = fm_path_new_for_str("/userdata/roms");
 +      new_path_item(model, &it, path, FM_PLACES_ID_BATOCERA_ROMS,
 +		    _("Roms"), "roms", job);
 +    }
 +
 +     {
-+      path = fm_path_new_for_str("/recalbox/share/screenshots");
++      path = fm_path_new_for_str("/userdata/screenshots");
 +      new_path_item(model, &it, path, FM_PLACES_ID_BATOCERA_SCREENSHOTS,
 +		    _("Screenshots"), "screenshots", job);
 +    }
 +
 +    {
-+      path = fm_path_new_for_str("/recalbox/share/bios");
++      path = fm_path_new_for_str("/userdata/bios");
 +      new_path_item(model, &it, path, FM_PLACES_ID_BATOCERA_BIOS,
 +		    _("Bios"), "bios", job);
      }

--- a/board/batocera/s912/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/s912/fsoverlay/etc/init.d/S31emulationstation
@@ -2,7 +2,7 @@
 #
 #
 
-log=/recalbox/share/system/logs/recalbox.log
+log=/userdata/system/logs/recalbox.log
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
 
 case "$1" in
@@ -14,7 +14,7 @@ case "$1" in
 		[ $? = "0" ] && tvservice -e "$videoMode"
 		settings_lang="`$systemsetting -command load -key system.language`"
         	recallog "starting emulationstation with lang = $settings_lang"
-                command="HOME=/recalbox/share/system LANG=\"${settings_lang}.UTF-8\" SDL_VIDEO_EGL_DRIVER=/usr/lib/libEGL.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
+                command="HOME=/userdata/system LANG=\"${settings_lang}.UTF-8\" SDL_VIDEO_EGL_DRIVER=/usr/lib/libEGL.so SDL_NOMOUSE=1 /usr/bin/emulationstation"
         	recallog "Starting emulationstation with command : "
         	recallog "$command"
         	eval $command >> $log &

--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -15,7 +15,7 @@ xset -dpms
 xset s off
 
 #
-export HOME=/recalbox/share/system
+export HOME=/userdata/system
 export LC_ALL="${settings_lang}.UTF-8"
 export LANG=${LC_ALL}
 

--- a/board/batocera/x86/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/x86/fsoverlay/etc/init.d/S31emulationstation
@@ -2,7 +2,7 @@
 #
 #
 
-log=/recalbox/share/system/logs/recalbox.log
+log=/userdata/system/logs/recalbox.log
 systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/recalboxSettings.py"
 
 case "$1" in
@@ -12,7 +12,7 @@ case "$1" in
 		settings_lang="`$systemsetting -command load -key system.language`"
         	recallog "starting emulationstation with lang = $settings_lang"
 		# HOME is important to be able to call ~/.xinitrc
-                command="HOME=/recalbox/share/system startx"
+                command="HOME=/userdata/system startx"
         	recallog "Starting emulationstation with command : "
         	recallog "$command"
         	eval $command >> $log &

--- a/board/batocera/x86/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
+++ b/board/batocera/x86/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
@@ -1,6 +1,6 @@
-core_options_path = /recalbox/share/system/configs/retroarch/cores/retroarch-core-options.cfg
+core_options_path = /userdata/system/configs/retroarch/cores/retroarch-core-options.cfg
 
-system_directory = /recalbox/share/bios/
+system_directory = /userdata/bios/
 
 config_save_on_exit = false
 
@@ -22,17 +22,17 @@ savestate_auto_save = false
 savestate_auto_load = false
 
 video_shader_dir = /recalbox/share_init/shaders/
-screenshot_directory = /recalbox/share/screenshots/
-savestate_directory = /recalbox/share/saves/
-savefile_directory = /recalbox/share/saves/
-extraction_directory = /recalbox/share/extractions/
+screenshot_directory = /userdata/screenshots/
+savestate_directory = /userdata/saves/
+savefile_directory = /userdata/saves/
+extraction_directory = /userdata/extractions/
 cheat_database_path = /recalbox/share_init/cheats/cht/
-cheat_settings_path = /recalbox/share/cheats/saves/
+cheat_settings_path = /userdata/cheats/saves/
 
 fastforward_ratio = -1.0
 input_autodetect_enable = false
 
-joypad_autoconfig_dir = /recalbox/share/system/configs/retroarch/inputs/
+joypad_autoconfig_dir = /userdata/system/configs/retroarch/inputs/
 
 input_joypad_driver = "sdl2"
 

--- a/board/batocera/xu4/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
+++ b/board/batocera/xu4/fsoverlay/recalbox/share_init/system/configs/retroarch/retroarchcustom.cfg
@@ -1,6 +1,6 @@
-core_options_path = /recalbox/share/system/configs/retroarch/cores/retroarch-core-options.cfg
+core_options_path = /userdata/system/configs/retroarch/cores/retroarch-core-options.cfg
 
-system_directory = /recalbox/share/bios/
+system_directory = /userdata/bios/
 
 config_save_on_exit = false
 
@@ -22,17 +22,17 @@ savestate_auto_save = false
 savestate_auto_load = false
 
 video_shader_dir = /recalbox/share_init/shaders/
-screenshot_directory = /recalbox/share/screenshots/
-savestate_directory = /recalbox/share/saves/
-savefile_directory = /recalbox/share/saves/
-extraction_directory = /recalbox/share/extractions/
+screenshot_directory = /userdata/screenshots/
+savestate_directory = /userdata/saves/
+savefile_directory = /userdata/saves/
+extraction_directory = /userdata/extractions/
 cheat_database_path = /recalbox/share_init/cheats/cht/
-cheat_settings_path = /recalbox/share/cheats/saves/
+cheat_settings_path = /userdata/cheats/saves/
 
 fastforward_ratio = -1.0
 input_autodetect_enable = false
 
-joypad_autoconfig_dir = /recalbox/share/system/configs/retroarch/inputs/
+joypad_autoconfig_dir = /userdata/system/configs/retroarch/inputs/
 
 input_joypad_driver = "sdl2"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -35,7 +35,7 @@ class AmiberryGenerator(Generator):
             commandArray.append("-autowhdload="+rom)
         else:
 	    commandArray.append("-s")
-	    commandArray.append("pandora.floppy_path=/recalbox/share/roms/amiga/" + system.config['core'])
+	    commandArray.append("pandora.floppy_path=/userdata/roms/amiga/" + system.config['core'])
 
         # controller
         libretroControllers.writeControllersConfig(retroconfig, system, playersControllers)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -116,4 +116,4 @@ def update(config, filepath, gameResolution):
     readWriteFile(filepath, arg_setval)
 
 if __name__ == '__main__':
-    readWriteFile("/recalbox/share/saves/dolphin-emu/Wii/shared2/sys/SYSCONF", {})
+    readWriteFile("/userdata/saves/dolphin-emu/Wii/shared2/sys/SYSCONF", {})

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/linapple/linappleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/linapple/linappleGenerator.py
@@ -25,7 +25,7 @@ class LinappleGenerator(Generator):
         
         path_user (str):
             Full path name where user settings are stored.
-            ('/recalbox/share/system/.linapple')
+            ('/userdata/system/.linapple')
             
     '''
     def __init__(self, path_init, path_user):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -71,7 +71,7 @@ def configureReg(config_directory):
     f.write("DocumentsFolderMode=User\n")
     f.write("CustomDocumentsFolder=/usr/PCSX/bin\n")
     f.write("UseDefaultSettingsFolder=enabled\n")
-    f.write("SettingsFolder=/recalbox/share/system/configs/PCSX2/inis\n")
+    f.write("SettingsFolder=/userdata/system/configs/PCSX2/inis\n")
     f.write("Install_Dir=/usr/PCSX/bin\n")
     f.write("RunWizard=0\n")
     f.close()

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/reicast/reicastGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/reicast/reicastGenerator.py
@@ -68,7 +68,7 @@ class ReicastGenerator(Generator):
         commandArray.append(rom)
         # Here is the trick to make reicast find files :
         # emu.cfg is in $XDG_CONFIG_DIRS or $XDG_CONFIG_HOME. The latter is better
-        # VMU will be in $XDG_DATA_HOME because it needs rw access -> /recalbox/share/saves/dreamcast
+        # VMU will be in $XDG_DATA_HOME because it needs rw access -> /userdata/saves/dreamcast
         # BIOS will be in $XDG_DATA_DIRS
         # controller cfg files are set with an absolute path, so no worry
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":recalboxFiles.CONF, "XDG_DATA_HOME":recalboxFiles.reicastSaves, "XDG_DATA_DIRS":recalboxFiles.reicastBios})

--- a/package/batocera/core/batocera-configgen/configgen/configgen/recalboxFiles.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/recalboxFiles.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 HOME_INIT = '/recalbox/share_init/system/'
-HOME = '/recalbox/share/system'
+HOME = '/userdata/system'
 CONF_INIT = HOME_INIT + '/configs'
 CONF = HOME + '/configs'
-SAVES = '/recalbox/share/saves'
-SCREENSHOTS = '/recalbox/share/screenshots'
-BIOS = '/recalbox/share/bios'
-OVERLAYS = '/recalbox/share/overlays'
-CACHE = '/recalbox/share/system/cache'
+SAVES = '/userdata/saves'
+SCREENSHOTS = '/userdata/screenshots'
+BIOS = '/userdata/bios'
+OVERLAYS = '/userdata/overlays'
+CACHE = '/userdata/system/cache'
 
 esInputs = HOME + '/.emulationstation/es_input.cfg'
 esSettings = HOME + '/.emulationstation/es_settings.cfg'
@@ -43,11 +43,11 @@ retroarchCustomOrigin = retroarchRootInit + "/retroarchcustom.cfg"
 retroarchCoreCustom = retroarchRoot + "/cores/retroarch-core-options.cfg"
 
 retroarchCores = "/usr/lib/libretro/"
-shadersRoot = "/recalbox/share/shaders/presets/"
+shadersRoot = "/userdata/shaders/presets/"
 shadersExt = '.gplsp'
 libretroExt = '_libretro.so'
-screenshotsDir = "/recalbox/share/screenshots/"
-savesDir = "/recalbox/share/saves/"
+screenshotsDir = "/userdata/screenshots/"
+savesDir = "/userdata/saves/"
 
 fbaRoot = CONF + '/fba/'
 fbaCustom = fbaRoot + 'fba2x.cfg'
@@ -91,7 +91,7 @@ dolphinSYSCONF = dolphinData + "/Wii/shared2/sys/SYSCONF"
 
 pcsx2PluginsDir     = "/usr/PCSX/bin/plugins"
 pcsx2Avx2PluginsDir = "/usr/PCSX_AVX2/bin/plugins"
-pcsx2ConfigDir      = "/recalbox/share/system/configs/PCSX2"
+pcsx2ConfigDir      = "/userdata/system/configs/PCSX2"
 
 ppssppConf = CONF + '/ppsspp/PSP/SYSTEM'
 ppssppControlsIni = ppssppConf + '/controls.ini'
@@ -116,8 +116,8 @@ advancemameConfig = CONF + '/advancemame/advmame.rc'
 advancemameConfigOrigin = CONF + '/advancemame/advmame.rc.origin'
 
 overlaySystem = "/recalbox/share_init/decorations"
-overlayUser = "/recalbox/share/decorations"
-overlayConfigFile = "/recalbox/share/system/configs/retroarch/overlay.cfg"
+overlayUser = "/userdata/decorations"
+overlayConfigFile = "/userdata/system/configs/retroarch/overlay.cfg"
 
 amiberryRoot = CONF + '/amiberry'
 amiberryRetroarchInputsDir = amiberryRoot + '/conf/retroarch/inputs'

--- a/package/batocera/core/batocera-desktopapps/scripts/filemanagerlauncher.sh
+++ b/package/batocera/core/batocera-desktopapps/scripts/filemanagerlauncher.sh
@@ -4,5 +4,5 @@ export XDG_MENU_PREFIX=batocera-
 export XDG_CONFIG_DIRS=/etc/xdg
 
 DISPLAY=:0.0 matchbox-remote -s # show the mouse
-DISPLAY=:0.0 pcmanfm /recalbox/share
+DISPLAY=:0.0 pcmanfm /userdata
 DISPLAY=:0.0 matchbox-remote -h # hide the mouse

--- a/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-dolphin.sh
+++ b/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-dolphin.sh
@@ -10,7 +10,7 @@ then
     matchbox-remote -s # show the mouse
 fi
 
-XDG_CONFIG_HOME=/recalbox/share/system/configs XDG_DATA_HOME=/recalbox/share/saves /usr/bin/dolphin-emu-wx
+XDG_CONFIG_HOME=/userdata/system/configs XDG_DATA_HOME=/userdata/saves /usr/bin/dolphin-emu-wx
 
 if test "${HANDLEMOUSE}" = "1"
 then

--- a/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-pcsx2.sh
+++ b/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-pcsx2.sh
@@ -18,7 +18,7 @@ then
     export LIBGL_DRIVERS_PATH="/lib32/dri"
 fi
 
-XDG_CONFIG_HOME=/recalbox/share/system/configs /usr/PCSX/bin/PCSX2 --gs=/usr/PCSX/bin/plugins/libGSdx.so --pad=/usr/PCSX/bin/plugins/libonepad-legacy.so --cdvd=/usr/PCSX/bin/plugins/libCDVDnull.so --usb=/usr/PCSX/bin/plugins/libUSBnull-0.7.0.so --fw=/usr/PCSX/bin/plugins/libFWnull-0.7.0.so --dev9=/usr/PCSX/bin/plugins/libdev9null-0.5.0.so --spu2=/usr/PCSX/bin/plugins/libspu2x-2.0.0.so
+XDG_CONFIG_HOME=/userdata/system/configs /usr/PCSX/bin/PCSX2 --gs=/usr/PCSX/bin/plugins/libGSdx.so --pad=/usr/PCSX/bin/plugins/libonepad-legacy.so --cdvd=/usr/PCSX/bin/plugins/libCDVDnull.so --usb=/usr/PCSX/bin/plugins/libUSBnull-0.7.0.so --fw=/usr/PCSX/bin/plugins/libFWnull-0.7.0.so --dev9=/usr/PCSX/bin/plugins/libdev9null-0.5.0.so --spu2=/usr/PCSX/bin/plugins/libspu2x-2.0.0.so
 
 if test "${HANDLEMOUSE}" = "1"
 then

--- a/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-retroarch.sh
+++ b/package/batocera/core/batocera-desktopapps/scripts/recalbox-config-retroarch.sh
@@ -2,4 +2,4 @@
 
 export DISPLAY=:0.0
 
-/usr/bin/retroarch --menu --config /recalbox/share/system/configs/retroarch/retroarchcustom.cfg
+/usr/bin/retroarch --menu --config /userdata/system/configs/retroarch/retroarchcustom.cfg

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -82,7 +82,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_BATOCERA_XORG                     if BR2_PACKAGE_BATOCERA_TARGET_X86  || BR2_PACKAGE_BATOCERA_TARGET_X86_64
 
     # compression tools
-    select BR2_PACKAGE_UNZIP                             # for /recalbox/share/system/upgrade/share.zip
+    select BR2_PACKAGE_UNZIP                             # for /userdata/system/upgrade/share.zip
     select BR2_PACKAGE_XZ                                # for updates
 
     help

--- a/package/batocera/core/batocera-system/c2/recalbox.conf
+++ b/package/batocera/core/batocera-system/c2/recalbox.conf
@@ -218,7 +218,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/rockpro64/recalbox.conf
+++ b/package/batocera/core/batocera-system/rockpro64/recalbox.conf
@@ -221,7 +221,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/rpi1/recalbox.conf
+++ b/package/batocera/core/batocera-system/rpi1/recalbox.conf
@@ -219,7 +219,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/rpi2/recalbox.conf
+++ b/package/batocera/core/batocera-system/rpi2/recalbox.conf
@@ -219,7 +219,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/rpi3/recalbox.conf
+++ b/package/batocera/core/batocera-system/rpi3/recalbox.conf
@@ -219,7 +219,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/s905/recalbox.conf
+++ b/package/batocera/core/batocera-system/s905/recalbox.conf
@@ -215,7 +215,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/s912/recalbox.conf
+++ b/package/batocera/core/batocera-system/s912/recalbox.conf
@@ -215,7 +215,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/x86/recalbox.conf
+++ b/package/batocera/core/batocera-system/x86/recalbox.conf
@@ -219,7 +219,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/x86_64/recalbox.conf
+++ b/package/batocera/core/batocera-system/x86_64/recalbox.conf
@@ -219,7 +219,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/core/batocera-system/xu4/recalbox.conf
+++ b/package/batocera/core/batocera-system/xu4/recalbox.conf
@@ -215,7 +215,7 @@ global.inputdriver=auto
 ## Here is the snes example
 ;snes.videomode=CEA 4 HDMI
 ;snes.core=snes9x_next
-;snes.shaders=/recalbox/share/shaders/shaders_glsl/mysnesshader.gplsp
+;snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 ;snes.ratio=16/9
 ;snes.smooth=0
 ;snes.rewind=1

--- a/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
+++ b/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
@@ -12,7 +12,7 @@ import shutil
 
 class EsSystemConf:
 
-    default_parentpath = "/recalbox/share/roms"
+    default_parentpath = "/userdata/roms"
     default_command    = "python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.py %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM% -emulator %EMULATOR% -core %CORE% -ratio %RATIO%"
 
     # Generate the es_systems.cfg file by searching the information in the es_system.yml file

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -410,7 +410,7 @@ fba_libretro:
     The file fba_libretro_gamelist.txt list compatible games.
 
     Special files for fba libretro core:
-    - Add your (audio) samples files in /recalbox/share/bios/fba/samples/
+    - Add your (audio) samples files in /userdata/bios/fba/samples/
   comment_fr: |
     La version des ROMs doit être 0.2.97.42
 
@@ -419,7 +419,7 @@ fba_libretro:
     Le fichier fba_libretro_gamelist.txt liste les jeux compatibles.
 
     Fichiers spéciaux pour le core fba libretro:
-    - Ajoutez vos samples (audio) dans le répertoire /recalbox/share/bios/fba/samples/
+    - Ajoutez vos samples (audio) dans le répertoire /userdata/bios/fba/samples/
 
 mame:
   name:       Mame
@@ -443,7 +443,7 @@ mame:
     https://github.com/recalbox/recalbox-os/wiki/recalbox.conf-%28EN%29
 
     Special files for mame2003 core:
-    - Add your samples files in /recalbox/share/bios/mame2003/samples/
+    - Add your samples files in /userdata/bios/mame2003/samples/
   comment_fr: |
     Le système utilise le core libretro mame2003 implicitement: Les ROMs compatibles doivent provenir du set 0.78
     Le core imame4all, basé sur MAME v0.37b5 est également disponible.
@@ -452,7 +452,7 @@ mame:
     https://github.com/recalbox/recalbox-os/wiki/recalbox.conf-%28FR%29
 
     Fichiers spéciaux pour le core mame2003 :
-    - Ajoutez vos fichiers samples dans le répertoire /recalbox/share/bios/mame2003/samples/
+    - Ajoutez vos fichiers samples dans le répertoire /userdata/bios/mame2003/samples/
 
 neogeo:
   name:       Neo-Geo
@@ -992,7 +992,7 @@ x68000:
 imageviewer:
   name:       Screenshots
   extensions: [jpg, jpeg, png, bmp, psd, tga, gif, hdr, pic, ppm, pgm]
-  path:       /recalbox/share/screenshots
+  path:       /userdata/screenshots
   platform:   ignore
   emulators:
     libretro:

--- a/package/batocera/emulators/amiberry/003-amiberry-path.patch
+++ b/package/batocera/emulators/amiberry/003-amiberry-path.patch
@@ -5,7 +5,7 @@
  void fetch_saveimagepath(char *out, int size, int dir)
  {
 -	strncpy(out, start_path_data, size);
-+	strncpy(out, "/recalbox/share/saves/amiga", size);
++	strncpy(out, "/userdata/saves/amiga", size);
  	strncat(out, "/savestates/", size);
  }
  
@@ -14,14 +14,14 @@
  void fetch_savestatepath(char *out, int size)
  {
 -	strncpy(out, start_path_data, size);
-+	strncpy(out, "/recalbox/share/saves/amiga", size);
++	strncpy(out, "/userdata/saves/amiga", size);
  	strncat(out, "/savestates/", size);
  }
  
  void fetch_screenshotpath(char *out, int size)
  {
 -	strncpy(out, start_path_data, size);
-+	strncpy(out, "/recalbox/share", size);
++	strncpy(out, "/userdata", size);
  	strncat(out, "/screenshots/", size);
  }
  
@@ -30,7 +30,7 @@
  	char path[MAX_DPATH];
  
 -	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", start_path_data);
-+	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", "/recalbox/share/system/configs/amiberry");
++	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", "/userdata/system/configs/amiberry");
  	const auto f = fopen(path, "we");
  	if (!f)
  		return;
@@ -39,15 +39,15 @@
  	fputs(buffer, f);
  
 -	snprintf(buffer, MAX_DPATH, "config_path=%s\n", config_path);
-+	snprintf(buffer, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf", config_path);
++	snprintf(buffer, MAX_DPATH, "/userdata/system/configs/amiberry/conf", config_path);
  	fputs(buffer, f);
  
 -	snprintf(buffer, MAX_DPATH, "controllers_path=%s\n", controllers_path);
-+	snprintf(buffer, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf/retroarch/inputs", controllers_path);
++	snprintf(buffer, MAX_DPATH, "/userdata/system/configs/amiberry/conf/retroarch/inputs", controllers_path);
  	fputs(buffer, f);
  
 -	snprintf(buffer, MAX_DPATH, "retroarch_config=%s\n", retroarch_file);
-+	snprintf(buffer, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf/retroarch/retroarchcustom.cfg", retroarch_file);
++	snprintf(buffer, MAX_DPATH, "/userdata/system/configs/amiberry/conf/retroarch/retroarchcustom.cfg", retroarch_file);
  	fputs(buffer, f);
  
  	snprintf(buffer, MAX_DPATH, "rom_path=%s\n", rom_path);
@@ -60,10 +60,10 @@
 -	snprintf(retroarch_file, MAX_DPATH, "%s/conf/retroarch.cfg", start_path_data);
 +	
 +	/* snprintf(config_path, MAX_DPATH, "%s/conf/", start_path_data);  */
-+	snprintf(config_path, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf");
++	snprintf(config_path, MAX_DPATH, "/userdata/system/configs/amiberry/conf");
 +	
-+	snprintf(controllers_path, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf/retroarch/inputs");
-+	snprintf(retroarch_file, MAX_DPATH, "/recalbox/share/system/configs/amiberry/conf/retroarch/retroarchcustom.cfg");
++	snprintf(controllers_path, MAX_DPATH, "/userdata/system/configs/amiberry/conf/retroarch/inputs");
++	snprintf(retroarch_file, MAX_DPATH, "/userdata/system/configs/amiberry/conf/retroarch/retroarchcustom.cfg");
  
  #ifdef ANDROID
      char afepath[MAX_DPATH];
@@ -72,15 +72,15 @@
      }
  	else
 -        snprintf(rom_path, MAX_DPATH, "%s/kickstarts/", start_path_data);
-+        snprintf(rom_path, MAX_DPATH, "/recalbox/share/bios/");
++        snprintf(rom_path, MAX_DPATH, "/userdata/bios/");
  #else
 -	snprintf(rom_path, MAX_DPATH, "%s/kickstarts/", start_path_data);
-+	snprintf(rom_path, MAX_DPATH, "/recalbox/share/bios/");
++	snprintf(rom_path, MAX_DPATH, "/userdata/bios/");
  #endif
  	snprintf(rp9_path, MAX_DPATH, "%s/rp9/", start_path_data);
  
 -	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", start_path_data);
-+	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", "/recalbox/share/system/configs/amiberry");
++	snprintf(path, MAX_DPATH, "%s/conf/adfdir.conf", "/userdata/system/configs/amiberry");
  
  	const auto fh = zfile_fopen(path, _T("r"), ZFD_NORMAL);
  	if (fh) {
@@ -89,7 +89,7 @@
  	rp9_init();
  
 -	snprintf(savestate_fname, sizeof savestate_fname, "%s/savestates/default.ads", start_path_data);
-+	snprintf(savestate_fname, sizeof savestate_fname, "%s/savestates/default.ads", "/recalbox/share/saves/amiga");
++	snprintf(savestate_fname, sizeof savestate_fname, "%s/savestates/default.ads", "/userdata/saves/amiga");
  	logging_init();
  
  	memset(&action, 0, sizeof action);

--- a/package/batocera/emulators/amiberry/amiberry.mk
+++ b/package/batocera/emulators/amiberry/amiberry.mk
@@ -36,7 +36,7 @@ endef
 define AMIBERRY_INSTALL_TARGET_CMDS
 	$(INSTALL) -D $(@D)/amiberry-$(AMIBERRY_BATOCERA_SYSTEM) $(TARGET_DIR)/usr/bin/amiberry
         mkdir -p $(TARGET_DIR)/usr/share/amiberry
-	ln -sf /recalbox/share/system/configs/amiberry/whdboot $(TARGET_DIR)/usr/share/amiberry/whdboot
+	ln -sf /userdata/system/configs/amiberry/whdboot $(TARGET_DIR)/usr/share/amiberry/whdboot
         mkdir -p $(TARGET_DIR)/recalbox/share_init/system/configs/amiberry
 	cp -pr $(@D)/whdboot $(TARGET_DIR)/recalbox/share_init/system/configs/amiberry/
 	cp -rf $(@D)/data $(TARGET_DIR)/usr/share/amiberry

--- a/package/batocera/emulators/linapple-pie/linapple-pie.mk
+++ b/package/batocera/emulators/linapple-pie/linapple-pie.mk
@@ -39,13 +39,13 @@ define LINAPPLE_PIE_INSTALL_TARGET_CMDS
 	mkdir -p $(LINAPPLE_PIE_CONFDIR)
 	cp $(@D)/linapple-pie/Master.dsk $(LINAPPLE_PIE_CONFDIR)/
 	cp $(@D)/linapple-pie/linapple.installed.conf $(LINAPPLE_PIE_CONFFILE)
-	$(SED) "s|^\(\s*\)Slot 6 Directory =.*|\1Slot 6 Directory = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
-	$(SED) "s|^\(\s*\)Save State Directory =.*|\1Save State Directory = /recalbox/share/saves/apple2|g" $(LINAPPLE_PIE_CONFFILE)
-	$(SED) "s|^\(\s*\)FTP Local Dir =.*|\1FTP Local Dir = /recalbox/share/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)Slot 6 Directory =.*|\1Slot 6 Directory = /userdata/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)Save State Directory =.*|\1Save State Directory = /userdata/saves/apple2|g" $(LINAPPLE_PIE_CONFFILE)
+	$(SED) "s|^\(\s*\)FTP Local Dir =.*|\1FTP Local Dir = /userdata/roms/apple2|g" $(LINAPPLE_PIE_CONFFILE)
 	echo -e "\n##########################################################################" >> $(LINAPPLE_PIE_CONFFILE)
 	echo -e "#\tRecalbox specific parameters\n" >> $(LINAPPLE_PIE_CONFFILE)
-	echo -e "\tRecalboxRomDirectory =\t/recalbox/share/roms/apple2" >> $(LINAPPLE_PIE_CONFFILE)
-	echo -e "\tRecalboxSaveDirectory =\t/recalbox/share/saves/apple2" >> $(LINAPPLE_PIE_CONFFILE)
+	echo -e "\tRecalboxRomDirectory =\t/userdata/roms/apple2" >> $(LINAPPLE_PIE_CONFFILE)
+	echo -e "\tRecalboxSaveDirectory =\t/userdata/saves/apple2" >> $(LINAPPLE_PIE_CONFFILE)
 endef
 else
 LINAPPLE_PIE_STARTUP = /usr/bin/linapple

--- a/package/batocera/emulators/pcsx2/003-path.patch
+++ b/package/batocera/emulators/pcsx2/003-path.patch
@@ -8,14 +8,14 @@ index 607a934..57cf5f6 100644
  	{
 -		return GetDocuments() + Base::Snapshots();
 +	  //return GetDocuments() + Base::Snapshots();
-+	  return wxDirName("/recalbox/share/screenshots");
++	  return wxDirName("/userdata/screenshots");
  	}
  
  	wxDirName GetBios()
  	{
 -		return GetDocuments() + Base::Bios();;
 +	  //return GetDocuments() + Base::Bios();;
-+	  return wxDirName("/recalbox/share/bios");
++	  return wxDirName("/userdata/bios");
  	}
  
  	wxDirName GetCheats()
@@ -25,7 +25,7 @@ index 607a934..57cf5f6 100644
  	{
 -		return GetDocuments() + Base::Savestates();
 +	  //return GetDocuments() + Base::Savestates();
-+	  return wxDirName("/recalbox/share/saves/ps2");
++	  return wxDirName("/userdata/saves/ps2");
  	}
  
  	wxDirName GetMemoryCards()

--- a/package/batocera/emulators/pcsx2_avx2/003-path.patch
+++ b/package/batocera/emulators/pcsx2_avx2/003-path.patch
@@ -8,14 +8,14 @@ index 607a934..57cf5f6 100644
  	{
 -		return GetDocuments() + Base::Snapshots();
 +	  //return GetDocuments() + Base::Snapshots();
-+	  return wxDirName("/recalbox/share/screenshots");
++	  return wxDirName("/userdata/screenshots");
  	}
  
  	wxDirName GetBios()
  	{
 -		return GetDocuments() + Base::Bios();;
 +	  //return GetDocuments() + Base::Bios();;
-+	  return wxDirName("/recalbox/share/bios");
++	  return wxDirName("/userdata/bios");
  	}
  
  	wxDirName GetCheats()
@@ -25,7 +25,7 @@ index 607a934..57cf5f6 100644
  	{
 -		return GetDocuments() + Base::Savestates();
 +	  //return GetDocuments() + Base::Savestates();
-+	  return wxDirName("/recalbox/share/saves/ps2");
++	  return wxDirName("/userdata/saves/ps2");
  	}
  
  	wxDirName GetMemoryCards()

--- a/package/batocera/emulators/ppsspp/001-controller.patch
+++ b/package/batocera/emulators/ppsspp/001-controller.patch
@@ -7,7 +7,7 @@ index 72254a1..585a75b 100644
  	}
  
 -	const char *dbPath = "gamecontrollerdb.txt";
-+	const char *dbPath = "/recalbox/share/system/configs/ppsspp/gamecontrollerdb.txt";
++	const char *dbPath = "/userdata/system/configs/ppsspp/gamecontrollerdb.txt";
  	cout << "loading control pad mappings from " << dbPath << ": ";
  
  	size_t size;

--- a/package/batocera/emulators/ppsspp15/001-gamecontrollerdb_patch.patch
+++ b/package/batocera/emulators/ppsspp15/001-gamecontrollerdb_patch.patch
@@ -7,7 +7,7 @@ index 72254a1..585a75b 100644
  	}
  
 -	const char *dbPath = "gamecontrollerdb.txt";
-+	const char *dbPath = "/recalbox/share/system/configs/ppsspp/gamecontrollerdb.txt";
++	const char *dbPath = "/userdata/system/configs/ppsspp/gamecontrollerdb.txt";
  	cout << "loading control pad mappings from " << dbPath << ": ";
  
  	size_t size;

--- a/package/batocera/emulators/reicast/004-force-patchs.patch
+++ b/package/batocera/emulators/reicast/004-force-patchs.patch
@@ -6,8 +6,8 @@ index 27cf443..c284fdf 100755
  
  settings_t settings;
  
-+std::string recalboxBiosPath = "/recalbox/share/bios/";
-+std::string recalboxNvmemPath = "/recalbox/share/bios/";
++std::string recalboxBiosPath = "/userdata/bios/";
++std::string recalboxNvmemPath = "/userdata/bios/";
 +
  /*
  	libndc

--- a/package/batocera/emulators/retroarch/libretro/libretro-redream/000-bios-save.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-redream/000-bios-save.patch
@@ -85,7 +85,7 @@ index b973207..8bdf65b 100644
    if (env_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &sysdir)) {
      char appdir[PATH_MAX];
 -    snprintf(appdir, sizeof(appdir), "%s" PATH_SEPARATOR "dc", sysdir);
-+    snprintf(appdir, sizeof(appdir), "%s" PATH_SEPARATOR "saves" PATH_SEPARATOR "dreamcast", "/recalbox/share");
++    snprintf(appdir, sizeof(appdir), "%s" PATH_SEPARATOR "saves" PATH_SEPARATOR "dreamcast", "/userdata");
      fs_set_appdir(appdir);
    }
  
@@ -93,7 +93,7 @@ index b973207..8bdf65b 100644
 +  const char *sysdirbios = NULL;
 +  if (env_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &sysdirbios)) {
 +    char appdirbios[PATH_MAX];
-+    snprintf(appdirbios, sizeof(appdirbios), "%s" PATH_SEPARATOR "bios", "/recalbox/share");
++    snprintf(appdirbios, sizeof(appdirbios), "%s" PATH_SEPARATOR "bios", "/userdata");
 +    fs_set_appdirbios(appdirbios);
 +  }
 +

--- a/package/batocera/emulators/retroarch/libretro/libretro-reicast/001-save.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-reicast/001-save.patch
@@ -22,7 +22,7 @@ index fd1f40a..628595d 100644
 +
 +string get_writable_data_save(const string& filename)
 +{
-+   return std::string("/recalbox/share/saves/dreamcast/" + 
++   return std::string("/userdata/saves/dreamcast/" + 
 +#ifdef _WIN32
 +         std::string("\\")
 +#else


### PR DESCRIPTION
note: some emulators must still be patches because some /recalbox/share were hardcoded in the
configuration file copied on the /userdata at first boot

example:
  /userdata/system/.hatari/hatari.cfg:szTosImageFileName = /recalbox/share/bios/tos.img

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>