### PR TITLE
Configuen Wii and OpenBOR update

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -42,6 +42,24 @@ class DolphinGenerator(Generator):
             dolphinSettings.set("General", "ShowLag", "False")
             dolphinSettings.set("General", "ShowFrameCount", "False")
 
+        # dual core
+        if system.isOptSet('dual_core'):
+            dolphinSettings.set("Core", "CPUThread", system.config["dual_core"])
+        else:
+            dolphinSettings.set("Core", "CPUThread", "False")
+        
+        # memory management unit
+        if system.isOptSet('mmu'):
+            dolphinSettings.set("Core", "MMU", system.config["mmu"])
+        else:
+            dolphinSettings.set("Core", "MMU", "False")
+        
+        # speed up disc transfert rate
+        if system.isOptSet('fastDiscSpeed'):
+            dolphinSettings.set("Core", "FastDiscSpeed", system.config["fastDiscSpeed"])
+        else:
+            dolphinSettings.set("Core", "FastDiscSpeed", "False")	
+        
         # don't ask about statistics
         dolphinSettings.set("Analytics", "PermissionAsked", "True")
 
@@ -80,7 +98,8 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "ShowFPS", "True")
         else:
             dolphinGFXSettings.set("Settings", "ShowFPS", "False")
-            
+        
+        # enable cheats
         if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
             dolphinGFXSettings.set("Core", "EnableCheats", "True")
         else:
@@ -131,7 +150,7 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "ArbitraryMipmapDetection")
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
                 dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")  
-  
+
         # internal resolution settings
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
@@ -143,20 +162,20 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Hardware", "VSync", system.config["vsync"])
         else:
             dolphinGFXSettings.set("Hardware", "VSync", "False")
-  
+
         # anisotropic filtering
         if system.isOptSet('anisotropic_filtering'):
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", system.config["anisotropic_filtering"])
         else:
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", "0")
-			
-		# anti aliasing
+        
+        # anti aliasing
         if system.isOptSet('antialiasing'):
             dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:
             dolphinGFXSettings.set("Settings", "MSAA", "0")
-			
-		# save gfx.ini
+        
+        # save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:
             dolphinGFXSettings.write(configfile)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
@@ -20,9 +20,9 @@ class OpenborGenerator(Generator):
         if not os.path.exists(savesDir):
             os.makedirs(savesDir)
 
-        # guess the version to run
+        # guess the build version to run if nothing forced
         core = system.config['core']
-        if system.config["core-forced"] == False:
+        if core == "openbor":
             core = OpenborGenerator.guessCore(rom)
 
         # config file
@@ -56,7 +56,7 @@ class OpenborGenerator(Generator):
 
     @staticmethod
     def executeCore(core, rom):
-        if core == "openbor4432":
+        if core == "openbor3b4432":
             commandArray = ["OpenBOR4432", rom]
         else:
             commandArray = ["OpenBOR", rom]
@@ -67,8 +67,8 @@ class OpenborGenerator(Generator):
         versionstr = re.search(r'\[.*([0-9]{4})\]+', os.path.basename(rom))
         if versionstr == None:
             return "openbor"
-        version = int(versionstr.group(1))
 
+        version = int(versionstr.group(1))
         if version < 6000:
-            return "openbor4432"
-        return "openbor"
+            return "openbor3b4432"
+        return "openbor3b6412"

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -157,6 +157,31 @@ daphne:
 dolphin:
   features: [ratio]
   cfeatures:
+        enable_cheats:
+            prompt: ENABLE CHEATS
+            choices:
+                OFF: 0
+                ON:  1
+        perf_hacks:
+            prompt: PERFORMANCE HACKS
+            choices:
+                OFF: 0
+                ON:  1
+        fastDiscSpeed:
+            prompt: SPEED UP DISC TRANSFER RATE
+            choices:
+                OFF: False
+                ON:  True
+        dual_core:
+            prompt: DUAL CORE
+            choices:
+                OFF: False
+                ON:  True
+        mmu:
+            prompt: MEMORY MANAGEMENT UNIT (MMU)
+            choices:
+                OFF: False
+                ON:  True
         internalresolution:
             prompt: INTERNAL RESOLUTION
             choices:
@@ -166,31 +191,23 @@ dolphin:
                 4x Native: 4
                 5x Native: 5
                 6x Native: 6
-        perf_hacks:
-            prompt: PERFORMANCE HACKS
-            choices:
-                OFF: 0
-                ON:  1
-        hires_textures:
-            prompt: HIRES TEXTURES
-            choices:
-                OFF: 0
-                ON:  1                
         widescreen_hack:
             prompt: WIDESCREEN HACK
             choices:
                 OFF: 0
                 ON:  1  
-        enable_cheats:
-            prompt: ENABLE CHEATS
+        antialiasing:
+            prompt: ANTI-ALIASING
             choices:
                 OFF: 0
-                ON:  1
-        vsync:
-            prompt: VSYNC
+                2x:  2
+                4x:  4
+                8x:  8
+        hires_textures:
+            prompt: HIRES TEXTURES
             choices:
-                OFF: False
-                ON:  True
+                OFF: 0
+                ON:  1                
         anisotropic_filtering:
             prompt: ANISOTROPIC FILTERING
             choices:
@@ -199,13 +216,11 @@ dolphin:
                 4x:  2
                 8x:  3
                 16x: 4
-        antialiasing:
-            prompt: ANTIALIASING
+        vsync:
+            prompt: V-SYNC
             choices:
-                OFF: 0
-                2x:  2
-                4x:  4
-                8x:  8
+                OFF: False
+                ON:  True
   systems:
     wii:
         features: [emulated_wiimotes]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1211,8 +1211,8 @@ openbor:
   extensions: [pak]
   emulators:
     openbor:
-      openbor: { requireAnyOf: [BR2_PACKAGE_OPENBOR] }
-      openbor4432: { requireAnyOf: [BR2_PACKAGE_OPENBOR4432] }
+      openbor3b6412: { requireAnyOf: [BR2_PACKAGE_OPENBOR] }
+      openbor3b4432: { requireAnyOf: [BR2_PACKAGE_OPENBOR4432] }
 
 satellaview:
   name:       Satellaview


### PR DESCRIPTION
- Add 3 last options to Wii: Dual core, MMU and Speed up disc
Only miss now ONLINE options...
- Fix OpenBOR detection of forced CORE/BUILD. And rename the last build with his real name to prevent future OpenBOR v4 that will come this year.