### PR TITLE
Splash Screen - Full length of video

### DIFF
--- a/package/batocera/core/batocera-splash/S03splash-ffplay
+++ b/package/batocera/core/batocera-splash/S03splash-ffplay
@@ -6,12 +6,12 @@ soundDisabled() {
 
 do_start ()
 {
-    if ls /boot/*.mp4 >/dev/null 2>/dev/null
+    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
     then
-        do_videostart "$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/*.{jpg,png}  2>/dev/null) ]]
+        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
+    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
     then
-        do_imagestart "$(ls /boot/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/*.{jpg,png} | wc -l)+1))!d")"
+        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
     else
         do_videostart "/usr/share/batocera/splash/splash.mp4"
     fi
@@ -28,6 +28,8 @@ do_imagestart()
         let N++
     done
     test -e /dev/fb0 && fbv -f -i "${image}"
+    sleep infinity
+    wait $!
 }
 
 do_videostart ()
@@ -39,19 +41,11 @@ do_videostart ()
         ffplay_opt=-an
     fi
     /usr/bin/ffplay $ffplay_opt -autoexit -loglevel 0 "$video" &
-    PID=$!
-    # Wait for emulationstation or Kodi, but not more than 20 seconds
-    count=0
-    while [[ ! -f "/tmp/emulationstation.ready" && ! -e "/var/run/kodi.msg" && $count -lt 400 ]]; do
-        sleep 0.1
-        ((count++))
-    done
-    kill -9 "${PID}"
+    wait $! 
 }
 
 case "$1" in
     start)
-	grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-image
+++ b/package/batocera/core/batocera-splash/S03splash-image
@@ -2,9 +2,9 @@
 
 do_start ()
 {
-    if [[ $(ls /boot/*.{jpg,png}  2>/dev/null) ]]
+    if [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
     then
-        image="$(ls /boot/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/*.{jpg,png} | wc -l)+1))!d")"
+        image="$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
     else
         image="/usr/share/batocera/splash/logo-version.png"
     fi
@@ -17,11 +17,12 @@ do_start ()
         let N++
     done
     test -e /dev/fb0 && fbv -f -i "${image}"
+    sleep infinity
+    wait $!
 }
 
 case "$1" in
     start)
-	grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-mpv
+++ b/package/batocera/core/batocera-splash/S03splash-mpv
@@ -6,12 +6,12 @@ soundDisabled() {
 
 do_start ()
 {
-    if ls /boot/*.mp4 >/dev/null 2>/dev/null
+    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
     then
-        do_videostart "$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/*.{jpg,png}  2>/dev/null) ]]
+        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
+    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
     then
-        do_imagestart "$(ls /boot/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/*.{jpg,png} | wc -l)+1))!d")"
+        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
     else
         do_videostart "/usr/share/batocera/splash/splash.mp4"
     fi
@@ -28,6 +28,8 @@ do_imagestart()
         let N++
     done
     test -e /dev/fb0 && fbv -f -i "${image}"
+    sleep infinity
+    wait $!
 }
 
 do_videostart ()
@@ -39,19 +41,11 @@ do_videostart ()
         mpv_opt=--no-audio
     fi
     /usr/bin/mpv --no-config $mpv_opt "$video" &
-    PID=$!
-    # Wait for emulationstation or Kodi, but not more than 20 seconds
-    count=0
-    while [[ ! -f "/tmp/emulationstation.ready" && ! -e "/var/run/kodi.msg" && $count -lt 400 ]]; do
-        sleep 0.1
-        ((count++))
-    done
-    kill -9 "${PID}"
+    wait $!
 }
 
 case "$1" in
     start)
-	grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-omx
+++ b/package/batocera/core/batocera-splash/S03splash-omx
@@ -6,12 +6,12 @@ soundDisabled() {
 
 do_start ()
 {
-    if ls /boot/*.mp4 >/dev/null 2>/dev/null
+    if ls /boot/splash/*.mp4 >/dev/null 2>/dev/null
     then
-        do_videostart "$(ls /boot/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/*.mp4 | wc -l)+1))!d")"
-    elif [[ $(ls /boot/*.{jpg,png}  2>/dev/null) ]]
+        do_videostart "$(ls /boot/splash/*.mp4 | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.mp4 | wc -l)+1))!d")"
+    elif [[ $(ls /boot/splash/*.{jpg,png}  2>/dev/null) ]]
     then
-        do_imagestart "$(ls /boot/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/*.{jpg,png} | wc -l)+1))!d")"
+        do_imagestart "$(ls /boot/splash/*.{jpg,png} | sed -e "$((RANDOM%$(ls -1 /boot/splash/*.{jpg,png} | wc -l)+1))!d")"
     else
         do_videostart "/usr/share/batocera/splash/splash.mp4"
     fi
@@ -28,26 +28,13 @@ do_imagestart()
         let N++
     done
     test -e /dev/fb0 && fbv -f -i "${image}"
+    sleep infinity
+    wait $!
 }
 
 do_videostart ()
 {
     video="$1"
-    # Initialize dbus session
-    OMXPLAYER_DBUS_ADDR="/tmp/omxplayerdbus.root"
-    OMXPLAYER_DBUS_PID="/tmp/omxplayerdbus.root.pid"
-    exec 5> "$OMXPLAYER_DBUS_ADDR"
-    exec 6> "$OMXPLAYER_DBUS_PID"
-    dbus-daemon --fork --print-address 5 --print-pid 6 --session
-    until [ -s "$OMXPLAYER_DBUS_ADDR" ]; do
-        echo "waiting for dbus address to appear" >&2
-        sleep .2
-    done
-    DBUS_SESSION_BUS_ADDRESS=`cat $OMXPLAYER_DBUS_ADDR`
-    DBUS_SESSION_BUS_PID=`cat $OMXPLAYER_DBUS_PID`
-    export DBUS_SESSION_BUS_ADDRESS
-    export DBUS_SESSION_BUS_PID
-
     # Launch the video
     omx_fnt="--font=/usr/share/fonts/dejavu/DejaVuSans-BoldOblique.ttf"
     omx_opt="--no-keys --layer=10000 --aspect-mode=fill"
@@ -59,38 +46,13 @@ do_videostart ()
         omx_nosound="-n -1"
     fi
 
-    # -911 = Volume set to 35% (On omxplayer)
-    # 1/(10^(911/2000)) = 0.35034828830157
-
-    /usr/bin/omxplayer -o both --vol -2500 $omx_opt $omx_srt $omx_nosound "$video" &
-    PID=$!
-
-    # Stop the video when ready
-    if [[ $? -eq 0 ]]; then
-        # Wait for emulationstation or Kodi, but not more than 20 seconds
-        count=0
-        while [[ ! -f "/tmp/emulationstation.ready" && ! -e "/var/run/kodi.msg" && $count -lt 400 ]]; do
-            sleep 0.1
-            ((count++))
-        done
-        # Finish with a one second fade out.
-        audio_fade=1
-        video_fade=250
-        while [[ $video_fade -gt 0 ]]; do
-            sleep .02
-            dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Volume double:$audio_fade >/dev/null
-            dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.SetAlpha objpath:/not/used int64:$video_fade >/dev/null
-            audio_fade=`echo "$audio_fade .02" | awk '{printf "%.2f", $1-$2}'`
-            ((video_fade=video_fade-5))
-        done
-        # Ready flag set or timeout occured; stop video process.
-        dbus-send --print-reply=literal --session --dest=org.mpris.MediaPlayer2.omxplayer /org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player.Action int32:15 >/dev/null
-    fi
+    /usr/bin/omxplayer -o both $omx_opt $omx_srt $omx_nosound "$video" &
+    wait $!    
 }
+
 
 case "$1" in
     start)
-	grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S29splashscreencontrol
+++ b/package/batocera/core/batocera-splash/S29splashscreencontrol
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Splash Screen Control
+# This service controls length of video/picture displayed during startup
+# Furthermore it copies content from /userdata/splash to /boot/splash
+# by cyperghost aka lala on discord
+
+splash_autoplay ()
+{
+    count=0
+    while [[ $count -lt 90 ]]
+    do
+        sleep 1
+        ((count++))
+        kill -0 $PID &>/dev/null  || { echo "Video finished"; break; }
+    done
+}
+
+splash_default ()
+{
+    # Stop the video when ready
+    # Wait for emulationstation or Kodi, but not more than 20 seconds
+    count=0
+    while [[ ! -f "/tmp/emulationstation.ready" && ! -e "/var/run/kodi.msg" && $count -lt 20 ]]
+    do
+        sleep 1
+        ((count++))
+    done
+    kill -9 $PID
+}
+
+#### MAIN ####
+
+INIT_SERVICE=/etc/init.d/S03splash
+SPLASHBOOT=/boot/splash/
+SPLASHUSER=/userdata/splash/
+
+case $1 in
+    start)
+        # Is service is active? PPID is videoplayer or pic sleep timer
+        PID=$(pgrep -P $(pgrep -f $INIT_SERVICE) 2>/dev/null ) || { echo "No service '$INIT_SERVICE' found!"; exit 0; }
+
+        # If the timer for picture is active then kill this PID to avoid
+        # unwanted behaviour in splash_autoplay
+        [[ $PID == $(pgrep -f "sleep infinity") ]] && picture=1 || picture=0
+
+        # Read Config and do action
+        splash_setting=$(batocera-settings -command load -key splash.screen.length)
+        [[ -z $splash_setting ]] && splash_setting=default
+
+        case ${splash_setting,,} in
+            def*)
+                # Standard BATOCERA setting, fastest boot possible
+                # A video splash will be displayed ~16s on Pi3 platform
+                #
+                splash_default &
+            ;;
+            auto)
+                # Play video as long as possible
+                #
+                [[ $picture -eq 0 ]] && splash_autoplay
+                kill -9 $PID
+            ;;
+            i[0-90]*|k[0-90]*|[0-90]*)
+                # k-mode: Stop loading process for x seconds, attention there will be no
+                #         further steps so you can "lock" the system
+                # i-mode: This mode will not kill video in background this is a posible setup
+                #         for RPi system and you will smoothly boot into ES
+                #
+                sleeptimer=${splash_setting//[^[:digit:]]/}
+                [[ $picture -eq 1 && $sleeptimer -gt 10 ]] && sleeptimer=10
+                sleep $sleeptimer
+                [[ $picture -eq 1 || ${splash_setting:0:1} != i ]] && kill -9 $PID
+            ;;
+            *)
+                # Other settings --> not valid
+                #
+                kill -9 $PID
+                exit 1
+            ;;
+        esac
+    ;;
+    stop)
+        #DryRun -n to test if there is a change in /userdata/splash/ if there is output then do sync job
+        RSYNC="rsync -tin --dirs --delete $SPLASHUSER $SPLASHBOOT"
+        #File changes can be detected by -i switch output
+        [[ -n $($RSYNC | grep -e '^\*deleting' -e '^>f++++++') ]] || exit 0
+
+        #Check filesize of /userdata/splash and set a directory size limit (256MB*1024kB)
+        [[ $(du -s $SPLASHUSER | awk '{print $1}') -lt 262144 ]] || exit 1
+
+        RSYNC="rsync -ti --dirs --delete $SPLASHUSER $SPLASHBOOT"
+        mount -o remount,rw /boot
+        $RSYNC | dialog --backtitle "batocera.linux" --progressbox "Syncing Splashscreen data..." 20 75 &>/dev/tty1
+        mount -o remount,ro /boot
+        sleep 3
+    ;;
+    *)
+        echo "Usage $0 {start|stop}"
+    ;;
+esac
+exit 0

--- a/package/batocera/core/batocera-splash/S29splashscreencontrol
+++ b/package/batocera/core/batocera-splash/S29splashscreencontrol
@@ -11,11 +11,11 @@ splash_autoplay ()
     do
         sleep 1
         ((count++))
-        kill -0 $PID &>/dev/null  || { echo "Video finished"; break; }
+        kill -0 $PID &>/dev/null  || break
     done
 }
 
-splash_default ()
+splash_default_rpi ()
 {
     # Stop the video when ready
     # Wait for emulationstation or Kodi, but not more than 20 seconds
@@ -33,6 +33,7 @@ splash_default ()
 INIT_SERVICE=/etc/init.d/S03splash
 SPLASHBOOT=/boot/splash/
 SPLASHUSER=/userdata/splash/
+ARCH=$(cat /usr/share/batocera/batocera.arch)
 
 case $1 in
     start)
@@ -43,19 +44,21 @@ case $1 in
         # unwanted behaviour in splash_autoplay
         [[ $PID == $(pgrep -f "sleep infinity") ]] && picture=1 || picture=0
 
-        # Read Config and do action
+        # Read Config and set some defaults
         splash_setting=$(batocera-settings -command load -key splash.screen.length)
         [[ -z $splash_setting ]] && splash_setting=default
+        [[ ${splash_setting,,} == default && $ARCH =~ rpi(1|2|3) ]] && splash_setting=$ARCH
+            
 
         case ${splash_setting,,} in
-            def*)
-                # Standard BATOCERA setting, fastest boot possible
-                # A video splash will be displayed ~16s on Pi3 platform
+            rpi*)
+                # Standard BATOCERA setting, for Pi platform
+                # A video splash will be displayed ~16s on Pi3 platform you'll smoothly boot into ES
                 #
-                splash_default &
+                splash_default_rpi &
             ;;
-            auto)
-                # Play video as long as possible
+            default|auto)
+                # Play video as long as possible, ideal for fast boards
                 #
                 [[ $picture -eq 0 ]] && splash_autoplay
                 kill -9 $PID
@@ -71,8 +74,8 @@ case $1 in
                 sleep $sleeptimer
                 [[ $picture -eq 1 || ${splash_setting:0:1} != i ]] && kill -9 $PID
             ;;
-            *)
-                # Other settings --> not valid
+            fastboot|*)
+                # fastboot or invalid settings
                 #
                 kill -9 $PID
                 exit 1

--- a/package/batocera/core/batocera-splash/S29splashscreencontrol
+++ b/package/batocera/core/batocera-splash/S29splashscreencontrol
@@ -92,7 +92,6 @@ case $1 in
         mount -o remount,rw /boot
         $RSYNC | dialog --backtitle "batocera.linux" --progressbox "Syncing Splashscreen data..." 20 75 &>/dev/tty1
         mount -o remount,ro /boot
-        sleep 3
     ;;
     *)
         echo "Usage $0 {start|stop}"

--- a/package/batocera/core/batocera-splash/batocera-splash.mk
+++ b/package/batocera/core/batocera-splash/batocera-splash.mk
@@ -3,7 +3,7 @@
 # Batocera splash
 #
 ################################################################################
-BATOCERA_SPLASH_VERSION = 1.3
+BATOCERA_SPLASH_VERSION = 1.4
 BATOCERA_SPLASH_SOURCE=
 
 BATOCERA_SPLASH_TGVERSION=$(BATOCERA_SYSTEM_VERSION) $(BATOCERA_SYSTEM_DATE_TIME)
@@ -52,7 +52,8 @@ endif
 
 define BATOCERA_SPLASH_INSTALL_SCRIPT
 	mkdir -p $(TARGET_DIR)/etc/init.d
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-splash/$(BATOCERA_SPLASH_SCRIPT)  $(TARGET_DIR)/etc/init.d/S03splash
+	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-splash/S29splashscreencontrol	$(TARGET_DIR)/etc/init.d/ 
+	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-splash/$(BATOCERA_SPLASH_SCRIPT)	$(TARGET_DIR)/etc/init.d/S03splash
 endef
 
 define BATOCERA_SPLASH_INSTALL_VIDEO


### PR DESCRIPTION
This PR is the base for
https://github.com/batocera-linux/batocera.linux/pull/2030 --> normalized splash.mp4
https://github.com/batocera-linux/batocera.linux/pull/2028 --> batocera.conf setted
https://github.com/batocera-linux/batocera.linux/pull/2019 --> datainit for first install

https://github.com/batocera-linux/batocera.linux/pull/2014 --> old PR with lots of hints and tests


**How to use**
Copy your video files or pictures to /userdata/splash
After reboot you can use them. Please mind *Not all arches support video splash screens!*
Splash screens directory can store 250MB of data.

This file is for the splash screen
- **default** : like today, fastest boot and a quick video
- **auto** : Plays video per automatic length (but not longer than 90s)
- **[0-90]** or **k[0-90]** : Plays a video between 0-90s (or shows the frambuffer if a png was loaded) and kills the video player AFTER the time (except the png in frambuffer of course)
- **i[0-90]** : Offers a sleep time of the video and stops loading process for x seconds, after that the VIDEO WILL NOT BE KILLED and ES loads in background, so with a bit of finetuning a user can achive a ready boot into ES without a black splash screen (good for RPi...) will possible glitch on other platforms

```
## Extend visible time of video/pictures
## Possible values are:
## default:   Video will be played for 20 seconds (default)
## auto:      All the video will be played but not longer than 90s
## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
## k[0-90]:   Time after the video will be terminated, after this ES starts (recommended)
## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
splash.screen.length=i42
```

**NOTE and TODO**

~~1. Rename serivce to S30~~ *Keep stick to S29 mabye a S30service will be added later* **DONE**
~~2. Update all batocera.confs~~ **DONE**
~~3. Update all batocera.confs regarding PR1986 (wifi.hidden.ssid)~~ **DONE**
~~4. Update batocera-boot.conf~~ **Not needed**
~~5. Rename Service itself~~ **DONE**
~~6. Add splash directory PR2019~~ **DONE**
~~7. Add limit for free space and add to STOP) condition @tcamargo~~ --> 256MB set **DONE**
~~8. Added default behaviour if users do upgrade from <5.27~~ **DONE**
~~9. Optimize video splash (normalize audio+fade in/out)~~ **DONE** https://github.com/batocera-linux/batocera.linux/pull/2030
~~10. Final tests --> close this PR & open a new one (just to many commits)~~ **DONE**