### PR TITLE
disable xauth

### DIFF
--- a/board/batocera/patches/xapp_xinit/001-disable-xauth.patch
+++ b/board/batocera/patches/xapp_xinit/001-disable-xauth.patch
@@ -1,0 +1,13 @@
+diff --git a/startx.cpp b/startx.cpp
+index dbc4cae..8a0282e 100644
+--- a/startx.cpp
++++ b/startx.cpp
+@@ -126,7 +126,7 @@ if defaults read $X11_PREFS_DOMAIN 2> /dev/null | grep -q 'dpi' && defaults read
+ fi
+ 
+ #else
+-enable_xauth=1
++enable_xauth=0
+ #endif
+ 
+ XCOMM Automatically determine an unused $DISPLAY

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_xorg
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_xorg
@@ -6,7 +6,6 @@ case "$1" in
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
 		settings_lang="`$systemsetting -command load -key system.language`"
-		export XAUTHORITY=/var/lib/.Xauthority # needed because $HOME/.Xauthority can't be used on fat
 		# HOME is important to be able to call ~/.xinitrc
                 HOME=/userdata/system startx &
 	fi


### PR DESCRIPTION
should we do that or keep XAUTHORITY and just replace the default serverauth.$$ file path in /usr/bin/startx ?


was required because of fat:
export XAUTHORITY=/var/lib/.Xauthority # needed because $HOME/.Xauthority can't be used on fat

and files:
$HOME/serverauth.$$ where created and kept when you shutdown badly

and xauth is not required as far as i understand (i understand it is to protect against users having already a local access while X is not open on network (xauth+))

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>