### PR TITLE
settings by game

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -10,7 +10,7 @@ import collections
 
 class Emulator():
 
-    def __init__(self, name):
+    def __init__(self, name, rom):
         self.name = name
 
         # read the configuration from the system name
@@ -23,10 +23,12 @@ class Emulator():
         recalSettings = UnixSettings(batoceraFiles.batoceraConf)
         globalSettings = recalSettings.loadAll('global')
         systemSettings = recalSettings.loadAll(self.name)
+        gameSettings = recalSettings.loadAll(os.path.basename(rom))
 
         # update config
         Emulator.updateConfiguration(self.config, globalSettings)
         Emulator.updateConfiguration(self.config, systemSettings)
+        Emulator.updateConfiguration(self.config, gameSettings)
         self.updateDrawFPS()
 
         # update renderconfig
@@ -38,6 +40,7 @@ class Emulator():
             self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults-arch.yml")
             Emulator.updateConfiguration(self.renderconfig, globalSettings)
             Emulator.updateConfiguration(self.renderconfig, systemSettings)
+            Emulator.updateConfiguration(self.renderconfig, gameSettings)
             eslog.log("shader file={}".format(self.renderconfig["shader"]))
         else:
             eslog.log("no shader")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -62,7 +62,7 @@ def main(args):
     # find the system to run
     systemName = args.system
     eslog.log("Running system: {}".format(systemName))
-    system = Emulator(systemName)
+    system = Emulator(systemName, args.rom)
     eslog.debug("Settings: {}".format(system.config))
     if "emulator" in system.config and "core" in system.config:
         eslog.log("emulator: {}, core: {}".format(system.config["emulator"], system.config["core"]))

--- a/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
@@ -20,6 +20,9 @@ class UnixSettings():
         # use ConfigParser as backend.
         eslog.debug("Creating parser for {0}".format(self.settingsFile))
         self.config = ConfigParser.ConfigParser()
+        # To prevent ConfigParser from converting to lower case
+        self.config.optionxform = str
+
         try:
             # TODO: remove me when we migrate to Python 3
             # pretend where have a [DEFAULT] section
@@ -68,11 +71,15 @@ class UnixSettings():
         raise Exception
         self.config.remove_option('DEFAULT', name)
 
+    @staticmethod
+    def protectString(str):
+        return re.sub('[^A-Za-z0-9\.]+', '_', str)
+
     def loadAll(self, name):
         eslog.debug("Looking for {0}.* in {1}".format(name, self.settingsFile))
         res = dict()
         for (key, value) in self.config.items('DEFAULT'):
-            m = re.match(r"^" + name + "\.(.+)", key)
+            m = re.match(r"^" + UnixSettings.protectString(name) + "\.(.+)", UnixSettings.protectString(key))
             if m:
                 res[m.group(1)] = value;
 


### PR DESCRIPTION
Disney's Aladdin.smc.bezel=ambiance_01
Disney's Aladdin.smc.showFPS=true
Sonic and Knuckles & Sonic 3 (W) [!].bin.bezel=ambiance_03

- non alphanumeric and . chars are ignored at comparison
- in batocera.conf, now, case is essential. i hope there is no impact

@poke, please read and give your mind
initially i wanted a [game name].bezel = xxx syntax, but while it uses ini format, it didn't work and finally, the current syntax seems ok while it is more consistent with the rest.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>