### PR TITLE
Statically build citra and lr-citra

### DIFF
--- a/package/batocera/emulators/citra/citra.mk
+++ b/package/batocera/emulators/citra/citra.mk
@@ -19,6 +19,7 @@ CITRA_CONF_OPTS += -DENABLE_WEB_SERVICE=OFF
 CITRA_CONF_OPTS += -DENABLE_QT_TRANSLATION=ON
 CITRA_CONF_OPTS += -DENABLE_FFMPEG=ON
 CITRA_CONF_OPTS += -DARCHITECTURE=x86_64
+CITRA_CONF_OPTS += -DBUILD_SHARED_LIBS=FALSE
 
 CITRA_CONF_ENV += LDFLAGS=-lpthread
 
@@ -28,18 +29,6 @@ define CITRA_INSTALL_TARGET_CMDS
 
 	$(INSTALL) -D $(@D)/buildroot-build/bin/citra-qt \
 		$(TARGET_DIR)/usr/bin/
-
-	cp -pr $(@D)/buildroot-build/externals/inih/*.so \
-		$(TARGET_DIR)/usr/lib/
-
-	cp -pr $(@D)/buildroot-build/externals/cubeb/*.so \
-		$(TARGET_DIR)/usr/lib/
-
-	cp -pr $(@D)/buildroot-build/externals/teakra/src/*.so \
-		$(TARGET_DIR)/usr/lib/
-
-	cp -pr $(@D)/buildroot-build/externals/lodepng/*.so \
-		$(TARGET_DIR)/usr/lib/
 endef
 
 $(eval $(cmake-package))

--- a/package/batocera/emulators/retroarch/libretro/libretro-citra/libretro-citra.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-citra/libretro-citra.mk
@@ -20,19 +20,12 @@ LIBRETRO_CITRA_CONF_OPTS += -DENABLE_SDL2=OFF
 LIBRETRO_CITRA_CONF_OPTS += -DENABLE_WEB_SERVICE=OFF
 LIBRETRO_CITRA_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
 LIBRETRO_CITRA_CONF_OPTS += -DTHREADS_PTHREAD_ARG=OFF
+LIBRETRO_CITRA_CONF_OPTS += -DBUILD_SHARED_LIBS=FALSE
 
 define LIBRETRO_CITRA_INSTALL_TARGET_CMDS
 	$(INSTALL) -D $(@D)/buildroot-build/src/citra_libretro/citra_libretro.so \
 		$(TARGET_DIR)/usr/lib/libretro/citra_libretro.so
-	
-	$(INSTALL) -D $(@D)/buildroot-build/externals/fmt/libfmt.so.5.1.0 \
-		$(TARGET_DIR)/usr/lib/
 
-	$(INSTALL) -D $(@D)/buildroot-build/externals/fmt/libfmt.so.5 \
-		$(TARGET_DIR)/usr/lib/
-
-	$(INSTALL) -D $(@D)/buildroot-build/externals/dynarmic/src/libdynarmic.so \
-		$(TARGET_DIR)/usr/lib/
 endef
 
 $(eval $(cmake-package))


### PR DESCRIPTION
Advantages :
- We do not depend on buildroot fmt or other lib
- We use whatever is provided in the package
- We do not copy/clutter core/emulator-specific into /usr/lib

Builds fine on x86_64.