### PR TITLE
batocera-es-theme: a CLI tool to list and install Batocera themes.

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -5,24 +5,43 @@
 # @lbrpdx on Batocera Forums and Discord
 #
 # Usage:
-# batocera-es-theme <theme>
+# batocera-es-theme 'list' or 'install <theme>' 
 # 
 # If you don't provide a <theme>, the list of themes available online will be returned back to you
 #
 CONFIGDIR="/userdata/themes/"
-# THEMESLIST="https://batocera-linux.xorhub.com/themes.list"
-THEMESLIST="/tmp/outlistthemes"
-# themes.list must be in the format 'theme_name   https://githubURL'
-THEME=""
+THEMESLIST="https://batocera-linux.xorhub.com/upgrades/themes.txt"
+LOCALTHEMESLIST="/userdata/system/themes.txt"
+# themes.txt must be a plain file with the format 'theme_name https://githubURL' (spaces or tabs)
+# Example of a themes.txt file: 
+#  fundamental	https://github.com/jdorigao/es-theme-fundamental
+#  Zoid		https://github.com/RetroPie/es-theme-zoid
 
 ###############################
 #
 function usage() {
-	echo "$0 <theme>"
-	echo " - where <theme> is the Batocera EmulationStation theme you want to install"
-	echo "If you don't provide a <theme>, the list of themes available online will be returned"
-	echo "back to you as a list of 'theme-name [A/I]' where [A] means Available and [I] installed."
+	echo "$0 - downloads and installs EmulationStation themes for Batocera"
+	echo " "
+	echo "It accepts two modes: 'list' and 'install <theme>'"
+	echo "- 'list' for the list of themes available online, and if they are"
+	echo "   [A]vailable to install, [I]nstalled or [?]unknown."
+	echo "- 'install <theme>' to install the theme, from its theme name."
+	echo " "
+	echo "If you have a local $LOCALTHEMESLIST file,"
+	echo "it will override the one hosted on Batocera website."
 	exit 1
+}
+
+###############################
+#
+function check_url() {
+	[[ "$1" =~ ^(https?|ftp)://.*$ ]] && echo "[A]" || echo "[?]"
+}
+
+###############################
+#
+function git_name() {
+	echo "$1" | sed "s,.*/\(.*\),\1,"
 }
 
 ###############################
@@ -30,34 +49,64 @@ function usage() {
 function list_themes() {
 	fn=$(date +"%s")
 	tmp="/tmp/themes_$fn"
-	echo "$fn - Listing themes"
-	# curl -sfL "$THEMESLIST" -o "$tmp" || exit 1
-	tmp="$THEMESLIST"
+	echo "* Batocera themes *"
+	if [ -f $LOCALTHEMESLIST ]; then
+		cp -f "$LOCALTHEMESLIST" "$tmp"
+	else
+		curl -sfL "$THEMESLIST" -o "$tmp" || exit 1
+	fi
 	while IFS=$' \t' read name url ; do
-		ia="[A]"
-		[ -d "$CONFIGDIR"/"$name" ] && ia="[I]"
-		echo "$name $ia"
+		[ x"$name" == "x" ] && continue 
+		ia=$(check_url "$url")
+		gitname=$(git_name "$url")
+		[ -d "$CONFIGDIR"/"$gitname" ] && ia="[I]"
+		echo "$ia $name - $url"
 	done < "$tmp"
-	# rm "$tmp"
-
+	rm "$tmp"
 }
 
 ###############################
 #
 function install_theme() {
 	theme="$1"
+	echo "* Installing $theme *"
 	fn=$(date +"%s")
-	tmpfile=/tmp/ra_$fn
-	echo "$fn - Installing $theme"
+	tmp="/tmp/themes_$fn"
+	if [ -f $LOCALTHEMESLIST ]; then
+		cp -f "$LOCALTHEMESLIST" "$tmp"
+	else
+		curl -sfL "$THEMESLIST" -o "$tmp" || exit 1
+	fi
+	while IFS=$' \t' read name url ; do
+		[ x"$name" != x"$theme" ] && continue 
+		ia=$(check_url "$url")
+		if [ x"$ia" != x"[A]" ]; then
+			echo "Error - invalid theme URL $url"
+			exit 1
+		else
+			gitname=$(git_name "$url")
+			[ -d "$CONFIGDIR"/"$gitname" ] && rm -rf "$CONFIGDIR"/"$gitname" 
+			cd "$CONFIGDIR" && git clone "$url"
+			echo "$theme is now installed."
+		fi
+	done < "$tmp"
+	rm "$tmp"
 }
 
 #### Main loop
 #
-if [ $# -ge 1 ]; then
-	tmp="$1"
-	[ x"${tmp::1}" == "x-" ] && usage || THEME="$1"
-	install_theme $THEME
-else 
+command="$1"
+theme="$2"
+
+if ! [ -d "$CONFIGDIR" ]; then
+	echo "Error - theme directory $CONFIGDIR is not valid."
+	exit 1
+fi 
+if [ x"$command" == "xlist" ]; then
 	list_themes
+elif [ x"$command" == "xinstall" ]; then
+	[ x"$theme" != "x" ] && install_theme $theme || usage
+else 
+	usage	
 fi
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -1,0 +1,63 @@
+#!/bin/bash 
+#
+# Download and install EmulationStation themes for Batocera
+#
+# @lbrpdx on Batocera Forums and Discord
+#
+# Usage:
+# batocera-es-theme <theme>
+# 
+# If you don't provide a <theme>, the list of themes available online will be returned back to you
+#
+CONFIGDIR="/userdata/themes/"
+# THEMESLIST="https://batocera-linux.xorhub.com/themes.list"
+THEMESLIST="/tmp/outlistthemes"
+# themes.list must be in the format 'theme_name   https://githubURL'
+THEME=""
+
+###############################
+#
+function usage() {
+	echo "$0 <theme>"
+	echo " - where <theme> is the Batocera EmulationStation theme you want to install"
+	echo "If you don't provide a <theme>, the list of themes available online will be returned"
+	echo "back to you as a list of 'theme-name [A/I]' where [A] means Available and [I] installed."
+	exit 1
+}
+
+###############################
+#
+function list_themes() {
+	fn=$(date +"%s")
+	tmp="/tmp/themes_$fn"
+	echo "$fn - Listing themes"
+	# curl -sfL "$THEMESLIST" -o "$tmp" || exit 1
+	tmp="$THEMESLIST"
+	while IFS=$' \t' read name url ; do
+		ia="[A]"
+		[ -d "$CONFIGDIR"/"$name" ] && ia="[I]"
+		echo "$name $ia"
+	done < "$tmp"
+	# rm "$tmp"
+
+}
+
+###############################
+#
+function install_theme() {
+	theme="$1"
+	fn=$(date +"%s")
+	tmpfile=/tmp/ra_$fn
+	echo "$fn - Installing $theme"
+}
+
+#### Main loop
+#
+if [ $# -ge 1 ]; then
+	tmp="$1"
+	[ x"${tmp::1}" == "x-" ] && usage || THEME="$1"
+	install_theme $THEME
+else 
+	list_themes
+fi
+

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -85,9 +85,19 @@ function install_theme() {
 			exit 1
 		else
 			gitname=$(git_name "$url")
-			[ -d "$CONFIGDIR"/"$gitname" ] && rm -rf "$CONFIGDIR"/"$gitname" 
-			cd "$CONFIGDIR" && git clone "$url"
-			echo "$theme is now installed."
+			cd "$CONFIGDIR"
+			echo "Downloading from $url"
+			curl -sfL "$url/archive/master.zip" -o "$gitname.zip"
+			if [ -f "$gitname.zip" ]; then 
+				[ -d "$CONFIGDIR"/"$gitname" ] && rm -rf "$CONFIGDIR"/"$gitname" 
+				unzip "$gitname.zip"
+				mv "$gitname-master" "$gitname"
+				rm "$gitname.zip"
+			else
+				echo "Error - $theme zip file could not be downloaded from $url"
+				exit 1
+			fi
+			echo "Theme $theme is now installed."
 		fi
 	done < "$tmp"
 	rm "$tmp"


### PR DESCRIPTION
A Bash script to install Batocera themes, listed in a either the hostedhttps://batocera-linux.xorhub.com/upgrades/themes.txt file, or a local /userdata/system/themes.txt.