### PR TITLE
Default map L2 for shaking controller on Dolphin

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -53,12 +53,16 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
     extraOptions["Source"] = "1"
 
     # side wiimote
+    # l2 for shaking actions
     if ".side." in rom:
         extraOptions["Options/Sideways Wiimote"] = "1"
         wiiMapping['x']   = 'Buttons/B'
         wiiMapping['y'] = 'Buttons/A'
         wiiMapping['a']   = 'Buttons/2'
         wiiMapping['b'] = 'Buttons/1'
+        wiiMapping['l2'] = 'Shake/X'
+        wiiMapping['l2'] = 'Shake/Y'
+        wiiMapping['l2'] = 'Shake/Z'
 
 
     # i: infrared, s: swing, t: tilt, n: nunchuk


### PR DESCRIPTION
Title pretty much self-explaining. If someone has a rom with `.side.` on its name, no shake function is available. 

With this little hack, L2 is the main "shake" button while using this controller orientation (side wiimote) and it solves the problem that now i can play "New Super Mario - Wii" with my wife without losing too much time creating custom mappings :)

In some cases `Shake/X` should be enough but, i'm thinking on other games that want the shake on other directions. Maybe, split shake into `l2` and `r2` in a future when more games are tested.