### PR TITLE
PSX patch to fix sound issue on Odroid XU4

### DIFF
--- a/package/batocera/core/batocera-system/xu4/batocera.conf
+++ b/package/batocera/core/batocera-system/xu4/batocera.conf
@@ -206,6 +206,14 @@ global.retroachievements.password=
 #snes.retroarch.menu_driver=rgui
 #global.retroarch.input_max_users=4
 
+# PSX patch to fix sound issue on Odroid XU4
+# 98% fixed for micro sound cut in game
+psx.retroarch.audio_latency=128
+psx.retroarch.audio_out_rate=44100
+psx.retroarch.audio_rate_control=true
+psx.retroarch.audio_sync=true
+psx.retroarch.video_hard_sync=true
+
 # scrapper
 # Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart
 #scrapper.style=s,b,f,a,l,3b


### PR DESCRIPTION
fix 98% of micro sound cut in game.
There will have only one cut at level start, when the race or the fight start, and after all is perfect.

Tested by many users from a long time on Batocera and Recallbox that use same LR emulator.
