### PR TITLE
Update emulators options in ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -35,44 +35,71 @@ class DolphinGenerator(Generator):
             dolphinSettings.add_section("Analytics")
 
         # draw or not FPS
-        if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
-            dolphinSettings.set("General", "ShowLag", "True")
-            dolphinSettings.set("General", "ShowFrameCount", "True")
+        if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
+            dolphinSettings.set("General", "ShowLag", '"True"')
+            dolphinSettings.set("General", "ShowFrameCount", '"True"')
         else:
-            dolphinSettings.set("General", "ShowLag", "False")
-            dolphinSettings.set("General", "ShowFrameCount", "False")
+            dolphinSettings.set("General", "ShowLag", '"False"')
+            dolphinSettings.set("General", "ShowFrameCount", '"False"')
 
         # don't ask about statistics
-        dolphinSettings.set("Analytics", "PermissionAsked", "True")
+        dolphinSettings.set("Analytics", "PermissionAsked", '"True"')
+
+        # PanicHandlers displaymessages
+        dolphinSettings.set("Interface", "UsePanicHandlers", '"False"')
+        dolphinSettings.set("Interface", "OnScreenDisplayMessages", '"False"')
 
         # don't confirm at stop
-        dolphinSettings.set("Interface", "ConfirmStop", "False")
+        dolphinSettings.set("Interface", "ConfirmStop", '"False"')
+
+        # Cheats - Default Off
+        if system.isOptSet("enable_cheats"):
+            dolphinSettings.set("Core", "EnableCheats", system.config['enable_cheats'])
+        else:
+            dolphinSettings.set("Core", "EnableCheats", '"False"')
+
+        # speed up disc transfert rate
+        if system.isOptSet("enable_fastdisc"):
+            dolphinSettings.set("Core", "FastDiscSpeed", system.config["enable_fastdisc"])
+        else:
+            dolphinSettings.set("Core", "FastDiscSpeed", '"False"')
+
+        # Dual Core
+        if system.isOptSet("dual_core") and not system.getOptBoolean("dual_core"):
+            dolphinSettings.set("Core", "CPUThread", '"True"')
+        else:
+            dolphinSettings.set("Core", "CPUThread", '"False"')
+
+        # Gpu Sync
+        if system.isOptSet("gpu_sync") and not system.getOptBoolean("gpu_sync"):
+            dolphinSettings.set("Core", "SyncGPU", '"False"')
+        else:
+            dolphinSettings.set("Core", "SyncGPU", '"True"')
 
         # language (for gamecube at least)
         dolphinSettings.set("Core", "SelectedLanguage", getGameCubeLangFromEnvironment())
         dolphinSettings.set("Core", "GameCubeLanguage", getGameCubeLangFromEnvironment())
-        
-        # backend - Default
-        if system.isOptSet('gfxbackend'):
-            dolphinSettings.set("Core", "GFXBackend", system.config['gfxbackend'])
+
+        # Enable MMU - Default On
+        if system.isOptSet("enable_mmu") and not system.getOptBoolean("enable_mmu"):
+            dolphinSettings.set("Core", "MMU", '"False"')
         else:
-            dolphinSettings.set("Core", "GFXBackend", "OGL")
-        
-        # Standardize Dual Core
-        dolphinSettings.set("Core", "CPUThread", "True")
-        dolphinSettings.set("Core", "SyncGPU", "True")
-        
-        # Standardize Fast Disc Speed
-        dolphinSettings.set("Core", "FastDiscSpeed", "True")
+            dolphinSettings.set("Core", "MMU", '"True"')
+
+        # backend - Default
+        if system.isOptSet("gfxbackend"):
+            dolphinSettings.set("Core", "GFXBackend", system.config["gfxbackend"])
+        else:
+            dolphinSettings.set("Core", "GFXBackend", '"OGL"')
 
         # wiimote scanning
-        dolphinSettings.set("Core", "WiimoteContinuousScanning", "True")
+        dolphinSettings.set("Core", "WiimoteContinuousScanning", '"True"')
 
         # gamecube pads forced as standard pad
-        dolphinSettings.set("Core", "SIDevice0", "6")
-        dolphinSettings.set("Core", "SIDevice1", "6")
-        dolphinSettings.set("Core", "SIDevice2", "6")
-        dolphinSettings.set("Core", "SIDevice3", "6")
+        dolphinSettings.set("Core", "SIDevice0", '"6"')
+        dolphinSettings.set("Core", "SIDevice1", '"6"')
+        dolphinSettings.set("Core", "SIDevice2", '"6"')
+        dolphinSettings.set("Core", "SIDevice3", '"6"')
 
         # save dolphin.ini
         with open(batoceraFiles.dolphinIni, 'w') as configfile:
@@ -98,56 +125,38 @@ class DolphinGenerator(Generator):
 
         # show fps
         if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
