### PR TITLE
Temporary change in rockchip-linux Github repos

### DIFF
--- a/package/batocera/gpu/rockchip-mpp/rockchip-mpp.mk
+++ b/package/batocera/gpu/rockchip-mpp/rockchip-mpp.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 ROCKCHIP_MPP_VERSION = fefa75939d51f32a70684c5106bd2b28715b4756
-ROCKCHIP_MPP_SITE =  $(call github,rockchip-linux,mpp,$(ROCKCHIP_MPP_VERSION))
+ROCKCHIP_MPP_SITE =  $(call github,HermanChen,mpp,$(ROCKCHIP_MPP_VERSION))
 ROCKCHIP_MPP_INSTALL_STAGING = YES
 ROCKCHIP_MPP_DEPENDENCIES = libdrm
 

--- a/package/batocera/libraries/librga/librga.mk
+++ b/package/batocera/libraries/librga/librga.mk
@@ -6,7 +6,7 @@
 
 # Version.: Commits on Oct 30, 2019
 LIBRGA_VERSION = 72e7764a9fe358e6ad50eb1b21176cc95802c7fb
-LIBRGA_SITE =  $(call github,rockchip-linux,linux-rga,$(LIBRGA_VERSION))
+LIBRGA_SITE =  $(call github,oiramario,linux-rga,$(LIBRGA_VERSION))
 LIBRGA_INSTALL_STAGING = YES
 
 define LIBRGA_BUILD_CMDS


### PR DESCRIPTION
So, Rockchip have temporarily made the rockchip-linux/mpp and rockchip-linux/linux-rga repos private, meaning that Rockchip builds hard-fail whilst pulling sources as of ~13 days ago.

@HermanChen (Rockchip employee) has a copy of the `mpp` repo, so I've made a temporary change whilst we wait for Rockchip to make the repo public again.

@oiramario has a copy of the `linux-rga` repo, so I've made that temporary change also.

Not sure at all what's going on with Rockchip suddenly pulling both repo's. Aware that this solution is also less than ideal, but it's a start I guess.