### PR TITLE
bump: retroarch to v1.8.8

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-beetle-psx/libretro-beetle-psx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-beetle-psx/libretro-beetle-psx.mk
@@ -3,8 +3,8 @@
 # LIBRETRO_BEETLE_PSX
 #
 ################################################################################
-# Version.: Commits on Apr 23, 2020
-LIBRETRO_BEETLE_PSX_VERSION = 9e0e95bc2b5f51c467e91defcbb09d7602ce4bc6
+# Version.: Commits on May 26, 2020
+LIBRETRO_BEETLE_PSX_VERSION = 12014e1f317ae8bda1c9ccce319d9dd78f253d2f
 LIBRETRO_BEETLE_PSX_SITE = $(call github,libretro,beetle-psx-libretro,$(LIBRETRO_BEETLE_PSX_VERSION))
 LIBRETRO_BEETLE_PSX_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-bluemsx/libretro-bluemsx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bluemsx/libretro-bluemsx.mk
@@ -3,8 +3,8 @@
 # BLUEMSX
 #
 ################################################################################
-# Version.: Commits on Jan 06, 2020
-LIBRETRO_BLUEMSX_VERSION = aace4ae8acf5dbe8b02e6fb49b703fdcb6c5603a
+# Version.: Commits on May 7, 2020
+LIBRETRO_BLUEMSX_VERSION = 1d441d908e73cf0fa7f52c42686f6c9e8cd254ed
 LIBRETRO_BLUEMSX_SITE = $(call github,libretro,blueMSX-libretro,$(LIBRETRO_BLUEMSX_VERSION))
 LIBRETRO_BLUEMSX_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox/libretro-dosbox.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox/libretro-dosbox.mk
@@ -3,8 +3,8 @@
 # DOSBOX
 #
 ################################################################################
-# Version.: Commits on May 2, 2020
-LIBRETRO_DOSBOX_VERSION = e45cafa9060916574b193b670032240f6948b84e
+# Version.: Commits on May 24, 2020
+LIBRETRO_DOSBOX_VERSION = 10e05343c044e7a1bd389a05be4a0b1d24480e5e
 LIBRETRO_DOSBOX_SITE = https://github.com/libretro/dosbox-svn.git
 LIBRETRO_DOSBOX_SITE_METHOD=git
 LIBRETRO_DOSBOX_GIT_SUBMODULES=YES

--- a/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
@@ -3,8 +3,8 @@
 # FBNEO
 #
 ################################################################################
-# Version.: Commits on Apr 30, 2020
-LIBRETRO_FBNEO_VERSION = d172888b6637b5c2b383bf44d9767dc8523cad37
+# Version.: Commits on May 27, 2020
+LIBRETRO_FBNEO_VERSION = 1573fcd6d7d2ff9be781f8107f146cb6233c81b5
 LIBRETRO_FBNEO_SITE = $(call github,libretro,FBNeo,$(LIBRETRO_FBNEO_VERSION))
 LIBRETRO_FBNEO_LICENSE = Non-commercial
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
@@ -3,8 +3,8 @@
 # FCEUMM
 #
 ################################################################################
-# Version.: Commits on Mar 25, 2020
-LIBRETRO_FCEUMM_VERSION = 0d569e9bab054f215f828184c1d63fa69f8abd0c
+# Version.: Commits on May 20, 2020
+LIBRETRO_FCEUMM_VERSION = f11f3afbd6a8a54f0656708cdd2b8398f1da6a9b
 LIBRETRO_FCEUMM_SITE = $(call github,libretro,libretro-fceumm,$(LIBRETRO_FCEUMM_VERSION))
 LIBRETRO_FCEUMM_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-flycast/libretro-flycast.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-flycast/libretro-flycast.mk
@@ -3,8 +3,8 @@
 # LIBRETRO-FLYCAST
 #
 ################################################################################
-# Version.: Commits on May 9, 2020
-LIBRETRO_FLYCAST_VERSION = 6b341667e88581c65cb5d4ad200cf3df665b2a35
+# Version.: Commits on May 27, 2020
+LIBRETRO_FLYCAST_VERSION = acd770b3400247186dec2e7e2772a3580a124ee5
 LIBRETRO_FLYCAST_SITE = $(call github,libretro,flycast,$(LIBRETRO_FLYCAST_VERSION))
 LIBRETRO_FLYCAST_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-fuse/libretro-fuse.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fuse/libretro-fuse.mk