-            dolphinGFXSettings.set("Settings", "ShowFPS", "True")
+            dolphinGFXSettings.set("Settings", "ShowFPS", '"True"')
         else:
-            dolphinGFXSettings.set("Settings", "ShowFPS", "False")
-        
-        #Fast Disc Speed - Default Off        
-        if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
-            dolphinSettings.set("Core", "EnableCheats", "True")
-        else:
-            dolphinSettings.set("Core", "EnableCheats", "False")
-
-        #Fast Disc Speed - Default Off
-        if system.isOptSet('enable_fastdisc') and system.getOptBoolean('enable_fastdisc'):
-            dolphinSettings.set("Core", "FastDiscSpeed", "True")
-        else:
-            dolphinSettings.set("Core", "FastDiscSpeed", "False")
-            
-        #Enable MMU - Default On
-        if system.isOptSet('enable_mmu') and not system.getOptBoolean('enable_mmu'):
-            dolphinSettings.set("Core", "MMU", "False")
-        else:
-            dolphinSettings.set("Core", "MMU", "True")
-
+            dolphinGFXSettings.set("Settings", "ShowFPS", '"False"')
+			
         # HiResTextures - Default On
         if system.isOptSet('hires_textures') and not system.getOptBoolean('hires_textures'):
-            dolphinGFXSettings.set("Settings", "HiresTextures", "False")
-            dolphinGFXSettings.set("Settings", "CacheHiresTextures", "False")
+            dolphinGFXSettings.set("Settings", "HiresTextures", '"False"')
+            dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"False"')
         else:
-            dolphinGFXSettings.set("Settings", "HiresTextures", "True")
-            dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
+            dolphinGFXSettings.set("Settings", "HiresTextures", '"True"')
+            dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"True"')
             
         # widescreen hack but only if enable cheats is not enabled - Default Off
         if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack') and system.isOptSet('enable_cheats') and not system.getOptBoolean('enable_cheats')):
-            dolphinGFXSettings.set("Settings", "wideScreenHack", "True")
+            dolphinGFXSettings.set("Settings", "wideScreenHack", '"True"')
         else:
-            dolphinGFXSettings.remove_option("Settings", "wideScreenHack")
+            dolphinGFXSettings.remove_option("Settings", '"wideScreenHack"')
 
         # various performance hacks - Default Off
         if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
        
-            dolphinGFXSettings.set("Hacks", "BBoxEnable", "False")
-            dolphinGFXSettings.set("Hacks", "DeferEFBCopies", "True")
-            dolphinGFXSettings.set("Hacks", "EFBEmulateFormatChanges", "False")
-            dolphinGFXSettings.set("Hacks", "EFBScaledCopy", "True")
-            dolphinGFXSettings.set("Hacks", "EFBToTextureEnable", "True")
-            dolphinGFXSettings.set("Hacks", "SkipDuplicateXFBs", "True")
-            dolphinGFXSettings.set("Hacks", "XFBToTextureEnable", "True")
-            dolphinGFXSettings.set("Enhancements", "ForceFiltering", "True")
-            dolphinGFXSettings.set("Enhancements", "ArbitraryMipmapDetection", "True")
-            dolphinGFXSettings.set("Enhancements", "DisableCopyFilter", "True")
-            dolphinGFXSettings.set("Enhancements", "ForceTrueColor", "True")            
+            dolphinGFXSettings.set("Hacks", "BBoxEnable", '"False"')
+            dolphinGFXSettings.set("Hacks", "DeferEFBCopies", '"True"')
+            dolphinGFXSettings.set("Hacks", "EFBEmulateFormatChanges", '"False"')
+            dolphinGFXSettings.set("Hacks", "EFBScaledCopy", '"True"')
+            dolphinGFXSettings.set("Hacks", "EFBToTextureEnable", '"True"')
+            dolphinGFXSettings.set("Hacks", "SkipDuplicateXFBs", '"True"')
+            dolphinGFXSettings.set("Hacks", "XFBToTextureEnable", '"True"')
+            dolphinGFXSettings.set("Enhancements", "ForceFiltering", '"True"')
+            dolphinGFXSettings.set("Enhancements", "ArbitraryMipmapDetection", '"True"')
+            dolphinGFXSettings.set("Enhancements", "DisableCopyFilter", '"True"')
+            dolphinGFXSettings.set("Enhancements", "ForceTrueColor", '"True"')            
         else:
             if dolphinGFXSettings.has_section("Hacks"):
                 dolphinGFXSettings.remove_option("Hacks", "BBoxEnable")
@@ -167,13 +176,13 @@ class DolphinGenerator(Generator):
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
         else:
-            dolphinGFXSettings.set("Settings", "InternalResolution", "1")
+            dolphinGFXSettings.set("Settings", "InternalResolution", '"1"')
 
         # vsync - Default
         if system.isOptSet('vsync'):
             dolphinGFXSettings.set("Hardware", "VSync", system.getOptBoolean('vsync'))
         else:
