### PR TITLE
Fix for bartops and arcade sticks with no analog control

### DIFF
--- a/board/batocera/patches/sdl2/sdl2_input_evdev_at_first_unrelease_button.patch
+++ b/board/batocera/patches/sdl2/sdl2_input_evdev_at_first_unrelease_button.patch
@@ -16,7 +16,7 @@ index 8058947..e41a746 100644
      int posted;
  
 +    // ignore axis events until a button is released
-+    if (joystick->initial_state_is_valid == SDL_FALSE) {
++    if (joystick->initial_state_is_valid == SDL_FALSE && joystick->naxes >2) {
 +      return;
 +    }
 +


### PR DESCRIPTION
This fixes the need to press a button when before being able to use your stick on ES, when your gamepad has no analog control (typically bartops and arcade systems). 

Discussed with @nadenislamarre - we don't seem to agree on this patch, but I tested it and it restores the correct behavior back on my tankstick, while introducing no regression for my Xbox One USB pad.

I can't think of any pad which would have only 1 analog controller, no d-pad.


