### PR TITLE
gpicase: Automatic activation of shutdown scripts

### DIFF
--- a/package/batocera/utils/gpicase/99-gpicase.rules
+++ b/package/batocera/utils/gpicase/99-gpicase.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", ATTR{manufacturer}=="RetroFlag", ATTR{product}=="GPi Case", RUN+="/usr/bin/batocera-gpicase-install"
+SUBSYSTEM=="usb", ATTR{manufacturer}=="RetroFlag", ATTR{product}=="GPi Case", RUN+="/usr/bin/batocera-gpicase-install", RUN+="/bin/echo RETROFLAG_GPI > /var/run/powerswitch-detected"

--- a/package/batocera/utils/gpicase/99-gpicase.rules
+++ b/package/batocera/utils/gpicase/99-gpicase.rules
@@ -1,1 +1,3 @@
-SUBSYSTEM=="usb", ATTR{manufacturer}=="RetroFlag", ATTR{product}=="GPi Case", RUN+="/usr/bin/batocera-gpicase-install", RUN+="/bin/echo RETROFLAG_GPI > /var/run/powerswitch-detected"
+SUBSYSTEM=="usb", ATTR{manufacturer}=="RetroFlag", ATTR{product}=="GPi Case",
+RUN+="/usr/bin/batocera-gpicase-install",
+RUN+="/bin/sh -c '/bin/echo RETROFLAG_GPI > /var/run/powerswitch-by-udevrule'"

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -3,7 +3,7 @@
 CONFIGFILE=/boot/config.txt
 CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
 CONFIGERR=$?
