### PR TITLE
disable wifi password encoding

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -159,7 +159,7 @@ EOF
 	    if test "${settings_key}" = "${settings_key_dec}"
 	    then
 		# sed the replace by the secure value in batocera.conf
-		settings_key=$(/recalbox/scripts/recalbox-encode.sh encode "${settings_key}")
+		#settings_key=$(/recalbox/scripts/recalbox-encode.sh encode "${settings_key}")
 		sed -i -e s@'^[ \t]*wifi.key[ \t]*=.*$'@"wifi.key=${settings_key}"@ "/userdata/system/batocera.conf"
 	    fi
 	fi


### PR DESCRIPTION
it seems to cause issues to some people.
one reason is that es doesn't decode it
but it may come from the key that may change depending on something.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>