### PR TITLE
fix hostname

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S26recalboxsystem
+++ b/board/batocera/fsoverlay/etc/init.d/S26recalboxsystem
@@ -82,7 +82,9 @@ rb_timezone() {
 rb_hostname() {
     settings_hostname="`$systemsetting -command load -key system.hostname`"
     if [[ "$settings_hostname" != "" ]];then
-        hostname "$settings_hostname"
+        hostname "${settings_hostname}"
+	echo "127.0.0.1	localhost"             > /etc/hosts
+	echo "127.0.1.1	${settings_hostname}" >> /etc/hosts
     fi
 }
 


### PR DESCRIPTION
X seems to search for the hostname at boot and can't ping it
if it's not in /etc/hosts

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>