### PR TITLE
fix: WiFi SSID list whitespace and wifi_

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -9,7 +9,7 @@ do_help() {
 }
 
 do_list() {
-    connmanctl services | awk -F 'wifi_' '{print $1}' | sed 's/^...\s*//;s/\s*$//'
+    connmanctl services | sed 's/^...[ ]*//' | awk -F '[ ]*[ ]wifi_[[:alnum:]]*_' '{if (NF==2) print $1}'
 }
 
 do_scanlist() {


### PR DESCRIPTION
This finally works.

1. SSID can contain Whitespaces
2. SSID can be maximazed (32 chars!)
3. Support of special signs like !?=
4. wifi_xyz support and variants like (name-wifi_5, name_wifi_5....)

If everything fails the script checks number of colums (=only a single seperator is used). If the colums are not 2 then there is not print of SSID.

Combo fail: `guest wifi_5_super_super` 
Combo works: `guest_wifi_5_super_super`

But to be hones ... the combo `whitespace+wifi_foo_` should not be very common ;)