### PR TITLE
Bump Dolphin and Fix configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -172,8 +172,8 @@ class DolphinGenerator(Generator):
         except Exception:
             pass # don't fail in case of SYSCONF update
 
-        commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-platform", "xcb", "-e", rom]
-        return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES})
+        commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-e", rom]
+        return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
 
 def getGfxRatioFromConfig(config, gameResolution):
     # 2: 4:3 ; 1: 16:9  ; 0: auto

--- a/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
+++ b/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
@@ -3,8 +3,8 @@
 # DOLPHIN EMU
 #
 ################################################################################
-# Version: Commits on Jun 28, 2020 (5.0-12230)
-DOLPHIN_EMU_VERSION = 27e49c00b3d65b8d8f3b1e858eea76d4ea06919f
+# Version: Commits on Jul 5, 2020 (5.0-12257)
+DOLPHIN_EMU_VERSION = 0dbe8fb2eaa608a6540df3d269648a596c29cf4b
 DOLPHIN_EMU_SITE = $(call github,dolphin-emu,dolphin,$(DOLPHIN_EMU_VERSION))
 DOLPHIN_EMU_LICENSE = GPLv2+
 DOLPHIN_EMU_DEPENDENCIES = xserver_xorg-server libevdev ffmpeg zlib libpng lzo libusb libcurl sfml bluez5_utils qt5base hidapi


### PR DESCRIPTION
Dolphin bump for most recent and configgen fix to pass QT variables as a system variable instead of on Dolphin command line.  This corrects issues with versions of Dolphin beyond Mar 22 version