### PR TITLE
psx: removed BIN extension

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -225,7 +225,7 @@ psp:
 
 psx:
   name:       Sony Playstation 1
-  extensions: [bin, cue, img, mdf, pbp, toc, cbn, m3u, ccd, chd, zip, 7z, iso]
+  extensions: [cue, img, mdf, pbp, toc, cbn, m3u, ccd, chd, zip, 7z, iso]
   emulators:
     libretro:
       pcsx_rearmed: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_PCSX]       }


### PR DESCRIPTION
@nadenislamarre 

2017/06/04 - batocera.linux 5.7 - release
        * psx: remove the .bin extension. please use .cue.

Was never done? Any reasons why?