### PR TITLE
GPIO SWITCH: Some small improvements made

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -11,7 +11,7 @@ case "$1" in
 	powerswitch="`$systemsetting  -command load -key system.power.switch`"
 	case "${powerswitch}" in
 	    ATX_RASPI_R2_6|MAUSBERRY|REMOTEPIBOARD_2003|REMOTEPIBOARD_2005|WITTYPI|PIN56ONOFF|PIN56PUSH|PIN356ONOFFRESET|ONOFFSHIM)
-		nice -n 19 $RUN start&
+		nice -n 19 $RUN start $powerswitch &
 		;;
 	esac
     ;;
@@ -20,7 +20,7 @@ case "$1" in
             kill $BTD_PID
             $RUN stop
         elif test -e "/tmp/poweroff.please"; then
-            $RUN stop
+            $RUN stop $powerswitch
         fi
     ;;
     status)

--- a/package/batocera/utils/rpigpioswitch/rpi-pin356-power.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-pin356-power.py
@@ -5,16 +5,27 @@ import os
 import RPi.GPIO as GPIO
 import time
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)	# GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setwarnings(False)                                 # no warnings
+GPIO.setmode(GPIO.BCM)                                  # BCM mode
+GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)        # Powerbutton - GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setup(2, GPIO.IN, pull_up_down=GPIO.PUD_UP)        # Resetbutton - GPIO on pin 3 is the GPIO 5 in BCM mode 
+GPIO.setup(4, GPIO.OUT)                                 # LED         - GPIO on pin 7 is the GPIO 4 in BCM mode
+GPIO.output(4, GPIO.HIGH)                               # Turn on LED
 
-
+def shutdownBatocera(channel):
+    print 'shutdownBatocera'
+    os.system('shutdown -h now')
+    #os.system('batocera-es-swissknife --shutdown')
+    
 def exitAllBatoceraEmulator(channel):
     print 'exitAllBatoceraEmulator'
     os.system('killall -9 retroarch PPSSPPSDL reicast.elf mupen64plus linapple-pie x64 scummvm dosbox vice amiberry fsuae dolphin-emu')
-
+    #os.system('batocera-es-swissknife --emukill')
 
 GPIO.add_event_detect(3, GPIO.FALLING, callback=exitAllBatoceraEmulator,
+                      bouncetime=500)
+
+GPIO.add_event_detect(21, GPIO.FALLING, callback=shutdownBatocera,
                       bouncetime=500)
 
 while True:

--- a/package/batocera/utils/rpigpioswitch/rpi-pin56-power.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-pin56-power.py
@@ -5,13 +5,15 @@ import os
 import RPi.GPIO as GPIO
 import time
 
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)	# GPIO on pin 5 is the GPIO 3 in BCM mode
+GPIO.setwarnings(False)                             # no warnings
+GPIO.setmode(GPIO.BCM)                              # BCM mode
+GPIO.setup(3, GPIO.IN, pull_up_down=GPIO.PUD_UP)    # GPIO on pin 5 is the GPIO 3 in BCM mode
 
 
 def shutdownBatocera(channel):
     print 'shutdownBatocera'
     os.system('shutdown -h now')
+    #os.system('batocera-es-swissknife --shutdown')
 
 
 GPIO.add_event_detect(3, GPIO.FALLING, callback=shutdownBatocera,


### PR DESCRIPTION
- made rpi356 script work again (power, reset, LED)
- hide error output in rpi56 script
- S92switch parses button config now to rpi_gpioswitches
- start rpi_gpioswitches from terminal will show you a nice dialog window
- removed read out of batocera.conf within rpi_gpioswitches (why should this script do the work from S92switch again)
- cleanup of scripts ....
- ....

![](https://user-images.githubusercontent.com/29715650/65899397-ef014600-e3b3-11e9-9465-ce7629125e19.png)