### PR TITLE
S31emulationstation - always save metadata

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -25,7 +25,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
+            [[ -e /proc/$watchdog && -n $watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -25,7 +25,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ $? -eq 0 ]] && kill -9 $watchdog
+	    kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -25,7 +25,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            kill -9 $watchdog
+            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -25,7 +25,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog && -n $watchdog ]] && kill -9 $watchdog
+            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -14,7 +14,20 @@ case "$1" in
 	;;
   stop)
         killall emulationstation
-	;;
+        if [[ $? -eq 0 ]]; then
+            sleep 0.25
+            while [[ -n $(pidof emulationstation) ]]; do
+                sleep 0.5
+                if [[ -n $watchdog ]]; then
+                    [[ -e /proc/$watchdog ]] || break
+                else
+                    sleep 20 &
+                    watchdog=$!
+                fi
+            done
+            [[ $? -eq 0 ]] && kill -9 $watchdog
+        fi
+        ;;
   restart|reload)
         "$0" stop
         "$0" start

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -15,17 +15,13 @@ case "$1" in
   stop)
         killall emulationstation
         if [[ $? -eq 0 ]]; then
-            sleep 0.25
+            sleep 20 &
+            watchdog=$!
             while [[ -n $(pidof emulationstation) ]]; do
-                sleep 0.5
-                if [[ -n $watchdog ]]; then
-                    [[ -e /proc/$watchdog ]] || break
-                else
-                    sleep 20 &
-                    watchdog=$!
-                fi
+                sleep 0.25
+                $(kill -0 $watchdog) || exit
             done
-            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_1cpu
@@ -25,7 +25,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-	    kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -14,17 +14,13 @@ case "$1" in
   stop)
         killall emulationstation
         if [[ $? -eq 0 ]]; then
-            sleep 0.25
+            sleep 20 &
+            watchdog=$!
             while [[ -n $(pidof emulationstation) ]]; do
-                sleep 0.5
-                if [[ -n $watchdog ]]; then
-                    [[ -e /proc/$watchdog ]] || break
-                else
-                    sleep 20 &
-                    watchdog=$!
-                fi
+                sleep 0.25
+                $(kill -0 $watchdog) || exit
             done
-            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -13,7 +13,20 @@ case "$1" in
 	;;
   stop)
         killall emulationstation
-	;;
+        if [[ $? -eq 0 ]]; then
+            sleep 0.25
+            while [[ -n $(pidof emulationstation) ]]; do
+                sleep 0.5
+                if [[ -n $watchdog ]]; then
+                    [[ -e /proc/$watchdog ]] || break
+                else
+                    sleep 20 &
+                    watchdog=$!
+                fi
+            done
+            [[ $? -eq 0 ]] && kill -9 $watchdog
+        fi
+        ;;
   restart|reload)
         "$0" stop
         "$0" start

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ $? -eq 0 ]] && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            kill -9 $watchdog
+            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
+            [[ -e /proc/$watchdog && -n $watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog && -n $watchdog ]] && kill -9 $watchdog
+            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
@@ -14,17 +14,13 @@ case "$1" in
   stop)
         killall emulationstation
         if [[ $? -eq 0 ]]; then
-            sleep 0.25
+            sleep 20 &
+            watchdog=$!
             while [[ -n $(pidof emulationstation) ]]; do
-                sleep 0.5
-                if [[ -n $watchdog ]]; then
-                    [[ -e /proc/$watchdog ]] || break
-                else
-                    sleep 20 &
-                    watchdog=$!
-                fi
+                sleep 0.25
+                $(kill -0 $watchdog) || exit
             done
-            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
+            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
@@ -13,7 +13,20 @@ case "$1" in
 	;;
   stop)
         killall emulationstation
-	;;
+        if [[ $? -eq 0 ]]; then
+            sleep 0.25
+            while [[ -n $(pidof emulationstation) ]]; do
+                sleep 0.5
+                if [[ -n $watchdog ]]; then
+                    [[ -e /proc/$watchdog ]] || break
+                else
+                    sleep 20 &
+                    watchdog=$!
+                fi
+            done
+            [[ $? -eq 0 ]] && kill -9 $watchdog
+        fi
+        ;;
   restart|reload)
         "$0" stop
         "$0" start

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ $? -eq 0 ]] && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fb_splash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            kill -9 $watchdog
+            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
@@ -14,17 +14,13 @@ case "$1" in
   stop)
         killall emulationstation
         if [[ $? -eq 0 ]]; then
-            sleep 0.25
+            sleep 20 &
+            watchdog=$!
             while [[ -n $(pidof emulationstation) ]]; do
-                sleep 0.5
-                if [[ -n $watchdog ]]; then
-                    [[ -e /proc/$watchdog ]] || break
-                else
-                    sleep 20 &
-                    watchdog=$!
-                fi
+                sleep 0.25
+                $(kill -0 $watchdog) || exit
             done
-            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
+            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
@@ -13,7 +13,20 @@ case "$1" in
 	;;
   stop)
         killall emulationstation
-	;;
+        if [[ $? -eq 0 ]]; then
+            sleep 0.25
+            while [[ -n $(pidof emulationstation) ]]; do
+                sleep 0.5
+                if [[ -n $watchdog ]]; then
+                    [[ -e /proc/$watchdog ]] || break
+                else
+                    sleep 20 &
+                    watchdog=$!
+                fi
+            done
+            [[ $? -eq 0 ]] && kill -9 $watchdog
+        fi
+        ;;
   restart|reload)
         "$0" stop
         "$0" start

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ $? -eq 0 ]] && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_fbegl_nosplash
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            kill -9 $watchdog
+            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
@@ -14,17 +14,13 @@ case "$1" in
   stop)
         killall emulationstation
         if [[ $? -eq 0 ]]; then
-            sleep 0.25
+            sleep 20 &
+            watchdog=$!
             while [[ -n $(pidof emulationstation) ]]; do
-                sleep 0.5
-                if [[ -n $watchdog ]]; then
-                    [[ -e /proc/$watchdog ]] || break
-                else
-                    sleep 20 &
-                    watchdog=$!
-                fi
+                sleep 0.25
+                $(kill -0 $watchdog) || exit
             done
-            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
+            kill -0 $watchdog > /dev/null 2>&1 && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            [[ $? -eq 0 ]] && kill -9 $watchdog
+            kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
@@ -24,7 +24,7 @@ case "$1" in
                     watchdog=$!
                 fi
             done
-            kill -9 $watchdog
+            [[ -e /proc/$watchdog ]] && kill -9 $watchdog
         fi
         ;;
   restart|reload)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation_xorg
@@ -12,8 +12,21 @@ case "$1" in
 	fi
 	;;
   stop)
-	killall emulationstation
-	;;
+        killall emulationstation
+        if [[ $? -eq 0 ]]; then
+            sleep 0.25
+            while [[ -n $(pidof emulationstation) ]]; do
+                sleep 0.5
+                if [[ -n $watchdog ]]; then
+                    [[ -e /proc/$watchdog ]] || break
+                else
+                    sleep 20 &
+                    watchdog=$!
+                fi
+            done
+            [[ $? -eq 0 ]] && kill -9 $watchdog
+        fi
+        ;;
   restart|reload)
         "$0" stop
         "$0" start


### PR DESCRIPTION
I take referenct to
https://github.com/batocera-linux/batocera.linux/pull/1017

Moved code to S31emulationstation

```
This will secure metadata issues (favourites, scrapes ....)
if you press a button for shutdown
The timeout is set to 20 seconds (as an alternative ways for counting watchdogs)
`` 
