### PR TITLE
WIFI connect to hidden APs

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -24,28 +24,23 @@ fi
 batocera_wifi_configure() {
     X=$1
 
-    if [[ $X -eq 1 ]]
-    then
-        settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi.ssid)"
-        settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi.key)"
-        settings_file="/var/lib/connman/batocera_wifi.config"
-        settings_name="default"
-    else
-        settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.ssid)"
-        settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.key)"
-        settings_file="/var/lib/connman/batocera_wifi${X}.config"
-        settings_name="${X}"
-    fi
+    settings_hide=false; settings_name="${X}"
+    [ "$X" = "1" ] && { X=; settings_name=default; }
+    [ "$X" = ".hidden" ] && { settings_name=hidden_AP; settings_hide=true; }
+    
+    settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.ssid)"
+    settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.key)"
+    settings_file="/var/lib/connman/batocera_wifi${X}.config"
 
-    if [[ -n "$settings_ssid" ]] ;then
+    if [ -n "$settings_ssid" ];then
         mkdir -p "/var/lib/connman"
         cat > "${settings_file}" <<-_EOF_
 		[global]
 		Name=batocera
-
 		[service_batocera_${settings_name}]
 		Type=wifi
 		Name=${settings_ssid}
+		Hidden=${settings_hide}
 		Passphrase=${settings_key}
 	_EOF_
 
@@ -60,7 +55,7 @@ batocera_wifi_configure() {
 # Soft unblock wifi
 rfkill unblock wifi
 
-for i in 1 2 3
+for i in 1 2 3 .hidden
 do
     batocera_wifi_configure $i &
     ret=$?

--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -11,7 +11,7 @@ BATOCONF="/userdata/system/batocera.conf"
 BOOTCONF="/boot/batocera-boot.conf"
 BOOTLOCK=0
 
-for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key audio.device audio.backend
+for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key audio.device audio.backend
 do
     userdata="$(grep -m1 ^[\ #]*$i\s*= "$BATOCONF")" || continue
     bootdata="$(grep -m1 ^[\ #]*$i\s*= "$BOOTCONF")"


### PR DESCRIPTION
This one works best and offers the best of two worlds. The average user won't mind this extra config because it is completly independent from ES and batocera-wifi. The advanced user can manually add the needed keyvalues.

We just need to add keyvalues to batocera.conf
```
# Add here values to connect to a hidden AP
#wifi.hidden.ssid=hidden SSID
#wifi.hidden.key=new key
```

EDIT: we need to add the code block from above to all batocera.conf SBC.

This is also the more straight and less user confusing approach, if you compare this [PR1991](https://github.com/batocera-linux/batocera.linux/pull/1991) then it should be clear what I ment