### PR TITLE
Fix when using GPIO powerswitch on RPi4

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -14,15 +14,19 @@ powerswitch="$(batocera-settings --command load --key system.power.switch)"
 if [ $? -ne 0 ] && [ -f /var/run/powerswitch-by-udevrule ]; then
     powerswitch="$(cat /var/run/powerswitch-by-udevrule)"
 fi
+# Read if a GPIO joypad is needed (to init on selected archs)
+gpiopad="$(batocera-settings --command load --key controllers.gpio.enabled)"
 
 # Carry out specific functions when asked to by the system
 case "$1" in
     start)
-        case $(cat /usr/share/batocera/batocera.arch) in
-            rpi4)
-                /usr/bin/rpi-gpio-init
-            ;;
-        esac
+        if [ "$gpiopad" == 1 ]; then
+            case $(cat /usr/share/batocera/batocera.arch) in
+                rpi4)
+                    /usr/bin/rpi-gpio-init
+                ;;
+            esac
+	fi
         for i in $devices; do
             if [ "$i" == "$powerswitch" ]; then
                 $RUN start "$powerswitch" &


### PR DESCRIPTION
Discussed with @crcerror : when you have a power switch on GPIO, the joypad initialization prevents it from loading. 
We still have an issue if a user would use GPIO for both joypad + power switch on RPi4... but that would need some lower level investigation and it's clearly a corner case.