### PR TITLE
batocera-gpio-install: Automatic enable power device

### DIFF
--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+#Activating Safe Shutdown feature
+batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+
+#Enable SRM,metadata saves, even if you powerdown during a game session
+cat > /userdata/system/custom.sh <<_EOF_
+#!/bin/bash
+[[ "\$1" == "stop" ]] && batocera-es-swissknife --emukill && sleep 1
+_EOF_
+
+#Make file executable
+chmod +x /userdata/system/custom.sh
+
+#Prepare /boot/config.txt
 CONFIGFILE=/boot/config.txt
 
 (cat <<EOF


### PR DESCRIPTION
1. Set batocera.conf `system.power.switch=RETROFLAG_GPI`
2. Automatic set custom.sh script to terminate running emulators
3. Set execute bit to custom.sh

@nadenislamarre The automatic setup is not tested! But I think it will help people for an automatic setup if they use the Retroflag Case

**BE AWARE SET SAFE SHUTDOWN SWITCH TO ON POSITION**