### PR TITLE
es_systems : rename manufacturer: Misc. Arcade & Misc. Port to Arcade & Ports

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -490,7 +490,7 @@ dos:
 
 fbneo:
   name:       Final Burn Neo
-  manufacturer: Misc. Arcade
+  manufacturer: Arcade
   release:
   hardware: arcade
   extensions: [zip, 7z]
@@ -509,7 +509,7 @@ fbneo:
 
 mame:
   name:       Mame
-  manufacturer: Misc. Arcade
+  manufacturer: Arcade
   release:
   hardware: arcade
   extensions: [zip, 7z]
@@ -705,7 +705,7 @@ wswanc:
 
 prboom:
   name:       PrBoom
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [wad, iwad, pwad]
@@ -726,7 +726,7 @@ prboom:
 
 tyrquake:
   name:       TyrQuake
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [pak]
@@ -741,7 +741,7 @@ tyrquake:
 
 mrboom:
   name:       MrBoom
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [libretro]
@@ -762,7 +762,7 @@ vectrex:
 
 lutro:
   name:       Lutro
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [lutro, zip, 7z]
@@ -1205,7 +1205,7 @@ x68000:
 
 openbor:
   name:       OpenBOR
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [pak]
@@ -1256,7 +1256,7 @@ gx4000:
 
 daphne:
   name:       Arcade (Daphne)
-  manufacturer: Misc. Arcade
+  manufacturer: Arcade
   release:
   hardware: arcade
   extensions: [daphne]
@@ -1320,7 +1320,7 @@ lightgun:
 
 ports:
   name:       Ports
-  manufacturer: Misc. Port
+  manufacturer: Ports
   release:
   hardware: port
   extensions: [sh]


### PR DESCRIPTION
- better sorting & presentation in ES.

Related to SystemView Manufacturer bar ( when systems are sorted by manufacturers ) #515 :
https://github.com/batocera-linux/batocera-emulationstation/pull/515