### PR TITLE
Rework big post-image-script.sh and call per-image scripts.

### DIFF
--- a/board/batocera/amlogic/odroidc2/post-image-script-odroidc2.sh
+++ b/board/batocera/amlogic/odroidc2/post-image-script-odroidc2.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+MKIMAGE=${HOST_DIR}/bin/mkimage
+# amlogic stuff
+"${HOST_DIR}/bin/fip_create" --bl30 "${BINARIES_DIR}/bl30.bin" --bl301 "${BINARIES_DIR}/bl301.bin" --bl31 "${BINARIES_DIR}/bl31.bin" --bl33 "${BINARIES_DIR}/u-boot.bin" "${BINARIES_DIR}/fip.bin"
+"${HOST_DIR}/bin/fip_create" --dump "${BINARIES_DIR}/fip.bin"
+cat "${BINARIES_DIR}/bl2.package" "${BINARIES_DIR}/fip.bin" > "${BINARIES_DIR}/boot_new.bin"
+"${HOST_DIR}/bin/amlbootsig" "${BINARIES_DIR}/boot_new.bin" "${BINARIES_DIR}/u-boot.img"
+dd if="${BINARIES_DIR}/u-boot.img" of="${BINARIES_DIR}/uboot-odc2.img" bs=512 skip=96
+
+# boot
+rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"   || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf" || exit 1
+cp "${BINARIES_DIR}/uImage" "${BINARIES_DIR}/boot/boot/linux" || exit 1
+cp "${BINARIES_DIR}/meson-gxbb-odroidc2.dtb" "${BINARIES_DIR}/boot/boot" || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+cp "${BINARIES_DIR}/bl1.bin.hardkernel" "${BINARIES_DIR}/boot/" || exit 1
+cp "${BINARIES_DIR}/uboot-odc2.img" "${BINARIES_DIR}/boot/" || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/amlogic/odroidc4/post-image-script-odroidc4.sh
+++ b/board/batocera/amlogic/odroidc4/post-image-script-odroidc4.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+MKIMAGE=${HOST_DIR}/bin/mkimage
+# boot
+rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz"                "${BINARIES_DIR}/boot"                                       || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
+cp "${BINARIES_DIR}/uImage"                            "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
+cp "${BINARIES_DIR}/meson-sm1-odroid-c4.dtb"           "${BINARIES_DIR}/boot/boot/meson-sm1-odroid-c4.dtb"          || exit 1
+cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/extlinux"                              || exit 1
+cp "${BINARIES_DIR}/u-boot.bin"                        "${BINARIES_DIR}/boot/u-boot.bin"                            || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux.conf"                    || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"                        "${BINARIES_DIR}/boot/boot.ini"                              || exit 1
+cp "${BOARD_DIR}/boot/config.ini"                      "${BINARIES_DIR}/boot/config.ini"                            || exit 1
+cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/" || exit 1
+cp "${BINARIES_DIR}/u-boot.bin.sd.bin"                  "${BINARIES_DIR}/boot/" || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz boot.ini config.ini) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/amlogic/odroidn2/post-image-script-odroidn2.sh
+++ b/board/batocera/amlogic/odroidn2/post-image-script-odroidn2.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+
+MKIMAGE=${HOST_DIR}/bin/mkimage
+# boot
+rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz"                "${BINARIES_DIR}/boot"                                       || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
+cp "${BINARIES_DIR}/uImage"                            "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
+cp "${BINARIES_DIR}/meson-g12b-odroid-n2.dtb"          "${BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2.dtb"         || exit 1
+cp "${BINARIES_DIR}/meson-g12b-odroid-n2-plus.dtb"     "${BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2_plus.dtb"    || exit 1
+cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/extlinux"                              || exit 1
+cp "${BINARIES_DIR}/u-boot.bin"                        "${BINARIES_DIR}/boot/u-boot.bin"                            || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux.conf"                    || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"                        "${BINARIES_DIR}/boot/boot.ini"                              || exit 1
+cp "${BOARD_DIR}/boot/config.ini"                      "${BINARIES_DIR}/boot/config.ini"                            || exit 1
+cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/" || exit 1
+cp "${BINARIES_DIR}/u-boot.bin.sd.bin"                  "${BINARIES_DIR}/boot/" || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz boot.ini config.ini) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/amlogic/s905/post-image-script-s905.sh
+++ b/board/batocera/amlogic/s905/post-image-script-s905.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# boot
+MKIMAGE=${HOST_DIR}/bin/mkimage
+rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"   || exit 1
+$MKIMAGE -C none -A arm64 -T script -d "${BOARD_DIR}/boot/s905_autoscript.txt" "${BINARIES_DIR}/boot/s905_autoscript"
+$MKIMAGE -C none -A arm64 -T script -d "${BOARD_DIR}/boot/aml_autoscript.txt" "${BINARIES_DIR}/boot/aml_autoscript"
+cp "${BOARD_DIR}/boot/aml_autoscript.zip" "${BINARIES_DIR}/boot"     || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf" || exit 1
+cp "${BOARD_DIR}/boot/README.txt" "${BINARIES_DIR}/boot/README.txt" || exit 1
+for DTB in gxbb_p200_2G.dtb  gxbb_p200.dtb  gxl_p212_1g.dtb  gxl_p212_2g.dtb all_merged.dtb
+do
+	cp "${BINARIES_DIR}/${DTB}" "${BINARIES_DIR}/boot/boot" || exit 1
+done
+
+cp "${BINARIES_DIR}/Image"           "${BINARIES_DIR}/boot/boot/linux"           || exit 1
+cp "${BINARIES_DIR}/uInitrd"         "${BINARIES_DIR}/boot/boot/uInitrd"         || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/amlogic/s912/post-image-script-s912.sh
+++ b/board/batocera/amlogic/s912/post-image-script-s912.sh
@@ -1,0 +1,57 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# boot
+MKIMAGE=${HOST_DIR}/bin/mkimage
+rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n 5.x -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"                      || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf"   || exit 1
+cp "${BINARIES_DIR}/uImage"             "${BINARIES_DIR}/boot/boot/linux"           || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"    "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
+cp "${BINARIES_DIR}/initrd.gz"          "${BINARIES_DIR}/boot/boot"                 || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"    "${BINARIES_DIR}/boot/extlinux"             || exit 1
+cp "${BOARD_DIR}/boot/logo.bmp"         "${BINARIES_DIR}/boot/boot/logo.bmp"        || exit 1
+cp "${BOARD_DIR}/boot/boot.cmd"         "${BINARIES_DIR}/boot/boot.cmd"             || exit 1
+
+for DTB in meson-gxm-khadas-vim2 meson-gxm-nexbox-a1 meson-gxm-q200 meson-gxm-q201 meson-gxm-rbox-pro meson-gxm-vega-s96 meson-gxm-s912-libretech-pc
+do
+	cp "${BINARIES_DIR}/${DTB}.dtb" "${BINARIES_DIR}/boot/boot" || exit 1
+done
+cp -pr "${BINARIES_DIR}/tools"          "${BINARIES_DIR}/boot/"                || exit 1
+cp "${BINARIES_DIR}/u-boot.bin.sd.bin"  "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/amlogic/vim3/post-image-script-vim3.sh
+++ b/board/batocera/amlogic/vim3/post-image-script-vim3.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR}/boot"                 || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/Image"                             "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
+cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
+cp "${BINARIES_DIR}/meson-g12b-a311d-khadas-vim3.dtb"  "${BINARIES_DIR}/boot/boot/meson-g12b-a311d-khadas-vim3.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
+cp "${BINARIES_DIR}/boot.scr"                          "${BINARIES_DIR}/boot/boot.scr"                              || exit 1
+cp "${BOARD_DIR}/boot/logo.bmp"                        "${BINARIES_DIR}/boot/boot/logo.bmp"                         || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux/extlinux.conf"           || exit 1
+cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/"                                      || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot batocera-boot.conf) || exit 1
+
+# batocera.img
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+echo "installing u-boot"
+dd if=${BINARIES_DIR}/u-boot.bin.sd.bin of=${BATOCERAIMG} conv=fsync,notrunc bs=512 skip=1 seek=1 || exit 1
+dd if=${BINARIES_DIR}/u-boot.bin.sd.bin of=${BATOCERAIMG} conv=fsync,notrunc bs=1 count=444 || exit 1
+sync || exit 1
+