@@ -3,8 +3,8 @@
 # FUSE
 #
 ################################################################################
-# Version.: Commits on Feb 07, 2020
-LIBRETRO_FUSE_VERSION = ef603d165914afc3f54971d082e69adea187c8ec
+# Version.: Commits on May 5, 2020
+LIBRETRO_FUSE_VERSION = c2f03e6f08f3e2a03d7888fe756e0beb7979f983
 LIBRETRO_FUSE_SITE = $(call github,libretro,fuse-libretro,$(LIBRETRO_FUSE_VERSION))
 LIBRETRO_FUSE_LICENSE = GPLv3
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-kronos/libretro-kronos.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-kronos/libretro-kronos.mk
@@ -3,8 +3,8 @@
 # LIBRETRO-KRONOS
 #
 ################################################################################
-# Version.: Commits on May 2, 2020
-LIBRETRO_KRONOS_VERSION = 9c92b211295997e8f4cd8070da0a26ba31b19fa3
+# Version.: Commits on May 27, 2020
+LIBRETRO_KRONOS_VERSION = 95a6176d9c059f8cce87a8aff8e25e98ef9d94a7
 LIBRETRO_KRONOS_SITE = $(call github,libretro,yabause,$(LIBRETRO_KRONOS_VERSION))
 LIBRETRO_KRONOS_LICENSE = BSD-3-Clause
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
@@ -3,8 +3,8 @@
 # MAME2003 PLUS
 #
 ################################################################################
-# Version.: Commits on Jan 18, 2020
-LIBRETRO_MAME2003_PLUS_VERSION = 123e0ecb3684afb48feb471c67f6c5ea0456817a
+# Version.: Commits on May 24, 2020
+LIBRETRO_MAME2003_PLUS_VERSION = 8242007805b4e382c9dca3198957c9c62d0e273e
 LIBRETRO_MAME2003_PLUS_SITE = $(call github,libretro,mame2003-plus-libretro,$(LIBRETRO_MAME2003_PLUS_VERSION))
 LIBRETRO_MAME2003_PLUS_LICENSE = MAME
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame2010/libretro-mame2010.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame2010/libretro-mame2010.mk
@@ -3,8 +3,8 @@
 # MAME2010
 #
 ################################################################################
-# Version.: Commits on Nov 7, 2019
-LIBRETRO_MAME2010_VERSION = d3151837758eade73c85c28c20e7d2a8706f30c6
+# Version.: Commits on May 24, 2020
+LIBRETRO_MAME2010_VERSION = bef96188e7276422eab81b44b41361896885bae5
 LIBRETRO_MAME2010_SITE = $(call github,libretro,mame2010-libretro,$(LIBRETRO_MAME2010_VERSION))
 LIBRETRO_MAME2010_LICENSE = MAME
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mgba/libretro-mgba.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mgba/libretro-mgba.mk
@@ -3,8 +3,8 @@
 # MGBA
 #
 ################################################################################
-# Version.: Commits on Feb 06, 2020
-LIBRETRO_MGBA_VERSION = 042aced46020ab3553aaa87a7527734b88c0dbad
+# Version.: Commits on May 20, 2020
+LIBRETRO_MGBA_VERSION = 7ad318f5f683b447db7bd8ef4a7a8f3570e8eca9
 LIBRETRO_MGBA_SITE = $(call github,libretro,mgba,$(LIBRETRO_MGBA_VERSION))
 LIBRETRO_MGBA_LICENSE = MPLv2.0
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mrboom/libretro-mrboom.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mrboom/libretro-mrboom.mk
@@ -3,9 +3,11 @@
 # MRBOOM
 #
 ################################################################################
-# Version.: Commits on Apr 2, 2020
-LIBRETRO_MRBOOM_VERSION = b974ce0ae13a8a85835351670d64ca7cb16e7bbc
-LIBRETRO_MRBOOM_SITE = $(call github,libretro,mrboom-libretro,$(LIBRETRO_MRBOOM_VERSION))
+# Version.: Commits on May 2, 2020
+LIBRETRO_MRBOOM_VERSION = 441ba41151f2a688c6d9a2c1a34ff2106d8c57f8
+LIBRETRO_MRBOOM_SITE = https://github.com/libretro/mrboom-libretro.git
+LIBRETRO_MRBOOM_SITE_METHOD=git
+LIBRETRO_MRBOOM_GIT_SUBMODULES=YES
 LIBRETRO_MRBOOM_LICENSE="GPLv2"
 
 ifeq ($(BR2_ARM_FPU_NEON_VFPV4)$(BR2_ARM_FPU_NEON)$(BR2_ARM_FPU_NEON_FP_ARMV8),y)

