### PR TITLE
RPi: Cleanup power.switch section batocera.conf

### DIFF
--- a/package/batocera/core/batocera-system/rpi1/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi1/batocera.conf
@@ -1,21 +1,22 @@
 # ------------ A - System Options ----------- #
-#    Uncomment the system.power.switch you use
-# http://lowpowerlab.com/atxraspi/#installation
-#system.power.switch=ATX_RASPI_R2_6
-# http://mausberry-circuits.myshopify.com/pages/setup
-#system.power.switch=MAUSBERRY
-# https://shop.pimoroni.de/products/onoff-shim
-#system.power.switch=ONOFFSHIM
-# http://www.msldigital.com/pages/support-for-remotepi-board-2013
-#system.power.switch=REMOTEPIBOARD_2003
-# http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
-#system.power.switch=REMOTEPIBOARD_2005
-# http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
-#system.power.switch=WITTYPI
-#system.power.switch=PIN56ONOFF
-#system.power.switch=PIN56PUSH
-#system.power.switch=PIN356ONOFFRESET
-# note that uart must be enabled too in config.txt
+##    Enter the value for system.power.switch you use
+##    Overview of switches and description how to install on your device
+##
+##  ATX_RASPI_R2_6     --> http://lowpowerlab.com/atxraspi/#installation
+##  MAUSBERRY          --> http://mausberry-circuits.myshopify.com/pages/setup
+##  ONOFFSHIM          --> https://shop.pimoroni.com/products/onoff-shim
+##  REMOTEPIBOARD_2003 --> http://www.msldigital.com/pages/support-for-remotepi-board-2013
+##  REMOTEPIBOARD_2005 --> http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
+##  WITTYPI            --> http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
+##  RETROFLAG          --> http://www.retroflag.com  -- note: enable UART in config.txt for LED action
+##
+##    Simple Switches without active devices
+##  https://batocera-linux.xorhub.com/wiki/doku.php?id=en:add_powerdevices_rpi_only
+##  PIN56ONOFF         --> For latching switches
+##  PIN56PUSH          --> For momentary buttons
+##  PIN356ONOFFRESET   --> Restarts and Shutdown the board, needs 2 switches
+##
+## Set switch value here
 #system.power.switch=RETROFLAG
 
 ## batocera.linux security

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -1,22 +1,24 @@
 # ------------ A - System Options ----------- #
-#    Uncomment the system.power.switch you use
-# http://lowpowerlab.com/atxraspi/#installation
-#system.power.switch=ATX_RASPI_R2_6
-# http://mausberry-circuits.myshopify.com/pages/setup
-#system.power.switch=MAUSBERRY
-# https://shop.pimoroni.de/products/onoff-shim
-#system.power.switch=ONOFFSHIM
-# http://www.msldigital.com/pages/support-for-remotepi-board-2013
-#system.power.switch=REMOTEPIBOARD_2003
-# http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
-#system.power.switch=REMOTEPIBOARD_2005
-# http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
-#system.power.switch=WITTYPI
-#system.power.switch=PIN56ONOFF
-#system.power.switch=PIN56PUSH
-#system.power.switch=PIN356ONOFFRESET
-# note that uart must be enabled too in config.txt
+##    Enter the value for system.power.switch you use
+##    Overview of switches and description how to install on your device
+##
+##  ATX_RASPI_R2_6     --> http://lowpowerlab.com/atxraspi/#installation
+##  MAUSBERRY          --> http://mausberry-circuits.myshopify.com/pages/setup
+##  ONOFFSHIM          --> https://shop.pimoroni.com/products/onoff-shim
+##  REMOTEPIBOARD_2003 --> http://www.msldigital.com/pages/support-for-remotepi-board-2013
+##  REMOTEPIBOARD_2005 --> http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
+##  WITTYPI            --> http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
+##  RETROFLAG          --> http://www.retroflag.com  -- note: enable UART in config.txt for LED action
+##
+##    Simple Switches without active devices
+##  https://batocera-linux.xorhub.com/wiki/doku.php?id=en:add_powerdevices_rpi_only
+##  PIN56ONOFF         --> For latching switches
+##  PIN56PUSH          --> For momentary buttons
+##  PIN356ONOFFRESET   --> Restarts and Shutdown the board, needs 2 switches
+##
+## Set switch value here
 #system.power.switch=RETROFLAG
