### PR TITLE
fix: WIFI list support for whitespace in SSID

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | awk -F 'wifi_' '{print $1}' | sed 's/^...\s//;s/ *$//'
+    connmanctl services | awk -F 'wifi_' '{print $1}' | sed 's/^...\s*//;s/\s*$//'
 }
 
 do_scanlist() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,9 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services |
-	grep -E "^... [^ ]* [ ]* wifi_.*$" |
-	sed -e s+"^... \([^ ]*\) [ ]* wifi_.*$"+"\1"+
+    connmanctl services | awk -F\wifi_ '{print $1}' | sed 's/^....//;s/ *$//'
 }
 
 do_scanlist() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | awk -F\wifi_ '{print $1}' | sed 's/^....//;s/ *$//'
+    connmanctl services | awk -F 'wifi_' '{print $1}' | sed 's/^...\s//;s/ *$//'
 }
 
 do_scanlist() {
@@ -45,8 +45,7 @@ do_disable() {
 }
 
 do_start() {
-    systemsetting="batocera-settings"
-    settingsWlan="`$systemsetting -command load -key wifi.enabled`"
+    settingsWlan="$(batocera-settings -command load -key wifi.enabled)"
     if [ "$settingsWlan" != "1" ];then
         return 0
     fi


### PR DESCRIPTION
Now supports whitespaces in names
Smoother toolchain used ;)

```
Vodafone Homespot
KabelBox-8D70
Vodafone Hotspot
FRITZ!Box Schnegge
FRITZ!Box 7362 SL
```