### PR TITLE
batocera-wifi: added WPS PBC  --- DNM!

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -6,6 +6,39 @@ shift
 do_help() {
     echo "${1} scanlist" >&2
     echo "${1} list" >&2
+    echo "${1} wps" >&2
+}
+
+do_wps() {
+    do_start
+    [ $? -eq 0 ] || exit 1
+
+    #use grep -v *AO to filter network already in usage!
+    #head will filter to n-evetns
+    for z in 1 2 3; do
+    for i in $(connmanctl services | grep -v *AO | grep -o "wifi_[[:xdigit:]]*_[[:xdigit:]]*_managed_psk" | head -n 3)
+    do
+        connmanctl connect "$i" &>/tmp/wps.log
+        sleep 2
+
+        if grep -q "^Connected" /tmp/wps.log; then
+            echo "WPS connected!"
+            conn_cred="/var/lib/connman/$i/settings"
+            ssid="$(batocera-settings "$conn_cred" get Name)"
+            psk="$(batocera-settings "$conn_cred" get Passphrase)"
+            echo "SSID is: $ssid"
+            echo "PKEY is: $psk"
+            #batocera-settings set wifi.ssid "$ssid"
+            #batocera-settings set wifi.key "$psk"
+            break 2
+        elif grep -q "Already connected" /tmp/wps.log; then
+            echo "Connections already established to network"
+            break 2
+        else
+            echo "Failed: WPS connection"
+        fi
+    done
+    done
 }
 
 do_list() {
@@ -58,7 +91,7 @@ case "${ACTION}" in
 	do_list
 	;;
     "scanlist")
-	do_scanlist
+	do_wps
 	;;
     "start")
 	do_start
@@ -71,6 +104,9 @@ case "${ACTION}" in
     "disable")
 	do_disable || exit 1
 	;;
+    "wps")
+        do_wps || exit 1
+        ;;
     *)
 	do_help "${0}"
 esac


### PR DESCRIPTION
I've added WPS support for PBC only.
Aim is to give users an easy method to connect to wifi networks with methods known as WPS.

This script is only a showcase how it could work. I redirected MAIN-MENU>NETWORKS>SSID>Refresh
as a WPA scanner. The output is presented in the screenshot. So if some people are eager to test, feel free to do then.

1. You need a router that can handle WPS PBC (PIN controll as second method can be added later)
2. I assume that the first 3 networks are relevant, the rest is skipped
3. We have 3 tries, so 9 networks connections with a delay of 2 seconds!
4. If you remove `grep -v *AO` the areadly connected network will not be dropped and the loop breaks if there is a vaild connection already detected
5. It works only for secured networks (managed_psk)
6. I've disabled the auto write to batocera.conf, so nothing changes
7. I've enabled output of SSID and PSK

Please give me feedback and improvements
Usage: `batocera-wifi wps`

![snapshot](https://user-images.githubusercontent.com/29715650/84161347-79379900-aa6f-11ea-9d4c-a7f3b4932611.png)
