### PR TITLE
added CSL GamePAD

### DIFF
--- a/board/batocera/fsoverlay/usr/share/batocera/datainit/system/configs/emulationstation/es_input.cfg
+++ b/board/batocera/fsoverlay/usr/share/batocera/datainit/system/configs/emulationstation/es_input.cfg
@@ -906,19 +906,19 @@
     </inputConfig>
     <!-- Elecom 8 buttons gamepad -->
     <inputConfig type="joystick" deviceName="USB Gamepad " deviceGUID="03000000790000001100000010010000">
-        <input name="a" type="button" id="3" value="1" code="291" />
-        <input name="b" type="button" id="2" value="1" code="290" />
-        <input name="down" type="axis" id="1" value="1" code="1" />
-        <input name="hotkey" type="button" id="6" value="1" code="294" />
-        <input name="left" type="axis" id="0" value="-1" code="0" />
-        <input name="pagedown" type="button" id="5" value="1" code="293" />
-        <input name="pageup" type="button" id="4" value="1" code="292" />
-        <input name="right" type="axis" id="0" value="1" code="0" />
-        <input name="select" type="button" id="6" value="1" code="294" />
-        <input name="start" type="button" id="7" value="1" code="295" />
-        <input name="up" type="axis" id="1" value="-1" code="1" />
-        <input name="x" type="button" id="1" value="1" code="289" />
-        <input name="y" type="button" id="0" value="1" code="288" />
+        <input name="a" type="button" id="1" value="1" />
+        <input name="b" type="button" id="2" value="1" />
+        <input name="down" type="axis" id="1" value="1" />
+        <input name="hotkey" type="button" id="8" value="1" />
+        <input name="left" type="axis" id="0" value="-1" />
+        <input name="pagedown" type="button" id="6" value="1" />
+        <input name="pageup" type="button" id="4" value="1" />
+        <input name="right" type="axis" id="0" value="1" />
+        <input name="select" type="button" id="8" value="1" />
+        <input name="start" type="button" id="9" value="1" />
+        <input name="up" type="axis" id="1" value="-1" />
+        <input name="x" type="button" id="0" value="1" />
+        <input name="y" type="button" id="3" value="1" />
     </inputConfig>
     <!-- SpeedLink SL-6603-Gold Competition Pro 25th Anniversary Edition -->
     <inputConfig type="joystick" deviceName="A SPEED-LINK Competition Pro" deviceGUID="030000000b0400003365000000010000">


### PR DESCRIPTION
I've a GamePAD from CSL with exact same GUID
If this PR will not merged it would be better to remove all "USB GAMEPAD..." devices
This version of ES will automatically popup a config window if a new device is detected