### PR TITLE
es_sytems clean and Wii new options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -138,7 +138,25 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Settings", "InternalResolution", "0")
 
-        # save gfx.ini
+        # vsync
+        if system.isOptSet('vsync'):
+            dolphinGFXSettings.set("Hardware", "VSync", system.config["vsync"])
+        else:
+            dolphinGFXSettings.set("Hardware", "VSync", "False")
+  
+        # anisotropic filtering
+        if system.isOptSet('anisotropic_filtering'):
+            dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", system.config["anisotropic_filtering"])
+        else:
+            dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", "0")
+			
+		# anti aliasing
+        if system.isOptSet('antialiasing'):
+            dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
+        else:
+            dolphinGFXSettings.set("Settings", "MSAA", "0")
+			
+		# save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:
             dolphinGFXSettings.write(configfile)
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7,9 +7,9 @@ libretro:
     '81':
       features: [netplay, rewind, autosave]
     atari800:
-      features: [         rewind, autosave]
+      features: [ ]
     beetle-saturn:
-      features: [netplay, rewind, autosave]
+      features: [netplay,         autosave]
     bluemsx:
       features: [         rewind, autosave]
     bsnes:
@@ -19,11 +19,11 @@ libretro:
     citra:
       features: [         rewind, autosave]
     daphne:
-      features: [         rewind, autosave]
+      features: [ ]
     desmume:
       features: [netplay, rewind, autosave]
     dosbox:
-      features: [         rewind, autosave]
+      features: [ ]
     fbneo:
       features: [netplay, rewind, autosave]
     fceumm:
@@ -31,7 +31,7 @@ libretro:
     flycast:
       features: [         rewind, autosave]
     freeintv:
-      features: [         rewind, autosave]
+      features: [ ]
     fuse:
       features: [         rewind, autosave]
     gambatte:
@@ -41,17 +41,17 @@ libretro:
     gpsp:
       features: [         rewind, autosave]
     gw:
-      features: [         rewind, autosave]
+      features: [ ]
     handy:
       features: [netplay, rewind, autosave]
     hatari:
-      features: [         rewind, autosave]
+      features: [                 autosave]
     imame4all:
       features: [netplay, rewind, autosave]
     kronos:
-      features: [         rewind, autosave]
+      features: [                 autosave]
     lutro:
-      features: [         rewind, autosave]
+      features: [ ]
     mame:
       features: [netplay, rewind, autosave]
     mame0139:
@@ -79,7 +79,7 @@ libretro:
     mupen64plus-next:
       features: [         rewind, autosave]
     neocd:
-      features: [         rewind, autosave]
+      features: [                 autosave]
     nestopia:
       features: [netplay, rewind, autosave]
     quasi88:
@@ -87,9 +87,9 @@ libretro:
     np2kai:
       features: [netplay, rewind, autosave]
     nxengine:
-      features: [         rewind, autosave]
+      features: [ ]
     o2em:
-      features: [         rewind, autosave]
+      features: [                 autosave]
     opera:
       features: [netplay, rewind, autosave]
     parallel_n64:
@@ -117,9 +117,9 @@ libretro:
     puae:
       features: [         rewind, autosave]
     px68k:
-      features: [         rewind, autosave]
+      features: [ ]
     scummvm:
-      features: [         rewind, autosave]
+      features: [ ]
     snes9x:
       features: [netplay, rewind, autosave]
     snes9x_next:
@@ -131,7 +131,7 @@ libretro:
     theodore:
       features: [netplay, rewind, autosave]
     tyrquake:
-      features: [         rewind, autosave]
+      features: [ ]
     vb:
       features: [netplay, rewind, autosave]
     vba-m:
@@ -141,18 +141,18 @@ libretro:
     vice:
       features: [         rewind, autosave]
     virtualjaguar:
-      features: [         rewind, autosave]
+      features: [ ]
     yabasanshiro:
-      features: [         rewind, autosave]
+      features: [                 autosave]
 
 amiberry:
-  features: [ratio, rewind]
+  features: [ratio]
 
 citra:
   features: [ratio, rewind, screen_layout]
 
 daphne:
-  features: [ratio, rewind]
+  features: [ratio]
 
 dolphin:
   features: [ratio]
@@ -164,28 +164,48 @@ dolphin:
                 2x Native: 2
                 3x Native: 3
                 4x Native: 4
-                5x Native: 5 
-                6x Native: 6 
+                5x Native: 5
+                6x Native: 6
         perf_hacks:
             prompt: PERFORMANCE HACKS
             choices:
                 OFF: 0
-                ON: 1
+                ON:  1
         hires_textures:
             prompt: HIRES TEXTURES
             choices:
                 OFF: 0
-                ON: 1                
+                ON:  1                
         widescreen_hack:
             prompt: WIDESCREEN HACK
             choices:
                 OFF: 0
-                ON: 1  
+                ON:  1  
         enable_cheats:
             prompt: ENABLE CHEATS
             choices:
                 OFF: 0
-                ON: 1
+                ON:  1
+        vsync:
+            prompt: VSYNC
+            choices:
+                OFF: False
+                ON:  True
+        anisotropic_filtering:
+            prompt: ANISOTROPIC FILTERING
+            choices:
+                OFF: 0
+                2x:  1
+                4x:  2
+                8x:  3
+                16x: 4
+        antialiasing:
+            prompt: ANTIALIASING
+            choices:
+                OFF: 0
+                2x:  2
+                4x:  4
+                8x:  8
   systems:
     wii:
         features: [emulated_wiimotes]
@@ -211,40 +231,40 @@ dolphin:
                     Tilt: ti   
                     Swing: sw                     
 dosbox:
-  features: [ratio, rewind]
+  features: [ratio]
 
 dosbox-x:
-  features: [ratio, rewind]
+  features: [ratio]
 
 fsuae:
-  features: [ratio, rewind]
+  features: [ratio]
 
 linapple:
-  features: [ratio, rewind]
+  features: [ratio]
 
 moonlight:
-  features: [ratio, rewind]
+  features: [ratio]
 
 mupen64plus:
-  features: [ratio, rewind]
+  features: [ratio]
 
 pcsx2:
-  features: [ratio, rewind, fullboot]
+  features: [ratio, fullboot]
 
 ppsspp:
-  features: [ratio, rewind, internal_resolution]
+  features: [ratio, internal_resolution]
 
 reicast:
-  features: [ratio, rewind]
+  features: [ratio]
 
 flycast:
-  features: [ratio, rewind]
+  features: [ratio]
 
 scummvm:
-  features: [ratio, rewind]
+  features: [ratio]
 
 vice:
-  features: [ratio, rewind]
+  features: [ratio]
 openbor:
   cfeatures:
     ratio:


### PR DESCRIPTION
- Remove all non used options from es_sytems in ES.
Like for example REWIND or AUTOSAVE when emulators not use them.
- Add 3 news WII options in ES
 * vsync
 * anisotropic_filtering
 * antialiasing