--- a/package/batocera/emulators/retroarch/libretro/libretro-mupen64plus-next/000-makefile.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mupen64plus-next/000-makefile.patch
@@ -1,7 +1,16 @@
 diff --git a/Makefile b/Makefile
-index 70db857..e3f9413 100644
+index 70db857..840d4fe 100644
 --- a/Makefile
 +++ b/Makefile
+@@ -185,7 +185,7 @@ else ifneq (,$(findstring odroid64,$(platform)))
+    TARGET := $(TARGET_NAME)_libretro.so
+    LDFLAGS += -shared -Wl,--version-script=$(LIBRETRO_DIR)/link.T -Wl,--no-undefined
+    BOARD ?= $(shell cat /proc/cpuinfo | grep -i odroid | awk '{print $$3}')
+-   GLES = 1
++   GLES3 = 1
+    GL_LIB := -lGLESv2
+    WITH_DYNAREC := aarch64
+    ifneq (,$(findstring C2,$(BOARD)))
 @@ -222,6 +222,9 @@ else ifneq (,$(findstring odroid,$(platform)))
        else
           CPUFLAGS += -mcpu=cortex-a9 -mfpu=neon

--- a/package/batocera/emulators/retroarch/libretro/libretro-neocd/libretro-neocd.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-neocd/libretro-neocd.mk
@@ -4,8 +4,8 @@
 # NEOCD
 #
 ################################################################################
-# Version.: Commits on Apr 22, 2020
-LIBRETRO_NEOCD_VERSION = 9565de1a9f37b13b7626a308aa87f6432879e4e1
+# Version.: Commits on May 14, 2020
+LIBRETRO_NEOCD_VERSION = e58c46d1653a4a309767ba286f19abdbdcbb7f87
 LIBRETRO_NEOCD_SITE = https://github.com/libretro/neocd_libretro.git
 LIBRETRO_NEOCD_SITE_METHOD=git
 LIBRETRO_NEOCD_GIT_SUBMODULES=YES

--- a/package/batocera/emulators/retroarch/libretro/libretro-nestopia/libretro-nestopia.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-nestopia/libretro-nestopia.mk
@@ -3,8 +3,8 @@
 # NESTOPIA
 #
 ################################################################################
-# Version.: Commits on Jan 22, 2020
-LIBRETRO_NESTOPIA_VERSION = 70c53f08c0cc92e90d095d6558ab737ce20431ac
+# Version.: Commits on May 10, 2020
+LIBRETRO_NESTOPIA_VERSION = 357e1463a01fe2ca0dd91941aacaaa9944f95e4d
 LIBRETRO_NESTOPIA_SITE = $(call github,libretro,nestopia,$(LIBRETRO_NESTOPIA_VERSION))
 LIBRETRO_NESTOPIA_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-o2em/libretro-o2em.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-o2em/libretro-o2em.mk
@@ -3,8 +3,8 @@
 # O2EM
 #
 ################################################################################
-# Version.: Commits on Feb 03, 2020
-LIBRETRO_O2EM_VERSION = b23a796dd3490e979ff43710317df6d43bd661e1
+# Version.: Commits on May 22, 2020
+LIBRETRO_O2EM_VERSION = 31a60bb551e9d72b66dab0c373a61e185cd25459
 LIBRETRO_O2EM_SITE = $(call github,libretro,libretro-o2em,$(LIBRETRO_O2EM_VERSION))
 LIBRETRO_O2EM_LICENSE = Artistic License
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-opera/libretro-opera.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-opera/libretro-opera.mk
@@ -3,8 +3,8 @@
 # OPERA
 #
 ################################################################################