-            dolphinGFXSettings.set("Hardware", "VSync", "True")
+            dolphinGFXSettings.set("Hardware", "VSync", '"True"')
             
 
   
@@ -181,13 +190,13 @@ class DolphinGenerator(Generator):
         if system.isOptSet('anisotropic_filtering'):
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", system.config["anisotropic_filtering"])
         else:
-            dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", "0")
+            dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", '"0"')
 			
 		# anti aliasing - Auto 0
         if system.isOptSet('antialiasing'):
             dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:
-            dolphinGFXSettings.set("Settings", "MSAA", "0")
+            dolphinGFXSettings.set("Settings", "MSAA", '"0"')
 			
 		# save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -69,19 +69,19 @@ def generateCoreSettings(retroarchCore, system):
         coreSettings.save('desmume_pointer_device_r',   '"emulated"')
         # multisampling aa
         if system.isOptSet('multisampling'):
-            coreSettings.save("desmume_gfx_multisampling", system.config["multisampling"])
+            coreSettings.save('desmume_gfx_multisampling', system.config['multisampling'])
         else:
-            coreSettings.save("desmume_gfx_multisampling", "disabled")
+            coreSettings.save('desmume_gfx_multisampling', '"disabled"')
         # texture smoothing
         if system.isOptSet('texture_smoothing'):
-            coreSettings.save("desmume_gfx_texture_smoothing", system.config["texture_smoothing"])
+            coreSettings.save('desmume_gfx_texture_smoothing', system.config['texture_smoothing'])
         else:
-            coreSettings.save("desmume_gfx_texture_smoothing", "disabled")
+            coreSettings.save('desmume_gfx_texture_smoothing', '"disabled"')
         # texture scaling (xBrz)
         if system.isOptSet('texture_scaling'):
-            coreSettings.save("desmume_gfx_texture_scaling", system.config["texture_scaling"])
+            coreSettings.save('desmume_gfx_texture_scaling', system.config['texture_scaling'])
         else:
-            coreSettings.save("desmume_gfx_texture_scaling", "1")
+            coreSettings.save('desmume_gfx_texture_scaling', '"1"')
 
     if (system.config['core'] == 'mame078'):
         coreSettings.save('mame2003_skip_disclaimer',   '"enabled"')
@@ -92,15 +92,102 @@ def generateCoreSettings(retroarchCore, system):
         coreSettings.save('mame2003-plus_skip_warnings',    '"enabled"')
         coreSettings.save('mame2003-plus_analog',           '"digital"')
 
+    if (system.config['core'] == 'mesen'):
+        coreSettings.save('mesen_nospritelimit',    '"enabled"')
+        # overscan horizontal
+        if system.isOptSet('overscan_h'):
+            coreSettings.save('mesen_overscan_horizontal', system.config['overscan_h'])
+        else:
+            coreSettings.save('mesen_overscan_horizontal', '"None"')
+        # overscan vertical
+        if system.isOptSet('overscan_v'):
+            coreSettings.save('mesen_overscan_vertical', system.config['overscan_v'])
+        else:
+            coreSettings.save('mesen_overscan_vertical', '"None"')
+
+    if (system.config['core'] == 'puae'):
+        coreSettings.save('puae_video_options_display ',    '"enabled"')
+        # video resolution
+        if system.isOptSet('video_resolution'):
+            coreSettings.save('puae_video_resolution', system.config['video_resolution'])
+        else:
+            coreSettings.save('puae_video_resolution', '"auto"')
+        # zoom mode	
+        if system.isOptSet('zoom_mode'):
+            coreSettings.save('puae_zoom_mode', system.config['zoom_mode'])
+        else:
+            coreSettings.save('puae_zoom_mode', '"auto"')
+        # standard video	
+        if system.isOptSet('video_standard'):
+            coreSettings.save('puae_video_standard', system.config['video_standard'])
+        else:
+            coreSettings.save('puae_video_standard', '"PAL"')
+        # keypad mapping 2p	
+        if system.isOptSet('keyrah_mapping'):
+            coreSettings.save('puae_keyrah_keypad_mappings', system.config['keyrah_mapping'])
+        else:
+            coreSettings.save('puae_keyrah_keypad_mappings', '"enabled"')
+        # mouse speed	
+        if system.isOptSet('mouse_speed'):
+            coreSettings.save('puae_mouse_speed', system.config['mouse_speed'])
+        else:
+            coreSettings.save('puae_mouse_speed', '"200"')
+        # whdload	
+        if system.isOptSet('whdload'):
+            coreSettings.save('puae_use_whdload_prefs', system.config['whdload'])
+        else:
+            coreSettings.save('puae_use_whdload_prefs', '"config"')
+        # retropad options	
+        if system.isOptSet('pad_options'):
+            coreSettings.save('puae_retropad_options', system.config['pad_options'])
+        else:
+            coreSettings.save('puae_retropad_options', '"jump"')
+
     if (system.config['core'] == 'pce'):
         coreSettings.save('pce_keepaspect', '"enabled"')
