### PR TITLE
ScummVM defaults to Libretro version

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -233,10 +233,8 @@ imageviewer:
   emulator: libretro
   core:     imageviewer
 scummvm:
-  emulator: scummvm
-  core: scummvm
-  options:
-    videomode: default
+  emulator: libretro
+  core:     scummvm
 colecovision:
   emulator: libretro
   core:     bluemsx


### PR DESCRIPTION
Fixes the stuttering we experience with standalone version on OGA, and provides features more consistent features with the rest of the emulators ([hotkey]+[start] to exit, shaders, bezels, AI translations...)