### PR TITLE
Splitout of S11share -> S10wifi is independent from /userdata now

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -15,6 +15,12 @@ if ! [ -f "$BATOCONF" ]; then
   BATOCONF="$BOOTCONF"
 fi
 
+# WLAN enabled?
+settingsWlan="$(batocera-settings "$BATOCONF" -command load -key wifi.enabled)"
+if [ "$settingsWlan" != "1" ];then
+    exit 0
+fi
+
 batocera_wifi_configure() {
     X=$1
 

--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -15,13 +15,6 @@ if ! [ -f "$BATOCONF" ]; then
   BATOCONF="$BOOTCONF"
 fi
 
-# WLAN enabled?
-settingsWlan="$(batocera-settings "$BATOCONF" -command load -key wifi.enabled)"
-if [ "$settingsWlan" != "1" ];then
-    exit 0
-fi
-
-
 batocera_wifi_configure() {
     X=$1
 

--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Prepare wifi even if /userdata isn't mounted
+# This service relies on S65values4boot 
+
+# Only init wifi on start condition
+[ "$1" = "start" ] || exit 0
+
+BATOCONF="/userdata/system/batocera.conf"
+BOOTCONF="/boot/batocera-boot.conf"
+
+# if /userdata is not yet available
+if ! [ -f "$BATOCONF" ]; then
+  # use the boot version of the file
+  BATOCONF="$BOOTCONF"
+fi
+
+# WLAN enabled?
+settingsWlan="$(batocera-settings "$BATOCONF" -command load -key wifi.enabled)"
+if [ "$settingsWlan" != "1" ];then
+    exit 0
+fi
+
+
+batocera_wifi_configure() {
+    X=$1
+
+    if [[ $X -eq 1 ]]
+    then
+        settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi.ssid)"
+        settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi.key)"
+        settings_file="/var/lib/connman/batocera_wifi.config"
+        settings_name="default"
+    else
+        settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.ssid)"
+        settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.key)"
+        settings_file="/var/lib/connman/batocera_wifi${X}.config"
+        settings_name="${X}"
+    fi
+
+    if [[ -n "$settings_ssid" ]] ;then
+        mkdir -p "/var/lib/connman"
+        cat > "${settings_file}" <<-_EOF_
+		[global]
+		Name=batocera
+
+		[service_batocera_${settings_name}]
+		Type=wifi
+		Name=${settings_ssid}
+		Passphrase=${settings_key}
+	_EOF_
+    fi
+}
+
+# Start wifi configuration
+# Soft unblock wifi
+rfkill unblock wifi
+
+for i in 1 2 3
+do
+    batocera_wifi_configure $i &
+done
+
+# Enable connman
+connmanctl enable wifi
+sleep 2
+connmanctl scan wifi
+exit $?

--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -48,6 +48,11 @@ batocera_wifi_configure() {
 		Name=${settings_ssid}
 		Passphrase=${settings_key}
 	_EOF_
+
+    connmanctl enable wifi || return 1
+    connmanctl scan   wifi || return 1
+    return 0
+
     fi
 }
 
@@ -58,10 +63,6 @@ rfkill unblock wifi
 for i in 1 2 3
 do
     batocera_wifi_configure $i &
+    ret=$?
 done
-
-# Enable connman
-connmanctl enable wifi
-sleep 2
-connmanctl scan wifi
-exit $?
+exit $ret

--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if test "$1" = "stop"
+if [[ "$1" == "stop" ]]
 then
     # umount all network configs
     # don't just remount the one of the config in case the config changed
@@ -9,9 +9,9 @@ then
     exit 0
 fi
 
-if test "$1" != "start"
+if [[ "$1" != "start" ]]
 then
-  exit 0
+    exit 0
 fi
 
 ###
@@ -36,8 +36,8 @@ getMaxTryConfig() {
     X=$(grep -E '^[ \t]*sharewait[ \t]*=' "${SHARECONFFILE}" | sed -e s+'^[ \t]*sharewait[ \t]*='+''+)
     if echo "${X}" | grep -qE '^[0-9][0-9]*$'
     then
-	echo "${X}"
-	return
+        echo "${X}"
+        return
     fi
     echo 7 # default value
 }
