### PR TITLE
clamcav integration VT

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S12antivirus
+++ b/board/batocera/fsoverlay/etc/init.d/S12antivirus
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+test $1 = "start" || exit 0
+
+# this action can take time depending on the number of roms of the user
+# this action is done at each boot
+# we may think to add a cache to make the scan faster (but we must do it in a secured crypted partition for security reason)
+
+if ! clamscan -r --bell --triple-pass --extended-checks /userdata
+then
+	echo "virus detected !" >/dev/tty1
+	sleep 10
+	shutdown -h now
+fi

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -54,6 +54,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_WPA_SUPPLICANT                    # wifi
     select BR2_PACKAGE_WPA_SUPPLICANT_CLI                # wifi
     select BR2_PACKAGE_WPA_SUPPLICANT_DBUS_INTROSPECTION # wifi
+    select BR2_PACKAGE_CLAMAV                            # antivirus
     select BR2_PACKAGE_RPI_FIRMWARE                      if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY # rpi firmwares
     select BR2_PACKAGE_RPI_WIFI_FIRMWARE                 if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY # rpi wifi firmware
     select BR2_PACKAGE_RPI_BT_FIRMWARE                   if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY # rpi bluetooth firmware


### PR DESCRIPTION
- at each boot, /userdata is scanned against virus/trojan added by the user having copied new roms
- zip are unzipped to check inside
- in a following pr, i will add an encrypted partition to store updated signatures and a cache to try to reduce
  the impact on the boot time
- i think to add a way to provide any way to disable it, including via batocera-saveoverlay to prevent the user security

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>