--- a/board/batocera/libretech-h5/post-image-script-libretech-h5.sh
+++ b/board/batocera/libretech-h5/post-image-script-libretech-h5.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+MKIMAGE=${HOST_DIR}/bin/mkimage
+# boot
+rm -rf "${BINARIES_DIR}/boot"            || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/sun50i-h5-libretech-all-h3-cc.dtb"  "${BINARIES_DIR}/boot/boot/sun50i-h5-libretech-all-h3-cc.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
+
+# blobs
+for F in u-boot-sunxi-with-spl.bin
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BR2_EXTERNAL_BATOCERA_PATH}/board/batocera/libretech-h5/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/odroidxu4/post-image-script-odroidxu4.sh
+++ b/board/batocera/odroidxu4/post-image-script-odroidxu4.sh
@@ -1,0 +1,90 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# XU4 SD/EMMC CARD
+#
+#       1      31      63          719     1231    1263
+# +-----+-------+-------+-----------+--------+-------+----------+--------------+
+# | MBR |  bl1  |  bl2  |   uboot   |  tzsw  |       |   BOOT   |     FREE     |
+# +-----+-------+-------+-----------+--------+-------+----------+--------------+
+#      512     15K     31K         359K     615K    631K       1.2G
+#
+# https://wiki.odroid.com/odroid-xu4/software/building_u-boot_mainline#u-boot_v201705
+
+xu4_fusing() {
+        BINARIES_DIR=$1
+        BATOCERAIMG=$2
+
+        # fusing
+        signed_bl1_position=1
+        bl2_position=31
+        uboot_position=63
+        tzsw_position=1503
+        env_position=2015
+
+        echo "BL1 fusing"
+        dd if="${BINARIES_DIR}/bl1.bin.hardkernel"            of="${BATOCERAIMG}" seek=$signed_bl1_position conv=notrunc || return 1
+
+        echo "BL2 fusing"
+        dd if="${BINARIES_DIR}/bl2.bin.hardkernel.720k_uboot" of="${BATOCERAIMG}" seek=$bl2_position        conv=notrunc || return 1
+
+        echo "u-boot fusing"
+        dd if="${BINARIES_DIR}/u-boot.bin.hardkernel"         of="${BATOCERAIMG}" seek=$uboot_position      conv=notrunc || return 1
+
+        echo "TrustZone S/W fusing"
+        dd if="${BINARIES_DIR}/tzsw.bin.hardkernel"           of="${BATOCERAIMG}" seek=$tzsw_position       conv=notrunc || return 1
+
+        echo "u-boot env erase"
+        dd if=/dev/zero of="${BATOCERAIMG}" seek=$env_position count=32 bs=512 conv=notrunc || return 1
+}
+
+BOARD_DIR="${BATO_DIR}/odroidxu4"
+# dirty boot binary files
+for F in bl1.bin.hardkernel bl2.bin.hardkernel.720k_uboot tzsw.bin.hardkernel u-boot.bin.hardkernel
+do
+	cp "${BUILD_DIR}/uboot-odroid-xu4-odroidxu4-v2017.05/sd_fuse/${F}" "${BINARIES_DIR}" || exit 1
+done
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"       || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"  || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"     "${BINARIES_DIR}/boot/boot.ini"              || exit 1
+cp "${BINARIES_DIR}/zImage"          "${BINARIES_DIR}/boot/boot/linux"           || exit 1
+cp "${BINARIES_DIR}/uInitrd"         "${BINARIES_DIR}/boot/boot/uInitrd"         || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
+cp "${BINARIES_DIR}/exynos5422-odroidxu4.dtb" "${BINARIES_DIR}/boot/boot/exynos5422-odroidxu4.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf"                  || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot.ini boot batocera-boot.conf) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+xu4_fusing "${BINARIES_DIR}" "${BATOCERAIMG}" || exit 1
+sync || exit 1