@@ -51,75 +51,63 @@ mountDeviceOrFallback() {
     BATOCERAFULLFS="/var/batocerafs"
     FALLBACK=1
 
-    if test -n "${DEVICE}"
+    if [[ -n "${DEVICE}" ]]
     then
-	if mkdir -p "${BATOCERAFULLFS}"
-	then
-	    if batocera-mount "${TDEVICE}" 1 "${DEVICE}" "${BATOCERAFULLFS}"
-	    then
-		if test -d "${BATOCERAFULLFS}/recalbox" -a ! -d "${BATOCERAFULLFS}/batocera" # legacy renaming (rename only if batocera doesn't exist and recalbox does)
-		then
-		    mv "${BATOCERAFULLFS}/recalbox" "${BATOCERAFULLFS}/batocera"
-		fi
-		if mkdir -p "${BATOCERAFULLFS}/batocera"
-		then
-		    if mount "${BATOCERAFULLFS}/batocera" "/userdata" -o "noatime"
-		    then
-			FALLBACK=0
-		    fi
-		fi
-	    fi
-	fi
+        if mkdir -p "${BATOCERAFULLFS}"
+        then
+            if batocera-mount "${TDEVICE}" 1 "${DEVICE}" "${BATOCERAFULLFS}"
+            then
+                if [[ -d "${BATOCERAFULLFS}/recalbox" && ! -d "${BATOCERAFULLFS}/batocera" ]] # legacy renaming (rename only if batocera doesn't exist and recalbox does)
+                then
+                    mv "${BATOCERAFULLFS}/recalbox" "${BATOCERAFULLFS}/batocera"
+                fi
+                if mkdir -p "${BATOCERAFULLFS}/batocera"
+                then
+                    if mount "${BATOCERAFULLFS}/batocera" "/userdata" -o "noatime"
+                    then
+                        FALLBACK=0
+                    fi
+                fi
+            fi
+        fi
     fi
 
-    if test "${FALLBACK}" = 1
+    if [[ "${FALLBACK}" == "1" ]]
     then
-	if ! batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
-	then
-	    mount -t tmpfs -o size=256M tmpfs /userdata
-	fi
+        if ! batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
+        then
+            mount -t tmpfs -o size=256M tmpfs /userdata
+        fi
     fi
 }
 
 batocera_wifi_configure() {
     X=$1
 
-    if test "$X" = 1
+    if [[ "$X" == 1 ]]
     then
-	settings_ssid="$(batocera-settings -command load -key wifi.ssid)"
-	settings_key="$(batocera-settings -command load -key wifi.key)"
-	settings_file="/var/lib/connman/batocera_wifi.config"
-	settings_name="default"
+        settings_ssid="$(batocera-settings -command load -key wifi.ssid)"
+        settings_key="$(batocera-settings -command load -key wifi.key)"
+        settings_file="/var/lib/connman/batocera_wifi.config"
+        settings_name="default"
     else
-	settings_ssid="$(batocera-settings -command load -key wifi"${X}".ssid)"
-	settings_key="$(batocera-settings -command load -key wifi"${X}".key)"
-	settings_file="/var/lib/connman/batocera_wifi${X}.config"
-	settings_name="${X}"
+        settings_ssid="$(batocera-settings -command load -key wifi${X}.ssid)"
+        settings_key="$(batocera-settings -command load -key wifi${X}.key)"
+        settings_file="/var/lib/connman/batocera_wifi${X}.config"
+        settings_name="${X}"
     fi
 
-    if [[ "$settings_ssid" != "" ]] ;then
-	mkdir -p "/var/lib/connman"
-	cat > "${settings_file}" <<EOF
-[global]
-Name=batocera
+    if [[ -n "$settings_ssid" ]] ;then
+        mkdir -p "/var/lib/connman"
+        cat > "${settings_file}" <<-_EOF_
+		[global]
+		Name=batocera
 
-[service_batocera_${settings_name}]
-Type=wifi
-Name=${settings_ssid}
-EOF
-	if test "${settings_key}" != ""
-	then
-	    settings_key_dec=$(batocera-encode decode "${settings_key}")
-	    echo "Passphrase=${settings_key_dec}" >> "${settings_file}"
-
-	    # # saved the value encoded
-	    # if test "${settings_key}" = "${settings_key_dec}"
-	    # then
-		# # sed the replace by the secure value in batocera.conf
-		# #settings_key=$(batocera-encode encode "${settings_key}")
-		# sed -i -e s@'^[ \t]*wifi.key[ \t]*=.*$'@"wifi.key=${settings_key}"@ "/userdata/system/batocera.conf"
-	    # fi
-	fi
+		[service_batocera_${settings_name}]
+		Type=wifi
+		Name=${settings_ssid}
+		Passphrase=${settings_key}
+	_EOF_
     fi
 }
 