-# Version.: Commits on Feb 17, 2020
-LIBRETRO_OPERA_VERSION = 27bc2653ed469072a6a95102a8212a35fbb1e590
+# Version.: Commits on May 21, 2020
+LIBRETRO_OPERA_VERSION = d7d21936f0c81f1541f2f7625ed2d9184c07e92e
 LIBRETRO_OPERA_SITE = $(call github,libretro,opera-libretro,$(LIBRETRO_OPERA_VERSION))
 LIBRETRO_OPERA_LICENSE = LGPL/Non-commercial
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-parallel-n64/000-makefile.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-parallel-n64/000-makefile.patch
@@ -32,10 +32,10 @@ index bfc5a47..f986efe 100644
 +   ifneq (,$(findstring n2,$(platform)))
 +      GLES = 1
 +      GL_LIB := -lGLESv2
-+      CPUFLAGS += -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE -DARM_FIX
++      CPUFLAGS += -DNO_ASM -DARM -DARM_ASM -DDONT_WANT_ARM_OPTIMIZATIONS -DARM_FIX -DCLASSIC -DARM64
 +      HAVE_NEON = 1
 +      WITH_DYNAREC=aarch64
-+      CPUFLAGS += -march=armv8-a+crc -mcpu=cortex-a73 -mtune=cortex-a73.cortex-a53
++      CPUFLAGS += -D__NEON_OPT -march=armv8-a+crc -mcpu=cortex-a73 -mtune=cortex-a73.cortex-a53
 +   endif
 +   
     # ODROIDs

--- a/package/batocera/emulators/retroarch/libretro/libretro-parallel-n64/libretro-parallel-n64.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-parallel-n64/libretro-parallel-n64.mk
@@ -3,8 +3,8 @@
 # PARALLEL_N64
 #
 ################################################################################
-# Version.: Commits on May 12, 2020
-LIBRETRO_PARALLEL_N64_VERSION = a4962b5cc6e552add3b18efe9e35eafeb8f716df
+# Version.: Commits on May 25, 2020
+LIBRETRO_PARALLEL_N64_VERSION = 43f893044c2c2d850482778e4e79e51e34c253af
 LIBRETRO_PARALLEL_N64_SITE = $(call github,libretro,parallel-n64,$(LIBRETRO_PARALLEL_N64_VERSION))
 LIBRETRO_PARALLEL_N64_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-pcsx/libretro-pcsx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-pcsx/libretro-pcsx.mk
@@ -3,8 +3,8 @@
 # PCSXREARMED
 #
 ################################################################################
-# Version.: Commits on May 02, 2020
-LIBRETRO_PCSX_VERSION = 14e45ca252a6b0bcd0863310b862538eb3af8aee
+# Version.: Commits on May 26, 2020
+LIBRETRO_PCSX_VERSION = 7973b25fe929f92e146a854ecaf4f3cea5b4ffb8
 LIBRETRO_PCSX_SITE = $(call github,libretro,pcsx_rearmed,$(LIBRETRO_PCSX_VERSION))
 LIBRETRO_PCSX_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-prboom/libretro-prboom.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-prboom/libretro-prboom.mk
@@ -3,8 +3,8 @@
 # PRBOOM
 #
 ################################################################################
-# Version.: Commits on Apr 8, 2020
-LIBRETRO_PRBOOM_VERSION = fd7306eed48beda41225c5d679310350e9862307
+# Version.: Commits on May 17, 2020
+LIBRETRO_PRBOOM_VERSION = 0d38f5da0109c33d195d6eb9f92cd97bd08e3311
 LIBRETRO_PRBOOM_SITE = $(call github,libretro,libretro-prboom,$(LIBRETRO_PRBOOM_VERSION))
 LIBRETRO_PRBOOM_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
@@ -3,8 +3,8 @@
 # PUAE
 #
 ################################################################################
-# Version.: Commits on May 11, 2020
-LIBRETRO_PUAE_VERSION = 25b42b237c778dbd295cf6f4b26899b2816fbdaa
+# Version.: Commits on May 22, 2020
+LIBRETRO_PUAE_VERSION = 638bf3421b6ab0ff534afe57fe1d55c45d643807
 LIBRETRO_PUAE_SITE = $(call github,libretro,libretro-uae,$(LIBRETRO_PUAE_VERSION))
 LIBRETRO_PUAE__LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-px68k/libretro-px68k.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-px68k/libretro-px68k.mk
@@ -3,8 +3,8 @@
 # PX68K
 #
 ################################################################################