-    
+        coreSettings.save('pce_nospritelimit', '"enabled"')
+
     if (system.config['core'] == 'pce_fast'):
         coreSettings.save('pce_keepaspect', '"enabled"')
+
+    if (system.config['core'] == 'mupen64plus-next'):
+        # BilinearMode
+        if system.isOptSet('BilinearMode'):
+            coreSettings.save('mupen64plus-BilinearMode', system.config['BilinearMode'])
+        else:
+            coreSettings.save('mupen64plus-BilinearMode', '"standard"')
+        # multisampling aa
+        if system.isOptSet('MultiSampling'):
+            coreSettings.save('mupen64plus-MultiSampling', system.config['MultiSampling'])
+        else:
+            coreSettings.save('mupen64plus-MultiSampling', '"0"')
+        # Texture filter
+        if system.isOptSet('Texture_filter'):
+            coreSettings.save('mupen64plus-txFilterMode', system.config['Texture_filter'])
+        else:
+            coreSettings.save('mupen64plus-txFilterMode', '"None"')
+        # Texture Enhancement
+        if system.isOptSet('Texture_Enhancement'):
+            coreSettings.save('mupen64plus-txEnhancementMode', system.config['Texture_Enhancement'])
+        else:
+            coreSettings.save('mupen64plus-txEnhancementMode', '"None"')
+
+    if (system.config['core'] == 'vb'):
+        # 2D color mode
+        if system.isOptSet('2d_color_mode'):
+            coreSettings.save('vb_color_mode', '"' + system.config['2d_color_mode'] + '"')
+        else:
+            coreSettings.save('vb_color_mode', '"black & red"')
+        # 3D color mode
+        if system.isOptSet('3d_color_mode'):
+            coreSettings.save('vb_anaglyph_preset', '"' + system.config['3d_color_mode'] + '"')
+        else:
+            coreSettings.save('vb_anaglyph_preset', '"disabled"')
 
     if (system.config['core'] == 'picodrive'):
         coreSettings.save('picodrive_input1',   '"6 button pad"')
         coreSettings.save('picodrive_input2',   '"6 button pad"')
+        coreSettings.save('picodrive_sprlim',    '"enabled"')
 
     if (system.config['core'] == '81'):
         coreSettings.save('81_sound',   '"Zon X-81"')
@@ -122,33 +209,83 @@ def generateCoreSettings(retroarchCore, system):
 
     if (system.config['core'] == 'vice'):
         coreSettings.save('vice_Controller',    '"joystick"')
+        coreSettings.save('vice_datasette_hotkeys',    '"enabled"')
+        coreSettings.save('vice_read_vicerc',    '"disabled"')
+        coreSettings.save('vice_retropad_options',    '"jump"')
         coreSettings.save('vice_JoyPort',       '"port_1"')
+        # aspect ratio
+        if system.isOptSet('aspect_ratio'):
+            coreSettings.save('vice_aspect_ratio', system.config['aspect_ratio'])
+        else:
+            coreSettings.save('vice_aspect_ratio', '"pal"')
+        # zoom mode
+        if system.isOptSet('zoom_mode'):
+            coreSettings.save('vice_zoom_mode', system.config['zoom_mode'])
+        else:
+            coreSettings.save('vice_zoom_mode', '"medium"')
+        # external palette
+        if system.isOptSet('external_palette'):
+            coreSettings.save('vice_external_palette', system.config['external_palette'])
+        else:
+            coreSettings.save('vice_external_palette', '"colodore"')
 
     if (system.config['core'] == 'theodore'):
         coreSettings.save('theodore_autorun',   '"enabled"')
 
+    if (system.config['core'] == 'genesisplusgx'):
+        coreSettings.save('genesis_plus_gx_no_sprite_limit',    '"enabled"')
+
+    if (system.config['core'] == 'snes9x_next'):
+        coreSettings.save('snes9x_2010_reduce_sprite_flicker',       '"enabled"')
+        # reduce slowdown
+        if system.isOptSet('reduce_slowdown'):
+            coreSettings.save('snes9x_2010_overclock_cycles', system.config['reduce_slowdown'])
+        else:
+            coreSettings.save('snes9x_2010_overclock_cycles', '"compatible"')
+
+    if (system.config['core'] == 'yabasanshiro'):
+        # resolution mode
+        if system.isOptSet('resolution_mode'):
+            coreSettings.save('yabasanshiro_resolution_mode', system.config['resolution_mode'])
+        else:
+            coreSettings.save('yabasanshiro_resolution_mode', '"original"')
+
+    if (system.config['core'] == 'nestopia'):
+        coreSettings.save('nestopia_nospritelimit',    '"enabled"')
+        coreSettings.save('nestopia_overscan_h',    '"enabled"')
+        coreSettings.save('nestopia_overscan_v',    '"enabled"')
+        # palette
+        if system.isOptSet('palette'):
+            coreSettings.save('nestopia_palette', system.config['palette'])
+        else:
+            coreSettings.save('nestopia_palette', '"consumer"')
+
+    if (system.config['core'] == 'fceumm'):
+        coreSettings.save('fceumm_nospritelimit',    '"enabled"')
+
     if (system.config['core'] == 'flycast'):
         coreSettings.save('reicast_threaded_rendering',   '"enabled"')
