### PR TITLE
Gpicase install automatic setup

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -1,4 +1,5 @@
 20XX/XX/XX - batocera.linux 5.25
+	* rpi: Activation of safe shutdown feature for GPi case added (read the GPi manual how to toggle hardware switch)
 	* rpi: Full support of several Retroflag cases (GPi, NesPi+, SuperPi, MegaPi) 
 	* lr-mame: version bump (0.215)
 	* bluetooth: fix some pairing issues

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -1,39 +1,43 @@
 #!/bin/bash
 
 CONFIGFILE=/boot/config.txt
+CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
+[[ $? -eq  12 || $CONFIG -eq 1 ]] || exit 0
 
-(cat <<EOF
-# enable UART
-# affect rpi performances
-# enable_uart=1
-display_rotate=1
-dtoverlay=dpi24_gpicase
-overscan_left=0
-overscan_right=0
-overscan_top=0
-overscan_bottom=0
-framebuffer_width=320
-framebuffer_height=240
-enable_dpi_lcd=1
-display_default_lcd=1
-dpi_group=2
-dpi_mode=87
-dpi_output_format=0x6016
-#hdmi_timings=320 0 28 18 28 480 0 2 2 4 0 0 0 60 0 32000000 6
-hdmi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1
-dtoverlay=pwm-2chan_gpicase,pin=18,func=2,pin2=19,func2=2
-disable_pvt=1
-disable_audio_dither=1
-dtoverlay=pwm-audio-pi-zero_gpicase
-EOF
-) | (
+setup=(
+       "# ====== GPi Case setup section ====="
+       "dtoverlay=dpi24_gpicase"
+       "dtoverlay=pwm-audio-pi-zero_gpicase"
+       "display_rotate=1"
+       "overscan_left=0"
+       "overscan_right=0"
+       "overscan_top=0"
+       "overscan_bottom=0"
+       "framebuffer_width=320"
+       "framebuffer_height=240"
+       "enable_dpi_lcd=1"
+       "display_default_lcd=1"
+       "dpi_group=2"
+       "dpi_mode=87"
+       "dpi_output_format=0x6016"
+       "#hdmi_timings=320 0 28 18 28 480 0 2 2 4 0 0 0 60 0 32000000 6"
+       "hdmi_timings=240 1 38 10 20 320 1 20 4 4 0 0 0 60 0 6400000 1"
+       "dtoverlay=pwm-2chan_gpicase,pin=18,func=2,pin2=19,func2=2"
+       "disable_pvt=1"
+       "disable_audio_dither=1"
+       "# ====== GPi Case toggle section ====="
+       "# This will preserve always the default GPi settings if enabled, needed if some values were wrong setted by user"
+       "#force_gpi_defaults=1"
+)
+
+
     CONFIGMODIFIED=0
 
-    while read LINE
-    do
+
+    for LINE in "${setup[@]}"; do
 	if ! grep -qE "^${LINE}$" "${CONFIGFILE}"
 	then
-	    test "${CONFIGMODIFIED}" = 0 && mount -o remount,rw /boot
+	    #test "${CONFIGMODIFIED}" = 0 && mount -o remount,rw /boot
 	    echo "${LINE}" >> "${CONFIGFILE}"
 	    CONFIGMODIFIED=1
 	fi
@@ -41,9 +45,11 @@ EOF
 
     if test "${CONFIGMODIFIED}" = 1
     then
-	echo rebooting...
-	shutdown -r now
+	echo "Activate Retroflag Safe Shutdown feature..."
+        batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+        sleep 2
+        echo "Rebooting now..."
+        shutdown -r now
     fi
-)
 
 exit 0

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -2,7 +2,8 @@
 
 CONFIGFILE=/boot/config.txt
 CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
-[[ $? -eq  12 || $CONFIG -eq 1 ]] || exit 0
+CONFIGERR=$?
+[[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
 
 setup=(
        "# ====== GPi Case setup section ====="
@@ -27,7 +28,6 @@ setup=(
        "disable_audio_dither=1"
        "# ====== GPi Case toggle section ====="
        "# This will preserve always the default GPi settings if enabled, needed if some values were wrong setted by user"
-       "#force_gpi_defaults=1"
 )
 
 
@@ -41,6 +41,7 @@ setup=(
 	    echo "${LINE}" >> "${CONFIGFILE}"
 	    CONFIGMODIFIED=1
 	fi
+	[[ $CONFIGERR -eq 12 ]] && echo "#force_gpi_defaults=1" >> "${CONFIGFILE}"
     done
 
     if test "${CONFIGMODIFIED}" = 1

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -37,7 +37,7 @@ setup=(
     for LINE in "${setup[@]}"; do
 	if ! grep -qE "^${LINE}$" "${CONFIGFILE}"
 	then
-	    #test "${CONFIGMODIFIED}" = 0 && mount -o remount,rw /boot
+	    test "${CONFIGMODIFIED}" = 0 && mount -o remount,rw /boot
 	    echo "${LINE}" >> "${CONFIGFILE}"
 	    CONFIGMODIFIED=1
 	fi


### PR DESCRIPTION
Some small improvements made
1. you can alter data in /boot/config.txt now
2. you can force the data writing to /boot/config.txt like it was done before (disabled for default)
3. you can change this behaviour by activating `force_gpi_defaults` in config.txt
4. set `RETROFLAG_GPI` as default value now
5. some speed improvements because the whole checking of the config is obsolet now.

```
CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
CONFIGERR=$?
[[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
```

This section is intersting
* Errorcode 12 means "VALUE NOT FOUND!" so we force a initial install of the GPi-case values
* CONFIG=1 means the user toggled the force_gpi_defaults in `/boot/config.txt` in this case the script behaves like the old one.