### PR TITLE
Add ".sh" into Ports (for 3rd party games/apps)

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
+++ b/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
@@ -103,7 +103,7 @@ class EsSystemConf:
         platformValue  = EsSystemConf.systemPlatform(system, data)
         listExtensions = EsSystemConf.listExtension(data, True)
         groupValue     = EsSystemConf.systemGroup(system, data)
-        command        = EsSystemConf.default_command
+        command        = EsSystemConf.commandName(data)
 
         systemTxt =  "  <system>\n"
         systemTxt += "        <fullname>%s</fullname>\n" % (data["name"])
@@ -163,6 +163,13 @@ class EsSystemConf:
         if "theme" in data:
           return data["theme"]
         return system
+
+    # In case you need to specify a different command line 
+    @staticmethod
+    def commandName(data):
+        if "command" in data:
+          return data["command"]
+        return EsSystemConf.default_command
 
     # Create the folders of the consoles in the roms folder
     @staticmethod

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1040,6 +1040,18 @@ lightgun:
           Un exemple de setup qui fonctionne est si vous utilisez une DolphinBar en 'mode 2' (mode jeu clavier/souris) avec une Wiimote comme flingue.
           Si vous avez plus d'une souris installee, assurez-vous que la DolphinBar / Wiimote soit reconnue comme une des deux premieres.
 
+ports:
+  name:       Ports
+  extensions: [sh]
+  group: ports
+  path:       /userdata/roms/ports
+  command:    "%ROM%"
+  force:      True
+  comment_en: |
+          Third party Linux games and apps that can be run from a .sh script.
+  comment_fr: |
+          Jeux et applications Linux additionnels qui peuvent etre lancés depuis un script .sh.
+
 imageviewer:
   name:       Screenshots
   extensions: [jpg, jpeg, png, bmp, psd, tga, gif, hdr, pic, ppm, pgm, mkv]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1045,7 +1045,7 @@ ports:
   extensions: [sh]
   group: ports
   path:       /userdata/roms/ports
-  command:    "%ROM%"
+  command:    "/bin/sh %ROM%"
   force:      True
   comment_en: |
           Third party Linux games and apps that can be run from a .sh script.


### PR DESCRIPTION
In order to add Linux games and apps that can be run from a .sh script. There is a whole community of Batocera users who are using these, and the result is a new section in `es_systems.cfg`: 
```
  <system>
        <fullname>Ports</fullname>
        <name>ports</name>
        <path>/userdata/roms/ports</path>
        <extension>.sh .SH</extension>
        <command>%ROM%</command>
        <platform>ports</platform>
        <theme>ports</theme>
        <group>ports</group>
  </system>
```
Might be useful for Wine games too -- I'm not sure we want to get into the full `emulatorlauncher.py` for Wine either.
