### PR TITLE
oga: fix splash screen

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -1,6 +1,7 @@
 2020/XX/XX - batocera.linux 29
 	* add: hbmame (x86, x86_64, odroid n2)
 	* add: wine (32 and 64 bits)
+	* fix: Odroid Go Advance splash screen
 
 2020/10/04 - batocera.linux 5.27.2
 	* fix some issues with some tvs (giving bad resolutions information)

--- a/package/batocera/core/batocera-splash/batocera-splash.mk
+++ b/package/batocera/core/batocera-splash/batocera-splash.mk
@@ -14,6 +14,9 @@ ifeq ($(BR2_PACKAGE_BATOCERA_SPLASH_OMXPLAYER),y)
 else ifeq ($(BR2_PACKAGE_BATOCERA_SPLASH_FFPLAY),y)
 	BATOCERA_SPLASH_SCRIPT=S03splash-ffplay
 	BATOCERA_SPLASH_MEDIA=video
+else ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA),y)
+	BATOCERA_SPLASH_SCRIPT=S03splash-image
+	BATOCERA_SPLASH_MEDIA=rotate-oga-image
 else ifeq ($(BR2_PACKAGE_BATOCERA_SPLASH_ROTATE_IMAGE),y)
 	BATOCERA_SPLASH_SCRIPT=S03splash-image
 	BATOCERA_SPLASH_MEDIA=rotate-image
@@ -29,6 +32,10 @@ BATOCERA_SPLASH_POST_INSTALL_TARGET_HOOKS += BATOCERA_SPLASH_INSTALL_SCRIPT
 
 ifeq ($(BATOCERA_SPLASH_MEDIA),image)
 	BATOCERA_SPLASH_POST_INSTALL_TARGET_HOOKS += BATOCERA_SPLASH_INSTALL_IMAGE
+endif
+
+ifeq ($(BATOCERA_SPLASH_MEDIA),rotate-oga-image)
+	BATOCERA_SPLASH_POST_INSTALL_TARGET_HOOKS += BATOCERA_SPLASH_INSTALL_ROTATE_OGA_IMAGE
 endif
 
 ifeq ($(BATOCERA_SPLASH_MEDIA),rotate-image)
@@ -54,6 +61,11 @@ endef
 define BATOCERA_SPLASH_INSTALL_IMAGE
 	mkdir -p $(TARGET_DIR)/usr/share/batocera/splash
 	convert "$(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-splash/logo.png" -fill white -pointsize 30 -annotate +50+1020 "$(BATOCERA_SPLASH_TGVERSION)" "${TARGET_DIR}/usr/share/batocera/splash/logo-version.png"
+endef
+
+define BATOCERA_SPLASH_INSTALL_ROTATE_OGA_IMAGE
+	mkdir -p $(TARGET_DIR)/usr/share/batocera/splash
+	convert "$(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-splash/logo.png" -shave 150x0 -resize 480x320 -fill white -pointsize 15 -annotate +40+300 "$(BATOCERA_SPLASH_TGVERSION)" -rotate -90 "${TARGET_DIR}/usr/share/batocera/splash/logo-version.png"
 endef
 
 define BATOCERA_SPLASH_INSTALL_ROTATE_IMAGE


### PR DESCRIPTION
Trim 300 horizontal pixels from full-size logo, resize to native OGA resolution, adjust font size, and text position.

This makes a cleaner looking splash screen for the OGA and version text that can be read.