### PR TITLE
fix: WiFi SSID whitespace fix and wifi_xyz fix

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*.wifi_' '{if (NF==2) print $1}'
+    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]wifi_' '{if (NF==2) print $1}'
 }
 
 do_scanlist() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*[ ]wifi_' '{if (NF==2) print $1}'
+    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*[ ].wifi_' '{if (NF==2) print $1}'
 }
 
 do_scanlist() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | awk -F 'wifi_' '{print $1}' | sed 's/^...\s*//;s/\s*$//'
+    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*.wifi_' '{if (NF==2) print $1}'
 }
 
 do_scanlist() {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]wifi_' '{if (NF==2) print $1}'
+    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*[ ]wifi_' '{if (NF==2) print $1}'
 }
 
 do_scanlist() {


### PR DESCRIPTION
First fix was able to break if SSID was `wifi_123` for example
This is fixed now!
Whitespaces works, too

```
wifi_5
Guest_wifi_5
wifi_5 Guest
Vodafone Homespot
KabelBox-8D70
Vodafone Hotspot
FRITZ!Box Schnegge
FRITZ!Box 7362 SL
```