### PR TITLE
Libretro AI service for game translations

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -227,7 +227,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         if system.config['ai_service_url']:
             retroarchConfig['ai_service_url'] = system.config['ai_service_url']+'&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
         else:
-            retroarchConfig['ai_service_url'] = 'https://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
+            retroarchConfig['ai_service_url'] = 'http://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
     else:
         retroarchConfig['ai_service_enable'] = 'false'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -219,6 +219,18 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         # force the assets directory while it was wrong in some beta versions
         retroarchConfig['assets_directory'] = '/usr/share/libretro/assets'
 
+    # AI service for game translations
+    if system.isOptSet('ai_service_enabled') and system.getOptBoolean('ai_service_enabled') == True:
+        retroarchConfig['ai_service_enable'] = 'true'
+        retroarchConfig['ai_service_mode'] = '0'
+        retroarchConfig['ai_service_source_lang'] = '0'
+        if system.config['ai_service_url']:
+            retroarchConfig['ai_service_url'] = system.config['ai_service_url']+'&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
+        else:
+            retroarchConfig['ai_service_url'] = 'https://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
+    else:
+        retroarchConfig['ai_service_enable'] = 'false'
+
     # bezel
     writeBezelConfig(bezel, retroarchConfig, system.name, rom, gameResolution)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -33,7 +33,7 @@ def writeControllersConfig(retroconfig, system, controllers):
     retroarchspecials = {'x': 'load_state', 'y': 'save_state', 'pageup': 'screenshot', \
                          'start': 'exit_emulator', 'up': 'state_slot_increase', \
                          'down': 'state_slot_decrease', 'left': 'rewind', 'right': 'hold_fast_forward', \
-                         'l2': 'shader_prev', 'r2': 'shader_next', 'a': 'reset'}
+                         'l2': 'shader_prev', 'r2': 'shader_next', 'a': 'reset', 'pagedown': 'ai_service'}
     retroarchspecials['b'] = 'menu_toggle'
 
     cleanControllerConfig(retroconfig, controllers, retroarchspecials)

--- a/package/batocera/core/batocera-system/c2/batocera.conf
+++ b/package/batocera/core/batocera-system/c2/batocera.conf
@@ -185,6 +185,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/c2/batocera.conf
+++ b/package/batocera/core/batocera-system/c2/batocera.conf
@@ -186,9 +186,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/miqi/batocera.conf
+++ b/package/batocera/core/batocera-system/miqi/batocera.conf
@@ -185,6 +185,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/miqi/batocera.conf
+++ b/package/batocera/core/batocera-system/miqi/batocera.conf
@@ -186,9 +186,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/odroidn2/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidn2/batocera.conf
@@ -180,6 +180,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/odroidn2/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidn2/batocera.conf
@@ -181,9 +181,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rockpro64/batocera.conf
+++ b/package/batocera/core/batocera-system/rockpro64/batocera.conf
@@ -185,6 +185,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rockpro64/batocera.conf
+++ b/package/batocera/core/batocera-system/rockpro64/batocera.conf
@@ -186,9 +186,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi1/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi1/batocera.conf
@@ -205,9 +205,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi1/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi1/batocera.conf
@@ -204,6 +204,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -205,9 +205,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -204,6 +204,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi3/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi3/batocera.conf
@@ -205,9 +205,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/rpi3/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi3/batocera.conf
@@ -204,6 +204,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/s905/batocera.conf
+++ b/package/batocera/core/batocera-system/s905/batocera.conf
@@ -180,6 +180,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/s905/batocera.conf
+++ b/package/batocera/core/batocera-system/s905/batocera.conf
@@ -181,9 +181,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/s912/batocera.conf
+++ b/package/batocera/core/batocera-system/s912/batocera.conf
@@ -180,6 +180,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/s912/batocera.conf
+++ b/package/batocera/core/batocera-system/s912/batocera.conf
@@ -181,9 +181,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/tinkerboard/batocera.conf
+++ b/package/batocera/core/batocera-system/tinkerboard/batocera.conf
@@ -185,6 +185,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/tinkerboard/batocera.conf
+++ b/package/batocera/core/batocera-system/tinkerboard/batocera.conf
@@ -186,9 +186,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -189,6 +189,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 ## If you do not want batocera.linux to generate the configuration for all emulators (string)
 #global.configfile=/path/to/my/configfile.cfg

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -190,9 +190,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 ## If you do not want batocera.linux to generate the configuration for all emulators (string)
 #global.configfile=/path/to/my/configfile.cfg

--- a/package/batocera/core/batocera-system/x86_64/batocera.conf
+++ b/package/batocera/core/batocera-system/x86_64/batocera.conf
@@ -189,6 +189,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 ## If you do not want batocera.linux to generate the configuration for all emulators (string)
 #global.configfile=/path/to/my/configfile.cfg

--- a/package/batocera/core/batocera-system/x86_64/batocera.conf
+++ b/package/batocera/core/batocera-system/x86_64/batocera.conf
@@ -190,9 +190,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 ## If you do not want batocera.linux to generate the configuration for all emulators (string)
 #global.configfile=/path/to/my/configfile.cfg

--- a/package/batocera/core/batocera-system/xu4/batocera.conf
+++ b/package/batocera/core/batocera-system/xu4/batocera.conf
@@ -185,6 +185,10 @@ global.retroachievements.verbose=0
 global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
+## Enable RetroArch AI game translation service
+global.ai_service_enabled=0
+global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here

--- a/package/batocera/core/batocera-system/xu4/batocera.conf
+++ b/package/batocera/core/batocera-system/xu4/batocera.conf
@@ -186,9 +186,9 @@ global.retroachievements.screenshot=0
 global.retroachievements.username=
 global.retroachievements.password=
 ## Enable RetroArch AI game translation service
-global.ai_service_enabled=0
-global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
-global.ai_target_lang=
+#global.ai_service_enabled=0
+#global.ai_service_url=
+#global.ai_target_lang=
 
 # ------------ I - EMULATORS CHOICES ----------- #
 ## You can override the global configuration here


### PR DESCRIPTION
This PR enables AI-assisted game translations for RetroArch/libretro-based emulators.
Three new fields have been added in `batocera.conf`:
```
  global.ai_service_enabled=1  # Is the service enabled?
  global.ai_service_url=       # URL of the translation service to use
  global.ai_target_lang=Fr     # Language to translate into (2-char language code)
```

I talked to **Beaker**, who manages https://ztranslate.net and he agreed to give a generic `api_key` for Batocera users so that they don't need to register individually and put their personal API key as a new parameter. If people want to do it, they can edit the `ai_service_url` with their own api_key, but by default we can use `http://ztranslate.net/service?api_key=BATOCERA`

I also pushed a PR on batocera-emulationstation to take those parameters into account and configure the language easily.

Once the service is enabled, you can load up a game in a foreign language and hit [hotkey]+[R1]. The game will pause, and after 1-5 seconds, you'll get the paused image replaced with a translation of the screen where you're at. Just hit the same [hotkey]+[R1] to get back to the game.

This Libretro translation service can also do voice translation, but I find the result to be poor (i.e. you have everything on the screen read out and you can't really locate what is translated, if you have to select one of multiple options offered). So I concienciously decided to do image translation only at the moment.

See the attached screenshot for a Japanese -> French translation example.

<img width="1056" alt="Screen Shot 2019-10-30 at 7 19 06 PM" src="https://user-images.githubusercontent.com/21372356/67913429-46790a00-fb4a-11e9-9088-e134d9bfae90.png">