@@ -139,7 +127,7 @@ batocera_wifi_configure_all() {
 }
 
 fixbatoceraconfname() {
-    test -e /userdata/system/recalbox.conf && mv /userdata/system/recalbox.conf /userdata/system/batocera.conf
+    [[ -e "/userdata/system/recalbox.conf" ]] && mv /userdata/system/recalbox.conf /userdata/system/batocera.conf
 }
 
 mountNetwork() {
@@ -163,79 +151,77 @@ mountNetwork() {
     # or
     # sharenetwork_cmd1=mount.cifs //192.168.0.1/batocera /userdata -o guest
 
-
     # execute all commands in /boot/batocera-boot.conf which are like : sharenetwork_cmd1=my command
     if ! grep -E '^[ ]*sharenetwork_[a-z]*[0-9][ ]*=' "${SHARECONFFILE}" |
-	    sed -e s+'^[ ]*sharenetwork_\([a-z]*\)[0-9][ ]*='+'\1 '+ |
-	    while read -r CTYPE CMD
-	    do
-		XTRY=5  # X tries and give up
-		XWAIT=4 # N seconds between each try
+        sed -e s+'^[ ]*sharenetwork_\([a-z]*\)[0-9][ ]*='+'\1 '+ |
+        while read -r CTYPE CMD
+        do
+            XTRY=5  # X tries and give up
+            XWAIT=4 # N seconds between each try
 
-		while test "${XTRY}" -gt 0
-		do
-		    (( XTRY-- ))
+            while [[ "${XTRY}" -gt 0 ]]
+            do
+                (( XTRY-- ))
+                CMD_EXEC=echo
+                if [[ "${CTYPE}" == "cmd" ]]
+                then
+                    CMD_EXEC="${CMD}"
+                else
+                    CMD_TARGET=$(echo "${CMD}" | sed -e s+'^\([^@]*\)@.*$'+'\1'+)
+                    CMD_HOST=$(echo "${CMD}" | sed -e s+'^[^@]*@\([^:]*\):.*$'+'\1'+)
+                    CMD_RDIR=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:\([^:]*\).*$'+'\1'+)
+                    CMD_OPT=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:[^:]*'+''+ -e s+'^:'++)
 
-		    CMD_EXEC=echo
-		    if test "${CTYPE}" = "cmd"
-		    then
-			CMD_EXEC="${CMD}"
-		    else
-			CMD_TARGET=$(echo "${CMD}" | sed -e s+'^\([^@]*\)@.*$'+'\1'+)
-			CMD_HOST=$(echo "${CMD}" | sed -e s+'^[^@]*@\([^:]*\):.*$'+'\1'+)
-			CMD_RDIR=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:\([^:]*\).*$'+'\1'+)
-			CMD_OPT=$(echo "${CMD}" | sed -e s+'^[^@]*@[^:]*:[^:]*'+''+ -e s+'^:'++)
+                    # MAP to the batocera directory
+                    CMD_TDIR="/userdata"
+                    case "${CMD_TARGET}" in
+                        "SHARE")
+                            CMD_TDIR="/userdata"
+                        ;;
+                        "ROMS")
+                            CMD_TDIR="/userdata/roms"
+                        ;;
+                        "SAVES")
+                            CMD_TDIR="/userdata/saves"
+                        ;;
+                        "BIOS")
+                            CMD_TDIR="/userdata/bios"
+                        ;;
+                    esac
 