--- a/board/batocera/post-image-script.sh
+++ b/board/batocera/post-image-script.sh
@@ -105,7 +105,7 @@ case "${BATOCERA_TARGET}" in
 	;;
 
 	LIBRETECH_H5)
-	BOARD_DIR="${BR2_EXTERNAL_BATOCERA_PATH}/board/batocera/libretech-h5"
+	BOARD_DIR="${BATO_DIR}/libretech-h5"
 	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-libretech-h5.sh"
 	;;
 

--- a/board/batocera/post-image-script.sh
+++ b/board/batocera/post-image-script.sh
@@ -7,43 +7,6 @@
 # BINARIES_DIR = images dir
 # TARGET_DIR = target dir
 
-# XU4 SD/EMMC CARD
-#
-#       1      31      63          719     1231    1263
-# +-----+-------+-------+-----------+--------+-------+----------+--------------+
-# | MBR |  bl1  |  bl2  |   uboot   |  tzsw  |       |   BOOT   |     FREE     |
-# +-----+-------+-------+-----------+--------+-------+----------+--------------+
-#      512     15K     31K         359K     615K    631K       1.2G
-#
-# https://wiki.odroid.com/odroid-xu4/software/building_u-boot_mainline#u-boot_v201705
-
-xu4_fusing() {
-	BINARIES_DIR=$1
-	BATOCERAIMG=$2
-
-	# fusing
-	signed_bl1_position=1
-	bl2_position=31
-	uboot_position=63
-	tzsw_position=1503
-	env_position=2015
-
-	echo "BL1 fusing"
-	dd if="${BINARIES_DIR}/bl1.bin.hardkernel"            of="${BATOCERAIMG}" seek=$signed_bl1_position conv=notrunc || return 1
-
-	echo "BL2 fusing"
-	dd if="${BINARIES_DIR}/bl2.bin.hardkernel.720k_uboot" of="${BATOCERAIMG}" seek=$bl2_position        conv=notrunc || return 1
-
-	echo "u-boot fusing"
-	dd if="${BINARIES_DIR}/u-boot.bin.hardkernel"         of="${BATOCERAIMG}" seek=$uboot_position      conv=notrunc || return 1
-
-	echo "TrustZone S/W fusing"
-	dd if="${BINARIES_DIR}/tzsw.bin.hardkernel"           of="${BATOCERAIMG}" seek=$tzsw_position       conv=notrunc || return 1
-
-	echo "u-boot env erase"
-	dd if=/dev/zero of="${BATOCERAIMG}" seek=$env_position count=32 bs=512 conv=notrunc || return 1
-}
-
 BATOCERA_BINARIES_DIR="${BINARIES_DIR}/batocera"
 BATOCERA_TARGET_DIR="${TARGET_DIR}/batocera"
 
@@ -58,674 +21,92 @@ BATO_DIR="${BR2_EXTERNAL_BATOCERA_PATH}/board/batocera"
 
 echo -e "\n----- Generating images/batocera files -----\n"
 
+BATOCERA_POST_IMAGE_SCRIPT=""
+
 case "${BATOCERA_TARGET}" in
 	RPI0|RPI1|RPI2)
 	BOARD_DIR="${BATO_DIR}/rpi"
-	# boot.tar.xz
-	cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
-	rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
-	mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
-	cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
-
-	KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
-	"${BUILD_DIR}/linux-${KERNEL_VERSION}/scripts/mkknlimg" "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
-	cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                || exit 1
-
-	echo "creating boot.tar.xz"
-	tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
-	{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
-	cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
-	rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-rpi012.sh"
 	;;
 
 	RPI3)
 	BOARD_DIR="${BATO_DIR}/rpi"
-	# boot.tar.xz
-	cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
-	rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
-	mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
-	cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
-
-	KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
-	cp "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
-	cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                     || exit 1
-
-	echo "creating boot.tar.xz"
-	tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
-	{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
-	cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
-	rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-rpi3.sh"
 	;;
 
 	RPI4)
 	BOARD_DIR="${BATO_DIR}/rpi4"
-	# boot.tar.xz
-	cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
-	rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
-	mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
-	cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
-
-	KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
-	cp "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
-	cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                     || exit 1
-
-	echo "creating boot.tar.xz"
-	tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
-	{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
-	cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
-	rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-rpi4.sh"
 	;;
 
 	S905)
-	MKIMAGE=${HOST_DIR}/bin/mkimage
 	BOARD_DIR="${BATO_DIR}/amlogic/s905"
-	# boot
-	rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
-	cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"   || exit 1
-	$MKIMAGE -C none -A arm64 -T script -d "${BOARD_DIR}/boot/s905_autoscript.txt" "${BINARIES_DIR}/boot/s905_autoscript"
-	$MKIMAGE -C none -A arm64 -T script -d "${BOARD_DIR}/boot/aml_autoscript.txt" "${BINARIES_DIR}/boot/aml_autoscript"
-	cp "${BOARD_DIR}/boot/aml_autoscript.zip" "${BINARIES_DIR}/boot"     || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf" || exit 1
-	cp "${BOARD_DIR}/boot/README.txt" "${BINARIES_DIR}/boot/README.txt" || exit 1
-	for DTB in gxbb_p200_2G.dtb  gxbb_p200.dtb  gxl_p212_1g.dtb  gxl_p212_2g.dtb all_merged.dtb
-	do
-		cp "${BINARIES_DIR}/${DTB}" "${BINARIES_DIR}/boot/boot" || exit 1
-	done
-
-	cp "${BINARIES_DIR}/Image"           "${BINARIES_DIR}/boot/boot/linux"           || exit 1
-	cp "${BINARIES_DIR}/uInitrd"         "${BINARIES_DIR}/boot/boot/uInitrd"    	 || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-s905.sh"
 	;;
 
 	S912)
