### PR TITLE
Added a new "curvature" shaders set

### DIFF
--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
@@ -42,7 +42,7 @@ define BATOCERA_SHADERS_INSTALL_TARGET_CMDS
 	fi
 
 	# sets
-	for set in retro scanlines enhanced; do \
+	for set in retro scanlines enhanced curvature; do \
                 mkdir -p $(TARGET_DIR)/usr/share/batocera/shaders/configs/$$set; \
 		cp $(BATOCERA_SHADERS_DIRIN)/$$set/rendering-defaults.yml     $(TARGET_DIR)/usr/share/batocera/shaders/configs/$$set/; \
 		if test -e $(BATOCERA_SHADERS_DIRIN)/$$set/rendering-defaults-$(BATOCERA_SHADERS_SYSTEM).yml; then \

--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/curvature/rendering-defaults.yml
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/curvature/rendering-defaults.yml
@@ -1,0 +1,108 @@
+## CURVATURE
+default:
+  # shader affects retroarch shaders
+  shader: crt/crt-pi-curvature-curvature
+  # scanline affect fba2x
+  scanline: true
+snes:
+  shader: crt/crt-pi-curvature
+nes:
+  shader: crt/crt-pi-curvature
+n64:
+  shader: crt/crt-pi-curvature
+gba:
+  shader: handheld/zfast-lcd
+gb:
+  shader: handheld/zfast-lcd
+gbc:
+  shader: handheld/zfast-lcd
+fds:
+  shader: crt/crt-pi-curvature
+virtualboy:
+  shader: retro/sharp-bilinear-scanlines
+# Sega
+sg1000:
+  shader: crt/crt-pi-curvature
+mastersystem:
+  shader: crt/crt-pi-curvature
+megadrive:
+  shader: crt/crt-pi-curvature
+gamegear:
+  shader: handheld/zfast-lcd
+sega32x:
+  shader: crt/crt-pi-curvature
+segacd:
+  shader: crt/crt-pi-curvature
+# Arcade
+neogeo:
+  shader: crt/crt-pi-curvature
+neogeocd:
+  shader: crt/crt-pi-curvature
+mame:
+  shader: crt/crt-pi-curvature
+fba:
+  shader: crt/crt-pi-curvature
+naomi:
+  shader: crt/crt-pi-curvature
+atomiswave:
+  shader: crt/crt-pi-curvature
+#
+ngp:
+  shader: handheld/zfast-lcd
+ngpc:
+  shader: handheld/zfast-lcd
+gw:
+  shader: crt/crt-pi-curvature
+vectrex:
+  shader: retro/sharp-bilinear-scanlines
+lynx:
+  shader: handheld/zfast-lcd
+lutro:
+  shader: crt/crt-pi-curvature
+wswan:
+  shader: handheld/zfast-lcd
+wswanc:
+  shader: handheld/zfast-lcd
+pcengine:
+  shader: crt/crt-pi-curvature
+pcenginecd:
+  shader: crt/crt-pi-curvature
+supergrafx:
+  shader: crt/crt-pi-curvature
+atari800:
+  shader: crt/crt-pi-curvature
+atari2600:
+  shader: crt/crt-pi-curvature
+atari5200:
+  shader: crt/crt-pi-curvature
+atari7800:
+  shader: crt/crt-pi-curvature
+prboom:
+  shader: crt/crt-pi-curvature
+psx:
+  shader: crt/crt-pi-curvature
+colecovision:
+  shader: crt/crt-pi-curvature
+# Computers
+msx:
+  shader: crt/crt-pi-curvature
+msx1:
+  shader: crt/crt-pi-curvature
+msx2:
+  shader: crt/crt-pi-curvature
+amiga:
+  shader: crt/crt-pi-curvature
+amstradcpc:
+  shader: crt/crt-pi-curvature
+atarist:
+  shader: crt/crt-pi-curvature
+zxspectrum:
+  shader: crt/crt-pi-curvature
+odyssey2:
+  shader: crt/crt-pi-curvature
+zx81:
+  shader: crt/crt-pi-curvature
+pcfx:
+  shader: crt/crt-pi-curvature
+x68000:
+  shader: crt/crt-pi-curvature

--- a/package/batocera/emulators/retroarch/shaders/glsl-shaders/glsl-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/glsl-shaders/glsl-shaders.mk
@@ -15,6 +15,8 @@ endef
 define GLSL_SHADERS_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/batocera/shaders
 	$(MAKE) CXX="$(TARGET_CXX)" -C $(@D) INSTALLDIR=$(TARGET_DIR)/usr/share/batocera/shaders install
+	sed -e "s:^//#define CURVATURE:#define CURVATURE:" $(TARGET_DIR)/usr/share/batocera/shaders/crt/shaders/crt-pi.glsl > $(TARGET_DIR)/usr/share/batocera/shaders/crt/shaders/crt-pi-curvature.glsl
+	sed -e 's:^shader0 = "shaders/crt-pi.glsl":shader0 = "shaders/crt-pi-curvature.glsl":' $(TARGET_DIR)/usr/share/batocera/shaders/crt/crt-pi.glslp > $(TARGET_DIR)/usr/share/batocera/shaders/crt/crt-pi-curvature.glslp
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
To simulate curved CRT screens on square LCD pixels -- should be low CPU enough to be compatible with RPi3. The code was already in the ``crt-pi`` shader, needed only a #define. 
Defined a new shaders set in ES for this, by popular demand.