### PR TITLE
ps2: add fullboot option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -35,6 +35,10 @@ class Pcsx2Generator(Generator):
         # no gui
         commandArray.append("--nogui")
 
+        # fullboot
+        if system.isOptSet('fullboot') and system.getOptBoolean('fullboot') == True:
+            commandArray.append("--fullboot")
+
         # plugins
         real_pluginsDir = recalboxFiles.pcsx2PluginsDir
         if isAVX2:

--- a/package/batocera/core/batocera-system/x86_64/recalbox.conf
+++ b/package/batocera/core/batocera-system/x86_64/recalbox.conf
@@ -214,6 +214,11 @@ global.retroachievements.password=
 ## set emulatedwiimotes to 1 to emulate wiimotes with standard pads
 #wii.emulatedwiimotes=0
 
+## PS2
+# Disables fast booting (does not skip PS2 BIOS when booting an ISO, this may require by some games relying on BIOS to get start-up parameters)
+# set fullboot to 1 to enable BIOS when booting an ISO
+#ps2.fullboot=0
+
 # scrapper
 # Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart
 #scrapper.style=s,b,f,a,l,3b


### PR DESCRIPTION
Disables fast booting (does not skip PS2 BIOS when booting an ISO, this may require by some games relying on BIOS to get start-up parameters)