### PR TITLE
add: S65values4boot

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Make batocera.conf specific values available to batocera-boot.conf
+# in a very early boot stage process where the regular conf-file
+# is not available
+
+# Only copy values on shutdown/reboot
+[ "$1" = "stop" ] || exit 0
+
+BATOCONF="/userdata/system/batocera.conf"
+BOOTCONF="/boot/batocera-boot.conf"
+BOOTLOCK=0
+
+for i in wifi.enabled wifi.ssid wifi.key audio.device audio.backend
+do
+    userdata="$(grep -m1 ^[\ #]*$i\s*= "$BATOCONF")" || continue
+    bootdata="$(grep -m1 ^[\ #]*$i\s*= "$BOOTCONF")"
+    ret=$?
+
+    if [ "$userdata" != "$bootdata" ]
+    then
+        # Make boot partition writeable and set trigger
+        mount -o remount,rw /boot
+        BOOTLOCK=1
+        # Change key values or create key - depence if key is available or not
+        [ $ret -eq 0 ] && sed -i "s/^[\ #]*$i\s*=.*/$userdata/" "$BOOTCONF"
+        [ $ret -eq 1 ] && echo "$userdata" >> "$BOOTCONF"
+    fi
+done
+
+# Lock boot partition
+[ $BOOTLOCK -eq 0 ] || mount -o remount,ro /boot
+exit $?

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -11,3 +11,7 @@ autoresize=true
 
 # enable the nvidia driver (remove the # to enable it)
 #nvidia-driver=true
+
+### below are copied values from batocera.conf to make them  ###
+### available for in an early boot stage - DON'T CHANGE THEM ###
+


### PR DESCRIPTION
This services copies values from batocera.conf to batocera-boot.conf to make the available for early boot stage

For now it copies:
wifi.enabled wifi.ssid wifi.key audio.device audio.backend

If you want to add/remove some please change this PR
@nadenislamarre @tcamargo

Missing values will be automatically adde to batocera-boot.conf
Already created values will be changed according batocera.conf data

Script can be easily extended