+
 
 ## batocera.linux security
 # enforce security

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -19,7 +19,6 @@
 ## Set switch value here
 #system.power.switch=RETROFLAG
 
-
 ## batocera.linux security
 # enforce security
 #   samba password required

--- a/package/batocera/core/batocera-system/rpi3/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi3/batocera.conf
@@ -1,21 +1,22 @@
 # ------------ A - System Options ----------- #
-#    Uncomment the system.power.switch you use
-# http://lowpowerlab.com/atxraspi/#installation
-#system.power.switch=ATX_RASPI_R2_6
-# http://mausberry-circuits.myshopify.com/pages/setup
-#system.power.switch=MAUSBERRY
-# https://shop.pimoroni.de/products/onoff-shim
-#system.power.switch=ONOFFSHIM
-# http://www.msldigital.com/pages/support-for-remotepi-board-2013
-#system.power.switch=REMOTEPIBOARD_2003
-# http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
-#system.power.switch=REMOTEPIBOARD_2005
-# http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
-#system.power.switch=WITTYPI
-#system.power.switch=PIN56ONOFF
-#system.power.switch=PIN56PUSH
-#system.power.switch=PIN356ONOFFRESET
-# note that uart must be enabled too in config.txt
+##    Enter the value for system.power.switch you use
+##    Overview of switches and description how to install on your device
+##
+##  ATX_RASPI_R2_6     --> http://lowpowerlab.com/atxraspi/#installation
+##  MAUSBERRY          --> http://mausberry-circuits.myshopify.com/pages/setup
+##  ONOFFSHIM          --> https://shop.pimoroni.com/products/onoff-shim
+##  REMOTEPIBOARD_2003 --> http://www.msldigital.com/pages/support-for-remotepi-board-2013
+##  REMOTEPIBOARD_2005 --> http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
+##  WITTYPI            --> http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
+##  RETROFLAG          --> http://www.retroflag.com  -- note: enable UART in config.txt for LED action
+##
+##    Simple Switches without active devices
+##  https://batocera-linux.xorhub.com/wiki/doku.php?id=en:add_powerdevices_rpi_only
+##  PIN56ONOFF         --> For latching switches
+##  PIN56PUSH          --> For momentary buttons
+##  PIN356ONOFFRESET   --> Restarts and Shutdown the board, needs 2 switches
+##
+## Set switch value here
 #system.power.switch=RETROFLAG
 
 ## batocera.linux security


### PR DESCRIPTION
Added page
https://batocera-linux.xorhub.com/wiki/doku.php?id=en:add_powerdevices_rpi_only

Original state before activating a switch
```
#    Uncomment the system.power.switch you use
# http://lowpowerlab.com/atxraspi/#installation
#system.power.switch=ATX_RASPI_R2_6
# http://mausberry-circuits.myshopify.com/pages/setup
#system.power.switch=MAUSBERRY
# http://www.msldigital.com/pages/support-for-remotepi-board-2013
#system.power.switch=REMOTEPIBOARD_2003
# http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
#system.power.switch=REMOTEPIBOARD_2005
# http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
#system.power.switch=WITTYPI
#system.power.switch=PIN56ONOFF
#system.power.switch=PIN56PUSH
#system.power.switch=PIN356ONOFFRESET
#system.power.switch=RETROFLAG
#system.power.switch=ONOFFSHIM
```

After activating one switch
the write command gets mad ... this is an old behaviour since RB times
```
#    Uncomment the system.power.switch you use
# http://lowpowerlab.com/atxraspi/#installation
system.power.switch=ONOFFSHIM
# http://mausberry-circuits.myshopify.com/pages/setup
system.power.switch=ONOFFSHIM
# https://shop.pimoroni.de/products/onoff-shim
system.power.switch=ONOFFSHIM
# http://www.msldigital.com/pages/support-for-remotepi-board-2013
system.power.switch=ONOFFSHIM
# http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
system.power.switch=ONOFFSHIM
# http://www.uugear.com/witty-pi-realtime-clock-power-management-for-raspberry-pi
system.power.switch=ONOFFSHIM
system.power.switch=ONOFFSHIM
system.power.switch=ONOFFSHIM
system.power.switch=ONOFFSHIM
# note that uart must be enabled too in config.txt
system.power.switch=ONOFFSHIM
```