-	MKIMAGE=${HOST_DIR}/bin/mkimage
-	#MKBOOTIMAGE=${HOST_DIR}/bin/mkbootimg
 	BOARD_DIR="${BATO_DIR}/amlogic/s912"
-	# boot
-	rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
-        mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-        "${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n 5.x -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
-	cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"                      || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf"   || exit 1
-	cp "${BINARIES_DIR}/uImage"             "${BINARIES_DIR}/boot/boot/linux"           || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"    "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"          "${BINARIES_DIR}/boot/boot"                 || exit 1
-        cp "${BOARD_DIR}/boot/extlinux.conf"    "${BINARIES_DIR}/boot/extlinux"             || exit 1
-	cp "${BOARD_DIR}/boot/logo.bmp"         "${BINARIES_DIR}/boot/boot/logo.bmp"        || exit 1
-	cp "${BOARD_DIR}/boot/boot.cmd"         "${BINARIES_DIR}/boot/boot.cmd"             || exit 1
-
-	for DTB in meson-gxm-khadas-vim2 meson-gxm-nexbox-a1 meson-gxm-q200 meson-gxm-q201 meson-gxm-rbox-pro meson-gxm-vega-s96 meson-gxm-s912-libretech-pc
-        do
-                cp "${BINARIES_DIR}/${DTB}.dtb" "${BINARIES_DIR}/boot/boot" || exit 1
-        done
-	cp -pr "${BINARIES_DIR}/tools"          "${BINARIES_DIR}/boot/"                || exit 1
-        cp "${BINARIES_DIR}/u-boot.bin.sd.bin"  "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-s912.sh"
 	;;
 
 	X86|X86_64)
 	BOARD_DIR="${BATO_DIR}/x86"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot"     || exit 1
-	cp "${BOARD_DIR}/boot/syslinux.cfg" "${BINARIES_DIR/}/boot/syslinux.cfg" || exit 1
-	cp "${BINARIES_DIR}/bzImage" "${BINARIES_DIR}/boot/linux" || exit 1
-	cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/boot" || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/batocera.update" || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# get UEFI files
-	mkdir -p "${BINARIES_DIR}/EFI/syslinux" || exit 1
-	cp "${BOARD_DIR}/boot/syslinux.cfg" "${BINARIES_DIR/}/EFI/syslinux/syslinux.cfg" || exit 1
-
-	# boot.tar.xz
-	# it must include the squashfs version with .update to not erase the current squashfs while running
-	echo "creating ${BATOCERA_BINARIES_DIR}/boot.tar.xz"
-	(cd "${BINARIES_DIR}" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools EFI boot batocera-boot.conf) || exit 1
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/batocera.update" "${BINARIES_DIR}/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage-boot.cfg" "${BINARIES_DIR}" || exit 1
-	echo "creating ${BINARIES_DIR}/batocera-boot.img"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BINARIES_DIR}" --config="${BINARIES_DIR}/genimage-boot.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	syslinux -i "${BINARIES_DIR}/batocera-boot.img" -d /boot/syslinux
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "creating ${BATOCERA_BINARIES_DIR}/batocera.img"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BINARIES_DIR}/batocera-boot.img" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-x86.sh"
 	;;
 
 	XU4)
 	BOARD_DIR="${BATO_DIR}/odroidxu4"
-	# dirty boot binary files
-	for F in bl1.bin.hardkernel bl2.bin.hardkernel.720k_uboot tzsw.bin.hardkernel u-boot.bin.hardkernel
-	do
-		cp "${BUILD_DIR}/uboot-odroid-xu4-odroidxu4-v2017.05/sd_fuse/${F}" "${BINARIES_DIR}" || exit 1
-	done
-
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"       || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"  || exit 1
-	cp "${BOARD_DIR}/boot/boot.ini"     "${BINARIES_DIR}/boot/boot.ini"        	 || exit 1
-	cp "${BINARIES_DIR}/zImage"          "${BINARIES_DIR}/boot/boot/linux"      	 || exit 1
-	cp "${BINARIES_DIR}/uInitrd"         "${BINARIES_DIR}/boot/boot/uInitrd"    	 || exit 1
-
-	# develop mode : use ext2 instead of squashfs
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-	cp "${BINARIES_DIR}/exynos5422-odroidxu4.dtb" "${BINARIES_DIR}/boot/boot/exynos5422-odroidxu4.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf"                  || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot.ini boot batocera-boot.conf) || exit 1
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	xu4_fusing "${BINARIES_DIR}" "${BATOCERAIMG}" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-odroidxu4.sh"
 	;;
 
 	ODROIDC2)
 	BOARD_DIR="${BATO_DIR}/amlogic/odroidc2"
