### PR TITLE
Fix Xarcade joypad config for 5.24.

### DIFF
--- a/board/batocera/fsoverlay/etc/udev/rules.d/99-joysticks-exotics.rules
+++ b/board/batocera/fsoverlay/etc/udev/rules.d/99-joysticks-exotics.rules
@@ -14,4 +14,3 @@ SUBSYSTEM=="input", ATTRS{name}=="SteelSeries Stratus XL", MODE="0666", ENV{ID_I
 # X-Arcade Tankstick
 SUBSYSTEM=="input", ATTRS{name}=="Xarcade-to-Gamepad Device 1", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
 SUBSYSTEM=="input", ATTRS{name}=="Xarcade-to-Gamepad Device 2", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
-SUBSYSTEM=="input", ATTRS{name}=="XGaming X-Arcade", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
The line removed prevents the Xarcade Tankstick to work with Batocera 5.24. The two joysticks on the Tankstick are regonized twice (once by "Xarcade-to-Gamepad Device x" and once by "XGaming X-Arcade").
With that extra line, you can see 4 joysticks instead of 2 in EmulationStation -- even though they seem to work well in ES, it's wrong. And it's now fully broken in RetroArch 1.7.8, where no Xarcade joystick is seen at all with that extra line. That's another change of behavior compared to 1.7.7.
