### PR TITLE
Fix DXVK Install

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -39,9 +39,6 @@ dxvk_install() {
     export WINEDLLOVERRIDES="winemenubuilder.exe="
     WINEPREFIX=$1
 
-    # install dxvk only on system where it is available (aka, not x86)
-    test -e "/userdata/system/dxvk" || return 0
-
     DXVK="$(batocera-settings -command load -key windows.dxvk)"
     DXVK_HUD="$(batocera-settings -command load -key windows.dxvk_hud)"
 


### PR DESCRIPTION
That force user to install DXVK on /userdata/system/dxvk
And is available on /usr/share/dxvk

Script work only for x64 need to fix DXVK on x32 now.