-        MKIMAGE=${HOST_DIR}/bin/mkimage
-	# amlogic stuff
-	"${HOST_DIR}/bin/fip_create" --bl30 "${BINARIES_DIR}/bl30.bin" --bl301 "${BINARIES_DIR}/bl301.bin" --bl31 "${BINARIES_DIR}/bl31.bin" --bl33 "${BINARIES_DIR}/u-boot.bin" "${BINARIES_DIR}/fip.bin"
-	"${HOST_DIR}/bin/fip_create" --dump "${BINARIES_DIR}/fip.bin"
-	cat "${BINARIES_DIR}/bl2.package" "${BINARIES_DIR}/fip.bin" > "${BINARIES_DIR}/boot_new.bin"
-	"${HOST_DIR}/bin/amlbootsig" "${BINARIES_DIR}/boot_new.bin" "${BINARIES_DIR}/u-boot.img"
-	dd if="${BINARIES_DIR}/u-boot.img" of="${BINARIES_DIR}/uboot-odc2.img" bs=512 skip=96
-	#support/scripts/genimage.sh -c ${BOARD_DIR}/genimage.cfg
-
-	# boot
-	rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-	"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
-	cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BINARIES_DIR}/boot"   || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf" "${BINARIES_DIR}/boot/batocera-boot.conf" || exit 1
-	cp "${BINARIES_DIR}/uImage" "${BINARIES_DIR}/boot/boot/linux" || exit 1
-	cp "${BINARIES_DIR}/meson-gxbb-odroidc2.dtb" "${BINARIES_DIR}/boot/boot" || exit 1
-        cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-        cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-	cp "${BINARIES_DIR}/bl1.bin.hardkernel" "${BINARIES_DIR}/boot/" || exit 1
-	cp "${BINARIES_DIR}/uboot-odc2.img" "${BINARIES_DIR}/boot/" || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz) || exit 1
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-odroidc2.sh"
 	;;
 
 	ODROIDC4)
         BOARD_DIR="${BATO_DIR}/amlogic/odroidc4"
-        MKIMAGE=${HOST_DIR}/bin/mkimage
-
-        # boot
-        rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
-        mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
-        mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-        "${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
-        cp "${BOARD_DIR}/boot/boot-logo.bmp.gz"                "${BINARIES_DIR}/boot"                                       || exit 1
-        cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
-        cp "${BINARIES_DIR}/uImage"                            "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
-	cp "${BINARIES_DIR}/meson-sm1-odroid-c4.dtb"           "${BINARIES_DIR}/boot/boot/meson-sm1-odroid-c4.dtb"          || exit 1
-        cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
-        cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
-        cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/extlinux"                              || exit 1
-	cp "${BINARIES_DIR}/u-boot.bin"                        "${BINARIES_DIR}/boot/u-boot.bin"                            || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux.conf"                    || exit 1
-	cp "${BOARD_DIR}/boot/boot.ini"                        "${BINARIES_DIR}/boot/boot.ini"                              || exit 1
-	cp "${BOARD_DIR}/boot/config.ini"                      "${BINARIES_DIR}/boot/config.ini"                            || exit 1
-        cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/" || exit 1
-        cp "${BINARIES_DIR}/u-boot.bin.sd.bin"                  "${BINARIES_DIR}/boot/" || exit 1
-
-        # boot.tar.xz
-        echo "creating boot.tar.xz"
-        (cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz boot.ini config.ini) || exit 1
-
-        # batocera.img
-        # rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-        mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-        GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-        BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-        rm -rf "${GENIMAGE_TMP}" || exit 1
-        cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-        echo "generating image"
-        genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-        rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-        rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-        sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-odroidc4.sh"
 	;;
 
 	ODROIDN2)
         BOARD_DIR="${BATO_DIR}/amlogic/odroidn2"
-        MKIMAGE=${HOST_DIR}/bin/mkimage
-
-        # boot
-        rm -rf "${BINARIES_DIR:?}/boot"      || exit 1
-        mkdir -p "${BINARIES_DIR}/boot/boot" || exit 1
-        mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-        "${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
-        cp "${BOARD_DIR}/boot/boot-logo.bmp.gz"                "${BINARIES_DIR}/boot"                                       || exit 1
-        cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
-        cp "${BINARIES_DIR}/uImage"                            "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
-	cp "${BINARIES_DIR}/meson-g12b-odroid-n2.dtb"          "${BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2.dtb"         || exit 1
-	cp "${BINARIES_DIR}/meson-g12b-odroid-n2-plus.dtb"     "${BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2_plus.dtb"    || exit 1
-        cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
-        cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
-        cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/extlinux"                              || exit 1
-	cp "${BINARIES_DIR}/u-boot.bin"                        "${BINARIES_DIR}/boot/u-boot.bin"                            || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux.conf"                    || exit 1
-	cp "${BOARD_DIR}/boot/boot.ini"                        "${BINARIES_DIR}/boot/boot.ini"                              || exit 1
-	cp "${BOARD_DIR}/boot/config.ini"                      "${BINARIES_DIR}/boot/config.ini"                            || exit 1
-        cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/" || exit 1
-        cp "${BINARIES_DIR}/u-boot.bin.sd.bin"                  "${BINARIES_DIR}/boot/" || exit 1
-
-        # boot.tar.xz
-        echo "creating boot.tar.xz"
-        (cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf boot-logo.bmp.gz boot.ini config.ini) || exit 1
-
-        # batocera.img
-        # rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-        mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-        GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-        BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-        rm -rf "${GENIMAGE_TMP}" || exit 1
-        cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-        echo "generating image"
-        genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-        rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-        rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-        sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-odroidn2.sh"
 	;;
 
 	ODROIDGOA)
 	BOARD_DIR="${BATO_DIR}/rockchip/odroidgoa"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n 5.x -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
