### PR TITLE
Add ".sh" into Ports - added %CONTROLLERSCONFIG% argument

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1051,7 +1051,7 @@ ports:
   extensions: [sh]
   group: ports
   path:       /userdata/roms/ports
-  command:    "/bin/sh %ROM%"
+  command:    "/bin/sh %ROM% %CONTROLLERSCONFIG%"
   force:      True
   comment_en: |
           Third party Linux games and apps that can be run from a .sh script.


### PR DESCRIPTION
We can use libretro cores now and call them via shell file

example for 

"QUAKE called by shell file.sh"
```
#!/bin/bash
controller=$@
python /usr/lib/python2.7/site-packages/configgen/emulatorlauncher.py $controller -system tyrquake -rom /userdata/roms/tyrquake/id1/PAK0.PAK
```