### PR TITLE
New lr-mame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .config
 Thumbs.db
 authorized_keys
+libretro-mame-tiny

--- a/configs/batocera-x86_64-dev_defconfig
+++ b/configs/batocera-x86_64-dev_defconfig
@@ -67,7 +67,7 @@ BR2_PACKAGE_HOST_GDB=y
 BR2_PACKAGE_GDB_DEBUGGER=y
 BR2_PACKAGE_GDB_SERVER=y
 BR2_ENABLE_DEBUG=y
-BR2_STRIP_EXCLUDE_FILES="retroarch emulationstation mame_libretro.so"
+BR2_STRIP_EXCLUDE_FILES="retroarch emulationstation"
 # gcc8.3.x doesn't like -Og
 # BR2_OPTIMIZE_G=y
 BR2_OPTIMIZE_2=y

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 # Version: 0.214
-LIBRETRO_MAME_VERSION = mame-0.214
+LIBRETRO_MAME_VERSION = 4d35f0d1212be9104abd56a1b7c7c142d2e5977e
 # using poke-1,0 repo until upstream accepts our PRs
 LIBRETRO_MAME_SITE = $(call github,tcamargo,mame,$(LIBRETRO_MAME_VERSION))
 # LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -4,10 +4,10 @@
 #
 ################################################################################
 # Version: 0.214
-LIBRETRO_MAME_VERSION = 3f88377f0257949dda5ab142b731b1e26a91e9ce
+LIBRETRO_MAME_VERSION = a88ebb32ba257de7bd33ff106092ee955b7b5db1
 # using poke-1,0 repo until upstream accepts our PRs
-LIBRETRO_MAME_SITE = $(call github,tcamargo,mame,$(LIBRETRO_MAME_VERSION))
-# LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))
+# LIBRETRO_MAME_SITE = $(call github,tcamargo,mame,$(LIBRETRO_MAME_VERSION))
+LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))
 # LIBRETRO_MAME_OVERRIDE_SRCDIR = /sources/mame
 LIBRETRO_MAME_LICENSE = MAME
 # install in staging for debugging (gdb)

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 # Version: 0.214
-LIBRETRO_MAME_VERSION = 4d35f0d1212be9104abd56a1b7c7c142d2e5977e
+LIBRETRO_MAME_VERSION = 3f88377f0257949dda5ab142b731b1e26a91e9ce
 # using poke-1,0 repo until upstream accepts our PRs
 LIBRETRO_MAME_SITE = $(call github,tcamargo,mame,$(LIBRETRO_MAME_VERSION))
 # LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))


### PR DESCRIPTION
Bump to consider my last changes to lr-mame.

libretro-mame-tiny is a development package I use to quick build (<5min) mame. I don't want to commit it, so I add it to gitignore.