### PR TITLE
Update dolphinGenerator.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -142,7 +142,7 @@ class DolphinGenerator(Generator):
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
         else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "0")
+            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
 
         # vsync
         if system.isOptSet('vsync'):


### PR DESCRIPTION
Resets default internal resolution to 1 now that users can update their internal resolution.  Will provide better general performance for lower powered boards.