### PR TITLE
Pacman : use with multiple repositories + XML fix

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-store
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-store
@@ -28,7 +28,7 @@ case "${ACTION}" in
 	then
 		pacman --noconfirm -Syu
 	fi
-	[ $TERMINAL -eq 1 ] && pacman --noconfirm -Ss --xml | xmllint --xpath "//package/name/text()" -
+	[ $TERMINAL -eq 1 ] && pacman --noconfirm -Ss
 	[ $TERMINAL -eq 0 ] && pacman --noconfirm -Ss --xml
 
 	;;

--- a/package/batocera/utils/pacman/004-xmloutput.patch
+++ b/package/batocera/utils/pacman/004-xmloutput.patch
@@ -54,15 +54,10 @@ index 35cfcd9..235f53b 100644
  		db_local = alpm_get_localdb(config->handle);
  	}
  
-@@ -543,10 +550,87 @@ int dump_pkg_search(alpm_db_t *db, alpm_list_t *targets, int show_status)
+@@ -543,10 +550,85 @@ int dump_pkg_search(alpm_db_t *db, alpm_list_t *targets, int show_status)
  		return 1;
  	}
  
-+	if(config->xml) {
-+	  printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
-+	  printf("<packages>\n");
-+	}
-+
 +	if(config->xml) {
 +	  (void) hcreate(1000);
 +	  if((protected_string = (char*) malloc(2048 * sizeof(char))) == NULL) {
@@ -104,6 +99,9 @@ index 35cfcd9..235f53b 100644
 +		  printf("    <repository>%s</repository>\n",   alpm_db_get_name(db));
 +		  printf("    <available_version>%s</available_version>\n",         alpm_pkg_get_version(pkg));
 +		  strncpy(protected_string, alpm_pkg_get_desc(pkg), 2048);
++		  argz_replace(&protected_string, &n, "&", "&amp;", NULL);
++		  argz_replace(&protected_string, &n, "\"", "&quot;", NULL);
++		  argz_replace(&protected_string, &n, "'", "&apos;", NULL);
 +		  argz_replace(&protected_string, &n, "<", "&lt;", NULL);
 +		  argz_replace(&protected_string, &n, ">", "&gt;", NULL);
 +		  printf("    <description>%s</description>\n", protected_string);
@@ -143,7 +141,7 @@ index 35cfcd9..235f53b 100644
  		if(config->quiet) {
  			fputs(alpm_pkg_get_name(pkg), stdout);
  		} else {
-@@ -564,6 +648,13 @@ int dump_pkg_search(alpm_db_t *db, alpm_list_t *targets, int show_status)
+@@ -564,6 +648,12 @@ int dump_pkg_search(alpm_db_t *db, alpm_list_t *targets, int show_status)
  			indentprint(alpm_pkg_get_desc(pkg), 4, cols);
  		}
  		fputc('\n', stdout);
@@ -151,7 +149,6 @@ index 35cfcd9..235f53b 100644
 +	}
 +
 +	if(config->xml) {
-+	  printf("</packages>\n");
 +	  hdestroy();
 +	  free(protected_string);
  	}
@@ -187,3 +184,25 @@ index a9b6437..d4f96f5 100644
  		{"config",     required_argument, 0, OP_CONFIG},
  		{"ignore",     required_argument, 0, OP_IGNORE},
  		{"assume-installed",     required_argument, 0, OP_ASSUMEINSTALLED},
+--- a/src/pacman/sync.c
++++ b/src/pacman/sync.c
+@@ -309,11 +309,20 @@
+ 	alpm_list_t *i;
+ 	int found = 0;
+ 
++	 if(config->xml) {
++	   printf("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n");
++	   printf("<packages>\n");
++	 }
++
+ 	for(i = syncs; i; i = alpm_list_next(i)) {
+ 		alpm_db_t *db = i->data;
+ 		found += !dump_pkg_search(db, targets, 1);
+ 	}
+ 
++	 if(config->xml) {
++	   printf("</packages>\n");
++	 }
++
+ 	return (found == 0);
+ }

--- a/package/batocera/utils/pacman/batocera-makepkg
+++ b/package/batocera/utils/pacman/batocera-makepkg
@@ -24,7 +24,7 @@ COMMENT_CHAR="#"
 # builddate = 1590539371 # epoch of creation
 
 ##### Valid "groups" for Batocera packages #####
-GRP_ARRAY=(game music theme bezel misc)
+GRP_ARRAY=(game music theme bezel misc 3do 3ds amiga1200 amiga500 amigacd32 amigacdtv amstradcpc apple2 atari2600 atari5200 atari7800 atari800 atarist atomiswave c128 c20 c64 cannonball cavestory colecovision daphne dos dreamcast fbneo fds gameandwatch gamecube gamegear gb gb2players gba gbc gbc2players gx4000 hbmame imageviewer intellivision jaguar lightgun lutro lynx mame mastersystem megadrive moonlight mrboom msx1 msx2 msx2+ n64 naomi nds neogeo neogeocd nes ngp ngpc odyssey2 openbor pc88 pc98 pcengine pcenginecd pcfx pokemini ports prboom ps2 ps3 psp psx satellaview saturn scummvm sega32x segacd sg1000 snes sufami supergrafx thomson tyrquake vectrex virtualboy wii wiiu windows32 windows32_installers windows64 windows64_installers wswan wswanc x68000 zx81 zxspectrum)
 
 ##### Function Calls #####
 
@@ -56,7 +56,7 @@ function check_argument() {
 	[[ -z "$val" && $ret -eq 0 ]] && echo "ERROR: '$vinput' is empty - you need to manually fill it in your .PKGINFO" >&2 && exit 1
 	[[ "$val" == "$COMMENT_CHAR" ]] && echo "ERROR: '$vinput' is commented with $COMMENT_CHAR in your .PKGINFO" >&2 && exit 1
 	if [[ "$vinput" == "group" ]]; then
-		# optionally accept sub-groups like game-nes, game-megadrive...
+		# optionally accept sub-groups like nes-platform, megadrive-shooter...
 		! (printf "%s\n" "${GRP_ARRAY[@]}" | grep -q ${val//-*/}) && echo "WARNING: Unknown group '$val' in your .PKGINFO" >&2
 	fi
 }


### PR DESCRIPTION
Fix pacman when using multiple repositories (corresponding patch in ES to come).
Fix XML output (&, ", ' characters).
Add more pacman "groups" for no warning when creating packages.
Speed up the console CLI for batocera-store, and made it suitable for multi-repositories.