### PR TITLE
Update Dreamcast emulators options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -61,6 +61,21 @@ def generateCoreSettings(retroarchCore, system):
 
     if (system.config['core'] == 'desmume'):
         coreSettings.save('desmume_pointer_device_r',   '"emulated"')
+        # multisampling aa
+        if system.isOptSet('multisampling'):
+            coreSettings.save("desmume_gfx_multisampling", system.config["multisampling"])
+        else:
+            coreSettings.save("desmume_gfx_multisampling", "disabled")
+        # texture smoothing
+        if system.isOptSet('texture_smoothing'):
+            coreSettings.save("desmume_gfx_texture_smoothing", system.config["texture_smoothing"])
+        else:
+            coreSettings.save("desmume_gfx_texture_smoothing", "disabled")
+        # texture scaling (xBrz)
+        if system.isOptSet('texture_scaling'):
+            coreSettings.save("desmume_gfx_texture_scaling", system.config["texture_scaling"])
+        else:
+            coreSettings.save("desmume_gfx_texture_scaling", "1")
 
     if (system.config['core'] == 'mame078'):
         coreSettings.save('mame2003_skip_disclaimer',   '"enabled"')
@@ -108,6 +123,26 @@ def generateCoreSettings(retroarchCore, system):
 
     if (system.config['core'] == 'flycast'):
         coreSettings.save('reicast_threaded_rendering',   '"enabled"')
+        # widescreen hack
+        if system.isOptSet('widescreen_hack'):
+            coreSettings.save("reicast_widescreen_hack", system.config["widescreen_hack"])
+        else:
+            coreSettings.save("reicast_widescreen_hack", "disabled")
+        # anisotropic filtering
+        if system.isOptSet('anisotropic_filtering'):
+            coreSettings.save("reicast_anisotropic_filtering", system.config["anisotropic_filtering"])
+        else:
+            coreSettings.save("reicast_anisotropic_filtering", "off")
+        # texture upscaling (xBRZ)
+        if system.isOptSet('texture_upscaling'):
+            coreSettings.save("reicast_texupscale", system.config["texture_upscaling"])
+        else:
+            coreSettings.save("reicast_texupscale", "off")
+        # render to texture upscaling
+        if system.isOptSet('render_to_texture_upscaling'):
+            coreSettings.save("reicast_render_to_texture_upscaling", system.config["render_to_texture_upscaling"])
+        else:
+            coreSettings.save("reicast_render_to_texture_upscaling", "1x")
 
     if (system.config['core'] == 'dosbox'):
         coreSettings.save('dosbox_svn_pcspeaker', '"true"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -22,6 +22,27 @@ libretro:
       features: [ ]
     desmume:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            texture_scaling:
+                prompt: TEXTURES UPSCALING (XBRZ)
+                choices:
+                    "Off": 1
+                    "2x":  2
+                    "4x":  4
+            texture_smoothing:
+                prompt: TEXTURES SMOOTHING
+                choices:
+                    "Off": disabled
+                    "On":  enabled
+            multisampling:
+                prompt: MULTISAMPLING AA
+                choices:
+                    "Off": disabled
+                    "2x":  2
+                    "4x":  4
+                    "8x":  8
+                    "16x": 16
+                    "32x": 32
     dosbox:
       features: [ ]
     fbneo:
@@ -30,6 +51,35 @@ libretro:
       features: [netplay, rewind, autosave]
     flycast:
       features: [         rewind, autosave]
+      cfeatures:
+            anisotropic_filtering:
+                prompt: ANISOTROPIC FILTERING
+                choices:
+                    "Off": off
+                    "2x":  2
+                    "4x":  4
+                    "8x":  8
+                    "16x": 16
+            texture_upscaling:
+                prompt: TEXTURES UPSCALING (XBRZ)
+                choices:
+                    "Off": off
+                    "2x":  2x
+                    "4x":  4x
+                    "6x":  6x
+            render_to_texture_upscaling:
+                prompt: RENDER TO TEXTURES UPSCALING
+                choices:
+                    "Off": 1x
+                    "2x":  2x
+                    "3x":  3x
+                    "4x":  4x
+                    "8x":  8x
+            widescreen_hack:
+                prompt: WIDESCREEN HACK
+                choices:
+                    "Off": disabled
+                    "On":  enabled
     freeintv:
       features: [ ]
     fuse:


### PR DESCRIPTION
Only the most used options, and by default with minimal value.

Flycast:
-widescreen hack: on/off
-anisotropic filtering: off/2x/4x/8x/16x
-texture upscaling (xBRZ): off/2x/4x/6x
-render to texture upscaling: off/2x/3x/4x/8x

Desmune:
-texture upscaling (xbrz) : off/2x/4x
-texture smoothing: on/off
-multisampling AA: off/2x/4x/8x/16x/32x