### PR TITLE
Set Immediate-Configure APT flag to boolean false within Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 ARG DEBIAN_FRONTEND=noninteractive
 RUN dpkg --add-architecture i386 && \
 	apt update && \
-	apt install -y libc6:i386 \
+	apt install -y -o APT::Immediate-Configure=0 libc6:i386 \
 		libncurses6:i386 \
 		libstdc++6:i386 \
 		build-essential \


### PR DESCRIPTION
In current `master` the Docker build environment image fails to successfully build due to an APT error within the post-install stage. I've traced this issue back to relatively recent changes in 20.04 which meant that i386 packages are configured out-of-order, failing the build. As far as I can gather, this is an upstream problem but I'm not seeing any signs of it being fixed any time soon.

Testing was completed by following the wiki Docker installation instructions to the letter.

Setting the Immediate-Configure APT flag to false works well and seems to have no ill effects, so submitting this PR to resolve the problem.