### PR TITLE
optimized parsing of conf files

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-settings
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-settings
@@ -28,7 +28,7 @@
 # 'batocera-settings disable wifi.enabled' will set key wifi.enabled=0
 # 'botocera-settings /myown/config.file --command status --key my.key' will output status of own config.file and my.key 
 
-# by cyperghost - 2019/07/07
+# by cyperghost - 2019/12/30
 
 ##### INITS #####
 BATOCERA_CONFIGFILE="/userdata/system/batocera.conf"
@@ -44,10 +44,12 @@ function get_config() {
     #Otherwise strip till the equal-char to obtain value
     local val
     local ret
-    val="$(grep -E -m1 "^$COMMENT_CHAR_SEARCH?\s*$1\s*=" $BATOCERA_CONFIGFILE)"
+    val="$(grep -E -m1 "^\s*$1\s*=" $BATOCERA_CONFIGFILE)"
     ret=$?
-    if [[ "$val" =~ ^$COMMENT_CHAR_SEARCH ]]; then
-         val="$COMMENT_CHAR"
+    if [[ $ret -eq 1 ]]; then 
+        val="$(grep -E -m1 "^$COMMENT_CHAR_SEARCH\s*$1\s*=" $BATOCERA_CONFIGFILE)"
+        ret=$?
+        [[ $ret -eq 0 ]] && val=$COMMENT_CHAR
     else
          #Maybe here some finetuning to catch key.value = ENTRY without blanks
          val="${val#*=}"
@@ -165,7 +167,7 @@ function main() {
         "read"|"get"|"load")
             val="$(get_config $keyvalue)"
             ret=$?
-            [[ "$val" == "$COMMENT_CHAR" ]] && echo "$val" >&2 && exit 11
+            [[ "$val" == "$COMMENT_CHAR" ]] && exit 11
             [[ -z "$val" && $ret -eq 0 ]] && exit 10
             [[ -z "$val" && $ret -eq 1 ]] && exit 12
             [[ -n "$val" ]] && echo "$val" && exit 0

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -146,7 +146,7 @@ updates.type=stable
 
 ## set the prefered output
 # use "batocera-config lsoutputs" to get your available outputs
-# global.videooutput=""
+#global.videooutput=""
 
 ## DPI
 ## Workaround when correct DPI setting is not detected

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -145,7 +145,7 @@ updates.type=stable
 #global.videomode=CEA 1 HDMI
 
 ## set the prefered output
-# use "batocera-config lsoutputs" to get your available outputs
+## use "batocera-config lsoutputs" to get your available outputs
 #global.videooutput=""
 
 ## DPI
@@ -164,7 +164,7 @@ updates.type=stable
 ## Set gpslp shader for all emulators (prefer shadersets above). Absolute path (string)
 #global.shaders=
 
-# bezel
+## bezel
 #global.bezel=default
 
 ## Set ratio for all emulators (auto,4/3,16/9,16/10,custom)

--- a/package/batocera/core/batocera-system/x86_64/batocera.conf
+++ b/package/batocera/core/batocera-system/x86_64/batocera.conf
@@ -145,8 +145,8 @@ updates.type=stable
 #global.videomode=CEA 1 HDMI
 
 ## set the prefered output
-# use "batocera-config lsoutputs" to get your available outputs
-# global.videooutput=""
+## use "batocera-config lsoutputs" to get your available outputs
+#global.videooutput=""
 
 ## DPI
 ## Workaround when correct DPI setting is not detected


### PR DESCRIPTION
Improvements made:
1. Finds values uncommented in first case
2. Finds commented values in second loop

Result: First uncommented value is used as proper value

Fixed layout in batocera.conf for x86 systems