-# Version.: Commits on Jan 24s, 2020
-LIBRETRO_PX68K_VERSION = 51ee79325a5aa5b3c86e6d62d888c255953fb8dc
+# Version.: Commits on May 4, 2020
+LIBRETRO_PX68K_VERSION = 415dd30665f92d86a08630d2a25d58b89c60bc80
 LIBRETRO_PX68K_SITE = $(call github,libretro,px68k-libretro,$(LIBRETRO_PX68K_VERSION))
 LIBRETRO_PX68K_LICENSE = Unknown
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-snes9x-next/libretro-snes9x-next.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-snes9x-next/libretro-snes9x-next.mk
@@ -3,8 +3,8 @@
 # SNES9X_NEXT
 #
 ################################################################################
-# Version.: Commits on Apr 24, 2019
-LIBRETRO_SNES9X_NEXT_VERSION = 59eb03d08058f4a714945f792de8d5f52716c2ce
+# Version.: Commits on May 18, 2020
+LIBRETRO_SNES9X_NEXT_VERSION = 187e2b58fc09dfeb9fdb5a95bc26786219a111cf
 LIBRETRO_SNES9X_NEXT_SITE = $(call github,libretro,snes9x2010,$(LIBRETRO_SNES9X_NEXT_VERSION))
 LIBRETRO_SNES9X_NEXT_LICENSE = Non-commercial
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-tgbdual/libretro-tgbdual.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-tgbdual/libretro-tgbdual.mk
@@ -3,8 +3,8 @@
 # TGBDUAL
 #
 ################################################################################
-# Version.: Commits on Jan 07, 2020
-LIBRETRO_TGBDUAL_VERSION = 9be31d373224cbf288db404afc785df41e61b213
+# Version.: Commits on Apr 22, 2020
+LIBRETRO_TGBDUAL_VERSION = 5b6e6f9807f889c26d7066a64970d308bff0474d
 LIBRETRO_TGBDUAL_SITE = $(call github,libretro,tgbdual-libretro,$(LIBRETRO_TGBDUAL_VERSION))
 LIBRETRO_TGBDUAL_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-tyrquake/libretro-tyrquake.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-tyrquake/libretro-tyrquake.mk
@@ -3,8 +3,8 @@
 # TYRQUAKE - Quake 1 Engine
 #
 ################################################################################
-# Version.: Commits on Apr 02, 2020
-LIBRETRO_TYRQUAKE_VERSION = 58fecfb326a44bf7937b6eaa648210b8e0d07f8e
+# Version.: Commits on Apr 17, 2020
+LIBRETRO_TYRQUAKE_VERSION = 7f175ba5c51c65e815a239ff32fb4aae6564c0a7
 LIBRETRO_TYRQUAKE_SITE = $(call github,libretro,tyrquake,$(LIBRETRO_TYRQUAKE_VERSION))
 LIBRETRO_TYRQUAKE_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-vecx/libretro-vecx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vecx/libretro-vecx.mk
@@ -3,8 +3,8 @@
 # VECX
 #
 ################################################################################
-# Version.: Commits on Jan 09, 2020
-LIBRETRO_VECX_VERSION = 321205271b1c6be5dbdb8d309097a5b5c2032dbd
+# Version.: Commits on May 17, 2020
+LIBRETRO_VECX_VERSION = 2a2e9291fd3733e714f9f8bf5e624325c7756960
 LIBRETRO_VECX_SITE = $(call github,libretro,libretro-vecx,$(LIBRETRO_VECX_VERSION))
 LIBRETRO_VECX_LICENSE = GPLv2|LGPLv2.1
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
@@ -3,8 +3,8 @@
 # LIBRETRO-VICE
 #
 ################################################################################
-# Version.: Commits on Apr 30, 2020
-LIBRETRO_VICE_VERSION = a0112ff3cf8733b4402d3f4be295fbfb23d08290
+# Version.: Commits on May 27, 2020
+LIBRETRO_VICE_VERSION = 461527f0ba52439223f1439ecb4a2006d6560735
 LIBRETRO_VICE_SITE = $(call github,libretro,vice-libretro,$(LIBRETRO_VICE_VERSION))
 LIBRETRO_VICE_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-virtualjaguar/libretro-virtualjaguar.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-virtualjaguar/libretro-virtualjaguar.mk
