### PR TITLE
disable: commodore C20 and C128

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -23,8 +23,6 @@
 	* add: Thomson - MO/TO (libretro-theodore)
 	* add: NEC PC-98 (libretro-pc98)
 	* add: Daphne (hypseus)
-	* add: commodore VIC20
-	* add: commodore 128
 	* add: libretro-puae (Commodore Amiga)
 	* bump: nvidia-driver (440.44)
 	* bump: lr-mame 0.218

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -22,22 +22,6 @@ c64:
     libretro:
       vice:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_VICE], 'netplay':false }
 
-c128:
-  name:       Commodore 128
-  extensions: [d64, d81, prg, lnx, zip]
-  platform:   c64
-  emulators:
-    vice:
-      x128:     { requireAnyOf: [BR2_PACKAGE_VICE]          }
-
-c20:
-  name:       Commodore VIC-20
-  extensions: [a0, b0, crt, d64, d81, prg, tap, t64, zip]
-  platform:   c64
-  emulators:
-    vice:
-      xvic:     { requireAnyOf: [BR2_PACKAGE_VICE]          }
-
 amiga:
   name:       Commodore Amiga
   extensions: [zip, adf, uae, ipf, dms, adz, lha]


### PR DESCRIPTION
Problems with emulators will be analyzed and corrected for version 5.26 of Batocera. 
 
Signed-off-by: Juliano Dorigão <jdorigao@gmail.com>