### PR TITLE
rpi-firmware: go back to default values

### DIFF
--- a/package/rpi-firmware/config.txt
+++ b/package/rpi-firmware/config.txt
@@ -34,7 +34,7 @@ disable_splash=1
 # Overclock
 gpu_mem_256=128
 gpu_mem_512=256
-gpu_mem_1024=384
+gpu_mem_1024=512
 
 avoid_safe_mode=1
 


### PR DESCRIPTION
batocera uses config.txt in board/batocera/rpi/