### PR TITLE
Update Emulator.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -101,7 +101,10 @@ class Emulator():
         return dict_result
 
     def isOptSet(self, key):
-        return key in self.config
+        if key in self.config:
+            return True
+        else:
+            return False
 
     def getOptBoolean(self, key):
         if unicode(self.config[key]) == u'1':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -107,12 +107,13 @@ class Emulator():
             return False
 
     def getOptBoolean(self, key):
-        if unicode(self.config[key]) == u'1':
-            return True
-        if unicode(self.config[key]) == u'true':
-            return True
-        if self.config[key] == True:
-            return True
+        if(isOptSet(self,key)):
+            if unicode(self.config[key]) == u'1':
+                return True
+            if unicode(self.config[key]) == u'true':
+                return True
+            if self.config[key] == True:
+                return True
         return False
 
     @staticmethod

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -107,7 +107,7 @@ class Emulator():
             return False
 
     def getOptBoolean(self, key):
-        if(isOptSet(self,key)):
+        if key in self.config:
             if unicode(self.config[key]) == u'1':
                 return True
             if unicode(self.config[key]) == u'true':


### PR DESCRIPTION
Turn isOptSet into a boolean return value rather than returning the key if it exists.  All current uses of isOptSet (42 in 9 files) are treating this as a boolean return.  

References:
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\citra\citraGenerator.py (1 hit)
	Line 54:         if system.isOptSet('layout_option'):
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\dolphin\dolphinControllers.py (2 hits)
	Line 14:         if ((system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') != False) and ((system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') == True) or (".cc." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom))):
	Line 14:         if ((system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') != False) and ((system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') == True) or (".cc." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom))):
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\dolphin\dolphinGenerator.py (11 hits)
	Line 38:         if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
	Line 86:         if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
	Line 93:         if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
	Line 99:         if system.isOptSet('hires_textures') and system.getOptBoolean('hires_textures'):
	Line 107:         if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack') and system.isOptSet('enable_cheats') and not system.getOptBoolean('enable_cheats')):
	Line 107:         if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack') and system.isOptSet('enable_cheats') and not system.getOptBoolean('enable_cheats')):
	Line 113:         if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
	Line 142:         if system.isOptSet('internalresolution'):
	Line 148:         if system.isOptSet('vsync'):
	Line 154:         if system.isOptSet('anisotropic_filtering'):
	Line 160:         if system.isOptSet('antialiasing'):
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\libretro\libretroConfig.py (18 hits)
	Line 78:     if system.isOptSet('smooth') and system.getOptBoolean('smooth') == True:
	Line 108:     if system.isOptSet('rewind') and system.getOptBoolean('rewind') == True:
	Line 118:     if system.isOptSet('runahead') and int(system.config['runahead']) >0:
	Line 122:           if system.isOptSet('secondinstance') and system.getOptBoolean('secondinstance') == True:
	Line 125:     if system.isOptSet('autosave') and system.getOptBoolean('autosave') == True:
	Line 160:     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
	Line 166:             if system.isOptSet('retroachievements.hardcore') and system.getOptBoolean('retroachievements.hardcore') == True:
	Line 171:             if system.isOptSet('retroachievements.leaderboards') and system.getOptBoolean('retroachievements.leaderboards') == True:
	Line 176:             if system.isOptSet('retroachievements.verbose') and system.getOptBoolean('retroachievements.verbose') == True:
	Line 181:             if system.isOptSet('retroachievements.screenshot') and system.getOptBoolean('retroachievements.screenshot') == True:
	Line 188:     if system.isOptSet('integerscale') and system.getOptBoolean('integerscale') == True:
	Line 229:         if system.isOptSet('netplay.spectator') and system.getOptBoolean('netplay.spectator') == True:
	Line 241:     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
	Line 261:     if system.isOptSet('ai_service_enabled') and system.getOptBoolean('ai_service_enabled') == True:
	Line 265:         if system.isOptSet('ai_target_lang'):
	Line 269:         if system.isOptSet('ai_service_url') and system.config['ai_service_url']:
	Line 273:         if system.isOptSet('ai_service_pause') and system.getOptBoolean('ai_service_pause') == True:
	Line 281:     if system.isOptSet('bezel_stretch') and system.getOptBoolean('bezel_stretch') == True:
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\libretro\libretroGenerator.py (1 hit)
	Line 36:             if system.isOptSet('forceNoBezel') and system.getOptBoolean('forceNoBezel'):
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\openbor\openborGenerator.py (2 hits)
	Line 42:         if system.isOptSet("ratio"):
	Line 47:         if system.isOptSet("filter"):
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\pcsx2\pcsx2Generator.py (1 hit)
	Line 39:         if system.isOptSet('fullboot') and system.getOptBoolean('fullboot') == True:
  C:\Git\batocera.linux\package\batocera\core\batocera-configgen\configgen\configgen\generators\ppsspp\ppssppConfig.py (5 hits)
	Line 36:     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
	Line 42:     if system.isOptSet('frameskip') and system.getOptBoolean('frameskip') == True:
	Line 47:     if system.isOptSet('frameskiptype'):
	Line 52:     if system.isOptSet('internalresolution'):
	Line 58:     if system.isOptSet('rewind') and system.getOptBoolean('rewind') == True:
