### PR TITLE
drop: batoceraSettings.py -> batocera-settings

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -80,7 +80,7 @@ mountDeviceOrFallback() {
     fi
 }
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 rb_wifi_configure() {
     X=$1
 

--- a/board/batocera/fsoverlay/etc/init.d/S26system
+++ b/board/batocera/fsoverlay/etc/init.d/S26system
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 config_script=batocera-config
 log="/userdata/system/logs/batocera.log"
 

--- a/board/batocera/fsoverlay/etc/init.d/S31sixad
+++ b/board/batocera/fsoverlay/etc/init.d/S31sixad
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 
 case "$1" in
   start)

--- a/board/batocera/fsoverlay/etc/init.d/S32bluetooth
+++ b/board/batocera/fsoverlay/etc/init.d/S32bluetooth
@@ -3,7 +3,7 @@
 # Auto connect bluetooth controllers
 #
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 
 case "$1" in
   start)

--- a/board/batocera/fsoverlay/etc/init.d/S35securepasswd
+++ b/board/batocera/fsoverlay/etc/init.d/S35securepasswd
@@ -5,7 +5,7 @@ then
   exit 0
 fi
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 
 # /etc/shadow is dynamically generated from the password found in /boot/batocera-boot.conf
 # the password is visible only in the es interface

--- a/board/batocera/fsoverlay/etc/init.d/S91smb
+++ b/board/batocera/fsoverlay/etc/init.d/S91smb
@@ -3,7 +3,7 @@
 # Stolen from RedHat FC5.
 #
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 securityenabled="`$systemsetting  -command load -key system.security.enabled`"
 
 if [ "$securityenabled" == "1" ];then

--- a/board/batocera/odroidgoa/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/odroidgoa/fsoverlay/etc/init.d/S31emulationstation
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
                 batocera-resolution minTomaxResolution

--- a/board/batocera/rock960/fsoverlay/etc/init.d/S32bluetooth
+++ b/board/batocera/rock960/fsoverlay/etc/init.d/S32bluetooth
@@ -3,7 +3,7 @@
 # Auto connect bluetooth controllers
 #
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 btTar=/userdata/system/bluetooth/bluetooth.tar
 
 case "$1" in

--- a/board/batocera/rockpro64/fsoverlay/etc/init.d/S32bluetooth
+++ b/board/batocera/rockpro64/fsoverlay/etc/init.d/S32bluetooth
@@ -3,7 +3,7 @@
 # Auto connect bluetooth controllers
 #
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 
 case "$1" in
   start)

--- a/board/batocera/rpi/fsoverlay/etc/init.d/S32bluetooth
+++ b/board/batocera/rpi/fsoverlay/etc/init.d/S32bluetooth
@@ -3,7 +3,7 @@
 # Auto connect bluetooth controllers
 #
 
-systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+systemsetting="batocera-settings"
 
 case "$1" in
   start)

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_1cpu
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
                 batocera-resolution minTomaxResolution

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_nosplash
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
                 batocera-resolution minTomaxResolution

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_splash
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
                 batocera-resolution minTomaxResolution

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbegl_nosplash
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
                 batocera-resolution minTomaxResolution

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_xorg
@@ -2,7 +2,7 @@
 
 case "$1" in
     start)
-	systemsetting="python /usr/lib/python2.7/site-packages/configgen/settings/batoceraSettings.py"
+	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
 		settings_lang="`$systemsetting -command load -key system.language`"


### PR DESCRIPTION
```
./board/batocera/fsoverlay/etc/init.d/S31sixad
./board/batocera/fsoverlay/etc/init.d/S91smb
./board/batocera/fsoverlay/etc/init.d/S11share
./board/batocera/fsoverlay/etc/init.d/S26system
./board/batocera/fsoverlay/etc/init.d/S32bluetooth
./board/batocera/fsoverlay/etc/init.d/S35securepasswd
./board/batocera/odroidgoa/fsoverlay/etc/init.d/S31emulationstation
./board/batocera/rock960/fsoverlay/etc/init.d/S32bluetooth
./board/batocera/rockpro64/fsoverlay/etc/init.d/S32bluetooth
./board/batocera/rpi/fsoverlay/etc/init.d/S32bluetooth

./package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbegl_nosplash
./package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_xorg
./package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_splash
./package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_1cpu
./package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_nosplash
```