### PR TITLE
S99custom minor fix - fixed execution on FAT32 file systems

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99custom
+++ b/board/batocera/fsoverlay/etc/init.d/S99custom
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-test -e "/userdata/system/custom.sh" && /userdata/system/custom.sh $1
+test -e "/userdata/system/custom.sh" && /userdata/system/custom.sh $1 &

--- a/board/batocera/fsoverlay/etc/init.d/S99custom
+++ b/board/batocera/fsoverlay/etc/init.d/S99custom
@@ -1,5 +1,6 @@
 #!/bin/bash
 
 if test -e "/userdata/system/custom.sh"; then
+    #bash interpreter executes scripts without x-flag e.g. for vFAT
     bash /userdata/system/custom.sh $1 &
 fi

--- a/board/batocera/fsoverlay/etc/init.d/S99custom
+++ b/board/batocera/fsoverlay/etc/init.d/S99custom
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-test -e "/userdata/system/custom.sh" && /userdata/system/custom.sh $1 &
+if test -e "/userdata/system/custom.sh"; then
+    bash /userdata/system/custom.sh $1 &
+fi


### PR DESCRIPTION
Part 1: @nadenislamarre nothing special - will finish init.d service if a custom.sh is present
Part 2: Since fat32 does not have an executable bit we have two possibilites (First: mount the fat partition with umask 0000. Second: In this (single) case we call the correspondening shell file with the bash interpreter)