@@ -3,8 +3,8 @@
 # VIRTUALJAGUAR
 #
 ################################################################################
-# Version.: Commits on Jan 06, 2020
-LIBRETRO_VIRTUALJAGUAR_VERSION = a162fb75926f5509f187e9bfc69958bced40b0a6
+# Version.: Commits on May 21, 2020
+LIBRETRO_VIRTUALJAGUAR_VERSION = 5a293de747823dc0a9ceba0dd878ef75e9a9d920
 LIBRETRO_VIRTUALJAGUAR_SITE = $(call github,libretro,virtualjaguar-libretro,$(LIBRETRO_VIRTUALJAGUAR_VERSION))
 LIBRETRO_VIRTUALJAGUAR_LICENSE = GPLv3
 

--- a/package/batocera/emulators/retroarch/retroarch-assets/retroarch-assets.mk
+++ b/package/batocera/emulators/retroarch/retroarch-assets/retroarch-assets.mk
@@ -3,8 +3,8 @@
 # RETROARCH ASSETS
 #
 ################################################################################
-# Version.: Commits on May 05, 2020
-RETROARCH_ASSETS_VERSION = 5b945e9fcfff6ae061371a7dc2937620a4cfd7dd
+# Version.: Commits on May 24, 2020
+RETROARCH_ASSETS_VERSION = 4ebe9abfe80dd58489d7ed0922cd4789c1999f07
 RETROARCH_ASSETS_SITE = $(call github,libretro,retroarch-assets,$(RETROARCH_ASSETS_VERSION))
 RETROARCH_ASSETS_LICENSE = GPL
 

--- a/package/batocera/emulators/retroarch/retroarch/000-input_sort_devices.patch
+++ b/package/batocera/emulators/retroarch/retroarch/000-input_sort_devices.patch
@@ -1,8 +1,8 @@
 diff --git a/input/drivers_joypad/udev_joypad.c b/input/drivers_joypad/udev_joypad.c
-index 182fc034a0..415b3b7599 100644
+index e60a8b2..03ba777 100644
 --- a/input/drivers_joypad/udev_joypad.c
 +++ b/input/drivers_joypad/udev_joypad.c
-@@ -540,6 +540,14 @@ static void udev_joypad_poll(void)
+@@ -542,6 +542,14 @@ static void udev_joypad_poll(void)
     }
  }
  
@@ -17,7 +17,7 @@ index 182fc034a0..415b3b7599 100644
  static bool udev_joypad_init(void *data)
  {
     unsigned i;
-@@ -574,13 +582,33 @@ static bool udev_joypad_init(void *data)
+@@ -576,12 +584,32 @@ static bool udev_joypad_init(void *data)
     udev_enumerate_scan_devices(enumerate);
     devs = udev_enumerate_get_list_entry(enumerate);
  
@@ -28,7 +28,6 @@ index 182fc034a0..415b3b7599 100644
        struct udev_device  *dev = udev_device_new_from_syspath(udev_joypad_fd, name);
        const char      *devnode = udev_device_get_devnode(dev);
  
--      if (devnode != NULL)
 +      if (devnode != NULL) {
 +         sorted[sorted_count].devnode = devnode;
 +         sorted[sorted_count].item = item;
@@ -49,7 +48,6 @@ index 182fc034a0..415b3b7599 100644
 +      struct udev_device  *dev = udev_device_new_from_syspath(udev_joypad_fd, name);
 +      const char      *devnode = udev_device_get_devnode(dev);
 +
-+      if (devnode)
+       if (devnode)
           udev_check_device(dev, devnode);
        udev_device_unref(dev);
-    }

--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -3,8 +3,8 @@
 # retroarch
 #
 ################################################################################
-# Version.: Commits on May 17, 2020
-RETROARCH_VERSION = v1.8.7
+# Version.: Commits on May 27, 2020
+RETROARCH_VERSION = v1.8.8
 RETROARCH_SITE = $(call github,libretro,RetroArch,$(RETROARCH_VERSION))
 RETROARCH_LICENSE = GPLv3+
 RETROARCH_DEPENDENCIES = host-pkgconf dejavu retroarch-assets flac


### PR DESCRIPTION
Retroarch
https://www.libretro.com/index.php/retroarch-1-8-8-released/

Libretro Cores
https://www.libretro.com/index.php/libretro-cores-progress-report-may-27-2020/