+        coreSettings.save('reicast_mipmapping',   '"disabled"')
         # widescreen hack
         if system.isOptSet('widescreen_hack'):
-            coreSettings.save("reicast_widescreen_hack", system.config["widescreen_hack"])
+            coreSettings.save('reicast_widescreen_hack', system.config['widescreen_hack'])
         else:
-            coreSettings.save("reicast_widescreen_hack", "disabled")
+            coreSettings.save('reicast_widescreen_hack', '"disabled"')
         # anisotropic filtering
         if system.isOptSet('anisotropic_filtering'):
-            coreSettings.save("reicast_anisotropic_filtering", system.config["anisotropic_filtering"])
+            coreSettings.save('reicast_anisotropic_filtering', system.config['anisotropic_filtering'])
         else:
-            coreSettings.save("reicast_anisotropic_filtering", "off")
+            coreSettings.save('reicast_anisotropic_filtering', '"off"')
         # texture upscaling (xBRZ)
         if system.isOptSet('texture_upscaling'):
-            coreSettings.save("reicast_texupscale", system.config["texture_upscaling"])
+            coreSettings.save('reicast_texupscale', system.config['texture_upscaling'])
         else:
-            coreSettings.save("reicast_texupscale", "off")
+            coreSettings.save('reicast_texupscale', '"off"')
         # render to texture upscaling
         if system.isOptSet('render_to_texture_upscaling'):
-            coreSettings.save("reicast_render_to_texture_upscaling", system.config["render_to_texture_upscaling"])
+            coreSettings.save('reicast_render_to_texture_upscaling', system.config['render_to_texture_upscaling'])
         else:
-            coreSettings.save("reicast_render_to_texture_upscaling", "1x")
+            coreSettings.save('reicast_render_to_texture_upscaling', '"1x"')
 
     if (system.config['core'] == 'dosbox'):
         coreSettings.save('dosbox_svn_pcspeaker', '"true"')
@@ -157,21 +294,22 @@ def generateCoreSettings(retroarchCore, system):
         coreSettings.save('px68k_disk_path', '"disabled"')
 
     if (system.config['core'] == 'mednafen_psx'):
+        coreSettings.save('beetle_psx_hw_cpu_freq_scale',   '"110%"')
         # internal resolution
         if system.isOptSet('internal_resolution'):
-            coreSettings.save("beetle_psx_hw_internal_resolution", system.config["internal_resolution"])
+            coreSettings.save('beetle_psx_hw_internal_resolution', system.config['internal_resolution'])
         else:
-            coreSettings.save("beetle_psx_hw_internal_resolution", "1x(native)")
+            coreSettings.save('beetle_psx_hw_internal_resolution', '"1x(native)"')
         # texture filtering
         if system.isOptSet('texture_filtering'):
-            coreSettings.save("beetle_psx_hw_filter", system.config["texture_filtering"])
+            coreSettings.save('beetle_psx_hw_filter', system.config['texture_filtering'])
         else:
-            coreSettings.save("beetle_psx_hw_filter", "nearest")
+            coreSettings.save('beetle_psx_hw_filter', '"nearest"')
         # widescreen hack
         if system.isOptSet('widescreen_hack'):
-            coreSettings.save("beetle_psx_hw_widescreen_hack", system.config["widescreen_hack"])
+            coreSettings.save('beetle_psx_hw_widescreen_hack', system.config['widescreen_hack'])
         else:
-            coreSettings.save("beetle_psx_hw_widescreen_hack", "disabled")
+            coreSettings.save('beetle_psx_hw_widescreen_hack', '"disabled"')
 
     if (system.config['core'] == 'pcsx_rearmed'):
         for n in range(1, 8+1):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -142,15 +142,27 @@ def configureGFX(config_directory, system):
     pcsx2GFXSettings = UnixSettings(configFileName, separator=' ')
     pcsx2GFXSettings.save("osd_fontname", "/usr/share/fonts/dejavu/DejaVuSans.ttf")
     pcsx2GFXSettings.save("osd_indicator_enabled", 1)
