### PR TITLE
Removed md5sum for naomi bios

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -123,7 +123,7 @@ systems = {
 												             { "md5": "854b9150240a198070150e4566ae1290", "file": "bios/bios_CD_U.bin" 	  },
 												             { "md5": "278a9397d192149e84e820ac621a8edd", "file": "bios/bios_CD_J.bin" 	  } ] },
     "naomi":        { "name": "Naomi", "biosFiles":        [ { "md5": "3bffafac42a7767d8dcecf771f5552ba", "file": "bios/naomi.bin"        },
-                                                             { "md5": "eb4099aeb42ef089cfe94f8fe95e51f6", "file": "bios/naomi.zip"        } ] },
+                                                             { "md5": "",                                 "file": "bios/naomi.zip"        } ] },
 
 
     # Sharp


### PR DESCRIPTION

Removed md5sum from bios naomi.zip as determined by official Retroarch documentation.
https://github.com/libretro/libretro-super/blob/master/dist/info/flycast_libretro.info#L39