### PR TITLE
Added: WiFi key import feature (RPi)

### DIFF
--- a/board/batocera/rpi/fsoverlay/etc/init.d/S61importwifikeyfile
+++ b/board/batocera/rpi/fsoverlay/etc/init.d/S61importwifikeyfile
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Setup Credentials for WiFi from /boot/batocera-boot.conf
+#
+# This imports WiFi credentials open batocera-boot.conf (this file is visible in FAT32 in windows systems)
+# to setup remove comments from wifi keys and enter your WiFi credentials
+# now boot to BATOCERA, reboot ... and voila wifi credentials are imported to wifi3 settings
+#
+# "/boot/batocera-boot.conf" should contain following structure
+# wifi.import.enabled=1
+# nas.wifi.key=write your key here
+# nas.wifi.ssid=set your wifi SSID here
+#
+# Triggers for activating this script
+# 1. 'wifi.import.enabled' key in /boot/batocera-boot must be enabled with 1
+# 2. File /boot/batocera-boot.conf contains activated wifi credentials
+# 3. Values of /boot/batocera-boot.conf are not equal to batocera.conf
+
+#
+# This demonstrates usage of batocera-settings
+# we will use read command, disable command, write command
+
+WIFI_KEYFILE="/boot/batocera-boot.conf"
+
+[[ "$1" == "stop" ]] || exit
+[[ $(batocera-settings $WIFI_KEYFILE -command load -key wifi.import.enabled) -eq 1 ]] || exit
+
+# This is a one time shoot, disable key import for next boot
+mount -o remount, rw /boot
+batocera-settings $WIFI_KEYFILE -command disable -key wifi.import.enabled
+
+psk="$(batocera-settings $WIFI_KEYFILE -command load -key nas.wifi.key)"
+[[ $? -eq 0 ]] || exit
+ssid="$($systemsetting $WIFI_KEYFILE -command load -key nas.wifi.ssid)"
+[[ $? -eq 0 ]] || exit
+
+# Set keys from "/boot/batocera-boot.conf" to wifi3.key and wifi3.ssid
+# These keys are not visible on ES Network config screen
+batocera-settings -command write -key wifi3.key -value "$psk"
+batocera-settings -command write -key wifi3.ssid -value "$ssid"

--- a/board/batocera/rpi/fsoverlay/etc/init.d/S61importwifikeyfile
+++ b/board/batocera/rpi/fsoverlay/etc/init.d/S61importwifikeyfile
@@ -13,9 +13,7 @@
 # Triggers for activating this script
 # 1. 'wifi.import.enabled' key in /boot/batocera-boot must be enabled with 1
 # 2. File /boot/batocera-boot.conf contains activated wifi credentials
-# 3. Values of /boot/batocera-boot.conf are not equal to batocera.conf
 
-#
 # This demonstrates usage of batocera-settings
 # we will use read command, disable command, write command
 
@@ -30,7 +28,7 @@ batocera-settings $WIFI_KEYFILE -command disable -key wifi.import.enabled
 
 psk="$(batocera-settings $WIFI_KEYFILE -command load -key nas.wifi.key)"
 [[ $? -eq 0 ]] || exit
-ssid="$($systemsetting $WIFI_KEYFILE -command load -key nas.wifi.ssid)"
+ssid="$(batocera-settings $WIFI_KEYFILE -command load -key nas.wifi.ssid)"
 [[ $? -eq 0 ]] || exit
 
 # Set keys from "/boot/batocera-boot.conf" to wifi3.key and wifi3.ssid

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -12,6 +12,6 @@ sharedevice=INTERNAL
 # wifi.import.enabled will import nas.wifi.ssid and nas.wifi.key to wifi3 (only RPi devices)
 wifi.import.enabled=0
 
-# enter wifi credentials here (remove the # to enable it)
+# enter wifi credentials here (remove the # to enable them)
 #nas.wifi.ssid=enter valid ssid
-#nas.wifi.ssid=enter valid psk
+#nas.wifi.key=enter valid psk

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -8,3 +8,10 @@ sharedevice=INTERNAL
 
 # enable the nvidia driver (remove the # to enable it)
 #nvidia-driver=true
+
+# wifi.import.enabled will import nas.wifi.ssid and nas.wifi.key to wifi3 (only RPi devices)
+wifi.import.enabled=0
+
+# enter wifi credentials here (remove the # to enable it)
+#nas.wifi.ssid=enter valid ssid
+#nas.wifi.ssid=enter valid psk


### PR DESCRIPTION
This is done only for RPi in the moment.
The `S61importwifikeyfile` service will read credentials out from `/boot/batocera-conf`

To trigger the action you need
1. set `wifi.import.enabled=1` in `/boot/batocera-conf`
2. set valid psk to `nas.wifi.key` and remove the # in `/boot/batocera-conf`
3. set valid ssid to `nas.wifi.ssid` and remove the # in `/boot/batocera-conf`
4. Boot to Batocera and Reboot

The data obtained will be automatically written to
`/userdata/system/batocera.conf` and `nas.wifi.ssid` will get copied to `wifi3.ssid`
`/userdata/system/batocera.conf` and `nas.wifi.key` will get copied to `wifi3.key`