+    pcsx2GFXSettings.save("UserHacks", 1)
+    #showFPS
     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
         pcsx2GFXSettings.save("osd_monitor_enabled", 1)
     else:
         pcsx2GFXSettings.save("osd_monitor_enabled", 0)
-        
+    #internal resolution
     if system.isOptSet('internalresolution'):
         pcsx2GFXSettings.save("upscale_multiplier", system.config["internalresolution"])
     else:
         pcsx2GFXSettings.save("upscale_multiplier", "1")
+    #skipdraw
+    if system.isOptSet('skipdraw'):
+        pcsx2GFXSettings.save('UserHacks_SkipDraw', system.config['skipdraw'])
+    else:
+        pcsx2GFXSettings.save('UserHacks_SkipDraw', '0')
+    #align sprite
+    if system.isOptSet('align_sprite'):
+        pcsx2GFXSettings.save('UserHacks_align_sprite_X', system.config['align_sprite'])
+    else:
+        pcsx2GFXSettings.save('UserHacks_align_sprite_X', '0')
         
     if system.isOptSet('vsync'):
         pcsx2GFXSettings.save("vsync", system.config["vsync"])

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -132,23 +132,36 @@ libretro:
             texture_filtering:
                 prompt: TEXTURE FILTERING
                 choices:
-                    "Nearest":  nearest
-                    "SABR":     SABR
-                    "xBR":      xBR
-                    "Bilinear": bilinear
-                    "3-Point":  3-point
-                    "JINC2":    JINC2
+                    "Nearest":    nearest
+                    "SABR":       SABR
+                    "xBR":        xBR
+                    "Bilinear":   bilinear
+                    "3-Point":    3-point
+                    "JINC2":      JINC2
             widescreen_hack:
                 prompt: WIDESCREEN HACK
                 choices:
-                    "Off": disabled
-                    "On":  enabled
+                    "Off":        disabled
+                    "On":         enabled
     mednafen_supergrafx:
       features: [netplay, rewind, autosave]
     mednafen_wswan:
       features: [netplay, rewind, autosave]
     mesen:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            overscan_h:
+                prompt: OVERSCAN HORIZONTAL
+                choices:
+                    "off":     None
+                    "8px":     8px
+                    "16px":    16px
+            overscan_v:
+                prompt: OVERSCAN VERTICAL
+                choices:
+                    "off":     None
+                    "8px":     8px
+                    "16px":    16px
     mesen-s:
       features: [netplay, rewind, autosave]
     mgba:
@@ -157,10 +170,67 @@ libretro:
       features: [netplay, rewind, autosave]
     mupen64plus-next:
       features: [         rewind, autosave]
+      cfeatures:
+            BilinearMode:
+                prompt: BILINEAR FILTERING
+                choices:
+                    "standard":   standard
+                    "3 point":    3point
+            MultiSampling:
+                prompt: MSAA LEVEL
+                choices:
+                    "off":        0
+                    "2x":         2
+                    "4x":         4
+                    "8x":         8
+                    "16x":        16
+            Texture_filter:
+                prompt: TEXTURE FILTER
+                choices:
+                    "off":        None
+                    "Smooth 1":   Smooth filtering 1
+                    "Smooth 2":   Smooth filtering 2
+                    "Smooth 3":   Smooth filtering 3
+                    "Smooth 4":   Smooth filtering 4
+                    "Sharp 1":    Sharp filtering 1
+                    "Sharp 2":    Sharp filtering 2
+            Texture_Enhancement:
+                prompt: Texture Enhancement
+                choices:
+                    "off":        None
+                    "As Is":      As Is
+                    "X2":         X2
+                    "X2SAI":      X2SAI
+                    "HQ2X":       HQ2X
+                    "HQ2XS":      HQ2XS
+                    "LQ2X":       LQ2X
+                    "LQ2XS":      LQ2XS
+                    "HQ4X":       HQ4X
+                    "2xBRZ":      2xBRZ
+                    "3xBRZ":      3xBRZ
+                    "4xBRZ":      4xBRZ
+                    "5xBRZ":      5xBRZ
+                    "6xBRZ":      6xBRZ
     neocd:
       features: [                 autosave]
     nestopia:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            palette:
+                prompt: COLOR PALETTE
+                choices:
+                    "consumer":             consumer
+                    "cxa2025as":            cxa2025as
+                    "canonical":            canonical
+                    "alternative":          alternative
+                    "rgb":                  rgb
+                    "pal":                  pal
+                    "composite-direct-fbx": composite-direct-fbx
+                    "pvm-style-d93-fbx":    pvm-style-d93-fbx
+                    "ntsc-hardware-fbx":    ntsc-hardware-fbx
+                    "nes-classic-fbx-fs":   nes-classic-fbx-fs
+                    "raw":                  raw
+                    "custom":               custom
     tic80:
       features: [                 autosave]
     quasi88:
