### PR TITLE
Link PPSSPP statically with dependencies (do not clutter /usr/lib)

### DIFF
--- a/package/batocera/emulators/ppsspp/ppsspp.mk
+++ b/package/batocera/emulators/ppsspp/ppsspp.mk
@@ -13,7 +13,7 @@ PPSSPP_DEPENDENCIES = sdl2 libzip ffmpeg
 
 PPSSPP_CONF_OPTS = -DUSE_FFMPEG=ON -DUSING_FBDEV=ON -DUSE_WAYLAND_WSI=OFF \
 		   -DCMAKE_BUILD_TYPE=Release -DCMAKE_SYSTEM_NAME=Linux -DUSE_DISCORD=OFF \
-		   -DUSING_X11_VULKAN=OFF -DARM_NO_VULKAN=ON
+		   -DUSING_X11_VULKAN=OFF -DARM_NO_VULKAN=ON -DBUILD_SHARED_LIBS=OFF
 
 # x86
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_X86),y)
@@ -76,8 +76,6 @@ define PPSSPP_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/PPSSPPSDL $(TARGET_DIR)/usr/bin
 	mkdir -p $(TARGET_DIR)/usr/share/ppsspp
 	cp -R $(@D)/assets $(TARGET_DIR)/usr/share/ppsspp/PPSSPP
-	mkdir -p $(TARGET_DIR)/lib
-	cp -R $(@D)/lib/*.so $(TARGET_DIR)/lib
 endef
 
 $(eval $(cmake-package))


### PR DESCRIPTION
This will be important later as I am planning to add Vulkan support and we might have conflicts with system Vulkan libs (glslang, SPIRV and so on).
Also this is tidyier but that's just my personal opinion :)