### PR TITLE
Removed ugly warning in es_launch_stderr.log

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -68,11 +68,11 @@ class Emulator():
 
     @staticmethod
     def get_generic_config(system, defaultyml, defaultarchyml):
-        systems_default      = yaml.load(file(defaultyml,     "r"))
+        systems_default = yaml.load(file(defaultyml, "r"), Loader=yaml.FullLoader)
 
         systems_default_arch = {}
         if os.path.exists(defaultarchyml):
-            systems_default_arch = yaml.load(file(defaultarchyml, "r"))
+            systems_default_arch = yaml.load(file(defaultarchyml, "r"), Loader=yaml.FullLoader)
         dict_all = {}
 
         if "default" in systems_default:


### PR DESCRIPTION
Removed the warning message we systematically get at the beginning of `es_launch_srderr.log`:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details
```