### PR TITLE
bump retroarch

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -3,8 +3,8 @@
 # retroarch
 #
 ################################################################################
-# Version.: Commits on May 05, 2020
-RETROARCH_VERSION = v1.8.6
+# Version.: Commits on May 09, 2020
+RETROARCH_VERSION = df3af35ee46fdd91dec7ef51d9b4493802b9ea56
 RETROARCH_SITE = $(call github,libretro,RetroArch,$(RETROARCH_VERSION))
 RETROARCH_LICENSE = GPLv3+
 RETROARCH_DEPENDENCIES = host-pkgconf dejavu retroarch-assets flac


### PR DESCRIPTION
With 1.8.6 retroarch I encountered problem with run-ahead and eg. snes9x -- emulation is very slow (30fps).
This version is 4 days ahead and works fine.