### PR TITLE
rpi2 snes defaults to snes9x_next

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi2.yml
@@ -5,7 +5,7 @@ default:
 
 snes:
   emulator: libretro
-  core:     pocketsnes
+  core:     snes9x_next
 n64:
   options:
     videomode: DMT 4 HDMI


### PR DESCRIPTION
Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>