### PR TITLE
Try to workaround Mesa/Intel OpenGL 1.4 vs 2.1 bug with /etc/drirc 

### DIFF
--- a/board/batocera/x86/fsoverlay/etc/drirc
+++ b/board/batocera/x86/fsoverlay/etc/drirc
@@ -1,0 +1,8 @@
+<driconf>
+    <device driver="i915">
+        <application name="Default">
+            <option name="stub_occlusion_query" value="true" />
+            <option name="fragment_shader" value="true" />
+        </application>
+    </device>
+</driconf>


### PR DESCRIPTION
Same thing as the "old" C patch, but through configuration file, so we can run vanilla Mesa code.
@jdorigao can you test it fixes your issue on Intel HD 5500 ?