### PR TITLE
Better volume balance between Retroarch and EmulationStation

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -63,6 +63,9 @@ def generateRetroarchCustom():
     retroarchSettings.save('video_gpu_screenshot',              '"true"')
     retroarchSettings.save('video_shader_enable',               '"false"')
     
+    # Audio
+    retroarchSettings.save('audio_volume',                       '"8.0"')
+    
     # Settings
     retroarchSettings.save('config_save_on_exit',               '"false"')
     retroarchSettings.save('savestate_auto_save',               '"false"')


### PR DESCRIPTION
While using Batocera, it seems to me that volume is "unbalanced" between games and the user UI.

Every time i play, i have to increase TV volume for better audio in-game. Replicating what other retrogaming [solutions](https://gitlab.com/recalbox/recalbox/-/commit/cc16ae92dba6fa6a9dc5ae3112fafae397044878) did by implementing some dB gain inside `retroarchcustom.cfg`, i suggest this little fix here.

Tested with Diablo(Playstation), Sunsetriders(SNES), Contra(NES) and Altered Beast(Genesis). Now sound seems better equalized :)