### PR TITLE
Added RETROFLAG_ADV - please discuss BEFORE merge!

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -13,6 +13,7 @@ devices=(
          WITTYPI
          ONOFFSHIM
          RETROFLAG
+         RETROFLAG_ADV
          RETROFLAG_GPI
          PIN56ONOFF
          PIN56PUSH

--- a/package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import RPi.GPIO as GPIO
+import os
+import time
+import subprocess
+from multiprocessing import Process
+
+#initialize pins
+powerPin = 3 #pin 5
+ledPin = 14 #TXD - pin 8
+resetPin = 2 #pin 3
+powerenPin = 4 #pin 7
+
+#initialize GPIO settings
+def init():
+	GPIO.setwarnings(False)
+	GPIO.setmode(GPIO.BCM)
+	GPIO.setup(powerPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+	GPIO.setup(resetPin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+	GPIO.setup(ledPin, GPIO.OUT)
+	GPIO.setup(powerenPin, GPIO.OUT)
+	GPIO.output(powerenPin, GPIO.HIGH)
+
+#waits for user to hold button up to 1 second before issuing poweroff command
+def poweroff():
+	while True:
+		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+ 		output = int(subprocess.check_output(['batocera-es-swissknife', '--espid']))
+ 		if output:
+			os.system("batocera-es-swissknife --shutdown")
+		else:
+			os.system("shutdown -h now")
+
+#blinks the LED to signal button being pushed
+def ledBlink():
+	while True:
+		GPIO.output(ledPin, GPIO.HIGH)
+		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
+		start = time.time()
+		while GPIO.input(powerPin) == GPIO.LOW:
+			GPIO.output(ledPin, GPIO.LOW)
+			time.sleep(0.2)
+			GPIO.output(ledPin, GPIO.HIGH)
+			time.sleep(0.2)
+
+#resets the pi
+def reset():
+	while True:
+		GPIO.wait_for_edge(resetPin, GPIO.FALLING)
+		output = int(subprocess.check_output(['batocera-es-swissknife', '--espid']))
+ 		output_rc = int(subprocess.check_output(['batocera-es-swissknife', '--emupid']))
+ 		if output_rc:
+			os.system("batocera-es-swissknife --emukill")
+ 		elif output:
+			os.system("batocera-es-swissknife --restart")
+		else:
+			os.system("shutdown -r now")
+
+if __name__ == "__main__":
+	#initialize GPIO settings
+	init()
+	#create a multiprocessing.Process instance for each function to enable parallelism 
+	powerProcess = Process(target = poweroff)
+	powerProcess.start()
+	ledProcess = Process(target = ledBlink)
+	ledProcess.start()
+	resetProcess = Process(target = reset)
+	resetProcess.start()
+
+	powerProcess.join()
+	ledProcess.join()
+	resetProcess.join()

--- a/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
+++ b/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
@@ -9,8 +9,9 @@
 #     - $2 argument is parsed by S92switch script now /etc/init.d
 #     - added help section, type 'rpi_gpioswitch help'
 #     - some other small improvements
-#v1.2 - add RETROFLAG power devices (means NESPi+, MegaPi, SuperPi+)
+#v1.2 - add RETROFLAG power devices (means NESPi+, MegaPi, SuperPi)
 #v1.3 - add RETROFLAG_GPI power device, the GameBoy look-a-like-device for Pi0/W
+#v1.4 - add RETROFLAG_ADV advanced reset script for NESPi+, MegaPi and SuperPi
 #by cyperghost 11.11.2019
 
 #dialog for selecting your switch or power device
@@ -324,7 +325,7 @@ function pin56_stop()
 #https://www.retroflag.com
 function retroflag_start()
 {
-    #$1 = rpi-retroflag-SafeShutdown/rpi-retroflag-GPiCase
+    #$1 = rpi-retroflag-SafeShutdown/rpi-retroflag-GPiCase/rpi-retroflag-AdvancedSafeShutdown
     "$1" &
     pid=$!
     echo "$pid" > "/tmp/$1.pid"
@@ -397,6 +398,9 @@ case "$CONFVALUE" in
     "RETROFLAG_GPI")
         retroflag_$1 rpi-retroflag-GPiCase
     ;;
+    "RETROFLAG_ADV")
+        retroflag_$1 rpi-retroflag-AdvancedSafeShutdown
+    ;;
     "DIALOG")
         # Go to selection dialog
         switch="$(powerdevice_dialog)"
@@ -414,8 +418,8 @@ case "$CONFVALUE" in
         echo
         echo "Try: rpi_gpioswitch.sh [start|stop] [value]"
         echo
-        echo "Vaild values are: REMOTEPIBOARD_2003, REMOTEPIBOARD_2005, WITTYPI 
-                  ATX_RASPI_R2_6, MAUSBERRY, ONOFFSHIM, RETROFLAG 
+        echo "Valid values are: REMOTEPIBOARD_2003, REMOTEPIBOARD_2005, WITTYPI 
+                  ATX_RASPI_R2_6, MAUSBERRY, ONOFFSHIM, RETROFLAG, RETROFLAG_GPI
                   PIN56ONOFF, PIN56PUSH, PIN356ONOFFRESET"
         exit 1
     ;;

--- a/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
+++ b/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
@@ -7,12 +7,13 @@ RPIGPIOSWITCH_VERSION = 1.0
 RPIGPIOSWITCH_SOURCE =
 
 define RPIGPIOSWITCH_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/S92switch                     $(TARGET_DIR)/etc/init.d/S92switch
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh             $(TARGET_DIR)/usr/bin/rpi_gpioswitch
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-pin56-power.py            $(TARGET_DIR)/usr/bin/rpi-pin56-power
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-pin356-power.py           $(TARGET_DIR)/usr/bin/rpi-pin356-power
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py $(TARGET_DIR)/usr/bin/rpi-retroflag-SafeShutdown
-	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-retroflag-GPiCase.py      $(TARGET_DIR)/usr/bin/rpi-retroflag-GPiCase
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/S92switch                             $(TARGET_DIR)/etc/init.d/S92switch
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh                     $(TARGET_DIR)/usr/bin/rpi_gpioswitch
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-pin56-power.py                    $(TARGET_DIR)/usr/bin/rpi-pin56-power
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-pin356-power.py                   $(TARGET_DIR)/usr/bin/rpi-pin356-power
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-retroflag-SafeShutdown.py         $(TARGET_DIR)/usr/bin/rpi-retroflag-SafeShutdown
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-retroflag-GPiCase.py              $(TARGET_DIR)/usr/bin/rpi-retroflag-GPiCase
+	$(INSTALL) -D -m 0755 package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py $(TARGET_DIR)/usr/bin/rpi-retroflag-AdvancedSafeShutdown
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Like @darknior wished....
This is an advanced version of the Retroflag scripts. The RESET-trigger button is now more versatile and is able to terminate a running emulator by just pressing the RESET button.

As result you'll be kicked back to ES main screen. This will not work for KODI!
It's a "state of the art" method well known in RetroPie

I understand the deep user wish to add this as default.
I do not want to let this be shown in the `rpi_gpioswitch` so it needs to be setted up manually by editing batocera.conf and add `RETROFLAG_ADV` to `system.power.switch` key

The alternate method is to use the installer like done before, this is the method available for RetroPie users, Recalbox ones and BATOCERAs
```
wget -O - "https://raw.githubusercontent.com/crcerror/retroflag-picase/master/install_batocera.sh" | bash
``` 