### PR TITLE
Auto turn-off monitor during poweroff

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S61cec
+++ b/board/batocera/fsoverlay/etc/init.d/S61cec
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-systemsetting="batocera-settings"
-
 case "$1" in
+        start)
+                ;;
         stop)
-                enabled="`$systemsetting  -command load -key system.cec.standby`"
+                enabled="`batocera-settings -command load -key system.cec.standby`"
                 if [ "$enabled" == "1" ];then
                         echo standby 0 | cec-client -s -d 1 &
                 fi

--- a/board/batocera/fsoverlay/etc/init.d/S61cec
+++ b/board/batocera/fsoverlay/etc/init.d/S61cec
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+systemsetting="batocera-settings"
+
+case "$1" in
+        stop)
+                enabled="`$systemsetting  -command load -key system.cec.standby`"
+                if [ "$enabled" == "1" ];then
+                        echo standby 0 | cec-client -s -d 1 &
+                fi
+                ;;
+        *)
+                echo "Usage: $0 {stop} - turns off first monitor device"
+esac
+
+exit $?

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -107,6 +107,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 							    BR2_PACKAGE_BATOCERA_TARGET_TINKERBOARD || \
 							    BR2_PACKAGE_BATOCERA_TARGET_MIQI
     select BR2_PACKAGE_LIRC_TOOLS                        # lirc (remote control)
+    select BR2_PACKAGE_LIBCEC				 # libcec
     select BR2_SYSTEM_ENABLE_NLS                         # locales
     select BR2_PACKAGE_ACPID                             if BR2_PACKAGE_BATOCERA_TARGET_X86_ANY
     select BR2_PACKAGE_BATOCERA_DESKTOPAPPS              if BR2_PACKAGE_XSERVER_XORG_SERVER # batocera applications config and scripts

--- a/package/batocera/core/batocera-system/c2/batocera.conf
+++ b/package/batocera/core/batocera-system/c2/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/miqi/batocera.conf
+++ b/package/batocera/core/batocera-system/miqi/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/odroidgoa/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidgoa/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/odroidn2/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidn2/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/rock960/batocera.conf
+++ b/package/batocera/core/batocera-system/rock960/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/rockpro64/batocera.conf
+++ b/package/batocera/core/batocera-system/rockpro64/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/rpi1/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi1/batocera.conf
@@ -31,6 +31,9 @@
 ## Leave commented for the default usual behaviour
 #system.es.videomode=CEA 4 HDMI
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -31,6 +31,9 @@
 ## Leave commented for the default usual behaviour
 #system.es.videomode=CEA 4 HDMI
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/rpi3/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi3/batocera.conf
@@ -31,6 +31,9 @@
 ## Leave commented for the default usual behaviour
 #system.es.videomode=CEA 4 HDMI
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/s905/batocera.conf
+++ b/package/batocera/core/batocera-system/s905/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/s912/batocera.conf
+++ b/package/batocera/core/batocera-system/s912/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/tinkerboard/batocera.conf
+++ b/package/batocera/core/batocera-system/tinkerboard/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/x86_64/batocera.conf
+++ b/package/batocera/core/batocera-system/x86_64/batocera.conf
@@ -5,6 +5,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style
 ## default -> default all options menu
 ## none -> no menu except the game search menu

--- a/package/batocera/core/batocera-system/xu4/batocera.conf
+++ b/package/batocera/core/batocera-system/xu4/batocera.conf
@@ -10,6 +10,9 @@
 #   disable virtual gamepads
 #system.security.enabled=0
 
+## Send cec standby command to your first tv/monitor device during shutdown
+#system.cec.standy=1
+
 ## EmulationStation menu style 
 ## default -> default all options menu
 ## none -> no menu except the game search menu


### PR DESCRIPTION
Adding the script with stop action and `batocera.conf`for RPI3. Other boards will need test.

`cec-client -l` and `echo 'scan' | cec-client -s -d 1` should be enough to probe the hdmi connector and the Television/monitor your board is plugged