### PR TITLE
Wine improvements

### DIFF
--- a/board/batocera/doWinepackage.sh
+++ b/board/batocera/doWinepackage.sh
@@ -149,6 +149,7 @@ cp "${G_TARGETDIR}/usr/lib/libGLX_mesa"* "${TMPOUT}/lib32"
 echo "binaries..."
 mkdir -p "${TMPOUT}/usr/bin"                           || exit 1
 echo " wine binaries"
+cp -p "${G_TARGETDIR}/usr/bin/cabextract"          "${TMPOUT}/usr/bin/" || exit 1
 cp -p "${G_TARGETDIR}/usr/bin/wine"*          "${TMPOUT}/usr/bin/" || exit 1
 cp -p "${G_TARGETDIR}/usr/bin/mono"*          "${TMPOUT}/usr/bin/" || exit 1
 cp -p "${G_TARGETDIR}/usr/bin/gst"*          "${TMPOUT}/usr/bin/" || exit 1

--- a/board/batocera/doWinepackage.sh
+++ b/board/batocera/doWinepackage.sh
@@ -12,6 +12,17 @@ findDeps() {
     local DEP=
     local DEPDIR=
 
+    # Skip useless libs
+    if grep -q libndr "${FILE}"; then
+        return 0
+    fi
+    if grep -q libnss "${FILE}"; then
+        return 0
+    fi
+    if grep -q libsamba "${FILE}"; then
+        return 0
+    fi
+
     if ! basicLdd "${FILE}" |
     while read DEP
     do
@@ -66,6 +77,10 @@ if ! rm -rf "${TMPOUT}"
 then
     exit 1
 fi
+if ! mkdir -p "${TMPOUT}/usr/lib"
+then
+    exit 1
+fi
 if ! mkdir -p "${TMPOUT}/lib32"
 then
     exit 1
@@ -74,24 +89,59 @@ if ! mkdir -p "${TMPOUT}/lib32/wine"
 then
     exit 1
 fi
+if ! mkdir -p "${TMPOUT}/lib32/mono"
+then
+    exit 1
+fi
+if ! mkdir -p "${TMPOUT}/lib32/gstreamer-1.0"
+then
+    exit 1
+fi
 if ! mkdir -p "${TMPOUT}/usr/share/wine"
+then
+    exit 1
+fi
+if ! mkdir -p "${TMPOUT}/usr/share/mono-2.0"
+then
+    exit 1
+fi
+if ! mkdir -p "${TMPOUT}/usr/share/libgc-mono"
+then
+    exit 1
+fi
+if ! mkdir -p "${TMPOUT}/usr/share/gst-plugins-base"
+then
+    exit 1
+fi
+if ! mkdir -p "${TMPOUT}/usr/share/gstreamer-1.0"
 then
     exit 1
 fi
 
 # libs32
 echo "libs..."
-for BIN in "${G_TARGETDIR}/usr/bin/wine"* \
-"${G_TARGETDIR}/usr/lib/libwine"*.so \
+for BIN in "${G_TARGETDIR}/usr/bin/wine" \
+"${G_TARGETDIR}/usr/bin/wineserver" \
+"${G_TARGETDIR}/usr/lib/"*.so \
 "${G_TARGETDIR}/usr/lib/wine/"*.so \
+"${G_TARGETDIR}/usr/lib/gstreamer-1.0/"*.so \
 "${G_TARGETDIR}/usr/lib/libEGL_mesa"* \
 "${G_TARGETDIR}/usr/lib/libGLX_mesa"*
 do
     findDeps "${BIN}" "${TMPOUT}/lib32" || exit 1
 done
-cp -p "${G_TARGETDIR}/usr/lib/libwine"* "${TMPOUT}/lib32"
+cp -p "${G_TARGETDIR}/usr/lib/"* "${TMPOUT}/lib32" 2>/dev/null
 cp -pr "${G_TARGETDIR}/usr/lib/wine/"* "${TMPOUT}/lib32/wine"
+cp -pr "${G_TARGETDIR}/usr/lib/mono/"* "${TMPOUT}/lib32/mono"
+cp -pr "${G_TARGETDIR}/usr/lib/gstreamer-1.0/"* "${TMPOUT}/lib32/gstreamer-1.0"
 cp -pr "${G_TARGETDIR}/usr/share/wine/"* "${TMPOUT}/usr/share/wine"
+cp -pr "${G_TARGETDIR}/usr/share/mono-2.0/"* "${TMPOUT}/usr/share/mono-2.0"
+cp -pr "${G_TARGETDIR}/usr/share/libgc-mono/"* "${TMPOUT}/usr/share/libgc-mono"
+cp -pr "${G_TARGETDIR}/usr/share/gst-plugins-base/"* "${TMPOUT}/usr/share/gst-plugins-base"
+cp -pr "${G_TARGETDIR}/usr/share/gstreamer-1.0/"* "${TMPOUT}/usr/share/gstreamer-1.0"
+ln -s /lib32/wine "${TMPOUT}/usr/lib/wine"
+ln -s /lib32/mono "${TMPOUT}/usr/lib/mono"
+ln -s /lib32/gstreamer-1.0 "${TMPOUT}/usr/lib/gstreamer-1.0"
 cp "${G_TARGETDIR}/usr/lib/libEGL_mesa"* "${TMPOUT}/lib32"
 cp "${G_TARGETDIR}/usr/lib/libGLX_mesa"* "${TMPOUT}/lib32"
 
@@ -100,6 +150,8 @@ echo "binaries..."
 mkdir -p "${TMPOUT}/usr/bin"                           || exit 1
 echo " wine binaries"
 cp -p "${G_TARGETDIR}/usr/bin/wine"*          "${TMPOUT}/usr/bin/" || exit 1
+cp -p "${G_TARGETDIR}/usr/bin/mono"*          "${TMPOUT}/usr/bin/" || exit 1
+cp -p "${G_TARGETDIR}/usr/bin/gst"*          "${TMPOUT}/usr/bin/" || exit 1
 
 # dri
 echo "dri..."

--- a/package/batocera/emulators/wine-x86/wine-x86.mk
+++ b/package/batocera/emulators/wine-x86/wine-x86.mk
@@ -9,8 +9,20 @@ WINE_X86_VERSION = $(BATOCERA_SYSTEM_VERSION)
 WINE_X86_SOURCE = wine-x86-$(WINE_X86_VERSION).tar.gz
 WINE_X86_SITE = https://github.com/rtissera/wine-x86/releases/download/$(WINE_X86_VERSION)
 
+# Wine Mono addon (required)
+WINE_MONO_VERSION = 4.9.4
+WINE_MONO_SOURCE = wine-mono-bin-$(WINE_MONO_VERSION).tar.gz
+WINE_MONO_SITE = https://dl.winehq.org/wine/wine-mono/$(WINE_MONO_VERSION)/$(WINE_MONO_SOURCE)
+
+# Wine Gecko addon (required)
+WINE_GECKO_VERSION = 2.47.1
+WINE_GECKO_SOURCE = wine-gecko-$(WINE_GECKO_VERSION)-x86.tar.bz2
+WINE_GECKO_SITE = https://dl.winehq.org/wine/wine-gecko/$(WINE_GECKO_VERSION)/$(WINE_GECKO_SOURCE)
+
 define WINE_X86_EXTRACT_CMDS
 	mkdir -p $(@D)/target && cd $(@D)/target && tar xf $(DL_DIR)/$(WINE_X86_DL_SUBDIR)/$(WINE_X86_SOURCE)
+	mkdir -p $(@D)/target/usr/share/wine/mono && cd $(@D)/target/usr/share/wine/mono && wget -qO- $(WINE_MONO_SITE) | tar -xzf -
+	mkdir -p $(@D)/target/usr/share/wine/gecko && cd $(@D)/target/usr/share/wine/gecko && wget -qO- $(WINE_GECKO_SITE) | tar -xjf -
 endef
 
 define WINE_X86_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Notes :

It's still unclear if wine-mono requires a native Linux Mono runtime, so we might be able to strip need at a later stage to save space and useless package.

GStreamer is a hit or miss depending of formats since it relies on libav which is compiled in GPL mode so without most MS codecs like ASF, WMV and so on....