### PR TITLE
es-themes: Niced Terminal output

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -10,7 +10,7 @@
 # If you don't provide a <theme>, the list of themes available online will be returned back to you
 #
 CONFIGDIR="/userdata/themes"
-THEMESLIST="https://batocera.org/upgrades/themes.txt"
+THEMESLIST="https://updates.batocera.org/themes.txt"
 LOCALTHEMESLIST="/userdata/system/themes.txt"
 # themes.txt must be a plain file with the format 'theme_name https://githubURL' (spaces or tabs)
 # Example of a themes.txt file: 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -10,7 +10,7 @@
 # If you don't provide a <theme>, the list of themes available online will be returned back to you
 #
 CONFIGDIR="/userdata/themes"
-THEMESLIST="https://updates.batocera.org/themes.txt"
+THEMESLIST="https://batocera.org/upgrades/themes.txt"
 LOCALTHEMESLIST="/userdata/system/themes.txt"
 # themes.txt must be a plain file with the format 'theme_name https://githubURL' (spaces or tabs)
 # Example of a themes.txt file: 
@@ -109,18 +109,26 @@ function install_theme() {
 			gitname=$(git_name "$url")
 			cd "$CONFIGDIR"
 			filezip="${url}/archive/master.zip"
-			# get size to download (hack to get it from github)
-			size=$(curl -sfL https://api.github.com/repos/"$reponame"/"$gitname" | grep size | head -1 | tr -dc '[:digit:]')
-			size=$((size / 1024 ))
-			test $? -eq 0 || exit 1
-			touch "$gitname.zip"
-			getPer "$CONFIGDIR"/"$gitname.zip" "${size}" &
-			GETPERPID=$!
-			curl -sfL "${filezip}" -o "$gitname.zip" || exit 1
-			kill -9 "${GETPERPID}" >/dev/null 2>/dev/null
-			GETPERPID=
-			if [ -f "$gitname.zip" ]; then 
-				echo "Unzipping $gitname theme files >>> 99%"
+
+			if [ $TERMINAL = 0 ]; then
+				# get size to download (hack to get it from github)
+				size=$(curl -sfL https://api.github.com/repos/"$reponame"/"$gitname" | grep size | head -1 | tr -dc '[:digit:]')
+				size=$((size / 1024 ))
+				test $? -eq 0 || exit 1
+				touch "$gitname.zip"
+				getPer "$CONFIGDIR"/"$gitname.zip" "${size}" &
+				GETPERPID=$!
+				curl -sfL "${filezip}" -o "$gitname.zip" || exit 1
+				kill -9 "${GETPERPID}" >/dev/null 2>/dev/null
+				GETPERPID=
+			else
+				wget -q --show-progress "$filezip" -O "$gitname.zip" || exit 1
+				GETPERPID=
+			fi
+
+			if [ -f "$gitname.zip" ]; then
+				[ $TERMINAL = 1 ] && echo -e "Unzipping $gitname to:\t\t$PWD"
+				[ $TERMINAL = 0 ] && echo "Unzipping $gitname theme files >>> 99%"
 				[ -d "$CONFIGDIR"/"$gitname" ] && rm -rf "$CONFIGDIR"/"$gitname" 
 				unzip "$gitname.zip" >/dev/null
 				mv "$gitname-master" "$gitname"
@@ -134,7 +142,8 @@ function install_theme() {
 	done < "$tmp"
 	rm "$tmp"
 	if [ "$success_installed" == 1 ]; then
-		echo "Theme $theme is now installed >>> 100%"
+		[ $TERMINAL = 1 ] && echo -e "Theme $theme installed to:\t\t$PWD/$gitname"
+		[ $TERMINAL = 0 ] && echo "Theme $theme is now installed >>> 100%"
 		exit 0
 	else
 		echo "Error - theme $theme could not be found"
@@ -147,6 +156,9 @@ function install_theme() {
 command="$1"
 theme="$2"
 
+#Started from Terminal/SSH or from Emulationstation?
+[ -t 1 ] && TERMINAL=1 || TERMINAL=0
+
 if ! [ -d "$CONFIGDIR" ]; then
 	echo "Error - theme directory $CONFIGDIR is not valid."
 	exit 1
@@ -158,4 +170,3 @@ elif [ x"$command" == "xinstall" ]; then
 else 
 	usage	
 fi
-


### PR DESCRIPTION
This was a minimal invasive code change
thanks to @lbrpdx

Output in terminal is now
```
# batocera-es-theme install Minimal
es-theme-minimal.zi 100%[===================>]   6.15M  2.16MB/s    in 2.8s
Unzipping es-theme-minimal to:          /userdata/themes
Theme Minimal installed to:             /userdata/themes/es-theme-minimal
#
```