### PR TITLE
Fixed capsimage git download

### DIFF
--- a/package/batocera/libraries/libcapsimage/libcapsimage.mk
+++ b/package/batocera/libraries/libcapsimage/libcapsimage.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBCAPSIMAGE_VERSION = 549b1955d52a70b9f7egie88a419f6ecfb6ee61142
+LIBCAPSIMAGE_VERSION = 549b195
 LIBCAPSIMAGE_SITE = https://github.com/simonowen/capsimage
 LIBCAPSIMAGE_SITE_METHOD = git
 


### PR DESCRIPTION
With the full GIT version for this new repo, I got an error at build time:
```
>>> libcapsimage 549b1955d52a70b9f7egie88a419f6ecfb6ee61142 Downloading
Reinitialized existing Git repository in /build/buildroot/dl/libcapsimage/git/.git/
Fetching all references
Could not fetch special ref '549b1955d52a70b9f7egie88a419f6ecfb6ee61142'; assuming it is not special.
Commit '549b1955d52a70b9f7egie88a419f6ecfb6ee61142' does not exist in this repository.
(...)
HTTP request sent, awaiting response... 404 Not Found
2020-04-20 01:44:54 ERROR 404: Not Found.
```
See https://github.com/batocera-linux/batocera.linux/commit/251e908eee347e66070f62ef004578d1df9f1380#commitcomment-38603517