### PR TITLE
Fix .md5 files to use "md5sum --check"

### DIFF
--- a/board/batocera/post-image-script.sh
+++ b/board/batocera/post-image-script.sh
@@ -563,7 +563,7 @@ for FILE in "${BATOCERA_BINARIES_DIR}/boot.tar.xz" "${BATOCERA_BINARIES_DIR}/bat
 do
 	echo "creating ${FILE}.md5"
 	CKS=$(md5sum "${FILE}" | sed -e s+'^\([^ ]*\) .*$'+'\1'+)
-	echo "${CKS}" > "${FILE}.md5"
+	echo "${CKS}  $(basename ${FILE})" > "${FILE}.md5"
 done
 
 # pcsx2 package

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -86,9 +86,12 @@ class DolphinGenerator(Generator):
         dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
 
         if system.isOptSet('internalresolution'):
-            dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
+            try:
+                dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
+            except:
+                dolphinGFXSettings.set("Settings", "InternalResolution", "1")
         else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
+            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -84,14 +84,7 @@ class DolphinGenerator(Generator):
         # for to search for custom textures
         dolphinGFXSettings.set("Settings", "HiresTextures", "True")
         dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
-
-        if system.isOptSet('internalresolution'):
-            try:
-                dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
-            except:
-                dolphinGFXSettings.set("Settings", "InternalResolution", "1")
-        else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
+        dolphinGFXSettings.set("Settings", "InternalResolution", "0")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -84,7 +84,11 @@ class DolphinGenerator(Generator):
         # for to search for custom textures
         dolphinGFXSettings.set("Settings", "HiresTextures", "True")
         dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
-        dolphinGFXSettings.set("Settings", "InternalResolution", "0")
+
+        if system.isOptSet('internalresolution'):
+            dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
+        else:
+            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
 
         # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:


### PR DESCRIPTION
Our previous `.md5` format was wrong. Now you can use
```
$ md5sum --check batocera-5.26-x86_64-20200402.img.gz.md5 
batocera-5.26-x86_64-20200402.img.gz: OK
```