-			# MAP to the batocera directory
-			CMD_TDIR="/userdata"
-			case "${CMD_TARGET}" in
-			    "SHARE")
-				CMD_TDIR="/userdata"
-			    ;;
-			    "ROMS")
-				CMD_TDIR="/userdata/roms"
-			    ;;
-			    "SAVES")
-				CMD_TDIR="/userdata/saves"
-			    ;;
-			    "BIOS")
-				CMD_TDIR="/userdata/bios"
-			    ;;
-			esac
+                    case "${CTYPE}" in
+                        "nfs")
+                            CMD_ADDOPT=
+                            [[ -n "${CMD_OPT}" ]] && CMD_ADDOPT=",${CMD_OPT}"
+                            CMD_EXEC="mount -o port=2049,nolock,proto=tcp${CMD_ADDOPT} ${CMD_HOST}:${CMD_RDIR} ${CMD_TDIR}"
+                        ;;
+                        "smb")
+                            CMD_ADDOPT=
+                            [[ -n "${CMD_OPT}" ]] && CMD_ADDOPT="-o ${CMD_OPT}"
+                            CMD_EXEC="mount.cifs //${CMD_HOST}/${CMD_RDIR} ${CMD_TDIR} ${CMD_ADDOPT}"
+                        ;;
+                    esac
+                fi
 
-			case "${CTYPE}" in
-			    "nfs")
-				CMD_ADDOPT=
-				test -n "${CMD_OPT}" && CMD_ADDOPT=",${CMD_OPT}"
-				CMD_EXEC="mount -o port=2049,nolock,proto=tcp${CMD_ADDOPT} ${CMD_HOST}:${CMD_RDIR} ${CMD_TDIR}"
-				;;
-			    "smb")
-				CMD_ADDOPT=
-				test -n "${CMD_OPT}" && CMD_ADDOPT="-o ${CMD_OPT}"
-				CMD_EXEC="mount.cifs //${CMD_HOST}/${CMD_RDIR} ${CMD_TDIR} ${CMD_ADDOPT}"
-				;;
-			esac
-		    fi
-
-		    echo "${CMD_EXEC}"
-		    if ${CMD_EXEC}
-		    then
-			echo "success"
-			XTRY=0
-		    else
-			echo "fail (${XTRY} : ${CMD_EXEC})"
-			# give up
-			if test ${XTRY} = 0
-			then
-			    echo "giving up"
-			    return 1
-			fi
-			sleep ${XWAIT} # wait n seconds between each try
-		    fi
-		done
-	    done
+                echo "${CMD_EXEC}"
+                if ${CMD_EXEC}
+                then
+                    echo "success"
+                    XTRY=0
+                else
+                    echo "fail (${XTRY} : ${CMD_EXEC})"
+                    # give up
+                    if [[ ${XTRY} -eq 0 ]]
+                    then
+                        echo "giving up"
+                        return 1
+                    fi
+                    sleep ${XWAIT} # wait n seconds between each try
+                fi
+            done
+        done
     then
-	return 1
+        return 1
     fi
     return 0
 }
@@ -252,95 +238,95 @@ fi
 
 case "${MODE}" in
     "DEV")
-	LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
-	while test -z "${LDEVICE}" -a "${NTRY}" -lt "${MAXTRY}" # wait the device that can take some seconds after udev started
-	do
-	    (( NTRY++ ))
-	    sleep 1
-	    LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
-	done
-	DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
-	TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
-	mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
-	fixbatoceraconfname
-	batocera_wifi_configure_all& # configure the wifi at the end
-	;;
+        LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
+        while [[ -z "${LDEVICE}" && "${NTRY}" -lt "${MAXTRY}" ]] # wait the device that can take some seconds after udev started
+        do
+            (( NTRY++ ))
+            sleep 1
+            LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
+        done
+        DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
+        TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
+        mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
+        fixbatoceraconfname
+        batocera_wifi_configure_all& # configure the wifi at the end
+    ;;
     "ANYEXTERNAL")
         PARTPREFIX=$(batocera-part prefix "${INTERNALDEVICE}")
-	LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
-	while test -z "${LDEVICE}" -a "${NTRY}" -lt "${MAXTRY}" # wait the device that can take some seconds after udev started
-	do
-	    (( NTRY++ ))
-	    sleep 1
-	    LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
-	done
-	DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
-	TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
-	mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
-	fixbatoceraconfname
-	batocera_wifi_configure_all& # configure the wifi at the end
-	;;
+        LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
+        while [[ -z "${LDEVICE}" && "${NTRY}" -lt "${MAXTRY}" ]] # wait the device that can take some seconds after udev started
+        do
+            (( NTRY++ ))
+            sleep 1
+            LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
+        done
+        DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
+        TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
+        mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
+        fixbatoceraconfname
+        batocera_wifi_configure_all& # configure the wifi at the end
+    ;;
     "RAM")
