### PR TITLE
min max resolution

### DIFF
--- a/board/batocera/rockchip/odroidgoa/fsoverlay/etc/init.d/S31emulationstation
+++ b/board/batocera/rockchip/odroidgoa/fsoverlay/etc/init.d/S31emulationstation
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so SDL_VIDEO_EGL_DRIVER=/usr/lib/libGLESv2.so SDL_NOMOUSE=1 /usr/bin/emulationstation --no-splash --resolution 480 320 &

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -107,12 +107,24 @@ def main(args, maxnbplayers):
     # the resolution must be changed before configuration while the configuration may depend on it (ie bezels)
     wantedGameMode = generators[system.config['emulator']].getResolutionMode(system.config)
     systemMode = videoMode.getCurrentMode()
+
     resolutionChanged = False
     exitCode = -1
     try:
-        eslog.log("current video mode: {}".format(systemMode))
+        # lower the resolution if mode is auto
+        newsystemMode = systemMode # newsystemmode is the mode after minmax (ie in 1K if tv was in 4K), systemmode is the mode before (ie in es)
+        if system.config["videomode"] == "" or system.config["videomode"] == "default":
+            eslog.log("minTomaxResolution")
+            eslog.log("video mode before minmax: {}".format(systemMode))
+            videoMode.minTomaxResolution()
+            newsystemMode = videoMode.getCurrentMode()
+            if newsystemMode != systemMode:
+                resolutionChanged = True
+
+        eslog.log("current video mode: {}".format(newsystemMode))
         eslog.log("wanted video mode: {}".format(wantedGameMode))
-        if wantedGameMode != 'default' and wantedGameMode != systemMode:
+
+        if wantedGameMode != 'default' and wantedGameMode != newsystemMode:
             videoMode.changeMode(wantedGameMode)
             resolutionChanged = True
         gameResolution = videoMode.getCurrentResolution()

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -22,6 +22,10 @@ def getCurrentMode():
         for val in out.splitlines():
             return val # return the first line
 
+def minTomaxResolution():
+	proc = subprocess.Popen(["batocera-resolution minTomaxResolution"], stdout=subprocess.PIPE, shell=True)
+	(out, err) = proc.communicate()
+
 def getCurrentResolution():
 	proc = subprocess.Popen(["batocera-resolution currentResolution"], stdout=subprocess.PIPE, shell=True)
 	(out, err) = proc.communicate()

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
@@ -5,6 +5,14 @@ shift
 
 FILEMODES="/sys/class/graphics/fb0/modes"
 
+if test -z "${ACTION}"
+then
+    echo "${0} currentMode" >&2
+    echo "${0} currentResolution" >&2
+    exit 1
+fi
+
+
 case "${ACTION}" in
     "listModes")
     ;;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
@@ -3,6 +3,17 @@
 ACTION=$1
 shift
 
+if test -z "${ACTION}"
+then
+    echo "${0} listModes" >&2
+    echo "${0} setMode <MODE>" >&2
+    echo "${0} currentMode" >&2
+    echo "${0} currentResolution" >&2
+    echo "${0} minTomaxResolution" >&2
+    echo "${0} minTomaxResolution-secure" >&2
+    exit 1
+fi
+
 f_listModes() {
     for GPU in /dev/dri/card*
     do
@@ -33,10 +44,39 @@ case "${ACTION}" in
 	;;
     "setOutput")
 	;;
-    "minTomaxResolution")
+    "minTomaxResolution-secure")
 	CURRENT=$(f_listModes "current" | head -1 | cut -d : -f 1)
 	echo "${CURRENT}" > /var/run/drmMode
 	exit 0 # dont minimize for 4K tv, causing too many troubles while tv don't give the correct informations
 	;;
