### PR TITLE
GPIO SWITCH: some lightweight code polishing

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Script for BATOCERA  to terminate every emulator instance
+# or to give feedback about state of EmulationStation and active EMULATORS
+# by cyperghost aka crcerror // 18.03.2019
+# Batocera versions // 04.06.2019
+# Added /bin/usr script // 22.09.2019
+# Added sigterm level, added second parameter to activate sigterm during smart_wait function
+
+# Get all childpids from calling process
+function getcpid() {
+local cpids="$(pgrep -P $1)"
+    for cpid in $cpids; do
+        pidarray+=($cpid)
+        getcpid $cpid
+    done
+}
+
+# Get a sleep while process is active in background
+# if PID is still active then use kill -9 switch
+function smart_wait() {
+    local PID=$2
+    local disablekill9=$1
+    local watchdog=0
+    sleep 1
+    while [[ -e /proc/$PID ]]; do
+        sleep 0.25
+        ((watchdog++))
+        [[ $disablekill9 -eq 1 ]] && [[ watchdog -gt 12 ]] && kill -9 $PID
+    done
+}
+
+# Emulator currently running?
+function check_emurun() {
+    local RC_PID="$(pgrep -f -n emulatorlauncher)"
+    echo $RC_PID
+}
+
+# Emulationstation currently running?
+function check_esrun() {
+    local ES_PID="$(pgrep -f -n emulationstation)"
+    echo $ES_PID
+}
+
+
+# Kill emulators running in a proper way! (SAVE SRM STATE!)
+function emu_kill() {
+    RC_PID=$(check_emurun)
+    if [[ -n $RC_PID ]]; then
+        getcpid $RC_PID
+        for ((z=${#pidarray[*]}-1; z>-1; z--)); do
+            kill ${pidarray[z]}
+            smart_wait 1 ${pidarray[z]}
+        done
+        unset pidarray
+    fi
+}
+
+# ---- MAINS ----
+
+case ${1,,} in
+    --restart)
+        /etc/init.d/S31emulationstation stop
+        ES_PID=$(check_esrun)
+        [[ -z $ES_PID ]] || smart_wait 0 $ES_PID 
+        /etc/init.d/S31emulationstation start
+    ;;
+
+    --espid)
+        # Display ES PID to stdout
+        ES_PID=$(check_esrun)
+        [[ -n $ES_PID ]] && echo $ES_PID || echo 0
+    ;;
+
+    --emupid)
+        # This helps to detect emulator is running or not
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && echo $RC_PID || echo 0
+    ;;
+
+    --emukill|--shutdown)
+        emu_kill && sleep 2
+        ES_PID=$(check_esrun)
+        if [[ "$1" == "--shutdown" && -n $ES_PID ]]; then
+            [[ -z $RC_PID ]] || smart_wait 1 $RC_PID && sleep 3
+            kill $ES_PID         
+            smart_wait 0 $ES_PID
+            shutdown -h now
+        fi
+    ;;
+
+    --kodi)
+        emu_kill && sleep 2
+        /etc/init.d/S31emulationstation stop
+        batocera-kodilauncher &
+        wait $!
+        exitcode=$?
+        [[ $exitcode -eq 0 ]] && /etc/init.d/S31emulationstation start
+        [[ $exitcode -eq 10 ]] && shutdown -r now
+        [[ $exitcode -eq 11 ]] && shutdown -h now
+    ;;
+
+    *)
+        echo -e "\n\t\t BATOCERA SWISS KNIFE FOR EmulationStation
+                 Please parse parameters to this script! \n
+                  --restart will RESTART EmulationStation only
+                            this may be usefull for refreshing gameslists \n
+                  --kodi will startup KODI Media Center stopping ES \n
+                  --shutdown will SHUTDOWN whole system \n
+                  --emukill to exit any running EMULATORS \n
+                  --espid to check if EmulationStation is currently active
+                          This number is the real PID of the binary!
+                          If the ouput is 0, then ES isn't active \n
+                  --emupid to check if an Emulator is running
+                           This number is just the PID of emulatorlauncher.py
+                           if the output is 0 then there is no emulator active!"
+    ;;
+
+esac

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -79,10 +79,11 @@ case ${1,,} in
     ;;
 
     --emukill|--shutdown)
-        emu_kill && sleep 2
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && emu_kill && sleep 2
+
         ES_PID=$(check_esrun)