-	mount -t tmpfs -o size=256M tmpfs /userdata
-	;;
+        mount -t tmpfs -o size=256M tmpfs /userdata
+    ;;
     "NETWORK")
-	# first, INTERNAL mount, then, network mount over the NETWORK mounts
-	# to allow to mount over /userdata, but only over /userdata/roms if wanted
-	# mounting network mounts over usb key have not really sense
-	if batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
-	then
-	    # we try to configure the wifi here
-	    # for people using the internal device for the wifi and some others mounts for data
-	    fixbatoceraconfname
-	    batocera_wifi_configure_all
-	else
-	    # fallback
-	    mount -t tmpfs -o size=256M tmpfs /userdata
-	fi
+        # first, INTERNAL mount, then, network mount over the NETWORK mounts
+        # to allow to mount over /userdata, but only over /userdata/roms if wanted
+        # mounting network mounts over usb key have not really sense
+        if batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
+        then
+            # we try to configure the wifi here
+            # for people using the internal device for the wifi and some others mounts for data
+            fixbatoceraconfname
+            batocera_wifi_configure_all
+        else
+            # fallback
+            mount -t tmpfs -o size=256M tmpfs /userdata
+        fi
 
-	# Network mounts
-	# no fallback required, mounted on the share
-	mountNetwork > /tmp/mountNetwork.log 2> /tmp/mountNetwork.err # could be usefull to debug
-	;;
+        # Network mounts
+        # no fallback required, mounted on the share
+        mountNetwork > /tmp/mountNetwork.log 2> /tmp/mountNetwork.err # could be usefull to debug
+    ;;
     "INTERNAL"|*)
-	if ! batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
-	then
-	    # fallback
-	    # the internal partition is no more required in fact
-	    mount -t tmpfs -o size=256M tmpfs /userdata
-	fi
-	fixbatoceraconfname
-	batocera_wifi_configure_all& # configure the wifi at the end
-	;;
+        if ! batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
+        then
+            # fallback
+            # the internal partition is no more required in fact
+           mount -t tmpfs -o size=256M tmpfs /userdata
+        fi
+        fixbatoceraconfname
+        batocera_wifi_configure_all& # configure the wifi at the end
+    ;;
 esac
 
 # fs compression
-compressenabled="`batocera-settings -command load -key system.fscompression.enabled`"
-if test "$compressenabled" == "1"
+compressenabled="$(batocera-settings -command load -key system.fscompression.enabled)"
+if [[ "$compressenabled" == "1" ]]
 then
     if grep -qE "^/dev/[^ ]* /userdata btrfs.*$" /proc/mounts
     then
-	mount -o remount,compress /userdata || exit 1
+        mount -o remount,compress /userdata || exit 1
     fi
 fi
 
 
 # share upgrade, just unzip share.zip from upgrade, no need to reboot
-if test -e "/userdata/system/upgrade/share.zip"
+if [[ -e "/userdata/system/upgrade/share.zip" ]]
 then
     (cd /userdata && unzip -o /userdata/system/upgrade/share.zip) > /userdata/system/upgrade/upgrade.share.out.log 2> /userdata/system/upgrade/upgrade.share.err.log
     # always remove to not apply indefinitly
     rm -f /userdata/system/upgrade/share.zip
 fi
 
-# now, let mount delayed usbmount devices
+# now, mount delayed usbmount devices
 ls /var/run/usbmount.delay |
     while read -r RULE
     do
-	RTYPE=$(echo "${RULE}" | sed -e s+'^[0-9]*\.'++)
-	# source the udev context and apply the usbmount
-	(. "/var/run/usbmount.delay/${RULE}"
-	 /usr/share/usbmount/usbmount "${RTYPE}"
-	 rm "/var/run/usbmount.delay/${RULE}")
+        RTYPE=$(echo "${RULE}" | sed -e s+'^[0-9]*\.'++)
+        # source the udev context and apply the usbmount
+        (. "/var/run/usbmount.delay/${RULE}"
+        /usr/share/usbmount/usbmount "${RTYPE}"
+        rm "/var/run/usbmount.delay/${RULE}")
     done
 touch /var/run/batocera.share.mounted # reenable standard usbmount

