### PR TITLE
Moonlight: fixed script, ported it to new theGamesDB JSON API

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-moonlight
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-moonlight
@@ -1,7 +1,7 @@
 #!/bin/bash
-
+# Updated for the new JSON theGamesDB API
 # More options available here: https://github.com/irtimmer/moonlight-embedded/tree/master/docs
-#cd /userdata/roms/moonlight/
+SEPARATOR=";"
 moonlight_config_dir=/userdata/system/configs/moonlight
 moonlight_romsdir=/userdata/roms/moonlight
 moonlight_ip=
@@ -10,7 +10,7 @@ moonlight_fps="60"
 moonlight_mapping="$moonlight_config_dir/mapping.conf"
 moonlight_keydir="$moonlight_config_dir/keydir"
 moonlight_gamesnames="$moonlight_config_dir/gamelist.txt"
-SEPERATOR=";"
+thegamesdb_batocera_key="b699c2e6f9f85730fc2e4aa831b24172e68701352310f4e4d301d9342ae39636"
 
 listGames() {
   batocera-moonlight list 2>/dev/null | grep '^[0-9][0-9.]' | cut -d '.' -f 2, | sed 's/^ \(.*\)$/\1/'
@@ -23,32 +23,44 @@ createRomLinks () {
   listGames | while read line
   do
     filename=$(echo $line | sed 's/[^ A-Za-z0-9._-]/-/g')
-    echo "$filename$SEPERATOR$line" >> $moonlight_gamesnames
+    echo "Game found: ${filename}"
+    echo "$filename$SEPARATOR$line" >> $moonlight_gamesnames
     touch "$moonlight_romsdir/${filename}.moonlight"
   done
 }
 
 findRealGameName () {
-  grep "$*" $moonlight_gamesnames | cut -d "$SEPERATOR" -f 2
+  grep "$*" $moonlight_gamesnames | cut -d "$SEPARATOR" -f 2
 }
 
 scrape () {
-  GDBURL="http://thegamesdb.net/api/GetGame.php?platform=pc&exactname="
+  GDBURL="https://api.thegamesdb.net/v1/Games/ByGameName?platform=pc&apikey=${thegamesdb_batocera_key}&fields=overview,players,rating,release_date,developers,publishers,genres&include=boxart&name="
   GAMELIST=/userdata/roms/moonlight/gamelist.xml
   IMGPATH=/userdata/roms/moonlight/downloaded_images
+  fn=$(date +"%s")
+  GENREURL="https://api.thegamesdb.net/v1/Genres?apikey=${thegamesdb_batocera_key}"
+  GENRELIST="/tmp/genrelist_$fn"
+  DEVURL="https://api.thegamesdb.net/v1/Developers?apikey=${thegamesdb_batocera_key}"
+  DEVLIST="/tmp/devlist_$fn"
+  PUBURL="https://api.thegamesdb.net/v1/Publishers?apikey=${thegamesdb_batocera_key}"
+  PUBLIST="/tmp/publist_$fn"
 
   # Test if $GDBURL is online, and stop if it's offline
   dbdns=$(echo $GDBURL | awk -F/ '{print $3}')
   ping -c 1 $dbdns > /dev/null 2>&1
   if [ $? -ne '0' ]
   then
-    echo "$dbdns is not online. Can't scrape" >&2
+    echo "Error: $dbdns is not online. Can't scrape" >&2
     exit
   fi
 
+  # download updated DBs
+  wget "$GENREURL" -O "$GENRELIST" >/dev/null 2>&1
+  wget "$DEVURL" -O "$DEVLIST" >/dev/null 2>&1
+  wget "$PUBURL" -O "$PUBLIST" >/dev/null 2>&1
+
   # Make sure the $IMGPATH exists
   [ ! -d $IMGPATH ] && mkdir -p $IMGPATH
-
 
   # This is what we were waiting for : generate the gamelist.xml
   echo '<?xml version="1.0"?>' > $GAMELIST
@@ -58,33 +70,37 @@ scrape () {
   do
     # Get the real game name, not the moonlight link + prepare xml game data
     moonlightfilename=$(echo $line | cut -d ';' -f 1)
-    xmlfilename=/tmp/${moonlightfilename}.xml
+    jsonfilename=/tmp/${moonlightfilename}.json
     gamename=$(echo $line | cut -d ';' -f 2)
+    echo "Scraping $gamename"
 
-    # download XML game data from TheGamesDB.net
-    wget "$GDBURL$gamename" -O "$xmlfilename" >/dev/null 2>&1
+    # download JSON game data from TheGamesDB.net
+    wget "$GDBURL$gamename" -O "$jsonfilename" >/dev/null 2>&1
 
-    # Time to get values for the gamelist.xml
-    id=$(xml sel -t -v "Data/Game/id" "$xmlfilename" 2>/dev/null)
+    # Time to get values for gamelist.xml
+    id=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['id']")
     source="theGamesDB.net"
     path="./${moonlightfilename}.moonlight"
-    desc=$(xml sel -t -v "Data/Game/Overview" "$xmlfilename" 2>/dev/null)
+    desc=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['overview']")
 
     # A few steps to get the cover art url
-    imgurl=$(xml sel -t -v "Data/baseImgUrl" -v "Data/Game/Images/boxart[@side='front']/@thumb" "$xmlfilename" 2>/dev/null)
+    imgbase=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['include']['boxart']['base_url']['medium']")
+    imgurl=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['include']['boxart']['data']['$id'][0]['filename']")
     extension=$(echo $imgurl | awk -F . '{print $NF}')
     img=$IMGPATH/${gamename}.${extension}
-    wget $imgurl -O "$img" >/dev/null 2>&1
+    wget $imgbase/$imgurl -O "$img" >/dev/null 2>&1
 
-    rating=$(xml sel -t -v "Data/Game/Rating" "$xmlfilename" 2>/dev/null)
-    releasedate=$(xml sel -t -v "Data/Game/ReleaseDate" "$xmlfilename" 2>/dev/null | sed 's/^\([0-9]\{2\}\)\/\([0-9]\{2\}\)\/\([0-9]\{4\}\)/\3\1\2T0000/')
-    developer=$(xml sel -t -v "Data/Game/Developer" "$xmlfilename" 2>/dev/null)
-    publisher=$(xml sel -t -v "Data/Game/Publisher" "$xmlfilename" 2>/dev/null)
-    genre=$(xml sel -T -t -m "Data/Game/Genres/genre" -v 'text()' -i 'not(position()=last())' -o ' / ' "$xmlfilename" 2>/dev/null)
-    players=$(xml sel -t -v "Data/Game/Players" "$xmlfilename" 2>/dev/null)
+    rating=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['rating']")
+    releasedate=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['release_date']" | sed 's/^\([0-9]\{4\}\)-\([0-9]\{2\}\)\-\([0-9]\{2\}\)/\1\2\3T000000/')
+    developerid=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['developers'][0]")
+    developer=$(cat "$DEVLIST" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['developers']['$developerid']['name']")
+    publisherid=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['publishers'][0]")
+    publisher=$(cat "$PUBLIST" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['publishers']['$publisherid']['name']")
+    genreid=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['genres'][0]")
+    genre=$(cat "$GENRELIST" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['genres']['$genreid']['name']")
+    players=$(cat "$jsonfilename" | PYTHONIOENCODING=utf8 python2 -c "import sys, json; print json.load(sys.stdin)['data']['games'][0]['players']")
 
-
-    # Write the XML data
+    # Write the actual XML data
     cat << EOF >> $GAMELIST
   <game id="$id" source="$source">
     <path>$path</path>
@@ -100,22 +116,36 @@ scrape () {
   </game>
 
 EOF
-    rm "$xmlfilename"
-  done < <(cat $moonlight_gamesnames | sed "s/\t/;/g")
+     rm "$jsonfilename"
+  done <<< $(cat $moonlight_gamesnames | sed "s/\t/;/g")
   echo '</gameList>' >> $GAMELIST
+
+  rm -f "$GENRELIST" "$DEVLIST" "$PUBLIST"
+
 }
 
 mkdir -p $moonlight_keydir;
-
+if ! [ -z "$2" ]; then
+    moonlight_ip="$2"
+    ping -c 1 "$moonlight_ip" > /dev/null 2>&1
+    if [ $? -ne '0' ]; then
+       echo "Error: Can't ping $moonlight_ip, trying autodetect." >&2
+       moonlight_ip=
+    fi
+fi
 case $1 in
     init)
-        echo "Fetching games from $moonlight_ip ..."
+        echo "Fetching games ..."
         createRomLinks
         echo "Scraping games ..."
         scrape
         exit
         ;;
-
+    scrape)
+        echo "Scraping games ..."
+        scrape
+        exit
+        ;;
     map)
         cmd="moonlight map ${moonlight_mapping} -keydir ${moonlight_keydir}" ;;
 


### PR DESCRIPTION
Fixed `batocera-moonlight` to make Moonlight work again, with scraping from theGamesDB. 
We still had an outdated XML-based implementation that is not supported anymore (ported it to the new JSON API).
Wrote a how-to on the wiki for Moonlight to go with that PR.