### PR TITLE
[libretro-flycast] Makefile OPTFLAGS fix for classic_arm* to enable CHD v5 functionality

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-flycast/003-chdv5.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-flycast/003-chdv5.patch
@@ -1,0 +1,14 @@
+diff --git a/Makefile b/Makefile
+index 0ee72599..2c477b4d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -891,7 +891,9 @@ ifeq ($(DEBUG),1)
+ else
+        ifneq (,$(findstring msvc,$(platform)))
+                OPTFLAGS       := -O2
+-       else ifneq ($(platform), classic_armv7_a7)
++       else ifneq (,$(findstring classic_arm,$(platform)))
++               OPTFLAGS       := -O2
++       else ifeq (,$(findstring classic_arm,$(platform)))
+                OPTFLAGS       := -O3
+        endif


### PR DESCRIPTION
Simple PR to force classic_arm* platforms onto `-O2` instead of `-O3` for `libretro-flycast`, which crashes the core when loading a CHD v5 disc image. Will do some further work in the coming days (perhaps weeks) to identify the specific compiler optimisation thats causing the issue, and disable it.

For brevity, it ought to be one of the following:

```
-fgcse-after-reload 
-fipa-cp-clone
-floop-interchange 
-floop-unroll-and-jam 
-fpeel-loops 
-fpredictive-commoning 
-fsplit-loops 
-fsplit-paths 
-ftree-loop-distribution 
-ftree-loop-vectorize 
-ftree-partial-pre 
-ftree-slp-vectorize 
-funswitch-loops 
-fvect-cost-model 
-fvect-cost-model=dynamic 
-fversion-loops-for-strides
```