### PR TITLE
Switched "curvature" to fakelottes (for Odroids)

### DIFF
--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/curvature/rendering-defaults.yml
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/curvature/rendering-defaults.yml
@@ -1,15 +1,15 @@
 ## CURVATURE
 default:
   # shader affects retroarch shaders
-  shader: crt/crt-pi-curvature-curvature
+  shader: crt/fakelottes
   # scanline affect fba2x
   scanline: true
 snes:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 nes:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 n64:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 gba:
   shader: handheld/zfast-lcd
 gb:
@@ -17,92 +17,92 @@ gb:
 gbc:
   shader: handheld/zfast-lcd
 fds:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 virtualboy:
   shader: retro/sharp-bilinear-scanlines
 # Sega
 sg1000:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 mastersystem:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 megadrive:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 gamegear:
   shader: handheld/zfast-lcd
 sega32x:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 segacd:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 # Arcade
 neogeo:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 neogeocd:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 mame:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 fba:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 naomi:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atomiswave:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 #
 ngp:
   shader: handheld/zfast-lcd
 ngpc:
   shader: handheld/zfast-lcd
 gw:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 vectrex:
   shader: retro/sharp-bilinear-scanlines
 lynx:
   shader: handheld/zfast-lcd
 lutro:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 wswan:
   shader: handheld/zfast-lcd
 wswanc:
   shader: handheld/zfast-lcd
 pcengine:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 pcenginecd:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 supergrafx:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atari800:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atari2600:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atari5200:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atari7800:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 prboom:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 psx:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 colecovision:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 # Computers
 msx:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 msx1:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 msx2:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 amiga:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 amstradcpc:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 atarist:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 zxspectrum:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 odyssey2:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 zx81:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 pcfx:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes
 x68000:
-  shader: crt/crt-pi-curvature
+  shader: crt/fakelottes


### PR DESCRIPTION
The previous shader for `curvature` set did not work on Odroid N2. This new `fakelottes` has been tested on PC (with Intel GPU), RPi3 and Odroids.