### PR TITLE
Added inclusion of $HOME/.bashrc

### DIFF
--- a/system/skeleton/etc/profile
+++ b/system/skeleton/etc/profile
@@ -17,3 +17,10 @@ for i in /etc/profile.d/*.sh ; do
 	fi
 done
 unset i
+
+if [ -n "$BASH_VERSION" ]; then
+	# include .bashrc if it exists
+	if [ -f "$HOME/.bashrc" ]; then
+		. "$HOME/.bashrc"
+	fi
+fi


### PR DESCRIPTION
Out from ` batocera.linux/package/bash-completion/Config.in`

>  If the system does not use the /etc/profile.d directory
>  mechanism, the /etc/profile.d/bash_completion.sh script can
>  be sourced from /etc/bashrc or ~/.bashrc.

Added an example .bashrc with some logo (not part of this PR)
https://gist.github.com/crcerror/5c06a96e3c2a923c0bfc2fb118c9199f