-	cp "${BINARIES_DIR}/uImage"                "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-	cp "${BINARIES_DIR}/uInitrd"             "${BINARIES_DIR}/boot/boot/uInitrd"                || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-	cp "${BINARIES_DIR}/rk3326-rg351p-linux.dtb"     "${BINARIES_DIR}/boot/boot/rk3326-rg351p-linux.dtb" || exit 1
-	cp "${BINARIES_DIR}/rk3326-odroidgo2-linux.dtb"  "${BINARIES_DIR}/boot/boot/rk3326-odroidgo2-linux.dtb" || exit 1
-	cp "${BINARIES_DIR}/rk3326-odroidgo2-linux-v11.dtb"  "${BINARIES_DIR}/boot/boot/rk3326-odroidgo2-linux-v11.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-	cp "${BOARD_DIR}/boot/boot.ini"      "${BINARIES_DIR}/boot/boot.ini"                  || exit 1
-	cp -pr "${BINARIES_DIR}/tools"             "${BINARIES_DIR}/boot/"                     || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot.ini boot batocera-boot.conf) || exit 1
-
-	# blobs
-	for F in idbloader.img uboot.img trust.img
-	do
-		cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-odroidgoa.sh"
 	;;
 
 	ROCKPRO64)
 	BOARD_DIR="${BATO_DIR}/rockchip/rk3399/rockpro64"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"          || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-	cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-	cp "${BINARIES_DIR}/rk3399-rockpro64.dtb"  "${BINARIES_DIR}/boot/boot/rk3399-rockpro64.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
-
-	# blobs
-	for F in idbloader.img trust.img uboot.img
-	do
-		cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-rockpro64.sh"
 	;;
 
 	ROCK960)
 	BOARD_DIR="${BATO_DIR}/rockchip/rk3399/rock960"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"          || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-	cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-	cp "${BINARIES_DIR}/rk3399-rock960-ab.dtb"  "${BINARIES_DIR}/boot/boot/rk3399-rock960-ab.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
-
-	# blobs
-	for F in idbspl.img u-boot.itb
-	do
-	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-rock960.sh"
 	;;
 
 	TINKERBOARD)
 	BOARD_DIR="${BATO_DIR}/rockchip/rk3288/tinkerboard"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-	cp "${BINARIES_DIR}/zImage"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-	cp "${BINARIES_DIR}/rk3288-miniarm.dtb"  "${BINARIES_DIR}/boot/boot/rk3288-miniarm.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
-
-	# blobs
-	MKIMAGE=$HOST_DIR/bin/mkimage
-
-	$MKIMAGE -n rk3288 -T rksd -d "$BINARIES_DIR"/u-boot-spl-dtb.bin "$BINARIES_DIR/u-boot-spl-dtb.img"
-	cat "$BINARIES_DIR/u-boot-dtb.bin" >> "$BINARIES_DIR/u-boot-spl-dtb.img"
-	for F in u-boot-spl-dtb.img
-	do
-		cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-tinkerboard.sh"
 	;;
 
 	MIQI)
 	BOARD_DIR="${BATO_DIR}/rockchip/rk3288/miqi"
-	# /boot
-	rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-	cp "${BINARIES_DIR}/zImage"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-	cp "${BINARIES_DIR}/rk3288-miqi.dtb"  "${BINARIES_DIR}/boot/boot/rk3288-miqi.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
-
-	# blobs
-	MKIMAGE=$HOST_DIR/bin/mkimage
-
-	$MKIMAGE -n rk3288 -T rksd -d "$BINARIES_DIR"/u-boot-spl-dtb.bin "$BINARIES_DIR/u-boot-spl-dtb.img"
-	cat "$BINARIES_DIR/u-boot-dtb.bin" >> "$BINARIES_DIR/u-boot-spl-dtb.img"
-	for F in u-boot-spl-dtb.img
-	do
-		cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-miqi.sh"
 	;;
 
 	VIM3)
 	BOARD_DIR="${BATO_DIR}/amlogic/vim3"
-	# /boot
-	rm -rf "${BINARIES_DIR}/boot"                 || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot/extlinux" || exit 1
-	cp "${BINARIES_DIR}/Image"                             "${BINARIES_DIR}/boot/boot/linux"                            || exit 1
-	cp "${BINARIES_DIR}/initrd.gz"                         "${BINARIES_DIR}/boot/boot/initrd.gz"                        || exit 1
-	cp "${BINARIES_DIR}/rootfs.squashfs"                   "${BINARIES_DIR}/boot/boot/batocera.update"                  || exit 1
-	cp "${BINARIES_DIR}/meson-g12b-a311d-khadas-vim3.dtb"  "${BINARIES_DIR}/boot/boot/meson-g12b-a311d-khadas-vim3.dtb" || exit 1
-	cp "${BINARIES_DIR}/batocera-boot.conf"                "${BINARIES_DIR}/boot/batocera-boot.conf"                    || exit 1
-	cp "${BINARIES_DIR}/boot.scr"                          "${BINARIES_DIR}/boot/boot.scr"                              || exit 1
-	cp "${BOARD_DIR}/boot/logo.bmp"                        "${BINARIES_DIR}/boot/boot/logo.bmp"                         || exit 1
-	cp "${BOARD_DIR}/boot/extlinux.conf"                   "${BINARIES_DIR}/boot/boot/extlinux/extlinux.conf"           || exit 1
-	cp -pr "${BINARIES_DIR}/tools"                         "${BINARIES_DIR}/boot/"                                      || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot batocera-boot.conf) || exit 1
-
-	# batocera.img
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	echo "installing u-boot"
-	dd if=${BINARIES_DIR}/u-boot.bin.sd.bin of=${BATOCERAIMG} conv=fsync,notrunc bs=512 skip=1 seek=1 || exit 1
-	dd if=${BINARIES_DIR}/u-boot.bin.sd.bin of=${BATOCERAIMG} conv=fsync,notrunc bs=1 count=444 || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-vim3.sh"
 	;;
 
 	LIBRETECH_H5)
-	MKIMAGE=${HOST_DIR}/bin/mkimage
 	BOARD_DIR="${BR2_EXTERNAL_BATOCERA_PATH}/board/batocera/libretech-h5"