--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -81,51 +81,6 @@ mountDeviceOrFallback() {
     fi
 }
 
-batocera_wifi_configure() {
-    X=$1
-
-    if [[ "$X" == 1 ]]
-    then
-        settings_ssid="$(batocera-settings -command load -key wifi.ssid)"
-        settings_key="$(batocera-settings -command load -key wifi.key)"
-        settings_file="/var/lib/connman/batocera_wifi.config"
-        settings_name="default"
-    else
-        settings_ssid="$(batocera-settings -command load -key wifi${X}.ssid)"
-        settings_key="$(batocera-settings -command load -key wifi${X}.key)"
-        settings_file="/var/lib/connman/batocera_wifi${X}.config"
-        settings_name="${X}"
-    fi
-
-    if [[ -n "$settings_ssid" ]] ;then
-        mkdir -p "/var/lib/connman"
-        cat > "${settings_file}" <<-_EOF_
-		[global]
-		Name=batocera
-
-		[service_batocera_${settings_name}]
-		Type=wifi
-		Name=${settings_ssid}
-		Passphrase=${settings_key}
-	_EOF_
-    fi
-}
-
-# wifi configuration is related to the share mounting
-# because some share mounts may depend on the wifi
-# because wifi password are on the share
-batocera_wifi_configure_all() {
-    rfkill unblock wifi
-
-    batocera_wifi_configure 1&  # 0.6
-    batocera_wifi_configure 2&  # 0.6
-    batocera_wifi_configure 3&  # 0.6
-
-    # wait a bit, otherwise, connman is not really started
-    sleep 2
-    batocera-wifi start
-}
-
 fixbatoceraconfname() {
     [[ -e "/userdata/system/recalbox.conf" ]] && mv /userdata/system/recalbox.conf /userdata/system/batocera.conf
 }
@@ -192,12 +147,12 @@ mountNetwork() {
                     case "${CTYPE}" in
                         "nfs")
                             CMD_ADDOPT=
-                            [[ -n "${CMD_OPT}" ]] && CMD_ADDOPT=",${CMD_OPT}"
+                            [ -n "${CMD_OPT}" ] && CMD_ADDOPT=",${CMD_OPT}"
                             CMD_EXEC="mount -o port=2049,nolock,proto=tcp${CMD_ADDOPT} ${CMD_HOST}:${CMD_RDIR} ${CMD_TDIR}"
                         ;;
                         "smb")
                             CMD_ADDOPT=
-                            [[ -n "${CMD_OPT}" ]] && CMD_ADDOPT="-o ${CMD_OPT}"
+                            [ -n "${CMD_OPT}" ] && CMD_ADDOPT="-o ${CMD_OPT}"
                             CMD_EXEC="mount.cifs //${CMD_HOST}/${CMD_RDIR} ${CMD_TDIR} ${CMD_ADDOPT}"
                         ;;
                     esac
@@ -211,7 +166,7 @@ mountNetwork() {
                 else
                     echo "fail (${XTRY} : ${CMD_EXEC})"
                     # give up
-                    if [[ ${XTRY} -eq 0 ]]
+                    if [ ${XTRY} -eq 0 ]
                     then
                         echo "giving up"
                         return 1
@@ -243,20 +198,19 @@ case "${MODE}" in
         do
             (( NTRY++ ))
             sleep 1
-            LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
+           LDEVICE=$(blkid | grep " UUID=\"${UUID}\"")
         done
         DEVICE=$(echo "${LDEVICE}" | sed -e s+'^\([^:]*\):.*$'+'\1'+)
         TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
         mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
         fixbatoceraconfname
-        batocera_wifi_configure_all& # configure the wifi at the end
     ;;
     "ANYEXTERNAL")
         PARTPREFIX=$(batocera-part prefix "${INTERNALDEVICE}")
         LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
-        while [[ -z "${LDEVICE}" && "${NTRY}" -lt "${MAXTRY}" ]] # wait the device that can take some seconds after udev started
+        while [ -z "${LDEVICE}" ] && [ "${NTRY}" -lt "${MAXTRY}" ] # wait the device that can take some seconds after udev started
         do
