### PR TITLE
Add Virtual Desktop + Fixe

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -36,9 +36,15 @@ waitWineServer() {
 }
 
 wine_options() {
-    ESYNC=$(batocera-settings -e -r esync -s windows -g "${ROMGAMENAME}")
-    FSYNC=$(batocera-settings -e -r fsync -s windows -g "${ROMGAMENAME}")
-    PBA=$(batocera-settings -e -r pba -s windows -g "${ROMGAMENAME}")
+    ESYNC=$(batocera-settings -e -r esync -s windows || batocera-settings -e -r esync -s windows -g "${ROMGAMENAME}")
+    FSYNC=$(batocera-settings -e -r fsync -s windows || batocera-settings -e -r fsync -s windows -g "${ROMGAMENAME}")
+    PBA=$(batocera-settings -e -r pba -s windows || batocera-settings -e -r pba -s windows -g "${ROMGAMENAME}")
+    VIRTUAL_DESKTOP=$(batocera-settings -e -r virtual_desktop -s windows || batocera-settings -e -r virtual_desktop -s windows -g "${ROMGAMENAME}")
+    VIRTUAL_DESKTOP_SIZE=$(batocera-settings -e -r videomode -s windows || batocera-settings -e -r videomode -s windows -g "${ROMGAMENAME}" || batocera-resolution currentResolution)
+
+    if [ "${VIRTUAL_DESKTOP}" = 1 ]; then
+	VDESKTOP="explorer /desktop=Wine,${VIRTUAL_DESKTOP_SIZE}"
+    fi
 
     export WINEESYNC=1
     test "${ESYNC}" = 0 && WINEESYNC=0
@@ -58,8 +64,8 @@ dxvk_install() {
     # install dxvk only on system where it is available (aka, not x86)
     test -e "/usr/share/dxvk" || return 0
 
-    DXVK=$(batocera-settings -e -r dxvk -s windows -g "${ROMGAMENAME}")
-    DXVK_HUD=$(batocera-settings -e -r dxvk_hud -s windows -g "${ROMGAMENAME}")
+    DXVK=$(batocera-settings -e -r dxvk -s windows || batocera-settings -e -r dxvk -s windows -g "${ROMGAMENAME}")
+    DXVK_HUD=$(batocera-settings -e -r dxvk_hud -s windows || batocera-settings -e -r dxvk_hud -s windows -g "${ROMGAMENAME}")
 
     if test "${DXVK_HUD}" = 1
     then
@@ -142,9 +148,10 @@ play_wine() {
     GAMENAME=$1
     WINEPOINT="${GAMENAME}"
 
+    wine_options
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${WINE_CMD}")
+    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${VDESKTOP} ${WINE_CMD}")
     waitWineServer
 }
 
@@ -158,7 +165,7 @@ play_pc() {
 
     WINE_CMD=$(getWine_var "${GAMENAME}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${GAMENAME}" "DIR" "")
-    (cd "${GAMENAME}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${WINE_CMD}")
+    (cd "${GAMENAME}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${VDESKTOP} ${WINE_CMD}")
     waitWineServer
 }
 
@@ -184,7 +191,7 @@ play_exe() {
     createWineDirectory "${WINEPOINT}" || return 1
     dxvk_install "${WINEPOINT}" || return 1
 
-    (cd "${GAMEDIR}" && WINEPREFIX=${WINEPOINT} wine "${GAMEEXE}")
+    (cd "${GAMEDIR}" && WINEPREFIX=${WINEPOINT} wine "${VDESKTOP}" "${GAMEEXE}")
     waitWineServer
 }
 
@@ -203,7 +210,7 @@ play_winetgz() {
 
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${WINE_CMD}")
+    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${VDESKTOP} ${WINE_CMD}")
     waitWineServer
 }
 
@@ -242,7 +249,7 @@ play_squashfs() {
 
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${WINE_CMD}")
+    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "wine ${VDESKTOP} ${WINE_CMD}")
     waitWineServer
 
     # try to clean the cdrom


### PR DESCRIPTION
Addition of the possibility of having a virtual desktop on wine.
Correction of a detection problem in batocera-settings
example:

```
batocera-settings -e -r esync -s windows -g ''
ERROR: '-g' is missing an argument.
Just type '/usr/bin/batocera-settings' to see usage page.
```

Added automatic detection of resolution if nothing is set.