### PR TITLE
Fixed audio for video snaps

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -1,4 +1,5 @@
 2020/XX/XX - batocera.linux 5.26
+	* fix missing audio for video snaps on some platforms
 	* bump: moonlight-embedded to 2.4.11
 	* bump: nvidia-driver (440.64)
 	* bump: libretro-bsnes to v115

--- a/board/batocera/fsoverlay/etc/asound.conf
+++ b/board/batocera/fsoverlay/etc/asound.conf
@@ -1,0 +1,22 @@
+pcm.!default {
+	type plug
+	slave.pcm "dmixer"
+}
+
+# configuration de Dmix
+pcm.dmixer  {
+	type dmix
+	ipc_key 1024
+	slave {
+	    pcm "hw:0,0"
+	    period_time 0
+	    period_size 1024
+	    buffer_size 4096
+	    rate 44100
+	}
+	bindings {
+	    0 0
+	    1 1
+	}
+}
+

--- a/board/batocera/fsoverlay/etc/init.d/S26system
+++ b/board/batocera/fsoverlay/etc/init.d/S26system
@@ -11,10 +11,14 @@ rb_volume_configure() {
     fi
 }
 
-rb_audio_configure() {
+batocera_audio_configure() {
     settingsAudio="`$systemsetting -command load -key audio.device`"
     if [[ "$settingsAudio" == "" ]];then
         settingsAudio="auto"
+    else
+        hw=$(echo $settingsAudio | cut -d' ' -f1)
+        sed 's/"hw:.*"/"hw:'$hw'"/' /etc/asound.conf > /tmp/asound_tmp
+        mv /tmp/asound_tmp /etc/asound.conf
     fi
     eval $config_script "audio" "$settingsAudio" >> $log
 }
@@ -127,7 +131,7 @@ case "$1" in
 	rb_gpio_configure&    # 0.9 start by the gpio while it's the longer
 	rb_keyboad_lang&      # 0.7
 	rb_xbox&              # 0.6
-	( rb_volume_configure ; rb_audio_configure ; rb_alsa_load) &  # 1.0
+	( rb_volume_configure ; batocera_audio_configure ; rb_alsa_load) &  # 1.0
 	rb_timezone&          # 0.4
 	rb_hostname&          # 0.4
 	rb_xarcade2jstick&    # 0.1
@@ -138,6 +142,7 @@ case "$1" in
         rb_alsa_save
 	;;
   restart|reload)
+	batocera_audio_configure
 	;;
   *)
 esac


### PR DESCRIPTION
Tested on x86_64, probably needs testing on other architectures. It fixes the problem when video snaps play, but without sound -- which is even more noticeable when you use the option to fade the ES background down when playing video snaps.