### PR TITLE
DevilutionX: Controller support

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/devilutionx/devilutionxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/devilutionx/devilutionxGenerator.py
@@ -2,6 +2,8 @@
 
 import Command
 from generators.Generator import Generator
+import controllersConfig
+
 
 class DevilutionXGenerator(Generator):
 
@@ -10,5 +12,9 @@ class DevilutionXGenerator(Generator):
                         "--config-dir", "/userdata/system/config/devilutionx",
                         "--save-dir", "/userdata/saves/devilutionx"]
         if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
-          commandArray.append("-f")
-        return Command.Command(array=commandArray)
+            commandArray.append("-f")
+        return Command.Command(
+            array=commandArray,
+            env={
+                'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
+            })

--- a/package/batocera/emulators/devilutionx/devilutionx.mk
+++ b/package/batocera/emulators/devilutionx/devilutionx.mk
@@ -4,8 +4,7 @@
 #
 ################################################################################
 
-# The first commit that allows specifying `--config-dir` (24 Nov 2020)
-DEVILUTIONX_VERSION = 9c7d6c96
+DEVILUTIONX_VERSION = b10b4381
 DEVILUTIONX_SITE = $(call github,diasurgical,devilutionx,$(DEVILUTIONX_VERSION))
 DEVILUTIONX_DEPENDENCIES = sdl2 sdl2_mixer sdl2_image sdl2_ttf libsodium
 


### PR DESCRIPTION
Starts DevilutionX with a generated SDL2 game controller config.

Follow-up to #2510, made possible by #2552.

DevilutionX version bumped to get fixes for the following controller issues on the DevilutionX side:

* https://github.com/diasurgical/devilutionX/issues/930
* https://github.com/diasurgical/devilutionX/issues/931