### PR TITLE
Select a random splash /boot/*.mp4 or *.png file

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -8,6 +8,8 @@
 	* gamecube: automatically use d-pad if no analog stick is available (for bartop and arcade cabinets)
 	* updated BIOS MD5 checks for some systems
 	* es: new RetroAchievements screen
+	* add: new <gametime> tag in gamelist.xml keeping track of playing time in a game
+	* add: if you have more than one .mp4 or .png file in /boot/, a random one is selected for splash screen
 	* nvidia-driver: version bump (440.44)
 	* lr-mame: version bump (0.217)
 	* bump: retroarch v1.8.2

--- a/package/batocera/core/batocera-splash/S02splash
+++ b/package/batocera/core/batocera-splash/S02splash
@@ -6,9 +6,9 @@ soundDisabled() {
 
 do_start ()
 {
-    if test -f "/boot/splash.mp4"
+    if ls /boot/*.mp4 >/dev/null 2>/dev/null
     then
-	video="/boot/splash.mp4"
+        video="$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
     else
 	video="/usr/share/batocera/splash/splash.mp4"
     fi

--- a/package/batocera/core/batocera-splash/S02splash-ffplay
+++ b/package/batocera/core/batocera-splash/S02splash-ffplay
@@ -6,9 +6,9 @@ soundDisabled() {
 
 do_start ()
 {
-    if test -f "/boot/splash.mp4"
+    if ls /boot/*.mp4 >/dev/null 2>/dev/null
     then
-	video="/boot/splash.mp4"
+        video="$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
     else
 	video="/usr/share/batocera/splash/splash.mp4"
     fi

--- a/package/batocera/core/batocera-splash/S02splash-image
+++ b/package/batocera/core/batocera-splash/S02splash-image
@@ -2,11 +2,11 @@
 
 do_start ()
 {
-    if test -f "/boot/splash.png"
+    if ls /boot/*.png >/dev/null 2>/dev/null
     then
-	image="/boot/splash.png"
+        image="$(ls /boot/*.png | sed -e "$((RANDOM%$(ls -1 /boot/*.png | wc -l)+1))!d")"
     else
-	image="/usr/share/batocera/splash/logo-version.png"
+        image="/usr/share/batocera/splash/logo-version.png"
     fi
 
     # on some sytems, fb0 is not immediatly loaded, so, keep a chance by waiting a bit

--- a/package/batocera/core/batocera-splash/S02splash-omx
+++ b/package/batocera/core/batocera-splash/S02splash-omx
@@ -6,11 +6,11 @@ soundDisabled() {
 
 do_start ()
 {
-    if test -f "/boot/splash.mp4"
+    if ls /boot/*.mp4 >/dev/null 2>/dev/null
     then
-	video="/boot/splash.mp4"
+        video="$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
     else
-	video="/usr/share/batocera/splash/splash.mp4"
+        video="/usr/share/batocera/splash/splash.mp4"
     fi
 
     # Initialize dbus session


### PR DESCRIPTION
You can have more than one .mp4 or .png file in /boot/ and Batocera will select one at random for display at each boot.