-        if [[ "$1" == "--shutdown" && -n $ES_PID ]]; then
-            [[ -z $RC_PID ]] || smart_wait 1 $RC_PID && sleep 3
+        if [[ "${1,,}" == "--shutdown" && -n $ES_PID ]]; then
             kill $ES_PID         
             smart_wait 0 $ES_PID
             shutdown -h now
@@ -90,7 +91,9 @@ case ${1,,} in
     ;;
 
     --kodi)
-        emu_kill && sleep 2
+        RC_PID=$(check_emurun)
+        [[ -n $RC_PID ]] && emu_kill && sleep 2
+        
         /etc/init.d/S31emulationstation stop
         batocera-kodilauncher &
         wait $!

--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -11,7 +11,7 @@ case "$1" in
 	powerswitch="`$systemsetting  -command load -key system.power.switch`"
 	case "${powerswitch}" in
 	    ATX_RASPI_R2_6|MAUSBERRY|REMOTEPIBOARD_2003|REMOTEPIBOARD_2005|WITTYPI|PIN56ONOFF|PIN56PUSH|PIN356ONOFFRESET|ONOFFSHIM)
-		nice -n 19 $RUN start&
+		nice -n 19 $RUN start $powerswitch &
 		;;
 	esac
     ;;
@@ -20,7 +20,7 @@ case "$1" in
             kill $BTD_PID
             $RUN stop
         elif test -e "/tmp/poweroff.please"; then
-            $RUN stop
+            $RUN stop $powerswitch
         fi
     ;;
     status)

--- a/package/batocera/utils/rpigpioswitch/rpi-pin356-power.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-pin356-power.py
@@ -5,16 +5,27 @@ import os
 import RPi.GPIO as GPIO
 import time
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)	# GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setwarnings(False)		                            # no warnings
+GPIO.setmode(GPIO.BCM)                                  # BCM mode
+GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)	    # Powerbutton - GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setup(2, GPIO.IN, pull_up_down=GPIO.PUD_UP)        # Resetbutton - GPIO on pin 3 is the GPIO 5 in BCM mode 
+GPIO.setup(4, GPIO.OUT)                                 # LED         - GPIO on pin 7 is the GPIO 4 in BCM mode
+GPIO.output(4, GPIO.HIGH)                               # Turn on LED
 
-
+def shutdownBatocera(channel):
+    print 'shutdownBatocera'
+    os.system('shutdown -h now')
+    #os.system('batocera-es-swissknife --shutdown')
+    
 def exitAllBatoceraEmulator(channel):
     print 'exitAllBatoceraEmulator'
     os.system('killall -9 retroarch PPSSPPSDL reicast.elf mupen64plus linapple-pie x64 scummvm dosbox vice amiberry fsuae dolphin-emu')
-
+    #os.system('batocera-es-swissknife --emukill')
 
 GPIO.add_event_detect(3, GPIO.FALLING, callback=exitAllBatoceraEmulator,
+                      bouncetime=500)
+
+GPIO.add_event_detect(21, GPIO.FALLING, callback=shutdownBatocera,
                       bouncetime=500)
 
 while True:

--- a/package/batocera/utils/rpigpioswitch/rpi-pin56-power.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-pin56-power.py
@@ -5,13 +5,15 @@ import os
 import RPi.GPIO as GPIO
 import time
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)	# GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setwarnings(False)		                        # no warnings
+GPIO.setmode(GPIO.BCM)                              # BCM mode
+GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # GPIO on pin 5 is the GPIO 3 in BCM mode
 
 
 def shutdownBatocera(channel):
     print 'shutdownBatocera'
     os.system('shutdown -h now')
+    #os.system('batocera-es-swissknife --shutdown')
 
 
 GPIO.add_event_detect(3, GPIO.FALLING, callback=shutdownBatocera,


### PR DESCRIPTION
- made rpi356 script work again (power, reset, LED)
- hide error output in rpi56 script
- S92switch parses button config now to rpi_gpioswitches
- start `rpi_gpioswitches` from terminal will show you a nice dialog window
- removed read out of `batocera.conf` within `rpi_gpioswitches` (why should this script do the work from S92switch again)
- cleanup of scripts ....
- ....

![grafik](https://user-images.githubusercontent.com/29715650/65899397-ef014600-e3b3-11e9-9465-ce7629125e19.png)