-	# boot
-	rm -rf "${BINARIES_DIR}/boot"            || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
-	mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
-        cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
-        cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
-        cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
-        cp "${BINARIES_DIR}/sun50i-h5-libretech-all-h3-cc.dtb"  "${BINARIES_DIR}/boot/boot/sun50i-h5-libretech-all-h3-cc.dtb" || exit 1
-        cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
-        cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
-	cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
-
-	# boot.tar.xz
-	echo "creating boot.tar.xz"
-	(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
-
-	# blobs
-	for F in u-boot-sunxi-with-spl.bin
-	do
-		cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
-	done
-
-	# batocera.img
-	mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
-	GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
-	BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
-	rm -rf "${GENIMAGE_TMP}" || exit 1
-	cp "${BR2_EXTERNAL_BATOCERA_PATH}/board/batocera/libretech-h5/genimage.cfg" "${BINARIES_DIR}" || exit 1
-	echo "generating image"
-	genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
-	rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
-	sync || exit 1
+	BATOCERA_POST_IMAGE_SCRIPT="${BOARD_DIR}/post-image-script-libretech-h5.sh"
 	;;
 
 	*)
@@ -733,6 +114,9 @@ case "${BATOCERA_TARGET}" in
 	bash
 	exit 1
 esac
+
+# run image script for specific target
+bash "${BATOCERA_POST_IMAGE_SCRIPT}" "${HOST_DIR}" "${BOARD_DIR}" "${BUILD_DIR}" "${BINARIES_DIR}" "${TARGET_DIR}" "${BATOCERA_BINARIES_DIR}" "${BATOCERA_TARGET_DIR}"
 
 # common
 

--- a/board/batocera/rockchip/odroidgoa/post-image-script-odroidgoa.sh
+++ b/board/batocera/rockchip/odroidgoa/post-image-script-odroidgoa.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n 5.x -d "${BINARIES_DIR}/Image" "${BINARIES_DIR}/uImage" || exit 1
+cp "${BINARIES_DIR}/uImage"                "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/uInitrd"             "${BINARIES_DIR}/boot/boot/uInitrd"                || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/rk3326-rg351p-linux.dtb"     "${BINARIES_DIR}/boot/boot/rk3326-rg351p-linux.dtb" || exit 1
+cp "${BINARIES_DIR}/rk3326-odroidgo2-linux.dtb"  "${BINARIES_DIR}/boot/boot/rk3326-odroidgo2-linux.dtb" || exit 1
+cp "${BINARIES_DIR}/rk3326-odroidgo2-linux-v11.dtb"  "${BINARIES_DIR}/boot/boot/rk3326-odroidgo2-linux-v11.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"      "${BINARIES_DIR}/boot/boot.ini"                  || exit 1
+cp -pr "${BINARIES_DIR}/tools"             "${BINARIES_DIR}/boot/"                     || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools boot.ini boot batocera-boot.conf) || exit 1
+
+# blobs
+for F in idbloader.img uboot.img trust.img
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1

--- a/board/batocera/rockchip/rk3288/miqi/post-image-script-miqi.sh
+++ b/board/batocera/rockchip/rk3288/miqi/post-image-script-miqi.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/zImage"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/rk3288-miqi.dtb"  "${BINARIES_DIR}/boot/boot/rk3288-miqi.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
+
+# blobs
+MKIMAGE=$HOST_DIR/bin/mkimage
+$MKIMAGE -n rk3288 -T rksd -d "$BINARIES_DIR"/u-boot-spl-dtb.bin "$BINARIES_DIR/u-boot-spl-dtb.img"
+cat "$BINARIES_DIR/u-boot-dtb.bin" >> "$BINARIES_DIR/u-boot-spl-dtb.img"
+for F in u-boot-spl-dtb.img
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/rockchip/rk3288/tinkerboard/post-image-script-tinkerboard.sh
+++ b/board/batocera/rockchip/rk3288/tinkerboard/post-image-script-tinkerboard.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/zImage"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/rk3288-miniarm.dtb"  "${BINARIES_DIR}/boot/boot/rk3288-miniarm.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
+
+# blobs
+MKIMAGE=$HOST_DIR/bin/mkimage
+$MKIMAGE -n rk3288 -T rksd -d "$BINARIES_DIR"/u-boot-spl-dtb.bin "$BINARIES_DIR/u-boot-spl-dtb.img"
+cat "$BINARIES_DIR/u-boot-dtb.bin" >> "$BINARIES_DIR/u-boot-spl-dtb.img"
+for F in u-boot-spl-dtb.img
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/rockchip/rk3399/rock960/post-image-script-rock960.sh
+++ b/board/batocera/rockchip/rk3399/rock960/post-image-script-rock960.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"          || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/rk3399-rock960-ab.dtb"  "${BINARIES_DIR}/boot/boot/rk3399-rock960-ab.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
+
+# blobs
+for F in idbspl.img u-boot.itb
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+sync || exit 1
+

--- a/board/batocera/rockchip/rk3399/rockpro64/post-image-script-rockpro64.sh
+++ b/board/batocera/rockchip/rk3399/rockpro64/post-image-script-rockpro64.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"          || exit 1
+mkdir -p "${BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot/extlinux" || exit 1
+cp "${BINARIES_DIR}/Image"                 "${BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.gz"             "${BINARIES_DIR}/boot/boot/initrd.gz"            || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/rk3399-rockpro64.dtb"  "${BINARIES_DIR}/boot/boot/rk3399-rockpro64.dtb" || exit 1
+cp "${BINARIES_DIR}/batocera-boot.conf"    "${BINARIES_DIR}/boot/batocera-boot.conf"        || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf" "${BINARIES_DIR}/boot/extlinux"                   || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# boot.tar.xz
+echo "creating boot.tar.xz"
+(cd "${BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" extlinux tools boot batocera-boot.conf) || exit 1
+
+# blobs
+for F in idbloader.img trust.img uboot.img
+do
+	cp "${BINARIES_DIR}/${F}" "${BINARIES_DIR}/boot/${F}" || exit 1
+done
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/boot/batocera.update" "${BINARIES_DIR}/boot/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}/boot" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1

