### PR TITLE
Fixed default resolution for Dolphin emu

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -82,7 +82,7 @@ class DolphinGenerator(Generator):
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
         else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
+            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:


### PR DESCRIPTION
As reported on the forum, and reproduced on my PC with integrated Intel GPU, a default value of "0" lets Dolphin choose what it believes is the best supported resolution, but it never works. Setting the default to "1" (i.e. Gamecube/Wii native resolution) works much better.