### PR TITLE
amigacd32 removed zip extension

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -73,7 +73,7 @@ amiga1200:
 
 amigacd32:
   name:       Amiga CD32
-  extensions: [iso, cue, zip, lha]
+  extensions: [iso, cue, lha]
   emulators:
     fsuae:
       CD32:   { requireAnyOf: [BR2_PACKAGE_FSUAE]         }


### PR DESCRIPTION
Amiberry emulator does not support zip for Amiga CD32