### PR TITLE
Added an option to pause after screen translation

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -233,6 +233,10 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             retroarchConfig['ai_service_url'] = system.config['ai_service_url']+'&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
         else:
             retroarchConfig['ai_service_url'] = 'http://ztranslate.net/service?api_key=BATOCERA&mode=Fast&output=png&target_lang='+system.config['ai_target_lang']
+        if system.isOptSet('ai_service_pause') and system.getOptBoolean('ai_service_pause') == True:
+            retroarchConfig['ai_service_pause'] = 'true'
+        else:
+            retroarchConfig['ai_service_pause'] = 'false'
     else:
         retroarchConfig['ai_service_enable'] = 'false'
 


### PR DESCRIPTION
RetroArch used to always pause after AI translation, now it's controlled by a specific setting in `retroarch.cfg` (by default: unpaused).

Look for the corresponding ES PR.
