### PR TITLE
Fixed Dolphin resolution setting (from ES)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -86,9 +86,12 @@ class DolphinGenerator(Generator):
         dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
 
         if system.isOptSet('internalresolution'):
-            dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
+            try:
+                dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
+            except:
+                dolphinGFXSettings.set("Settings", "InternalResolution", "1")
         else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
+            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -84,14 +84,7 @@ class DolphinGenerator(Generator):
         # for to search for custom textures
         dolphinGFXSettings.set("Settings", "HiresTextures", "True")
         dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
-
-        if system.isOptSet('internalresolution'):
-            try:
-                dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
-            except:
-                dolphinGFXSettings.set("Settings", "InternalResolution", "1")
-        else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
+        dolphinGFXSettings.set("Settings", "InternalResolution", "0")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:


### PR DESCRIPTION
Previous change in 5.25 prevented to set resolution in ES. Should be fixed for good now.