### PR TITLE
fix: filesize theme download

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -3,7 +3,7 @@
 # Download and install EmulationStation themes for Batocera
 #
 # @lbrpdx on Batocera Forums and Discord
-# @lala aka cyperghost on Discord
+# @cyperghost aka lala on Discord
 #
 # Usage:
 # batocera-es-theme 'list' or 'install <theme>' 
@@ -112,15 +112,15 @@ function install_theme() {
 			filezip="${url}/archive/master.zip"
 
 			if [ $TERMINAL = 0 ]; then
-               			# First hook to check theme and get a filsize (this works relieable but filesize is wrong)
+				# First hook to check theme and get a filsize (this works relieable but filesize is wrong)
 	                        size_json=$(curl -sfL "https://api.github.com/repos/${reponame}/${gitname}" | grep size | head -1 | tr -dc '[:digit:]')
         	                test $? -eq 0 || exit 1
 
 				# Attempt to get real filesize to download
-                        	# if after 20 attempts nothing happens we use old method
-                        	for i in {0..19}; do
+                        	# if after 100 attempts nothing happens we use old method
+                        	for i in {0..99}; do
 			    		size=$(curl -Is "https://codeload.github.com/${reponame}/${gitname}/zip/master" | grep Content-Length | cut -d ' ' -f2 | tr -d '\r')
-                            		[[ -z $size ]] && sleep 0.25 || { size=$((size / 1024 / 1024 )); break; }
+                            		[[ -z $size ]] || { size=$((size / 1024 / 1024 )); break; }
                         	done
 				# Fallback Option (old format), JSON hack
                         	[[ -z $size ]] && size=$((size_json / 1024 ))

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-theme
@@ -112,19 +112,18 @@ function install_theme() {
 			filezip="${url}/archive/master.zip"
 
 			if [ $TERMINAL = 0 ]; then
-				# First attempt to get size to download
-                        	# you need 2-3 times to get correct filesize
-                        	# if after 10 attempts nothing happens we use old method
-                        	for i in {0..9}; do
+               			# First hook to check theme and get a filsize (this works relieable but filesize is wrong)
+	                        size_json=$(curl -sfL "https://api.github.com/repos/${reponame}/${gitname}" | grep size | head -1 | tr -dc '[:digit:]')
+        	                test $? -eq 0 || exit 1
+
+				# Attempt to get real filesize to download
+                        	# if after 20 attempts nothing happens we use old method
+                        	for i in {0..19}; do
 			    		size=$(curl -Is "https://codeload.github.com/${reponame}/${gitname}/zip/master" | grep Content-Length | cut -d ' ' -f2 | tr -d '\r')
-                            		[[ -z $size ]] && sleep 0.2 || { size=$((size / 1024 / 1024 )); break; }
+                            		[[ -z $size ]] && sleep 0.25 || { size=$((size / 1024 / 1024 )); break; }
                         	done
-				# Second attempt (old format), JSON hack
-                        	if [[ -z $size ]]; then
-                            	size=$(curl -sfL "https://api.github.com/repos/${reponame}/${gitname}" | grep size | head -1 | tr -dc '[:digit:]')
-                            	size=$((size / 1024 ))
-			    	test $? -eq 0 || exit 1
-                        	fi
+				# Fallback Option (old format), JSON hack
+                        	[[ -z $size ]] && size=$((size_json / 1024 ))
 				touch "$gitname.zip"
 				getPer "$CONFIGDIR"/"$gitname.zip" "${size}" &
 				GETPERPID=$!
@@ -133,7 +132,6 @@ function install_theme() {
 				GETPERPID=
 			else
 				wget -q --show-progress "$filezip" -O "$gitname.zip" || exit 1
-				GETPERPID=
 			fi
 
 			if [ -f "$gitname.zip" ]; then


### PR DESCRIPTION
It could fail if themes got a huge download size (+100MB -- fixed now!)
This needs to be fixed in ES, too because in this cases there is now progress bar displayed (idk if this depends on the filesize only)
Code logic is more maintable now