### PR TITLE
Avoid duplicate resolution lines when using optimus

### DIFF
--- a/board/batocera/x86/fsoverlay/usr/bin/batocera-resolution
+++ b/board/batocera/x86/fsoverlay/usr/bin/batocera-resolution
@@ -16,7 +16,7 @@ case "${ACTION}" in
 	xrandr --listModes | grep -E '\*$' | sed -e s+'\*$'++ | sed -e s+'\*$'++ -e s+'^[^ ]* '++
 	;;
     "currentResolution")
-	xrandr --currentResolution
+	xrandr --currentResolution | tail -n1
 	;;
     "listOutputs")
 	xrandr --listConnectedOutputs | sed -e s+"*$"++


### PR DESCRIPTION
Nvidia Optimus causes the OS to see two screens - one on the Intel adapter which is used for display output and one on the Nvidia adapter which is used for rendering the frames. So we have two lines returned from xrandr --currentResolution and one must be discarded. ES will not launch otherwise.