### PR TITLE
Add: batocera-settings a conf parser tool

### DIFF
--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -14,7 +14,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 	cp -R package/batocera/core/batocera-scripts/scripts/* \
 		$(TARGET_DIR)/recalbox/scripts 
 		
-	ln -s $(TARGET_DIR)/recalbox/scripts/batocera-settings $(TARGET_DIR)/usr/bin/batocera-settings
+	cp package/batocera/core/batocera-scripts/scripts/batocera-settings $(TARGET_DIR)/usr/bin/batocera-settings
 	
 endef
 

--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -13,6 +13,9 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 
 	cp -R package/batocera/core/batocera-scripts/scripts/* \
 		$(TARGET_DIR)/recalbox/scripts 
+		
+	ln -s $(TARGET_DIR)/recalbox/scripts/batocera-settings $(TARGET_DIR)/usr/bin/batocera-settings
+	
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/core/batocera-scripts/scripts/batocera-settings
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-settings
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# batoceraSettings.sh to mimic batoceraSettings.py
+# goal: abbolish this python script, it's useless for the sake of the load feature only
+#
+# Usage of BASE COMMAND:
+#           <filename> -command <cmd> -key <key> -value <value>
+#
+#           -command    load write enable disable status
+#           -key        any key in batocera.conf (kodi.enabled...)
+#           -value      any alphanumerical string
+#                       use quotation marks to avoid globbing use slashe escape special characters 
+
+# This script reads only 1st occourance if string and writes only to 1st occurance
+# So 10 entries overwritten with system.power.switch will never occour again.
+#
+# This script uses #-Character to comment vales
+#
+# If there is a bolean value (0,1) then then enable and disable command will set the correspondending
+# boolean value.
+
+# Examples:
+# ./batoceraSettings.sh -command load -key wifi.enabled will print out 0 or 1
+# ./batoceraSettings.sh -command write -key wifi.ssid -value "This is my NET" will set wlan.ssid=This is my NET
+# ./batoceraSettings.sh -command enable -key wifi.ssid will remove # from  configfile (activate)
+# ./batoceraSettings.sh -command disable -key wifi.enabled will set key wifi.enabled=0
+
+# by cyperghost - 2019/06/25
+
+BATOCERA_CONFIGFILE="/userdata/system/batocera.conf"
+COMMENT_CHAR="#"
+
+function get_config() {
+     #Will look for key.value and #key.value for only one occourance
+     #If the character is the COMMENT CHAR then set value to it
+     #Otherwise strip to equal-char
+    local val
+    val="$(grep -E -m1 ^$COMMENT_CHAR?\s*$1\s*= $BATOCERA_CONFIGFILE)"
+    if [[ "${val:0:1}" == "$COMMENT_CHAR" ]]; then
+         val="$COMMENT_CHAR"
+    else
+         #Maybe here some finetuning to catch key.value = ENTRY without blanks
+         val="${val#*=}"
+    fi
+    echo "$val"
+}
+
+function set_config() {
+     #Will look for first key.name at line beginnng and write value to it
+     sed -i "1,/^\(\s*$1\s*=\).*/s//\1$2/" "$BATOCERA_CONFIGFILE"
+}
+
+function uncomment_config() {
+     #Will look for first Comment Char at line beginnng and remove it
+     sed -i "1,/^$COMMENT_CHAR\(\s*$1\)/s//\1/" "$BATOCERA_CONFIGFILE"
+}
+
+function comment_config() {
+     #Will look for first key.name at line beginnng and add a comment char to it
+     sed -i "1,/^\(\s*$1\)/s//$COMMENT_CHAR\1/" "$BATOCERA_CONFIGFILE"
+}
+
+function check_argument() {
+    # This method does not accept arguments starting with '-'.
+    if [[ -z "$2" || "$2" =~ ^- ]]; then
+        echo >&2
+        echo "ERROR: '$1' is missing an argument." >&2
+        echo >&2
+        echo "Try '$0 --help' for more info." >&2
+        echo >&2
+        return 1
+    fi
+}
+
+function usage() {
+val=" Usage of BASE COMMAND:
+
+           <file> -command <cmd> -key <key> -value <value>
+
+           -command    load write enable disable status
+           -key        any key in batocera.conf (kodi.enabled...)
+           -value      any alphanumerical string
+                       use quotation marks to avoid globbing
+
+           Special charcters like brackets needs to be escaped!
+
+           For write command -value <value> must be provided
+
+           exit codes: exit 0  = value is available, proper exit
+                       exit 1  = general error
+                       exit 2  = file error
+                       exit 11 = value found, but not activated
+                       exit 12 = value not found 
+
+           If you don't set a filename then default is '~/batocera.conf'"
+
+echo "$val"
+
+}
+
+# MAIN
+function main() {
+
+    #Filename parsed?
+    if [[ -f "$1" ]]; then
+        BATOCERA_CONFIGFILE="$1"
+        shift 
+    else
+       [[ -f "$BATOCERA_CONFIGFILE" ]] || { echo "not found: $BATOCERA_CONFIGFILE" >&2; exit 2; }
+    fi
+
+    #First command line parameter set, shift 2
+    [[ "${1,,}" != "-command" ]] && usage && exit 1
+    check_argument $1 $2
+    [[ $? -eq 0 ]] || exit 1
+    command="$2"
+    shift 2
+
+    #Second command line parameter set, shift
+    [[ "${1,,}" != "-key" ]] && usage && exit 1
+    check_argument $1 $2
+    [[ $? -eq 0 ]] || exit 1
+    keyvalue="$2"
+    shift 2
+
+    # value processing, switch case
+    case "$command" in
+
+        "read"|"get"|"load")
+            val="$(get_config $keyvalue)"
+            [[ "$val" == "$COMMENT_CHAR" ]] && echo "$val" >&2 && exit 11
+            [[ -z "$val" ]] && exit 12
+            [[ -n "$val" ]] && echo "$val" && exit 0
+        ;;
+
+        "stat"|"status")
+            val="$(get_config $keyvalue)"
+            [[ -f "$BATOCERA_CONFIGFILE" ]] && echo "ok: found '$BATOCERA_CONFIGFILE'" >&2|| echo "error: not found '$BATOCERA_CONFIGFILE'" >&2
+            [[ -w "$BATOCERA_CONFIGFILE" ]] && echo "ok: r/w file '$BATOCERA_CONFIGFILE'" >&2 || echo "error: r/o file '$BATOCERA_CONFIGFILE'" >&2
+            [[ -z "$val" ]] && echo "error: '$keyvalue' not found!" >&2
+            [[ "$val" == "$COMMENT_CHAR" ]] && echo "error: '$keyvalue' is commented $COMMENT_CHAR!" >&2 && val=
+            [[ -n "$val" ]] && echo "ok: '$keyvalue' $val" || echo "error: '$keyvalue' not available" >&2
+            exit 0
+        ;;
+
+        "set"|"write"|"save")
+            [[ ${1,,} != "-value" ]] && usage && exit 1
+            check_argument $1 $2
+            [[ $? -eq 0 ]] || exit 1
+
+            ! [[ -w "$BATOCERA_CONFIGFILE" ]] && echo "r/o only: $BATOCERA_CONFIGFILE" >&2 && exit 2
+
+            val="$(get_config $keyvalue)"
+            if [[ "$val" == "$COMMENT_CHAR" ]]; then
+                echo "$keyvalue: hashed out!" >&2
+                uncomment_config "$keyvalue"
+                set_config "$keyvalue" "$2"
+                echo "$keyvalue: set to $2" >&2
+                exit 0
+            elif [[ -z "$val" ]]; then
+                echo "$keyvalue: not found!" >&2
+                exit 12
+            elif [[ "$val" != "$2" ]]; then
+                set_config "$keyvalue" "$2"
+                exit 0 
+            fi
+        ;;
+
+        "uncomment"|"enable"|"activate")
+            val="$(get_config $keyvalue)"
+            # Boolean
+            if [[ "$val" == "$COMMENT_CHAR" ]]; then
+                 uncomment_config "$keyvalue"
+                 echo "$keyvalue: removed '$COMMENT_CHAR', key is active" >&2
+            elif [[ "$val" == "0" ]]; then
+                 set_config "$keyvalue" "1"
+                 echo "$keyvalue: boolean set '1'" >&2
+            elif [[ -z "$val" ]]; then
+                 echo "$keyvalue: not found!" && exit 2
+            fi
+        ;;
+
+        "comment"|"disable"|"remark")
+            val="$(get_config $keyvalue)"
+            # Boolean
+            [[ "$val" == "$COMMENT_CHAR" || "$val" == "0" ]] && exit 0
+            if [[ -z "$val" ]]; then
+                echo "$keyvalue: not found!" >&2 && exit 12
+            elif [[ "$val" == "1" ]]; then
+                 set_config "$keyvalue" "0"
+                 echo "$keyvalue: boolean set to '0'" >&2
+            else
+                 comment_config "$keyvalue"
+                 echo "$keyvalue: added '$COMMENT_CHAR', key is not active" >&2
+            fi
+        ;;
+
+        *)
+            echo "ERROR: invalid command '$command'" >&2
+            exit 1
+        ;;
+    esac
+}
+
+# Prepare arrays from fob python script
+# Delimiter is |
+# Keyword for python call is mimic_python
+# Attention the unset is needed to eliminate first argument (python basefile)
+
+if [[ "${#@}" -eq 1 && "$1" =~ "mimic_python" ]]; then
+   #batoceraSettings.py fob
+   readarray -t arr <<< "$1"
+   unset arr[0]
+else
+   #regular call by shell
+   arr=("$@")
+fi
+
+main "${arr[@]}"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-settings
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-settings
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# batoceraSettings.sh to mimic batoceraSettings.py
+# batocera-settings can mimic batoceraSettings.py
 # goal: abbolish this python script, it's useless for the sake of the load feature only
