### PR TITLE
Wifi access to hidden AP - DNM

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -53,7 +53,7 @@ batocera_wifi_configure() {
 		[service_batocera_${settings_name}]
 		Type=wifi
 		Name=${settings_ssid}
-		Hide=${settings_hide}
+		Hidden=${settings_hide}
 		Passphrase=${settings_key}
 	_EOF_
 

--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -24,28 +24,36 @@ fi
 batocera_wifi_configure() {
     X=$1
 
-    if [[ $X -eq 1 ]]
+    if [ $X -eq 1 ]
     then
         settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi.ssid)"
+        settings_hide="$(batocera-settings "$BATOCONF" -command load -key wifi.hidden)"
         settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi.key)"
         settings_file="/var/lib/connman/batocera_wifi.config"
         settings_name="default"
     else
         settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.ssid)"
+        settings_hide="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.hidden)"
         settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.key)"
         settings_file="/var/lib/connman/batocera_wifi${X}.config"
         settings_name="${X}"
     fi
 
-    if [[ -n "$settings_ssid" ]] ;then
+    if [ "$settings_hide" == "1" ]; then
+        settings_hide=true
+    else
+        settings_hide=false
+    fi
+
+    if [ -n "$settings_ssid" ];then
         mkdir -p "/var/lib/connman"
         cat > "${settings_file}" <<-_EOF_
 		[global]
 		Name=batocera
-
 		[service_batocera_${settings_name}]
 		Type=wifi
 		Name=${settings_ssid}
+		Hide=${settings_hide}
 		Passphrase=${settings_key}
 	_EOF_
 

--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -11,7 +11,7 @@ BATOCONF="/userdata/system/batocera.conf"
 BOOTCONF="/boot/batocera-boot.conf"
 BOOTLOCK=0
 
-for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key audio.device audio.backend
+for i in wifi.enabled wifi.ssid wifi.key wifi.hidden wifi2.ssid wifi2.key wifi2.hidden wifi3.ssid wifi3.key wifi3.hidden audio.device audio.backend
 do
     userdata="$(grep -m1 ^[\ #]*$i\s*= "$BATOCONF")" || continue
     bootdata="$(grep -m1 ^[\ #]*$i\s*= "$BOOTCONF")"


### PR DESCRIPTION
CONNMAN can directly connect to hidden AP
So we set `Hidden=true` for selected AP

Please do not merge. We need to find a solution for make it use in batocera-wifi (maybe via ES switch).

1. Add a possibility to select in ES that this is a hidden AP
2. Update batocera.conf for boards so we can access hidden AP per setup (wifi.hidden, wifi2.hidden, wifi3.hidden set to 0 or 1)

FOR NOW IT WORKS FOR HIDDEN APs ONLY AFTER REBOOT BECAUSE BATOCERA-WIFI DOES NOT SUPPORT HIDDEN APs