### PR TITLE
WiringPi is deprecated (git source tree removed).

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -73,7 +73,8 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_XARCADE2JSTICK                    # keyboard events of the Xarcade Tankstick
     select BR2_PACKAGE_UTIL_LINUX_LIBMOUNT               # for util-linux compilation to work (so, may be removed in the future)
     select BR2_PACKAGE_DBUS_PYTHON                       # required for bluetooth scripts
-    select BR2_PACKAGE_WIRINGPI                          if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY || BR2_PACKAGE_BATOCERA_TARGET_RPI4 # gpio
+    # Deprecated, which what library should we replace ?
+    #select BR2_PACKAGE_WIRINGPI                          if BR2_PACKAGE_BATOCERA_TARGET_RPI_ANY || BR2_PACKAGE_BATOCERA_TARGET_RPI4 # gpio
     select BR2_PACKAGE_PARTED                            # partition management (for the first boot)
     select BR2_PACKAGE_USBMOUNT                          # usb key/sd card mounter
     select BR2_PACKAGE_USBUTILS                          # usb key/sd card tools


### PR DESCRIPTION
We have to remove it and find an alternative GPIO library