+#       get a more user friendly environment for setting, getting and saving keys
 #
 # Usage of BASE COMMAND:
 #           <filename> -command <cmd> -key <key> -value <value>
@@ -12,18 +13,18 @@
 #                       use quotation marks to avoid globbing use slashe escape special characters 
 
 # This script reads only 1st occourance if string and writes only to 1st occurance
-# So 10 entries overwritten with system.power.switch will never occour again.
 #
-# This script uses #-Character to comment vales
+# This script uses #-Character to comment values
 #
 # If there is a bolean value (0,1) then then enable and disable command will set the correspondending
 # boolean value.
 
 # Examples:
-# ./batoceraSettings.sh -command load -key wifi.enabled will print out 0 or 1
-# ./batoceraSettings.sh -command write -key wifi.ssid -value "This is my NET" will set wlan.ssid=This is my NET
-# ./batoceraSettings.sh -command enable -key wifi.ssid will remove # from  configfile (activate)
-# ./batoceraSettings.sh -command disable -key wifi.enabled will set key wifi.enabled=0
+# 'batocera-settings -command load -key wifi.enabled' will print out 0 or 1
+# 'batocera-settings -command write -key wifi.ssid -value "This is my NET"' will set 'wlan.ssid=This is my NET'
+# 'batocera-settings -command enable -key wifi.ssid' will remove # from  configfile (activate)
+# 'batocera-settings -command disable -key wifi.enabled' will set key wifi.enabled=0
+# 'botocera-settings /myown/config.file -command status -key my.key' will output status of own config.file and my.key 
 
 # by cyperghost - 2019/06/25
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-settings
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-settings
@@ -76,8 +76,8 @@ function check_argument() {
 }
 
 function pythonscript_style() {
-
-   #This is done the call old python script!
+    #This function is needed to "simulate" the python script!
+    #with it's -command -key -value structure
 
     #First command line parameter set
     [[ "${1,,}" != *command ]] && usage && exit 1
@@ -87,7 +87,7 @@ function pythonscript_style() {
 
     #Second command line parameter set
     [[ "${3,,}" != *key ]] && usage && exit 1
-    check_argument $1 $2
+    check_argument $3 $4
     [[ $? -eq 0 ]] || exit 1
     keyvalue="$4"
 }

--- a/package/batocera/core/batocera-scripts/scripts/batocera-settings
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-settings
@@ -5,11 +5,13 @@
 #       get a more user friendly environment for setting, getting and saving keys
 #
 # Usage of BASE COMMAND:
-#           <filename> -command <cmd> -key <key> -value <value>
+#           longform:   <filename> --command <cmd> --key <key> --value <value>
 #
-#           -command    load write enable disable status
-#           -key        any key in batocera.conf (kodi.enabled...)
-#           -value      any alphanumerical string
+#           shortform:  <file> <cmd> <key> <value>
+#
+#           --command    load write enable disable status
+#           --key        any key in batocera.conf (kodi.enabled...)
+#           --value      any alphanumerical string
 #                       use quotation marks to avoid globbing use slashe escape special characters 
 
 # This script reads only 1st occourance if string and writes only to 1st occurance
@@ -20,11 +22,11 @@
 # boolean value.
 
 # Examples:
-# 'batocera-settings -command load -key wifi.enabled' will print out 0 or 1
-# 'batocera-settings -command write -key wifi.ssid -value "This is my NET"' will set 'wlan.ssid=This is my NET'
-# 'batocera-settings -command enable -key wifi.ssid' will remove # from  configfile (activate)
-# 'batocera-settings -command disable -key wifi.enabled' will set key wifi.enabled=0
-# 'botocera-settings /myown/config.file -command status -key my.key' will output status of own config.file and my.key 
+# 'batocera-settings --command load --key wifi.enabled' will print out 0 or 1
+# 'batocera-settings --command write --key wifi.ssid -value "This is my NET"' will set 'wlan.ssid=This is my NET'
+# 'batocera-settings enable wifi.ssid' will remove # from  configfile (activate)
+# 'batocera-settings disable wifi.enabled' will set key wifi.enabled=0
+# 'botocera-settings /myown/config.file --command status --key my.key' will output status of own config.file and my.key 
 
 # by cyperghost - 2019/06/25
 
@@ -73,25 +75,43 @@ function check_argument() {
     fi
 }
 
+function pythonscript_style() {
+
+   #This is done the call old python script!
+
+    #First command line parameter set
+    [[ "${1,,}" != *command ]] && usage && exit 1
+    check_argument $1 $2
+    [[ $? -eq 0 ]] || exit 1
+    command="$2"
+
+    #Second command line parameter set
+    [[ "${3,,}" != *key ]] && usage && exit 1
+    check_argument $1 $2
+    [[ $? -eq 0 ]] || exit 1
+    keyvalue="$4"
+}
+
+
 function usage() {
 val=" Usage of BASE COMMAND:
 
-           <file> -command <cmd> -key <key> -value <value>
+           <file> --command <cmd> --key <key> --value <value>
 
-           -command    load write enable disable status
-           -key        any key in batocera.conf (kodi.enabled...)
-           -value      any alphanumerical string
+           shortform: <file> <cmd> <key> <value>
+
+           --command    load write enable disable status
+           --key        any key in batocera.conf (kodi.enabled...)
+           --value      any alphanumerical string
                        use quotation marks to avoid globbing
 
-           Special charcters like brackets needs to be escaped!
-
-           For write command -value <value> must be provided
+           For write command --value <value> must be provided
 
            exit codes: exit 0  = value is available, proper exit
                        exit 1  = general error
                        exit 2  = file error
                        exit 11 = value found, but not activated
-                       exit 12 = value not found 
+                       exit 12 = value not found
 
            If you don't set a filename then default is '~/batocera.conf'"
 
@@ -110,20 +130,18 @@ function main() {
        [[ -f "$BATOCERA_CONFIGFILE" ]] || { echo "not found: $BATOCERA_CONFIGFILE" >&2; exit 2; }
     fi
 
-    #First command line parameter set, shift 2
-    [[ "${1,,}" != "-command" ]] && usage && exit 1
-    check_argument $1 $2
-    [[ $? -eq 0 ]] || exit 1
-    command="$2"
-    shift 2
-
-    #Second command line parameter set, shift
-    [[ "${1,,}" != "-key" ]] && usage && exit 1
-    check_argument $1 $2
-    [[ $? -eq 0 ]] || exit 1
-    keyvalue="$2"
-    shift 2
-
+    if [[ ${#@} -eq 0 && ${#@} -gt 6 ]]; then
+        usage
+        exit 1
+    elif [[ ${#@} -le 3 ]]; then
+        command="$1"
+        keyvalue="$2"
+        shift 2
+    else
+        pythonscript_style "$@"
+        shift 4
+    fi
+ 
     # value processing, switch case
     case "$command" in
 
@@ -136,7 +154,7 @@ function main() {
 
         "stat"|"status")
             val="$(get_config $keyvalue)"
-            [[ -f "$BATOCERA_CONFIGFILE" ]] && echo "ok: found '$BATOCERA_CONFIGFILE'" >&2|| echo "error: not found '$BATOCERA_CONFIGFILE'" >&2
+            [[ -f "$BATOCERA_CONFIGFILE" ]] && echo "ok: found '$BATOCERA_CONFIGFILE'" >&2 || echo "error: not found '$BATOCERA_CONFIGFILE'" >&2
             [[ -w "$BATOCERA_CONFIGFILE" ]] && echo "ok: r/w file '$BATOCERA_CONFIGFILE'" >&2 || echo "error: r/o file '$BATOCERA_CONFIGFILE'" >&2
             [[ -z "$val" ]] && echo "error: '$keyvalue' not found!" >&2
             [[ "$val" == "$COMMENT_CHAR" ]] && echo "error: '$keyvalue' is commented $COMMENT_CHAR!" >&2 && val=
@@ -145,9 +163,8 @@ function main() {
         ;;
 
         "set"|"write"|"save")
-            [[ ${1,,} != "-value" ]] && usage && exit 1
-            check_argument $1 $2
-            [[ $? -eq 0 ]] || exit 1
+            [[ ${1,,} == "-value" || ${1,,} == "--value" ]] && shift
+            [[ -z "$1" ]] && echo "error: '$keyvalue' needs value to be setted" >&2 && exit 1
 
             ! [[ -w "$BATOCERA_CONFIGFILE" ]] && echo "r/o only: $BATOCERA_CONFIGFILE" >&2 && exit 2
 
@@ -155,14 +172,14 @@ function main() {
             if [[ "$val" == "$COMMENT_CHAR" ]]; then
                 echo "$keyvalue: hashed out!" >&2
                 uncomment_config "$keyvalue"
-                set_config "$keyvalue" "$2"
-                echo "$keyvalue: set to $2" >&2
+                set_config "$keyvalue" "$1"
+                echo "$keyvalue: set to $1" >&2
                 exit 0
             elif [[ -z "$val" ]]; then
                 echo "$keyvalue: not found!" >&2
                 exit 12
-            elif [[ "$val" != "$2" ]]; then
-                set_config "$keyvalue" "$2"
+            elif [[ "$val" != "$1" ]]; then
+                set_config "$keyvalue" "$1"
                 exit 0 
             fi
         ;;
@@ -204,7 +221,6 @@ function main() {
 }
 
 # Prepare arrays from fob python script
-# Delimiter is |
 # Keyword for python call is mimic_python
 # Attention the unset is needed to eliminate first argument (python basefile)
 


### PR DESCRIPTION
This is a config parser written in pure bash, it is much faster then it's python pendant. Goal is to give the user and future developers an easy method to read, change and save values.

If you serve a filename at first argument then these file will be processed.
Currently you can't add new, keys ... I think a bash statement like `[[ $? -eq 12 ]] && echo "new.key=" >> /my/config/file.conf` will solve this

[Read more about it's usage here](https://github.com/crcerror/BATOCERA-Shares/blob/master/conf-parser/README.md)

Talking about speed:

```
1. Original script
# time python batoceraSettings.py.bak -command load -key wifi.key
2019-06-24 19:34:17 DEBUG (unixSettings.py:21):__init__(): Creating parser for /userdata/system/batocera.conf
2019-06-24 19:34:17 DEBUG (unixSettings.py:43):load(): Looking for wifi.key in /userdata/system/batocera.conf
new key
real    0m0.136s
user    0m0.107s
sys     0m0.029s

3. crcerrors bash script, arguments are directly parsed to script
# time bash batocera-settings -command load -key wifi.key
new key

real    0m0.018s
user    0m0.013s
sys     0m0.005s
#
```

Some base commands

```
 Usage of BASE COMMAND:

         longform:      <file> --command <cmd> --key <key> --value <value>
         shortform:     <file> <cmd> <key> <value>

           --command    load write enable disable status
           --key        any key in batocera.conf (kodi.enabled...)
           --value      any alphanumerical string
                        use quotation marks to avoid globbing

           Special charcters like brackets needs to be escaped!

           For write command --value <value> must be provided

           exit codes: exit 0  = value is available, proper exit
                       exit 1  = general error
                       exit 2  = file error
                       exit 11 = value found, but not activated
                       exit 12 = value not found 

           If you don't set a filename then default is '~/batocera.conf'
```

