### PR TITLE
Moved splash-screen sound option to batocera.conf

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -11,7 +11,7 @@ BATOCONF="/userdata/system/batocera.conf"
 BOOTCONF="/boot/batocera-boot.conf"
 BOOTLOCK=0
 
-for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key
+for i in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled splash.screen.sound
 do
     userdata="$(grep -m1 ^[\ #]*$i\s*= "$BATOCONF")" || continue
     bootdata="$(grep -m1 ^[\ #]*$i\s*= "$BOOTCONF")"

--- a/package/batocera/core/batocera-splash/S03splash-ffplay
+++ b/package/batocera/core/batocera-splash/S03splash-ffplay
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 soundDisabled() {
-    grep -qE "^[ ]*splashsound[ ]*=[ ]*false[ ]*$" /boot/batocera-boot.conf
+    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
 do_start ()
@@ -46,6 +46,7 @@ do_videostart ()
 
 case "$1" in
     start)
+        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-image
+++ b/package/batocera/core/batocera-splash/S03splash-image
@@ -23,6 +23,7 @@ do_start ()
 
 case "$1" in
     start)
+        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-mpv
+++ b/package/batocera/core/batocera-splash/S03splash-mpv
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 soundDisabled() {
-    grep -qE "^[ ]*splashsound[ ]*=[ ]*false[ ]*$" /boot/batocera-boot.conf
+    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
 do_start ()
@@ -46,6 +46,7 @@ do_videostart ()
 
 case "$1" in
     start)
+        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-splash/S03splash-omx
+++ b/package/batocera/core/batocera-splash/S03splash-omx
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 soundDisabled() {
-    grep -qE "^[ ]*splashsound[ ]*=[ ]*false[ ]*$" /boot/batocera-boot.conf
+    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
 }
 
 do_start ()
@@ -53,6 +53,7 @@ do_videostart ()
 
 case "$1" in
     start)
+        grep -qE '^[ ]*splash.screen.enabled[ ]*=[ ]*0[ ]*$' "/boot/batocera-boot.conf" && exit 0
         do_start &
         ;;
     stop)

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -6,9 +6,6 @@ sharedevice=INTERNAL
 # resize the internal partition if needed (disabled automatically once done)
 autoresize=true
 
-# disable the splashsound (remove the # to disable sound)
-#splashsound=false
-
 # enable the nvidia driver (remove the # to enable it)
 #nvidia-driver=true
 

--- a/package/batocera/core/batocera-system/c2/batocera.conf
+++ b/package/batocera/core/batocera-system/c2/batocera.conf
@@ -38,13 +38,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/libretech_h5/batocera.conf
+++ b/package/batocera/core/batocera-system/libretech_h5/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/miqi/batocera.conf
+++ b/package/batocera/core/batocera-system/miqi/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/odroidgoa/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidgoa/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/odroidn2/batocera.conf
+++ b/package/batocera/core/batocera-system/odroidn2/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rock960/batocera.conf
+++ b/package/batocera/core/batocera-system/rock960/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rockpro64/batocera.conf
+++ b/package/batocera/core/batocera-system/rockpro64/batocera.conf
@@ -36,13 +36,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rpi1/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi1/batocera.conf
@@ -60,13 +60,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rpi2/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi2/batocera.conf
@@ -60,13 +60,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rpi3/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi3/batocera.conf
@@ -60,13 +60,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/rpi4/batocera.conf
+++ b/package/batocera/core/batocera-system/rpi4/batocera.conf
@@ -63,13 +63,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/s905/batocera.conf
+++ b/package/batocera/core/batocera-system/s905/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/s912/batocera.conf
+++ b/package/batocera/core/batocera-system/s912/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/tinkerboard/batocera.conf
+++ b/package/batocera/core/batocera-system/tinkerboard/batocera.conf
@@ -33,13 +33,19 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
+
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/vim3/batocera.conf
+++ b/package/batocera/core/batocera-system/vim3/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/x86/batocera.conf
+++ b/package/batocera/core/batocera-system/x86/batocera.conf
@@ -37,13 +37,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/x86_64/batocera.conf
+++ b/package/batocera/core/batocera-system/x86_64/batocera.conf
@@ -33,13 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #

--- a/package/batocera/core/batocera-system/xu4/batocera.conf
+++ b/package/batocera/core/batocera-system/xu4/batocera.conf
@@ -33,14 +33,18 @@ kodi.xbutton=1
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
 ## Extend visible time of video/pictures
 ## Possible values are:
-## default:   Video will be played for 20 seconds (default)
 ## auto:      All the video will be played but not longer than 90s
 ## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
-# splash.screen.length=auto
+#splash.screen.length=auto
 
 
 # ------------ B - Network ------------ #


### PR DESCRIPTION
Added possibility to disable splash at all
Added possibilty to disable splash.sound inside batocera.conf

@tcamargo
For 5.28 you can add a switch `splash.screen.es` to enable/disable S31emulationstation loading bar