### PR TITLE
xa: version bump (2.3.10)

### DIFF
--- a/package/batocera/utils-host/xa/xa.mk
+++ b/package/batocera/utils-host/xa/xa.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 
-XA_VERSION = 2.3.9
+XA_VERSION = 2.3.10
 XA_SOURCE=xa-$(XA_VERSION).tar.gz
 XA_SITE = https://www.floodgap.com/retrotech/xa/dists
 


### PR DESCRIPTION
xa 2.3.9 is now unsupported and gives a 404 while compiling
Bump to latest stable 2.3.10