### PR TITLE
Call scripts before and after emulator call

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/fsoverlay/etc/init.d/S31emulationstation
@@ -11,12 +11,8 @@ case "$1" in
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation --no-splash &
 	fi
 	;;
-  stop) # Safe Shutdown for securing metadata
-        PID=$(pidof -s emulationstation)
+  stop)
         killall emulationstation
-        while [ -e "/proc/$PID" -a "$PID" ]; do
-            sleep 0.25
-        done
 	;;
   restart|reload)
         "$0" stop


### PR DESCRIPTION
This change will call scripts `/userdata/system/scripts/script_at_start.sh` and `/userdata/system/scripts/script_at_end.sh`

There are 4 parameter parse to this one
$1=systemname (lynx), $2==emulatorcore (mednafen_lynx)
$3=Fullpath to rom+Romname, $4=emulatortype

This is kind of how RetroPie works
Read more about here
https://github.com/RetroPie/RetroPie-Setup/wiki/runcommand

I hope path location is okay
File naming okay

This leads to a powerfull possibilty to make changes on system level like bezels for each ROM
Or automate scraping after a screenshot was made ....