### PR TITLE
sdl2: fix pads 1/2

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation-config-event-codes.patch
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation-config-event-codes.patch
@@ -66,7 +66,7 @@ index d18eeac..50d22e7 100644
      InputConfig * playerInputConfig = playerJoysticks[player];
      if(playerInputConfig != NULL){
        command << "-p" << player+1 << "index " <<  playerInputConfig->getDeviceIndex() << " -p" << player+1 << "guid " << playerInputConfig->getDeviceGUIDString() << " -p" << player+1 << "name \"" <<  playerInputConfig->getDeviceName() << "\" -p" << player+1 << "nbaxes " << playerInputConfig->getDeviceNbAxes() << " ";
-+      command << "-p" << player+1 << "devicepath " <<  SDL_JoystickDevicePathById(playerInputConfig->getDeviceIndex()) << " ";
++      command << "-p" << player+1 << "devicepath " <<  SDL_JoystickDevicePathById(playerInputConfig->getDeviceId()) << " ";
      }
    }
    LOG(LogInfo) << "Configure emulators command : " << command.str().c_str();


### PR DESCRIPTION
fix the main sdl2 pad issues.
an other once remaining to fix line 68 of the same patch (to handle cases when you unplug/plug pads)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>