-            (( NTRY++ ))
+            let NTRY++
             sleep 1
             LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
         done
@@ -264,7 +218,6 @@ case "${MODE}" in
         TDEVICE=$(echo "${LDEVICE}" | sed -e s+'^.* TYPE="\([^"]*\)"$'+'\1'+)
         mountDeviceOrFallback "${DEVICE}" "${TDEVICE}"
         fixbatoceraconfname
-        batocera_wifi_configure_all& # configure the wifi at the end
     ;;
     "RAM")
         mount -t tmpfs -o size=256M tmpfs /userdata
@@ -275,10 +228,9 @@ case "${MODE}" in
         # mounting network mounts over usb key have not really sense
         if batocera-mount "${INTERNALDEVICETYPE}" 1 "${INTERNALDEVICE}" /userdata
         then
-            # we try to configure the wifi here
-            # for people using the internal device for the wifi and some others mounts for data
+            # we try to fix old residues from former timer here
+            # if share mount for network fails then we fallback to internal data
             fixbatoceraconfname
-            batocera_wifi_configure_all
         else
             # fallback
             mount -t tmpfs -o size=256M tmpfs /userdata
@@ -296,12 +248,11 @@ case "${MODE}" in
            mount -t tmpfs -o size=256M tmpfs /userdata
         fi
         fixbatoceraconfname
-        batocera_wifi_configure_all& # configure the wifi at the end
     ;;
 esac
 
 # fs compression
-compressenabled="$(batocera-settings -command load -key system.fscompression.enabled)"
+compressenabled="`batocera-settings -command load -key system.fscompression.enabled`"
 if [[ "$compressenabled" == "1" ]]
 then
     if grep -qE "^/dev/[^ ]* /userdata btrfs.*$" /proc/mounts
@@ -319,7 +270,7 @@ then
     rm -f /userdata/system/upgrade/share.zip
 fi
 
-# now, mount delayed usbmount devices
+# now, let mount delayed usbmount devices
 ls /var/run/usbmount.delay |
     while read -r RULE
     do

--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+# Make batocera.conf specific values available to batocera-boot.conf
+# in a very early boot stage process where the regular conf-file
+# is not available.
+
+# Only copy values on shutdown/reboot
+[ "$1" = "stop" ] || exit 0
+
+BATOCONF="/userdata/system/batocera.conf"
+BOOTCONF="/boot/batocera-boot.conf"
+BOOTLOCK=0
+
+for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key audio.device audio.backend
+do
+    userdata="$(grep -m1 ^[\ #]*$i\s*= "$BATOCONF")" || continue
+    bootdata="$(grep -m1 ^[\ #]*$i\s*= "$BOOTCONF")"
+    ret=$?
+
+    if [ "$userdata" != "$bootdata" ]
+    then
+        # Make boot partition writeable and set trigger
+        mount -o remount,rw /boot
+        BOOTLOCK=1
+        # Change key values or create key - depence if key is available or not
+        [ $ret -eq 0 ] && sed -i "s/^[\ #]*$i\s*=.*/$userdata/" "$BOOTCONF"
+        [ $ret -eq 1 ] && echo "$userdata" >> "$BOOTCONF"
+    fi
+done
+
+# Lock boot partition
+[ $BOOTLOCK -eq 0 ] || mount -o remount,ro /boot
+exit $?

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -11,3 +11,7 @@ autoresize=true
 
 # enable the nvidia driver (remove the # to enable it)
 #nvidia-driver=true
+
+### below are copied values from batocera.conf to make them ###
+### available in an early boot stage ---- DON'T CHANGE THEM ###
+


### PR DESCRIPTION
CREATED S10wifi
* WIFI key is now directly stored into cat-EOF-construct
* Removed residues from WiFi credentials encryption

Modified S11share
* Setted proper idents
* Changed test commands to more modernd bash statements
* splitted network connection out off S11 and transfered to S10

Add S65values for boot
* This services copies settings to batocera-boot.conf
* wifi services does not need to rely on mounted userdata anymore

Add batocera-boot.conf
* setup section
* description

@nadenislamarre This should be a better PR