### PR TITLE
default odroidgoa to 3/4 ratio

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
@@ -2,7 +2,7 @@ default:
   options:
     video_threaded: true
     # rotation
-    retroarch.aspect_ratio_index: 21
+    retroarch.aspect_ratio_index: 8
     retroarch.video_rotation: 1
     # menu retroarch
     retroarch.menu_driver: rgui


### PR DESCRIPTION
it's not perfect.
it is because 4/3 don't count rotation

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>