### PR TITLE
arcade: core

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -375,10 +375,11 @@ mame:
   platform:   arcade
   emulators:
     libretro:
-      imame4all:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_IMAME], 'netplay':true }
-      mame078plus:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2003_PLUS], 'netplay':true }
-      mame0139:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2010], 'netplay':true }
-      mame:         { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME], 'netplay':true }
+      imame4all:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_IMAME], 'netplay':true          }
+      mame078plus:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2003_PLUS], 'netplay':true  }
+      mame0139:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2010], 'netplay':true       }
+      mame:         { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME], 'netplay':true           }
+      fbneo:        { requireAnyOf: [BR2_PACKAGE_LIBRETRO_FBNEO], 'netplay':true          }
   comment_en: |
     The system uses libretro mame2003 as default core: compatible ROMs must come from set 0.78
     The libretro core imame4all, based on MAME v0.37b5, is also included.
@@ -397,7 +398,11 @@ neogeo:
   extensions: [7z, zip]
   emulators:
     libretro:
-      fbneo:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_FBNEO], 'netplay':true }
+      fbneo:        { requireAnyOf: [BR2_PACKAGE_LIBRETRO_FBNEO], 'netplay':true          }
+      imame4all:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_IMAME], 'netplay':true          }
+      mame078plus:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2003_PLUS], 'netplay':true  }
+      mame0139:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME2010], 'netplay':true       }
+      mame:         { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME], 'netplay':true           }
 
 neogeocd:
   name:       Neo-Geo CD


### PR DESCRIPTION
Mame and NeoGeo having the arcade core but each maintaining its default core.

Signed-off-by: Juliano Dorigão <jdorigao@gmail.com>