### PR TITLE
Fix for 5.26: X68000 drives boot order

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -112,6 +112,9 @@ def generateCoreSettings(retroarchCore, system):
     if (system.config['core'] == 'dosbox'):
         coreSettings.save('dosbox_svn_pcspeaker', '"true"')
 
+    if (system.config['core'] == 'px68k'):
+        coreSettings.save('px68k_disk_path', '"disabled"')
+
     if (system.config['core'] == 'pcsx_rearmed'):
         for n in range(1, 8+1):
             val = coreSettings.load('pcsx_rearmed_pad{}type'.format(n))


### PR DESCRIPTION
Fix for the bug reported at https://forum.batocera.org/d/3790-batoceralinux-526-rc1/20 