### PR TITLE
py: Fixed rpi-retroflag-SafeShutdown script

### DIFF
--- a/package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py
@@ -8,9 +8,9 @@ from multiprocessing import Process
 
 #initialize pins
 powerPin = 3 #pin 5
-ledPin = 14 #TXD
-resetPin = 2 #pin 13
-powerenPin = 4 #pin 5
+ledPin = 14 #TXD - pin 8
+resetPin = 2 #pin 3
+powerenPin = 4 #pin 7
 
 #initialize GPIO settings
 def init():

--- a/package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py
@@ -33,7 +33,6 @@ def ledBlink():
 	while True:
 		GPIO.output(ledPin, GPIO.HIGH)
 		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
-		start = time.time()
 		while GPIO.input(powerPin) == GPIO.LOW:
 			GPIO.output(ledPin, GPIO.LOW)
 			time.sleep(0.2)
@@ -61,5 +60,3 @@ if __name__ == "__main__":
 	powerProcess.join()
 	ledProcess.join()
 	resetProcess.join()
-
-	GPIO.cleanup()


### PR DESCRIPTION
Fixed ` GPIO.cleanup() `
Removed useless line `start = time.time()`

The GPIO.cleanup code-line cutted down the whole power and then metadata was lost, because the shutdown process can't reach S31emulationstation and other processes. Usually I use annother powerdevice so I was not able to track down these errors so quick.

So we have two possible solutions here
1. change python script (done here)
2. change rpi_gpioswitch script to **not** kill python process

For code style equality I decided to take the first route!
regards