### PR TITLE
xa: version bump (2.3.11)

### DIFF
--- a/package/batocera/utils-host/xa/xa.mk
+++ b/package/batocera/utils-host/xa/xa.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 
-XA_VERSION = 2.3.10
+XA_VERSION = 2.3.11
 XA_SOURCE=xa-$(XA_VERSION).tar.gz
 XA_SITE = https://www.floodgap.com/retrotech/xa/dists
 


### PR DESCRIPTION
xa-2.3.10.tar.gz moved to https://www.floodgap.com/retrotech/xa/dists/unsupported/, so download fails. Should we bump the version or point to the unsupported one?