### PR TITLE
RPCS with working LLVM submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
-FROM ubuntu:18.04
-
+FROM ubuntu:20.04
 RUN dpkg --add-architecture i386 && \
 	apt update && \
 	apt install -y libc6:i386 \
-		libncurses5:i386 \
+		libncurses6:i386 \
 		libstdc++6:i386 \
 		build-essential \
 		git \
-		libncurses5-dev \
+		libncurses-dev \
 		libssl-dev \
 		mercurial \
 		texinfo \
@@ -40,6 +39,7 @@ RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+ENV TZ Europe/Paris
 
 # Workaround host-tar configure error
 ENV FORCE_UNSAFE_CONFIGURE 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 RUN dpkg --add-architecture i386 && \
 	apt update && \
 	apt install -y libc6:i386 \
@@ -6,6 +7,7 @@ RUN dpkg --add-architecture i386 && \
 		libstdc++6:i386 \
 		build-essential \
 		git \
+		libncurses6 \
 		libncurses-dev \
 		libssl-dev \
 		mercurial \

--- a/package/batocera/emulators/rpcs3/006-llvm-crosscompile.patch
+++ b/package/batocera/emulators/rpcs3/006-llvm-crosscompile.patch
@@ -1,0 +1,66 @@
+From 1dbb7a3518bb7e82403d57238273283310d9e9e1 Mon Sep 17 00:00:00 2001
+From: Sebastian Neubauer <sebastian.neubauer@amd.com>
+Date: Mon, 27 Apr 2020 11:40:31 +0200
+Subject: [PATCH] [CMake] Fix cross-compiling with LLVM as CMake subproject
+
+When embedding LLVM as a CMake subproject, using cross-compiling does
+not work at the moment. This also affects -DLLVM_OPTIMIZED_TABLEGEN=1,
+which uses the same CMake infrastructure.
+
+This patch replaces global CMake variables with the current version,
+which allows cross-compilation to work in a subproject.
+
+CMAKE_BINARY_DIR -> CMAKE_CURRENT_BINARY_DIR
+CMAKE_SOURCE_DIR -> CMAKE_CURRENT_SOURCE_DIR
+CMAKE_PROJECT_NAME -> PROJECT_NAME
+
+Differential Revision: https://reviews.llvm.org/D78913
+---
+ llvm/cmake/modules/CrossCompile.cmake | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/llvm/cmake/modules/CrossCompile.cmake b/llvm/cmake/modules/CrossCompile.cmake
+index 8a6e880c4e21..01cd37124841 100644
+--- a/llvm/cmake/modules/CrossCompile.cmake
++++ b/llvm/cmake/modules/CrossCompile.cmake
+@@ -6,7 +6,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
+ 
+   if(NOT DEFINED ${project_name}_${target_name}_BUILD)
+     set(${project_name}_${target_name}_BUILD
+-      "${CMAKE_BINARY_DIR}/${target_name}")
++      "${CMAKE_CURRENT_BINARY_DIR}/${target_name}")
+     set(${project_name}_${target_name}_BUILD
+       ${${project_name}_${target_name}_BUILD} PARENT_SCOPE)
+     message(STATUS "Setting native build dir to " ${${project_name}_${target_name}_BUILD})
+@@ -68,7 +68,7 @@ function(llvm_create_cross_target project_name target_name toolchain buildtype)
+   add_custom_command(OUTPUT ${${project_name}_${target_name}_BUILD}/CMakeCache.txt
+     COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+         -DCMAKE_MAKE_PROGRAM="${CMAKE_MAKE_PROGRAM}"
+-        ${CROSS_TOOLCHAIN_FLAGS_${target_name}} ${CMAKE_SOURCE_DIR}
++        ${CROSS_TOOLCHAIN_FLAGS_${target_name}} ${CMAKE_CURRENT_SOURCE_DIR}
+         ${CROSS_TOOLCHAIN_FLAGS_${project_name}_${target_name}}
+         -DLLVM_TARGET_IS_CROSSCOMPILE_HOST=TRUE
+         -DLLVM_TARGETS_TO_BUILD="${targets_to_build_arg}"
+@@ -99,17 +99,17 @@ function(build_native_tool target output_path_var)
+   cmake_parse_arguments(ARG "" "" "DEPENDS" ${ARGN})
+ 
+   if(CMAKE_CONFIGURATION_TYPES)
+-    set(output_path "${${CMAKE_PROJECT_NAME}_NATIVE_BUILD}/Release/bin/${target}")
++    set(output_path "${${PROJECT_NAME}_NATIVE_BUILD}/Release/bin/${target}")
+   else()
+-    set(output_path "${${CMAKE_PROJECT_NAME}_NATIVE_BUILD}/bin/${target}")
++    set(output_path "${${PROJECT_NAME}_NATIVE_BUILD}/bin/${target}")
+   endif()
+ 
+-  llvm_ExternalProject_BuildCmd(build_cmd ${target} ${${CMAKE_PROJECT_NAME}_NATIVE_BUILD}
++  llvm_ExternalProject_BuildCmd(build_cmd ${target} ${${PROJECT_NAME}_NATIVE_BUILD}
+                                 CONFIGURATION Release)
+   add_custom_command(OUTPUT "${output_path}"
+                      COMMAND ${build_cmd}
+-                     DEPENDS CONFIGURE_${CMAKE_PROJECT_NAME}_NATIVE ${ARG_DEPENDS}
+-                     WORKING_DIRECTORY "${${CMAKE_PROJECT_NAME}_NATIVE_BUILD}"
++                     DEPENDS CONFIGURE_${PROJECT_NAME}_NATIVE ${ARG_DEPENDS}
++                     WORKING_DIRECTORY "${${PROJECT_NAME}_NATIVE_BUILD}"
+                      COMMENT "Building native ${target}..."
+                      USES_TERMINAL)
+   set(${output_path_var} "${output_path}" PARENT_SCOPE)

--- a/package/batocera/emulators/rpcs3/007-fix-wolfssl.patch
+++ b/package/batocera/emulators/rpcs3/007-fix-wolfssl.patch
@@ -1,0 +1,10 @@
+--- a/3rdparty/wolfssl/CMakeLists.txt	2020-07-21 15:06:25.534717568 +0200
++++ b/3rdparty/wolfssl/CMakeLists.txt	2020-07-21 15:06:35.250874736 +0200
+@@ -20,6 +20,7 @@
+ include_directories(${wolfssl_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+ 
+ # Add wolfSSL library source files, to be compiled as STATIC library
++set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+ add_library(wolfssl-3-static STATIC
+             ${wolfssl_DIR}/wolfcrypt/src/aes.c
+             ${wolfssl_DIR}/wolfcrypt/src/arc4.c

--- a/package/batocera/emulators/rpcs3/008-llvm-no-ccache.patch
+++ b/package/batocera/emulators/rpcs3/008-llvm-no-ccache.patch
@@ -1,0 +1,10 @@
+--- a/3rdparty/llvm.cmake	2020-07-21 19:43:05.695354255 +0200
++++ b/3rdparty/llvm.cmake	2020-07-21 19:43:10.951430148 +0200
+@@ -12,7 +12,7 @@
+ 		option(LLVM_INCLUDE_TOOLS OFF)
+ 		option(LLVM_INCLUDE_UTILS OFF)
+ 		option(WITH_POLLY OFF)
+-		option(LLVM_CCACHE_BUILD ON)
++		option(LLVM_CCACHE_BUILD OFF)
+ 
+ 		set(CXX_FLAGS_OLD ${CMAKE_CXX_FLAGS})

--- a/package/batocera/emulators/rpcs3/Config.in
+++ b/package/batocera/emulators/rpcs3/Config.in
@@ -15,6 +15,7 @@ config BR2_PACKAGE_RPCS3
 	select BR2_PACKAGE_LIBUSB
 	select BR2_PACKAGE_LIBGLU
 	select BR2_PACKAGE_FFMPEG_SWSCALE
+	select BR2_PACKAGE_NCURSES
 
         help
           A  ps3 emulator

--- a/package/batocera/emulators/rpcs3/rpcs3.mk
+++ b/package/batocera/emulators/rpcs3/rpcs3.mk
@@ -23,38 +23,33 @@ RPCS3_SITE = https://github.com/RPCS3/rpcs3.git
 RPCS3_SITE_METHOD=git
 RPCS3_GIT_SUBMODULES=YES
 RPCS3_LICENSE = GPLv2
-RPCS3_DEPENDENCIES = qt5declarative libxml2 mesa3d libglu openal alsa-lib libevdev libglew libusb ffmpeg llvm
+RPCS3_DEPENDENCIES = qt5declarative libxml2 mesa3d libglu openal alsa-lib libevdev libglew libusb ffmpeg
 
 RPCS3_CONF_OPTS += -DUSE_PULSE=OFF
 RPCS3_CONF_OPTS += -DUSE_SYSTEM_FFMPEG=ON
 RPCS3_CONF_OPTS += -DUSE_SYSTEM_LIBPNG=ON
 RPCS3_CONF_OPTS += -DUSE_DISCORD_RPC=OFF
 RPCS3_CONF_OPTS += -DUSE_VULKAN=OFF
-RPCS3_CONF_OPTS += -DCMAKE_CROSSCOMPILING=ON
+#RPCS3_CONF_OPTS += -DCMAKE_CROSSCOMPILING=ON
 RPCS3_CONF_OPTS += -DWITH_LLVM=ON
 RPCS3_CONF_OPTS += -DBUILD_LLVM_SUBMODULE=ON
 RPCS3_CONF_OPTS += -DUSE_NATIVE_INSTRUCTIONS=OFF
-RPCS3_CONF_OPTS += -DBUILD_SHARED_LIBS=FALSE
+RPCS3_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
 RPCS3_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
-
-RPCS3_CONF_ENV += LD_LIBRARY_PATH="$(TARGET_DIR)/usr/lib:$LD_LIBRARY_PATH"
-
 #RPCS3_CONF_OPTS += -DLLVM_USE_HOST_TOOLS=ON
 
-# It seems to support in-source tree build, but easier to track down issues
-#RPCS3_SUPPORTS_IN_SOURCE_BUILD = NO
-
-#RPCS3_CONF_OPTS += -DCMAKE_EXE_LINKER_FLAGS="-L$(STAGING_DIR)/usr/lib"
-
-# Use native llvm-tblgen from host-llvm (needed for cross-compilation)
-#RPCS3_CONF_OPTS += -DLLVM_TABLEGEN=/usr/bin/llvm-tblgen
-
-# Use native llvm-config from host-llvm (needed for cross-compilation)
-#RPCS3_CONF_OPTS += -DLLVM_CONFIG_PATH=/usr/bin/llvm-config
+RPCS3_CONF_ENV += PATH="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/bin:$$PATH"
 
 define RPCS3_BUILD_CMDS
-	#LD_LIBRARY_PATH=$(HOST_DIR)/lib
-	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
+	$(TARGET_CONFIGURE_OPTS) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" \
+		CC_FOR_BUILD="$(TARGET_CC)" GCC_FOR_BUILD="$(TARGET_CC)" \
+		CXX_FOR_BUILD="$(TARGET_CXX)" LD_FOR_BUILD="$(TARGET_LD)" \
+                CROSS_COMPILE="$(STAGING_DIR)/usr/bin/" \
+                PREFIX="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/" \
+                PKG_CONFIG="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/bin/pkg-config" \
+		$(MAKE) -C $(@D)
 endef
+
+#		LD_LIBRARY_PATH="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/lib:/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/lib:$LD_LIBRARY_PATH" \
 
 $(eval $(cmake-package))

--- a/package/batocera/emulators/rpcs3/rpcs3.mk
+++ b/package/batocera/emulators/rpcs3/rpcs3.mk
@@ -4,20 +4,12 @@
 #
 ################################################################################
 
-# last version without gcc-9 and qt bump
-#RPCS3_VERSION = 491526b42185c864883176f5000e144b9ac3c83e
-
-# original
-#RPCS3_VERSION = cb66d05693504f4e453999af489786d05d2a8e51
-
-# 1er january
-#RPCS3_VERSION = 4c20881f8f40f4dfd45ffb3eca94ac206a56e7f9
-
-# 1er december
-#RPCS3_VERSION = 1a6e8e20dca9fd259e03c607d4c9d93ae5375298
 
 # Jun, 30 2020 release
-RPCS3_VERSION = v0.0.11
+#RPCS3_VERSION = v0.0.11
+
+# Jul, 19 2020
+RPCS3_VERSION = f8d2d8ca11c7a10ad5185ebe761271e960e7cb5b
 
 RPCS3_SITE = https://github.com/RPCS3/rpcs3.git
 RPCS3_SITE_METHOD=git
@@ -36,7 +28,6 @@ RPCS3_CONF_OPTS += -DBUILD_LLVM_SUBMODULE=ON
 RPCS3_CONF_OPTS += -DUSE_NATIVE_INSTRUCTIONS=OFF
 RPCS3_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
 RPCS3_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
-#RPCS3_CONF_OPTS += -DLLVM_USE_HOST_TOOLS=ON
 
 RPCS3_CONF_ENV += PATH="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/bin:$$PATH"
 
@@ -49,7 +40,5 @@ define RPCS3_BUILD_CMDS
                 PKG_CONFIG="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/bin/pkg-config" \
 		$(MAKE) -C $(@D)
 endef
-
-#		LD_LIBRARY_PATH="/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/usr/lib:/x86_64/host/x86_64-buildroot-linux-gnu/sysroot/lib:$LD_LIBRARY_PATH" \
 
 $(eval $(cmake-package))

--- a/package/batocera/emulators/rpcs3/rpcs3.mk
+++ b/package/batocera/emulators/rpcs3/rpcs3.mk
@@ -23,21 +23,38 @@ RPCS3_SITE = https://github.com/RPCS3/rpcs3.git
 RPCS3_SITE_METHOD=git
 RPCS3_GIT_SUBMODULES=YES
 RPCS3_LICENSE = GPLv2
-RPCS3_DEPENDENCIES = qt5declarative libxml2 mesa3d libglu openal alsa-lib libevdev libglew libusb ffmpeg
+RPCS3_DEPENDENCIES = qt5declarative libxml2 mesa3d libglu openal alsa-lib libevdev libglew libusb ffmpeg llvm
 
 RPCS3_CONF_OPTS += -DUSE_PULSE=OFF
 RPCS3_CONF_OPTS += -DUSE_SYSTEM_FFMPEG=ON
 RPCS3_CONF_OPTS += -DUSE_SYSTEM_LIBPNG=ON
 RPCS3_CONF_OPTS += -DUSE_DISCORD_RPC=OFF
 RPCS3_CONF_OPTS += -DUSE_VULKAN=OFF
-RPCS3_CONF_OPTS += -DCMAKE_CROSSCOMPILING=OFF
-RPCS3_CONF_OPTS += -DWITH_LLVM=OFF
-RPCS3_CONF_OPTS += -DBUILD_LLVM_SUBMODULE=OFF
+RPCS3_CONF_OPTS += -DCMAKE_CROSSCOMPILING=ON
+RPCS3_CONF_OPTS += -DWITH_LLVM=ON
+RPCS3_CONF_OPTS += -DBUILD_LLVM_SUBMODULE=ON
 RPCS3_CONF_OPTS += -DUSE_NATIVE_INSTRUCTIONS=OFF
 RPCS3_CONF_OPTS += -DBUILD_SHARED_LIBS=FALSE
+RPCS3_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
+
+RPCS3_CONF_ENV += LD_LIBRARY_PATH="$(TARGET_DIR)/usr/lib:$LD_LIBRARY_PATH"
+
+#RPCS3_CONF_OPTS += -DLLVM_USE_HOST_TOOLS=ON
+
+# It seems to support in-source tree build, but easier to track down issues
+#RPCS3_SUPPORTS_IN_SOURCE_BUILD = NO
+
+#RPCS3_CONF_OPTS += -DCMAKE_EXE_LINKER_FLAGS="-L$(STAGING_DIR)/usr/lib"
+
+# Use native llvm-tblgen from host-llvm (needed for cross-compilation)
+#RPCS3_CONF_OPTS += -DLLVM_TABLEGEN=/usr/bin/llvm-tblgen
+
+# Use native llvm-config from host-llvm (needed for cross-compilation)
+#RPCS3_CONF_OPTS += -DLLVM_CONFIG_PATH=/usr/bin/llvm-config
 
 define RPCS3_BUILD_CMDS
-	LD_LIBRARY_PATH=$(HOST_DIR)/lib $(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
+	#LD_LIBRARY_PATH=$(HOST_DIR)/lib
+	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)
 endef
 
 $(eval $(cmake-package))


### PR DESCRIPTION
Warning !
I had to change the Dockerfile to bump to Ubuntu 20.04 base image and ncurses6 to workaround some tedious LLVM cross-compile bug.
I managed to build successfully master tree for x86, x86_64, odroidn2, odroidga, rpi3 and rpi4 with this new Docker image but some other archs are untested.
RPCS3 is indeed working as experimental with this PR and PS3 games can be "played".
The whole thing is a bit rough but its' a good starting point from the previous non-compiling one.