### PR TITLE
Gpi case autoinstall

### DIFF
--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -3,7 +3,7 @@
 CONFIGFILE=/boot/config.txt
 CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
 CONFIGERR=$?
-[[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
+[[ $CONFIGERR -eq  12 || $CONFIGERR -eq 11 || $CONFIG -eq 1 ]] || exit 0
 
 setup=(
        "# ====== GPi Case setup section ====="
@@ -44,15 +44,32 @@ setup=(
     done
     
     #Write force_gpi_defaults if it wasn't already in config
-    [[ $CONFIGERR -eq 12 ]] && echo "#force_gpi_defaults=1" >> "${CONFIGFILE}"
+    if [[ $CONFIGERR -eq 12 ]]; then
+        echo "#force_gpi_defaults=0" >> "${CONFIGFILE}"
+    fi
 
+    #Reboot if there was a change in line
     if test "${CONFIGMODIFIED}" = 1
     then
-	echo "Activate Retroflag Safe Shutdown feature..."
-        batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
-        sleep 2
         echo "Rebooting now..."
         shutdown -r now
+    fi
+
+    # Create Subshell and wait till batocera.cfg is available
+    # Then write values and uncomment force_gpi_defaults, to decide between boot 1st and 2nd boot ;)
+    if [[ $CONFIGERR -eq 11 ]]; then
+        (
+            until [[ -w /userdata/system/batocera.conf ]]; do
+                sleep 2
+              done
+              batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+              mount -o remount,rw /boot
+              batocera-settings $CONFIGFILE uncomment force_gpi_defaults
+              # Some fine tuning
+              RA_CUSTOM="/userdata/system/configs/retroarch/retroarchcustom.cfg"
+              echo "video_fullscreen_x = 640" >> "$RA_CUSTOM"
+              echo "video_fullscreen_y = 480" >> "$RA_CUSTOM"
+         ) &
     fi
 
 exit 0

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -63,13 +63,13 @@ setup=(
                 sleep 1
             done
             
-	    # Set correct power switch device
-	    batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+            # Set correct power switch device
+            batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
             # Avoid second run of script by removing # from force_gpi_defaults (Errcode 11)
-	    mount -o remount,rw /boot
+            mount -o remount,rw /boot
             batocera-settings $CONFIGFILE uncomment force_gpi_defaults
             
-	    # Some fine tuning
+            # Some fine tuning
             RA_CUSTOM="/userdata/system/configs/retroarch/retroarchcustom.cfg"
             echo "video_fullscreen_x = 640" >> "$RA_CUSTOM"
             echo "video_fullscreen_y = 480" >> "$RA_CUSTOM"

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -60,15 +60,19 @@ setup=(
     if [[ $CONFIGERR -eq 11 ]]; then
         (
             until [[ -w /userdata/system/batocera.conf ]]; do
-                sleep 2
-              done
-              batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
-              mount -o remount,rw /boot
-              batocera-settings $CONFIGFILE uncomment force_gpi_defaults
-              # Some fine tuning
-              RA_CUSTOM="/userdata/system/configs/retroarch/retroarchcustom.cfg"
-              echo "video_fullscreen_x = 640" >> "$RA_CUSTOM"
-              echo "video_fullscreen_y = 480" >> "$RA_CUSTOM"
+                sleep 1
+            done
+            
+	    # Set correct power switch device
+	    batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+            # Avoid second run of script by removing # from force_gpi_defaults (Errcode 11)
+	    mount -o remount,rw /boot
+            batocera-settings $CONFIGFILE uncomment force_gpi_defaults
+            
+	    # Some fine tuning
+            RA_CUSTOM="/userdata/system/configs/retroarch/retroarchcustom.cfg"
+            echo "video_fullscreen_x = 640" >> "$RA_CUSTOM"
+            echo "video_fullscreen_y = 480" >> "$RA_CUSTOM"
          ) &
     fi
 


### PR DESCRIPTION
Sets RETROFLAG_GPI now
Sets video resolution to 640x480 for better gaming experince

@nadenislamarre I've tested several other resolutions
320x240 are equal to the default res
0x0 seems to have the same effect as letting the keys unavailable