### PR TITLE
fix-md5sum-bios-bios

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -118,12 +118,12 @@ systems = {
 													         { "md5": "3240872c70984b6cbfda1586cab68dbe", "file": "bios/mpr-17933.bin"	  },
 													         { "md5": "255113ba943c92a54facd25a10fd780c", "file": "bios/mpr-18811-mx.ic1" },
 													         { "md5": "1cd19988d1d72a3e7caa0b73234c96b4", "file": "bios/mpr-19367-mx.ic1" },
-													         { "md5": "53a094ad3a188f86de4e64624fe9b3ca", "file": "bios/stvbios.zip"	  } ] },
+													         { "md5": "",                                 "file": "bios/stvbios.zip"	  } ] },
     "segacd":       { "name": "Sega CD", "biosFiles":      [ { "md5": "e66fa1dc5820d254611fdcdba0662372", "file": "bios/bios_CD_E.bin" 	  },
 												             { "md5": "854b9150240a198070150e4566ae1290", "file": "bios/bios_CD_U.bin" 	  },
 												             { "md5": "278a9397d192149e84e820ac621a8edd", "file": "bios/bios_CD_J.bin" 	  } ] },
     "naomi":        { "name": "Naomi", "biosFiles":        [ { "md5": "3bffafac42a7767d8dcecf771f5552ba", "file": "bios/naomi.bin"        },
-                                                             { "md5": "e63d892cdb8b532351dc7020bb60b6f4", "file": "bios/naomi.zip"        } ] },
+                                                             { "md5": "",                                 "file": "bios/naomi.zip"        } ] },
 
 
     # Sharp


### PR DESCRIPTION
Compressed files have different md5sum depending on the program used and the compression ratio. In these files md5sum cannot be used.