--- a/board/batocera/rpi/post-image-script-rpi012.sh
+++ b/board/batocera/rpi/post-image-script-rpi012.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# boot.tar.xz
+cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
+rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
+mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
+cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
+
+KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
+"${BUILD_DIR}/linux-${KERNEL_VERSION}/scripts/mkknlimg" "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
+cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                || exit 1
+
+echo "creating boot.tar.xz"
+tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
+{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
+cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
+rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1

--- a/board/batocera/rpi/post-image-script-rpi3.sh
+++ b/board/batocera/rpi/post-image-script-rpi3.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# boot.tar.xz
+cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
+rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
+mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
+cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
+
+KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
+cp "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
+cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                     || exit 1
+
+echo "creating boot.tar.xz"
+tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
+{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
+cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
+rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/rpi4/post-image-script-rpi4.sh
+++ b/board/batocera/rpi4/post-image-script-rpi4.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# boot.tar.xz
+cp -f "${BINARIES_DIR}/"*.dtb "${BINARIES_DIR}/rpi-firmware"
+rm -rf "${BINARIES_DIR}/rpi-firmware/boot"   || exit 1
+mkdir -p "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BOARD_DIR}/boot/config.txt" "${BINARIES_DIR}/rpi-firmware/config.txt"   || exit 1
+cp "${BOARD_DIR}/boot/cmdline.txt" "${BINARIES_DIR}/rpi-firmware/cmdline.txt" || exit 1
+
+KERNEL_VERSION=$(grep -E "^BR2_LINUX_KERNEL_VERSION=" "${BR2_CONFIG}" | sed -e s+'^BR2_LINUX_KERNEL_VERSION="\(.*\)"$'+'\1'+)
+cp "${BINARIES_DIR}/zImage" "${BINARIES_DIR}/rpi-firmware/boot/linux" || exit 1
+cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/rpi-firmware/boot" || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/rpi-firmware/"                     || exit 1
+
+echo "creating boot.tar.xz"
+tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" -C "${BINARIES_DIR}/rpi-firmware" "." ||
+{ echo "ERROR : unable to create boot.tar.xz" && exit 1 ;}
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/rpi-firmware/boot/batocera.update" "${BINARIES_DIR}/rpi-firmware/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+BATOCERAIMG="${BATOCERA_BINARIES_DIR}/batocera.img"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+FILES=$(find "${BINARIES_DIR}/rpi-firmware" -type f | sed -e s+"^${BINARIES_DIR}/rpi-firmware/\(.*\)$"+"file \1 \{ image = 'rpi-firmware/\1' }"+ | tr '\n' '@')
+cat "${BINARIES_DIR}/genimage.cfg.tmp" | sed -e s+'@files'+"${FILES}"+ | tr '@' '\n' > "${BINARIES_DIR}/genimage.cfg" || exit 1
+rm -f "${BINARIES_DIR}/genimage.cfg.tmp" || exit 1
+echo "generating image"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/boot.vfat" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+

--- a/board/batocera/x86/post-image-script-x86.sh
+++ b/board/batocera/x86/post-image-script-x86.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+# BATOCERA_TARGET_DIR = batocera target sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+BATOCERA_TARGET_DIR=$7
+
+# /boot
+rm -rf "${BINARIES_DIR:?}/boot"     || exit 1
+mkdir -p "${BINARIES_DIR}/boot"     || exit 1
+cp "${BOARD_DIR}/boot/syslinux.cfg" "${BINARIES_DIR/}/boot/syslinux.cfg" || exit 1
+cp "${BINARIES_DIR}/bzImage" "${BINARIES_DIR}/boot/linux" || exit 1
+cp "${BINARIES_DIR}/initrd.gz" "${BINARIES_DIR}/boot" || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BINARIES_DIR}/boot/batocera.update" || exit 1
+cp -pr "${BINARIES_DIR}/tools"       "${BINARIES_DIR}/boot/"                || exit 1
+
+# get UEFI files
+mkdir -p "${BINARIES_DIR}/EFI/syslinux" || exit 1
+cp "${BOARD_DIR}/boot/syslinux.cfg" "${BINARIES_DIR/}/EFI/syslinux/syslinux.cfg" || exit 1
+
+# boot.tar.xz
+# it must include the squashfs version with .update to not erase the current squashfs while running
+echo "creating ${BATOCERA_BINARIES_DIR}/boot.tar.xz"
+(cd "${BINARIES_DIR}" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/boot.tar.xz" tools EFI boot batocera-boot.conf) || exit 1
+
+# batocera.img
+# rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
+mv "${BINARIES_DIR}/boot/batocera.update" "${BINARIES_DIR}/boot/batocera" || exit 1
+GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage-boot.cfg" "${BINARIES_DIR}" || exit 1
+echo "creating ${BINARIES_DIR}/batocera-boot.img"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BINARIES_DIR}" --config="${BINARIES_DIR}/genimage-boot.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+syslinux -i "${BINARIES_DIR}/batocera-boot.img" -d /boot/syslinux
+rm -rf "${GENIMAGE_TMP}" || exit 1
+cp "${BOARD_DIR}/genimage.cfg" "${BINARIES_DIR}" || exit 1
+echo "creating ${BATOCERA_BINARIES_DIR}/batocera.img"
+genimage --rootpath="${TARGET_DIR}" --inputpath="${BINARIES_DIR}" --outputpath="${BATOCERA_BINARIES_DIR}" --config="${BINARIES_DIR}/genimage.cfg" --tmppath="${GENIMAGE_TMP}" || exit 1
+rm -f "${BINARIES_DIR}/batocera-boot.img" || exit 1
+rm -f "${BATOCERA_BINARIES_DIR}/userdata.ext4" || exit 1
+sync || exit 1
+


### PR DESCRIPTION
Should limit conflicts on this "big" script file and allow building variants per SoC later.