+    "minTomaxResolution")
+	# minimize resolution because of 4K tv
+	MAXWIDTH=1920
+	MAXHEIGHT=1080
+
+	# if current resolution is ok, keep it
+	read CURRENTWIDTH CURRENTHEIGHT <<< $(f_listModes "current" | sed -e s+"^\([0-9]*\):\([0-9]*\)x\([0-9]*\) \([0-9]*\)\(.*\)$"+"\2 \3"+)
+	if test "${CURRENTWIDTH}" -le "${MAXWIDTH}" -a "${CURRENTHEIGHT}" -le "${MAXHEIGHT}"
+	then
+	    exit 0
+	fi
+
+	# select a new one
+	# select the first one valid
+	# is it the best ? or should we loop to search the first with the same ratio ?
+	f_listModes | sed -e s+"^\([0-9]*\):\([0-9]*x[0-9]*\) \([0-9]*\)\(.*\)$"+"\2_\3:\1:\2"+ | sort -rn | # highest resolution first
+            while IFS=':\n' read SORTSTR SUGGMODE SUGGRESOLUTION
+            do
+		SUGGWIDTH=$(echo "${SUGGRESOLUTION}" | cut -d x -f 1)
+		SUGGHEIGHT=$(echo "${SUGGRESOLUTION}" | cut -d x -f 2)
+
+		if test "${SUGGWIDTH}" -le "${MAXWIDTH}" -a "${SUGGHEIGHT}" -le "${MAXHEIGHT}"
+		then
+                    echo "${SUGGMODE}" > /var/run/drmMode
+                    exit 0
+		fi
+            done
+        ;;
+
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
@@ -3,6 +3,17 @@
 ACTION=$1
 shift
 
+if test -z "${ACTION}"
+then
+    echo "${0} listModes" >&2
+    echo "${0} setMode <MODE>" >&2
+    echo "${0} currentMode" >&2
+    echo "${0} currentResolution" >&2
+    echo "${0} minTomaxResolution" >&2
+    echo "${0} minTomaxResolution-secure" >&2
+    exit 1
+fi
+
 case "${ACTION}" in
     "listModes")
 	tvservice --list-modes | sed -e s+'^[^ ]*:\(.*\)$'+'\1'+
@@ -22,7 +33,7 @@ case "${ACTION}" in
 	;;
     "setOutput")
 	;;
-    "minTomaxResolution")
+    "minTomaxResolution" | "minTomaxResolution-secure")
 	# minimize resolution because of 4K tv
 	MAXWIDTH=1920
 	MAXHEIGHT=1080

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -3,6 +3,19 @@
 ACTION=$1
 shift
 
+if test -z "${ACTION}"
+then
+    echo "${0} listModes" >&2
+    echo "${0} setMode <MODE>" >&2
+    echo "${0} currentMode" >&2
+    echo "${0} currentResolution" >&2
+    echo "${0} listOutputs" >&2
+    echo "${0} setOutput <output>" >&2
+    echo "${0} minTomaxResolution" >&2
+    echo "${0} minTomaxResolution-secure" >&2
+    exit 1
+fi
+
 case "${ACTION}" in
     "listModes")
 	xrandr --listModes | sed -e s+'\*$'++ | sed -e s+'^[^ ]* \(.*\)$'+'\1:\1'+
@@ -43,7 +56,7 @@ case "${ACTION}" in
 		)
 	fi
 	;;
-    "minTomaxResolution")
+    "minTomaxResolution" | "minTomaxResolution-secure")
 	# minimize resolution because of 4K tv
 	MAXWIDTH=1920
 	MAXHEIGHT=1080

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_1cpu
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_1cpu
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_NOMOUSE=1 /usr/bin/emulationstation &

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_nosplash
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_NOMOUSE=1 /usr/bin/emulationstation --no-splash &

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_splash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fb_splash
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_NOMOUSE=1 /usr/bin/emulationstation &

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbegl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbegl_nosplash
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_VIDEO_EGL_DRIVER=/usr/lib/libEGL.so SDL_NOMOUSE=1 /usr/bin/emulationstation --no-splash &

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbgl_nosplash
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation/S31emulationstation_fbgl_nosplash
@@ -5,7 +5,7 @@ case "$1" in
 	systemsetting="batocera-settings"
 	enabled="`$systemsetting  -command load -key system.es.atstartup`"
         if [ "$enabled" != "0" ];then
-                batocera-resolution minTomaxResolution
+                batocera-resolution minTomaxResolution-secure
 		settings_lang="`$systemsetting -command load -key system.language`"
 		cd /userdata # es need a PWD
                 HOME=/userdata/system LANG="${settings_lang}.UTF-8" SDL_NOMOUSE=1 SDL_VIDEO_GL_DRIVER=/usr/lib/libGLESv2.so /usr/bin/emulationstation --no-splash &


### PR DESCRIPTION
reintegrate minmax resolution to minimize resolution of game to 1K in case your tv is 4K;
implement minmax and minmax-secure : es is in minmax-secure : it means that no risk it taken for a black screen (so, on drm, no resolution change, while on tvservice and xorg, it is ok)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>