### PR TITLE
Added configgen code for "runahead" option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -33,6 +33,9 @@ systemToRetroachievements = {'snes', 'nes', 'gba', 'gb', 'gbc', 'megadrive', 'ma
 # Define systems not compatible with rewind option
 systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'odyssey2', 'mame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
 
+# Define systems not compatible with run-ahead option (warning: this option is CPU intensive!)
+systemNoRunahead = {'sega32x', 'psx', 'mame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
+
 # Define system emulated by bluemsx core
 systemToBluemsx = {'msx': '"MSX2"', 'msx1': '"MSX2"', 'msx2': '"MSX2"', 'colecovision': '"COL - ColecoVision"' };
 
@@ -104,6 +107,17 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             retroarchConfig['rewind_enable'] = 'true'
     else:
         retroarchConfig['rewind_enable'] = 'false'
+
+    retroarchConfig['run_ahead_enabled'] = 'false'
+    retroarchConfig['run_ahead_frames'] = '0'
+    retroarchConfig['run_ahead_secondary_instance'] = 'false'
+
+    if system.isOptSet('runahead') and int(system.config['runahead']) >0:
+        if (not system.name in systemNoRunahead):
+            retroarchConfig['run_ahead_enabled'] = 'true'
+            retroarchConfig['run_ahead_frames'] = system.config['runahead']
+            if system.isOptSet('secondinstance') and system.getOptBoolean('secondinstance') == True: 
+                retroarchConfig['run_ahead_secondary_instance'] = 'true'
 
     if system.isOptSet('autosave') and system.getOptBoolean('autosave') == True:
         retroarchConfig['savestate_auto_save'] = 'true'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -34,7 +34,7 @@ systemToRetroachievements = {'snes', 'nes', 'gba', 'gb', 'gbc', 'megadrive', 'ma
 systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'odyssey2', 'mame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
 
 # Define systems not compatible with run-ahead option (warning: this option is CPU intensive!)
-systemNoRunahead = {'sega32x', 'psx', 'mame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
+systemNoRunahead = {'sega32x', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
 
 # Define system emulated by bluemsx core
 systemToBluemsx = {'msx': '"MSX2"', 'msx1': '"MSX2"', 'msx2': '"MSX2"', 'colecovision': '"COL - ColecoVision"' };


### PR DESCRIPTION
This is the configgen code to enable the libretro `runahead` option (https://docs.libretro.com/guides/runahead/) - it basically enables faster response time than actual real hardware consoles. 

It's a follow up to @shantigilbert's PR on Batocera-ES https://github.com/batocera-linux/batocera-emulationstation/pull/245 

**THIS FEATURE IS CPU INTENSIVE:** while it can run on a reasonable x86_64 PC, but I am not sure about all the SBCs we support. A Raspberry Pi3 might be too slow to enable this, even on "old" machines. I am curious about feedback on this from other users.  Because it's quite experimental, the early 5.25 cycle is probably a good timing for testing this out. :)