### PR TITLE
Fix for Rpi4/ArgonOne shutdown

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -44,7 +44,7 @@ case "$1" in
         if [ ! -z "$BTD_PID" ]; then
             kill $BTD_PID
             $RUN stop $powerswitch
-        elif test -e "/tmp/poweroff.please"; then
+        elif [ -e "/tmp/shutdown.please" -o -e "/tmp/poweroff.please" ]; then
             $RUN stop $powerswitch
         fi
     ;;


### PR DESCRIPTION
Might be good to port back to 5.26 if we ever need to rebuild a RPi4 image.
Batocera-ES sets up `/tmp/shutdown.please`, not poweroff.please. As currently written the "stop" command is never invoked, preventing the Argon One case for RPi4 to stop correctly.