-[[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
+[[ $CONFIGERR -eq  12 || $CONFIGERR -eq 11 || $CONFIG -eq 1 ]] || exit 0
 
 setup=(
        "# ====== GPi Case setup section ====="
@@ -44,15 +44,31 @@ setup=(
     done
     
     #Write force_gpi_defaults if it wasn't already in config
-    [[ $CONFIGERR -eq 12 ]] && echo "#force_gpi_defaults=1" >> "${CONFIGFILE}"
+    if [[ $CONFIGERR -eq 12 ]]; then
+        echo "#force_gpi_defaults=0" >> "${CONFIGFILE}"
+    fi
 
+    #Reboot if there was a change in line
     if test "${CONFIGMODIFIED}" = 1
     then
-	echo "Activate Retroflag Safe Shutdown feature..."
-        batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
-        sleep 2
         echo "Rebooting now..."
         shutdown -r now
+    fi
+
+    # Create Subshell and wait till batocera.cfg is available
+    # Then write values and uncomment force_gpi_defaults, to decide between boot 1st and 2nd boot ;)
+    if [[ $CONFIGERR -eq 11 ]]; then
+        (
+            until [[ -w /userdata/system/batocera.conf ]]; do
+                sleep 1
+            done
+            
+            # Set correct power switch device
+            batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
+            # Avoid second run of script by removing # from force_gpi_defaults (Errcode 11)
+            mount -o remount,rw /boot
+            batocera-settings $CONFIGFILE uncomment force_gpi_defaults
+         ) &
     fi
 
 exit 0

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -3,7 +3,7 @@
 CONFIGFILE=/boot/config.txt
 CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
 CONFIGERR=$?
-[[ $CONFIGERR -eq  12 || $CONFIGERR -eq 11 || $CONFIG -eq 1 ]] || exit 0
+[[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
 
 setup=(
        "# ====== GPi Case setup section ====="
@@ -45,7 +45,7 @@ setup=(
     
     #Write force_gpi_defaults if it wasn't already in config
     if [[ $CONFIGERR -eq 12 ]]; then
-        echo "#force_gpi_defaults=0" >> "${CONFIGFILE}"
+        echo "#force_gpi_defaults=1" >> "${CONFIGFILE}"
     fi
 
     #Reboot if there was a change in line
@@ -53,22 +53,6 @@ setup=(
     then
         echo "Rebooting now..."
         shutdown -r now
-    fi
-
-    # Create Subshell and wait till batocera.cfg is available
-    # Then write values and uncomment force_gpi_defaults, to decide between boot 1st and 2nd boot ;)
-    if [[ $CONFIGERR -eq 11 ]]; then
-        (
-            until [[ -w /userdata/system/batocera.conf ]]; do
-                sleep 1
-            done
-            
-            # Set correct power switch device
-            batocera-settings --command write --key system.power.switch --value RETROFLAG_GPI
-            # Avoid second run of script by removing # from force_gpi_defaults (Errcode 11)
-            mount -o remount,rw /boot
-            batocera-settings $CONFIGFILE uncomment force_gpi_defaults
-         ) &
     fi
 
 exit 0

--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -23,8 +23,13 @@ devices=(
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
-        systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
-        powerswitch="`$systemsetting  -command load -key system.power.switch`"
+        if [[ -f /var/run/powerswitch-detected ]]; then
+            powerswitch=$(cat /var/run/powerswitch-detected)
+        else
+            systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+            powerswitch="`$systemsetting  -command load -key system.power.switch`"
+        fi
+
         for i in ${devices[@]}; do
             [ "$i" == "$powerswitch" ] && break
         done
@@ -32,9 +37,15 @@ case "$1" in
             nice -n 19 $RUN start $powerswitch &
         fi
     ;;
+
     stop)
-        systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
-        powerswitch="`$systemsetting  -command load -key system.power.switch`"
+        if [[ -f /var/run/powerswitch-detected ]]; then
+            powerswitch=$(cat /var/run/powerswitch-detected)
+        else
+            systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+            powerswitch="`$systemsetting  -command load -key system.power.switch`"
+        fi
+
         if [ ! -z "$BTD_PID" ]; then
             kill $BTD_PID
             $RUN stop $powerswitch
@@ -42,6 +53,7 @@ case "$1" in
             $RUN stop $powerswitch
         fi
     ;;
+
     status)
         if [ ! -z "$BTD_PID" ]; then
             echo "Service rpi_gpioswitch ["$BTD_PID"] [ OK ]"
@@ -49,9 +61,11 @@ case "$1" in
             echo "Service rpi_gpioswitch [ KO ]"
         fi
     ;;
+
     setup)
         rpi_gpioswitch
     ;;
+
     *)
         echo "Usage: /etc/init.d/S92switch {start | stop | status | setup}"
         exit 1

--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -20,16 +20,16 @@ devices=(
          PIN356ONOFFRESET
         )
 
+# Read current config, if no key is set in batocera.conf then try to use
+# default value setted by udev-rule
+powerswitch="$(batocera-settings --command load --key system.power.switch)"
+if [ $? -ne 0 ] && [ -f /var/run/powerswitch-by-udevrule ]; then
+    powerswitch="$(cat /var/run/powerswitch-by-udevrule)"
+fi
+
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
-        if [[ -f /var/run/powerswitch-detected ]]; then
-            powerswitch=$(cat /var/run/powerswitch-detected)
-        else
-            systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
-            powerswitch="`$systemsetting  -command load -key system.power.switch`"
-        fi
-
         for i in ${devices[@]}; do
             [ "$i" == "$powerswitch" ] && break
         done
@@ -39,13 +39,6 @@ case "$1" in
     ;;
 
     stop)
-        if [[ -f /var/run/powerswitch-detected ]]; then
-            powerswitch=$(cat /var/run/powerswitch-detected)
-        else
-            systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
-            powerswitch="`$systemsetting  -command load -key system.power.switch`"
-        fi
-
         if [ ! -z "$BTD_PID" ]; then
             kill $BTD_PID
             $RUN stop $powerswitch


### PR DESCRIPTION
~~Using subshell during 2nd boot~~
~~Switch becames active then....~~

1. The installation script **DOES NOT** modify the batocera.conf file anymore, because this file contains only user setted configuration.
2. The udev rule sets a file in : /var/run/powerswitch-detected with the content RETROFLAG_GPI (at each boot) now
3. ~~in the powerswitch script in /etc, if powerswitch is enabled on batocera.conf, choose this value, else, if /var/run/powerswitch-detected exists, choose this value~~
3. ~~**Modfied** The S92switch service in /etc/init.d enables the powerswitch (forced!) if /var/run/powerswitch-detected is available, if not then allow user settings.~~
3. User settings done in batocera.conf will be used in first instance. If no value is setted here then a value setted by udev-rule will be used. The file is `/var/run/powerswitch-by-udevrule`

@nadenislamarre Ready for merge!
