### PR TITLE
Fix for Xarcade Tankstick

### DIFF
--- a/board/batocera/fsoverlay/etc/udev/rules.d/99-joysticks-exotics.rules
+++ b/board/batocera/fsoverlay/etc/udev/rules.d/99-joysticks-exotics.rules
@@ -8,6 +8,10 @@ SUBSYSTEM=="input", ATTRS{name}=="Gamepad", MODE="0666", ENV{ID_INPUT_JOYSTICK}=
 SUBSYSTEM=="input", ATTRS{name}=="GamePad", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
 # Neo-Geo X Arcade Stick
 SUBSYSTEM=="input", ATTRS{name}=="TOMMO NEOGEOX Arcade Stick", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
-#Mad Catz C.T.R.L.R gamepad
+# Mad Catz C.T.R.L.R gamepad
 SUBSYSTEM=="input", ATTRS{name}=="Mad Catz C.T.R.L.R", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
 SUBSYSTEM=="input", ATTRS{name}=="SteelSeries Stratus XL", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+# X-Arcade Tankstick
+SUBSYSTEM=="input", ATTRS{name}=="Xarcade-to-Gamepad Device 1", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+SUBSYSTEM=="input", ATTRS{name}=="Xarcade-to-Gamepad Device 2", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+SUBSYSTEM=="input", ATTRS{name}=="XGaming X-Arcade", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
XArcade Tankstick was not recognized any more after update to the last kernel version.