@@ -197,14 +267,74 @@ libretro:
       features: [         rewind, autosave]
     puae:
       features: [         rewind, autosave]
+      cfeatures:
+            video_resolution:
+                prompt: VIDEO RESOLUTION
+                choices:
+                    "360p":       lores
+                    "720p":       hires
+                    "1440p":      superhires
+            video_standard:
+                prompt: VIDEO STANDARD
+                choices:
+                    "pal":        PAL
+                    "ntsc":       NTSC
+            zoom_mode:
+                prompt: ZOOM MODE
+                choices:
+                    "deactivate": none
+                    "medium":     medium
+                    "large":      large
+                    "larger":     larger
+            keyrah_mapping:
+                prompt: KEYRAH 2P MAPPING
+                choices:
+                    "On":         enabled
+                    "Off":        disabled
+            mouse_speed:
+                prompt: MOUSE SPEED
+                choices:
+                    "original":   100
+                    "50%":        50
+                    "70%":        70
+                    "120%":       120
+                    "150%":       150
+                    "170%":       170
+                    "200%":       200
+            whdload:
+                prompt: WHDLOAD
+                choices:
+                    "On":         config
+                    "Off":        disabled
+            pad_options:
+                prompt: JUMP ON B
+                choices:
+                    "On":         jump
+                    "Off":        disabled
     px68k:
       features: [ ]
     scummvm:
       features: [ ]
     snes9x:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            reduce_slowdown:
+                prompt: REDUCE SLOWDOWN
+                choices:
+                    "off":        disabled
+                    "light":      light
+                    "compatible": compatible
+                    "max":        max
     snes9x_next:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            reduce_slowdown:
+                prompt: REDUCE SLOWDOWN
+                choices:
+                    "off":        disabled
+                    "light":      light
+                    "compatible": compatible
+                    "max":        max
     stella:
       features: [netplay, rewind, autosave]
     tgbdual:
@@ -215,16 +345,80 @@ libretro:
       features: [ ]
     vb:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            2d_color_mode:
+                prompt: 2D COLOR MODE
+                choices:
+                    "original":            black & red
+                    "black/white":         black & white
+                    "black/blue":          black & blue
+                    "black/cyan":          black & cyan
+                    "black/electric cyan": black & electric cyan
+                    "black/green":         black & green
+                    "black/magenta":       black & magenta
+                    "black/yellow":        black & yellow
+            3d_color_mode:
+                prompt: 3D GLASSES COLOR MODE
+                choices:
+                    "off":                 disabled
+                    "red/blue":            red & blue
+                    "red/cyan":            red & cyan
+                    "red/electric cyan":   red & electric cyan
+                    "green/magenta":       green & magenta
+                    "yellow/blue":         yellow & blue
     vba-m:
       features: [         rewind, autosave]
     vecx:
       features: [         rewind, autosave]
     vice:
       features: [         rewind, autosave]
+      cfeatures:
+            external_palette:
+                prompt: EXTERNAL PALETTE
+                choices:
+                    "default":          default
+                    "colodore":         colodore
+                    "pepto-pal":        pepto-pal
+                    "pepto-ntsc":       pepto-ntsc
+                    "pepto-ntsc-sony":  pepto-ntsc-sony
+                    "cjam":             cjam
+                    "c64hq":            c64hq
+                    "c64s":             c64s
+                    "ccs64":            ccs64
+                    "community-colors": community-colors
+                    "deekay":           deekay
+                    "frodo":            frodo
+                    "godot":            godot
+                    "pc64":             pc64
+                    "ptoing":           ptoing
+                    "rgb":              rgb
+                    "vice":             vice
+            aspect_ratio:
+                prompt: ASPECT RATIO
+                choices:
+                    "pal":              pal
+                    "ntsc":             ntsc
+            zoom_mode:
+                prompt: ZOOM MODE
+                choices:
+                    "deactivate":       none
+                    "small":            small
+                    "medium":           medium
+                    "maximum":          maximum
     virtualjaguar:
       features: [ ]
     yabasanshiro:
-      features: [                 autosave]
+      features: [         rewind, autosave]
+      cfeatures:
+            resolution_mode:
+                prompt: RESOLUTION MODE
+                choices:
+                    "original": original
+                    "2x":       2x
+                    "4x":       4x
+                    "720p":     720p
+                    "1080p":    1080p
+                    "4k":       4k
 
 amiberry:
   features: [ratio]
@@ -251,6 +445,16 @@ dolphin:
                 "4x":  2
                 "8x":  3
                 "16x": 4
+        dual_core:
+            prompt: DUAL CORE
+            choices:
+                "Off": 0
+                "On":  1
+        gpu_sync:
+            prompt: GPU SYNC
+            choices:
+                "Off": 0
+                "On":  1
         antialiasing:
             prompt: ANTIALIASING
             choices:
@@ -292,7 +496,7 @@ dolphin:
             prompt: GRAPHICS BACKEND
             choices:
                 "OpenGL": OGL
