### PR TITLE
ozone: video_driver

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -64,7 +64,6 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
 
     # basic configuration
     retroarchConfig['quit_press_twice'] = 'false'            # not aligned behavior on other emus
-    retroarchConfig['video_driver'] = ''                     # keep the default one, always the best
     retroarchConfig['video_black_frame_insertion'] = 'false' # don't use anymore this value while it doesn't allow the shaders to work
     retroarchConfig['pause_nonactive'] = 'false'             # required at least on x86 x86_64 otherwise, the game is paused at launch
     retroarchConfig['cache_directory'] = '/userdata/system/.cache'


### PR DESCRIPTION
If video_driver = ' ', Retroarch's ozone theme does not work.