### PR TITLE
Disable building mesen-s for rpi architecture

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -440,7 +440,8 @@ config BR2_PACKAGE_BATOCERA_RETROARCH
         select BR2_PACKAGE_LIBRETRO_MESEN_S           if !BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA && \
                                                          !BR2_PACKAGE_BATOCERA_TARGET_ODROIDN2  && \
                                                          !BR2_PACKAGE_BATOCERA_TARGET_XU4       && \
-                                                         !BR2_PACKAGE_BATOCERA_TARGET_ROCKPRO64
+                                                         !BR2_PACKAGE_BATOCERA_TARGET_ROCKPRO64 && \
+							   !BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY
                                                          # MESEN-S
 
         ### Experimental Emulators ###


### PR DESCRIPTION
None of RPI systems if powerful to run mesen-s. For instance on my rpi3 Alladin games is running with ~30FPS (it should be running with 60FPS). Thus building mesen-s for RPI is pointless.