### PR TITLE
Fix typo in msx2 and msx2+ extensions

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -896,7 +896,7 @@ msx2:
   manufacturer: Microsoft
   release: 1985
   hardware: computer
-  extensions: [dsk, mx2, om, zip, 7z]
+  extensions: [dsk, mx2, rom, zip, 7z]
   platform:   msx
   group:      msx
   emulators:
@@ -956,7 +956,7 @@ msx2+:
   manufacturer: Microsoft
   release: 1988
   hardware: computer
-  extensions: [dsk, mx2, om, zip, 7z]
+  extensions: [dsk, mx2, rom, zip, 7z]
   platform:   msx
   group:      msx
   emulators:


### PR DESCRIPTION
`rom` is wrongly typed `om` for msx2 and msx2++ preventing some games to appear