### PR TITLE
Reactivate dosbox + fix for dosbox-x configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
@@ -2,7 +2,7 @@
 import Command
 import batoceraFiles
 from generators.Generator import Generator
-import os.path
+import os.path, shutil
 from os.path import dirname
 from os.path import isdir
 from os.path import isfile
@@ -25,8 +25,13 @@ class DosBoxxGenerator(Generator):
         iniSettings = ConfigParser.ConfigParser()
         # To prevent ConfigParser from converting to lower case
         iniSettings.optionxform = str
+
+        # copy config file to custom config file to avoid overwritting by dosbox-x
+        customConfFile = os.path.join(batoceraFiles.dosboxxCustom,'dosboxx-custom.conf')
+
         if os.path.exists(configFile):
-            iniSettings.read(configFile)
+            shutil.copy2(configFile, customConfFile)
+            iniSettings.read(customConfFile)
 
         # sections
         if not iniSettings.has_section("sdl"):
@@ -34,7 +39,7 @@ class DosBoxxGenerator(Generator):
         iniSettings.set("sdl", "output", "opengl")
 
         # save
-        with open(configFile, 'w') as config:
+        with open(customConfFile, 'w') as config:
             iniSettings.write(config)
 
         commandArray = [batoceraFiles.batoceraBins[system.config['emulator']],
@@ -44,6 +49,6 @@ class DosBoxxGenerator(Generator):
                         "-c", "dosbox.bat",
                         "-fastbioslogo",
                         "-fullscreen",
-                        "-conf {}".format(configFile)]
+                        "-conf {}".format(customConfFile)]
 
         return Command.Command(array=commandArray)

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -302,9 +302,7 @@ config BR2_PACKAGE_BATOCERA_ALL_SYSTEMS
         select BR2_PACKAGE_MOONLIGHT_EMBEDDED   if !BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA # moonlight
         select BR2_PACKAGE_SCUMMVM              # ALL # scummvm
 
-        select BR2_PACKAGE_DOSBOX               if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY  || \
-                                                   BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA
-                                                   # dos
+        select BR2_PACKAGE_DOSBOX               # ALL # dos
 
         select BR2_PACKAGE_DOSBOX_X             if !BR2_PACKAGE_BATOCERA_TARGET_ROCK960 && \
                                                    !BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY && \


### PR DESCRIPTION
### Why this PR ?

After further testing on N2, there are still a lot of problem with dos emulation through dosbox-x and lr-dosbox :

- `lr-dosbox` doesn't take into account custom `dosbox.cfg` nor `dosbox.conf` for a specific a game, it should according to documentation but it does n't, and I don't know why. This breaks emulation for games needing more than standard configuration, like windows 3.1 games

- on N2 `dosbox-x` is completely broken, when it manages to launch it displays a completely broken screen 
![IMG_20200720_091920475](https://user-images.githubusercontent.com/1405681/88221175-5bf80c00-cc64-11ea-888a-367c70536b4f.jpg)
![IMG_20200720_091926834](https://user-images.githubusercontent.com/1405681/88221181-5ef2fc80-cc64-11ea-9923-b122c366209c.jpg)

Displaying the internal menu of dosbox-x is ok though but something doesn't work with display (I tried all possible display configurations (`output=` values of `surface, overlay, opengl, openglnb, openglhq or ddraw`) it simply doesn't work

And after a while it simply ceases to work with a lot of problems and errors in the log : https://pastebin.com/9fJRBWFk

So in essence, on N2 at least, nothing allows us to have the same emulation level as regular dosbox as the two other emulators are either broken or bugged

The main aim of the PR is then just to reactivate for all platforms.

Also included is a small fix for dosbox-x which is actually overwriting custom `dosbox.cfg` of a launched game, removing all comments and line jumps in it, leading to a loss of documentation (all comments related to how to configure a file are deleted)
It also did the same to the standard `/userdata/system/configs/dosbox/dosboxx.conf` file which contains all instructions about what the parameters are doing for dosbox-x

I fixed that by copying the configuration file used a launch of a rom (either the one of the game or the standard one) to a `dosboxx-custom.conf` file also located in `/userdata/system/configs/dosbox/`  and using that one for launch instead to launch the emulator, thus keeping the user `dosbox.cfg` files intact
