### PR TITLE
Add script: Batocera ES Swissknife

### DIFF
--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -37,7 +37,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 	cp package/batocera/core/batocera-scripts/scripts/batocera-config                 $(TARGET_DIR)/usr/bin/
 	cp package/batocera/core/batocera-scripts/scripts/batocera-moonlight              $(TARGET_DIR)/usr/bin/
 	cp package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject     $(TARGET_DIR)/usr/bin/
-	cp package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife          $(TARGET_DIR)/usr/bin/
+	install -m 0755 package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife          $(TARGET_DIR)/usr/bin/
 
 endef
 

--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -37,6 +37,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 	cp package/batocera/core/batocera-scripts/scripts/batocera-config                 $(TARGET_DIR)/usr/bin/
 	cp package/batocera/core/batocera-scripts/scripts/batocera-moonlight              $(TARGET_DIR)/usr/bin/
 	cp package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject     $(TARGET_DIR)/usr/bin/
+	cp package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife          $(TARGET_DIR)/usr/bin/
 
 endef
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Script for BATOCERA  to terminate every emulator instance
+# or to give feedback about state of EmulationStation and active EMULATORS
+# by cyperghost aka crcerror // 18.03.2019
+# Batocera versions // 04.06.2019
+# Added /bin/usr script // 22.09.2019
+# Added sigterm level, added second parameter to activate sigterm during smart_wait function
+
+# Get all childpids from calling process
+function getcpid() {
+local cpids="$(pgrep -P $1)"
+    for cpid in $cpids; do
+        pidarray+=($cpid)
+        getcpid $cpid
+    done
+}
+
+# Get a sleep while process is active in background
+# if PID is still active then use kill -9 switch
+function smart_wait() {
+    local PID=$2
+    local disablekill9=$1
+    local watchdog=0
+    sleep 1
+    while [[ -e /proc/$PID ]]; do
+        sleep 0.25
+        ((watchdog++))
+        [[ $disablekill9 -eq 1 ]] && [[ watchdog -gt 12 ]] && kill -9 $PID
+    done
+}
+
+# Emulator currently running?
+function check_emurun() {
+    local RC_PID="$(pgrep -f -n emulatorlauncher)"
+    echo $RC_PID
+}
+
+# Emulationstation currently running?
+function check_esrun() {
+    local ES_PID="$(pgrep -f -n emulationstation)"
+    echo $ES_PID
+}
+
+
+# Kill emulators running in a proper way! (SAVE SRM STATE!)
+function emu_kill() {
+    RC_PID=$(check_emurun)
+    if [[ -n $RC_PID ]]; then
+        getcpid $RC_PID
+        for ((z=${#pidarray[*]}-1; z>-1; z--)); do
+            kill ${pidarray[z]}
+            smart_wait 1 ${pidarray[z]}
+        done
+        unset pidarray
+    fi
+}
+
+# ---- MAINS ----
+
+case ${1,,} in
+    --restart)
+        /etc/init.d/S31emulationstation stop
+        ES_PID=$(check_esrun)
+        [[ -z $ES_PID ]] || smart_wait 0 $ES_PID 
+        /etc/init.d/S31emulationstation start
+    ;;
+
+    --espid)
+        # Display ES PID to stdout
+        ES_PID=$(check_esrun)
+        [[ -n $ES_PID ]] && echo $ES_PID || echo 0
+    ;;
+
+    --emupid)
+        # This helps to detect emulator is running or not
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && echo $RC_PID || echo 0
+    ;;
+
+    --emukill|--shutdown)
+        emu_kill && sleep 2
+        ES_PID=$(check_esrun)
+        if [[ "$1" == "--shutdown" && -n $ES_PID ]]; then
+            [[ -z $RC_PID ]] || smart_wait 1 $RC_PID && sleep 3
+            kill $ES_PID         
+            smart_wait 0 $ES_PID
+            shutdown -h now
+        fi
+    ;;
+
+    --kodi)
+        emu_kill && sleep 2
+        /etc/init.d/S31emulationstation stop
+        batocera-kodilauncher &
+        wait $!
+        exitcode=$?
+        [[ $exitcode -eq 0 ]] && /etc/init.d/S31emulationstation start
+        [[ $exitcode -eq 10 ]] && shutdown -r now
+        [[ $exitcode -eq 11 ]] && shutdown -h now
+    ;;
+
+    *)
+        echo -e "\n\t\t BATOCERA SWISS KNIFE FOR EmulationStation
+                 Please parse parameters to this script! \n
+                  --restart will RESTART EmulationStation only
+                            this may be usefull for refreshing gameslists \n
+                  --kodi will startup KODI Media Center stopping ES \n
+                  --shutdown will SHUTDOWN whole system \n
+                  --emukill to exit any running EMULATORS \n
+                  --espid to check if EmulationStation is currently active
+                          This number is the real PID of the binary!
+                          If the ouput is 0, then ES isn't active \n
+                  --emupid to check if an Emulator is running
+                           This number is just the PID of emulatorlauncher.py
+                           if the output is 0 then there is no emulator active!"
+    ;;
+
+esac

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -79,10 +79,11 @@ case ${1,,} in
     ;;
 
     --emukill|--shutdown)
-        emu_kill && sleep 2
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && emu_kill && sleep 2
+
         ES_PID=$(check_esrun)
-        if [[ "$1" == "--shutdown" && -n $ES_PID ]]; then
-            [[ -z $RC_PID ]] || smart_wait 1 $RC_PID && sleep 3
+        if [[ "${1,,}" == "--shutdown" && -n $ES_PID ]]; then
             kill $ES_PID         
             smart_wait 0 $ES_PID
             shutdown -h now
@@ -90,7 +91,9 @@ case ${1,,} in
     ;;
 
     --kodi)
-        emu_kill && sleep 2
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && emu_kill && sleep 2
+        
         /etc/init.d/S31emulationstation stop
         batocera-kodilauncher &
         wait $!


### PR DESCRIPTION
This script offers additional information about running instances of emulators
1. Reports back if ES is running (through the real binary PID)
2. Reports back if an EMULATOR is running (by displaying PID of emulatorlaunch.py)
3. Proper Shutdown from command line are possible now (even in active emulator session)
4. You can terminate ANY emulator and you'll be kicked back to ES main menu
5. You can properly start KODI by CLI now

It's usefull if you want to control BATOCERA by GPIO buttons or if you simply want to do some tests by command line ;) I will step into the button scripts later. They do not work as expected ... cya

@jdorigao @nadenislamarre remeber to make batocera-es-swissknife executeable
would a `install -m 0755 path/from path/to` not be better?