-                "Vulkan":  Vulkan
+                "Vulkan": Vulkan
 
   systems:
     wii:
@@ -329,6 +533,20 @@ pcsx2:
                 "4x":  4
                 "8x":  8
                 "16x": 16
+        skipdraw:
+            prompt: SKIPDRAW
+            choices:
+                "Off": 0
+                "1":   1
+                "2":   2
+                "3":   3
+                "4":   4
+                "5":   5
+        align_sprite:
+            prompt: ALIGN SPRITE
+            choices:
+                "Off": 0
+                "On":  1
         vsync:
             prompt: VSYNC
             choices:
@@ -383,8 +601,8 @@ cannonball:
     highResolution:
       prompt: HIGH RESOLUTION
       choices:
-        Off:  0
-        On: 1
+        Off: 0
+        On:  1
 cemu:
   features: [emulated_wiimotes]
 


### PR DESCRIPTION
Liste des ajouts.
(valeur la plus basse par défaut à chaque parametres).Tous testés et fonctionnel.

Flycast:
-reicast mipmapping: sur off par défaut (incompatible avec texture upscalling xbrz "texture noire" si activé)
-widescreen hack: on/off
-anisotropic filtering: off/2x/4x/8x/16x
-texture upscaling (xBRZ): off/2x/4x/6x
-render to texture upscaling: off/2x/3x/4x/8x

Desmune:
-texture upscaling (xbrz) : off/2x/4x
-texture smoothing: on/off
-multisampling AA: off/2x/4x/8x/16x/32x

Mednafen psx:
-internal resolution: 1x(native)/2x/4x/8x/16x
-texture filtering: nearest/sabr/xbr/bilinear/3point/jinc2
-widescreen hack: disabled/enabled

Genesisplus gx:
-no sprite limit : enabled, par défaut

Nestopia:
-no sprite limit: enabled, par défaut
-mask overscan h: enabled, par défaut
-mask overscan v: enabled, par défaut
-palette: "consumer"par défaut, modifiable dans ES

Fceumm:
-no sprite limit: enabled, par défaut

Mesen:
-no sprite limit: enabled, par défaut
-overscan vertical: None par défaut, modifiable dans ES
-overscan horizontal: None par défaut, modifiable dans ES
Pce:
-no sprite limit: enabled, par défaut

Picodrive:
-no sprite limit: enabled, par défaut

Snes9x:
-overclock cycles: compatible par défaut, modifiable dans ES
-reduce sprite flicker: enabled

Snes9x next:
-overclock cycles: compatible par défaut, modifiable dans ES
-reduce sprite flicker: enabled

Yabasanshiro:
-resolution mode: orignal par défaut, 2x/4x/720p/1080p/4K modifiable dans ES

Amiga "PUAE"
-display video options: activé par défaut.
-video resolution: auto par défaut, 360p/720p/1440p modifiable dans ES
-zoom mode: désactivé par défaut, medium/large/larger modifiable dans ES
-video standard: pal par défaut, auto/pal/ntsc modifiable dans ES
-keyrah 2p mapping: enabled par défaut, on/off modifiable dans ES
-mouse speed: 200% par défaut, 50/70/100"original"/120/150/170/200
-Whdload: "config" par défaut, "config"/disabled modifiable dans ES
-retropad options (jump on B): "config" par défaut, config/off modifiable dans ES

C64 "libretro/vice"
-aspect ratio: "pal" par défaut, pal/ntsc modifiable dans ES
-external palette: "colodore" par défaut modifiable dans ES
-datasette hotkeys: "enabled" par défaut
-read vicerc: "disabled" par défaut
-retropad options: "jump" par défaut
-zoom mode: "medium" par défaut, none/small/medium/max modifiable dans ES

N64 "libretro/mupen64plus-next"
-bilinear filtering: "standard" par défaut, 3point modifiable dans ES
-MSAA: " off" par défaut 2x/4x/8x/16x modifiable dans ES
-Texture filter: None par défaut, Smooth filtering 1/Smooth filtering 2/Smooth filtering 3/Smooth filtering 4/Sharp filtering 1/Sharp filtering 2 modifiable dans ES
-Texture Enhancement: None par défaut, AsIs/X2/X2SAI/HQ2X/HQ2XS/LQ2X/LQ2XS/HQ4X/2xBRZ/3xBRZ/4xBRZ/5xBRZ/6xBRZ

Virtualboy
-color mode 2d: original par défaut, 7 couleurs modifiable depuis ES
-color mode lunette 3d: off par défaut, 5 couleurs de lunettes modifiable depuis ES

Ps2
-userhack activé par défaut.
-skipdraw désactivé par defaut, modifiable via ES
-align sprites desactivé par défaut, modifiable via ES

+ les options dolphin deja ajoutées "corrigé".