### PR TITLE
Bsnes architecture correction

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-bsnes/libretro-bsnes.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bsnes/libretro-bsnes.mk
@@ -3,14 +3,14 @@
 # BSNES
 #
 ################################################################################
-# Version.: Commits on Jan 08, 2020
-LIBRETRO_BSNES_VERSION = 55e78b03deb7c4104580dec9593ac0e861d684e9
+# Version.: Commits on Jan 18, 2020 (v114.3)
+LIBRETRO_BSNES_VERSION = 7053a0b60513f51984a5bc8b551fc8592dc0bb1d
 LIBRETRO_BSNES_SITE = $(call github,byuu,bsnes,$(LIBRETRO_BSNES_VERSION))
 LIBRETRO_BSNES_LICENSE = GPLv3
 
 define LIBRETRO_BSNES_BUILD_CMDS
 	CFLAGS="$(TARGET_CFLAGS)" CXXFLAGS="$(TARGET_CXXFLAGS)" $(MAKE) CXX="$(TARGET_CXX)" \
-		CC="$(TARGET_CC)" -C $(@D)/bsnes -f GNUmakefile target="libretro" platform=linux
+		CC="$(TARGET_CC)" -C $(@D)/bsnes -f GNUmakefile target="libretro" platform=linux local=false
 endef
 
 define LIBRETRO_BSNES_INSTALL_TARGET_CMDS


### PR DESCRIPTION
By default, bsnes compiles by enabling optimizations for the local processor (native) and does not work on different processors.