### PR TITLE
batocera-settings: Migrate callers to new-style args

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S10wifi
+++ b/board/batocera/fsoverlay/etc/init.d/S10wifi
@@ -16,7 +16,7 @@ if ! [ -f "$BATOCONF" ]; then
 fi
 
 # WLAN enabled?
-settingsWlan="$(batocera-settings "$BATOCONF" -command load -key wifi.enabled)"
+settingsWlan="$(batocera-settings -f "$BATOCONF" -r wifi.enabled)"
 if [ "$settingsWlan" != "1" ];then
     exit 0
 fi
@@ -28,8 +28,8 @@ batocera_wifi_configure() {
     [ "$X" = "1" ] && { X=; settings_name=default; }
     [ "$X" = ".hidden" ] && { settings_name=hidden_AP; settings_hide=true; }
     
-    settings_ssid="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.ssid)"
-    settings_key="$(batocera-settings "$BATOCONF" -command load -key wifi${X}.key)"
+    settings_ssid="$(batocera-settings -f "$BATOCONF" -r wifi${X}.ssid)"
+    settings_key="$(batocera-settings -f "$BATOCONF" -r wifi${X}.key)"
     settings_file="/var/lib/connman/batocera_wifi${X}.config"
 
     if [ -n "$settings_ssid" ];then

--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -252,7 +252,7 @@ case "${MODE}" in
 esac
 
 # fs compression
-compressenabled="`batocera-settings -command load -key system.fscompression.enabled`"
+compressenabled="`batocera-settings -r system.fscompression.enabled`"
 if [[ "$compressenabled" == "1" ]]
 then
     if grep -qE "^/dev/[^ ]* /userdata btrfs.*$" /proc/mounts

--- a/board/batocera/fsoverlay/etc/init.d/S26system
+++ b/board/batocera/fsoverlay/etc/init.d/S26system
@@ -5,22 +5,22 @@ config_script=batocera-config
 log="/userdata/system/logs/batocera.log"
 
 rb_gpio_configure() {
-    settings_gpio_mk="`$systemsetting -command load -key controllers.gpio.enabled`"
+    settings_gpio_mk="`$systemsetting -r controllers.gpio.enabled`"
     if [ "$settings_gpio_mk" == "1" ];then
-	settings_gpio_map="`$systemsetting -command load -key controllers.gpio.args`"
+	settings_gpio_map="`$systemsetting -r controllers.gpio.args`"
 	[ "$settings_gpio_map" == "" ] && settings_gpio_map="map=1,2"
         eval $config_script "module" "load" mk_arcade_joystick_rpi "$settings_gpio_map" >> $log
     else
 	# mk disabled let's check for db9
-	settings_db9="`$systemsetting -command load -key controllers.db9.enabled`"
+	settings_db9="`$systemsetting -r controllers.db9.enabled`"
 	if [ "$settings_db9" == "1" ];then
-            settings_db9_map="`$systemsetting -command load -key controllers.db9.args`"
+            settings_db9_map="`$systemsetting -r controllers.db9.args`"
             eval $config_script "module" "load" db9_gpio_rpi "$settings_db9_map" >> $log
 	else
 	    # db9 and mk disabled let's check for gamecon
-            settings_gamecon="`$systemsetting -command load -key controllers.gamecon.enabled`"
+            settings_gamecon="`$systemsetting -r controllers.gamecon.enabled`"
             if [ "$settings_gamecon" == "1" ];then
-                settings_gamecon_map="`$systemsetting -command load -key controllers.gamecon.args`"
+                settings_gamecon_map="`$systemsetting -r controllers.gamecon.args`"
                 eval $config_script "module" "load" gamecon_gpio_rpi "$settings_gamecon_map" >> $log
 	    fi
 	fi
@@ -28,8 +28,8 @@ rb_gpio_configure() {
 }
 
 rb_keyboad_lang() {
-    settings_lang="`$systemsetting -command load -key system.language`"
-    settings_kb="`$systemsetting -command load -key system.kblayout`"
+    settings_lang="`$systemsetting -r system.language`"
+    settings_kb="`$systemsetting -r system.kblayout`"
     if [[ "$settings_kb" != "" ]];then
 	loadkeys "$settings_kb" >> $log
     else
@@ -41,8 +41,8 @@ rb_keyboad_lang() {
 }
 
 rb_xbox() {
-    settings_xbox="`$systemsetting -command load -key controllers.xboxdrv.enabled`"
-    settings_xbox_nb="`$systemsetting -command load -key controllers.xboxdrv.nbcontrols`"
+    settings_xbox="`$systemsetting -r controllers.xboxdrv.enabled`"
+    settings_xbox_nb="`$systemsetting -r controllers.xboxdrv.nbcontrols`"
     if [[ "$settings_xbox" == "1" ]];then
         rmmod xpad
         if [[ "$settings_xbox_nb" == "1" ]];then
@@ -58,14 +58,14 @@ rb_xbox() {
 }
 
 rb_timezone() {
-    settings_timezone="`$systemsetting -command load -key system.timezone`"
+    settings_timezone="`$systemsetting -r system.timezone`"
     if [[ "$settings_timezone" != "" ]];then
         eval $config_script "tz" "$settings_timezone" >> $log
     fi
 }
 
 rb_hostname() {
-    settings_hostname="`$systemsetting -command load -key system.hostname`"
+    settings_hostname="`$systemsetting -r system.hostname`"
     if [[ "$settings_hostname" != "" ]];then
         hostname "${settings_hostname}"
 	echo "127.0.0.1	localhost"             > /etc/hosts
@@ -74,7 +74,7 @@ rb_hostname() {
 }
 
 rb_xarcade2jstick() {
-    settings_xarcade="`$systemsetting -command load -key controllers.xarcade.enabled`"
+    settings_xarcade="`$systemsetting -r controllers.xarcade.enabled`"
     if [[ "$settings_xarcade" == "1" ]];then
         # First try : suppose a real X-Arcade is plugged
         /usr/bin/xarcade2jstick -d

--- a/board/batocera/fsoverlay/etc/init.d/S31sixad
+++ b/board/batocera/fsoverlay/etc/init.d/S31sixad
@@ -4,9 +4,9 @@ systemsetting="batocera-settings"
 
 case "$1" in
   start)
-        enabled="`$systemsetting  -command load -key controllers.ps3.enabled`"
+        enabled="`$systemsetting -r controllers.ps3.enabled`"
         if [ "$enabled" == "1" ];then
-                settings_version="`$systemsetting -command load -key controllers.ps3.driver`"
+                settings_version="`$systemsetting -r controllers.ps3.driver`"
                 [ "$settings_version" == "bluez" ] && exit 0
                 if [ "$settings_version" == "" ];then
                         settings_version="official"

--- a/board/batocera/fsoverlay/etc/init.d/S35securepasswd
+++ b/board/batocera/fsoverlay/etc/init.d/S35securepasswd
@@ -20,7 +20,7 @@ then
 fi
 
 # secure ssh
-enabled="`$systemsetting  -command load -key system.security.enabled`"
+enabled="`$systemsetting -r system.security.enabled`"
 if [ "$enabled" != "1" ];then
     MASTERPASSWD="linux"
 fi

--- a/board/batocera/fsoverlay/etc/init.d/S50triggerhappy
+++ b/board/batocera/fsoverlay/etc/init.d/S50triggerhappy
@@ -2,7 +2,7 @@
 
 CONFFILE=multimedia_keys.conf
 
-enabled="`batocera-settings -command load -key system.multimediakeys.enabled`"
+enabled="`batocera-settings -r system.multimediakeys.enabled`"
 if [ "$enabled" = "0" ];then
     CONFFILE=multimedia_keys_disabled.conf
 fi

--- a/board/batocera/fsoverlay/etc/init.d/S61cec
+++ b/board/batocera/fsoverlay/etc/init.d/S61cec
@@ -4,7 +4,7 @@ case "$1" in
         start)
                 ;;
         stop)
-                enabled="`batocera-settings -command load -key system.cec.standby`"
+                enabled="`batocera-settings -r system.cec.standby`"
                 if [ "$enabled" == "1" ];then
                         echo standby 0 | cec-client -s -d 1 &
                 fi

--- a/board/batocera/fsoverlay/etc/init.d/S91smb
+++ b/board/batocera/fsoverlay/etc/init.d/S91smb
@@ -4,7 +4,7 @@
 #
 
 systemsetting="batocera-settings"
-securityenabled="`$systemsetting  -command load -key system.security.enabled`"
+securityenabled="`$systemsetting -r system.security.enabled`"
 
 if [ "$securityenabled" == "1" ];then
     CONFIGFILE="/etc/samba/smb-secure.conf"
@@ -21,7 +21,7 @@ mkdir -p /var/run/samba
 RETVAL=0
 
 start() {
-	enabled="`$systemsetting  -command load -key system.samba.enabled`"
+	enabled="`$systemsetting -r system.samba.enabled`"
     	if [ "$enabled" == "0" ];then
 	  echo "SMB services: disabled"
 	  exit 0

--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -6,7 +6,7 @@ unclutter --noevents -b
 systemsetting="batocera-settings"
 
 # set the keyboard
-settings_lang="`$systemsetting -command load -key system.language`"
+settings_lang="`$systemsetting -r system.language`"
 
 # not always true (en_US for us), but it's really better than always english
 map_name=$(echo $settings_lang | cut -c 1-2)
@@ -22,11 +22,11 @@ export LC_ALL="${settings_lang}.UTF-8"
 export LANG=${LC_ALL}
 
 # because of xinerama breaking es, enable only one screen at a time
-settings_output="`$systemsetting -command load -key global.videooutput`"
+settings_output="`$systemsetting -r global.videooutput`"
 batocera-resolution setOutput "${settings_output}" # empty or invalid values defaults to the first valid
 
 # dpi override for nvidia gpus
-settings_output="`$systemsetting -command load -key global.dpi`"
+settings_output="`$systemsetting -r global.dpi`"
 [ ! -z "${settings_output}" ] && batocera-resolution setDPI "${settings_output}"
 
 #####################
@@ -49,7 +49,7 @@ settings_output="`$systemsetting -command load -key global.dpi`"
 
 # set user desired resolution
 # nice workaround for displays which tell X11 to use strange resolutions
-settings_output="`$systemsetting -command load -key global.videomode`"
+settings_output="`$systemsetting -r global.videomode`"
 [ ! -z "${settings_output}" ] && batocera-resolution setMode "${settings_output}"
 
 batocera-resolution minTomaxResolution

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -14,7 +14,7 @@ case "${ACTION}" in
 	;;	
 
 	"get")	
-		batocera-settings -command load -key audio.device	
+		batocera-settings -r audio.device	
 	;;	
 
 	"set")	

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-odroidga
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-odroidga
@@ -14,7 +14,7 @@ case "${ACTION}" in
 	;;	
 
 	"get")	
-		batocera-settings -command load -key audio.device	
+		batocera-settings -r audio.device	
 	;;	
 
 	"set")	

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-rockpro64
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-rockpro64
@@ -15,7 +15,7 @@ case "${ACTION}" in
 	;;	
 
 	"get")	
-		batocera-settings -command load -key audio.device	
+		batocera-settings -r audio.device	
 	;;	
 
 	"set")	

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-rpi
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-rpi
@@ -14,7 +14,7 @@ case "${ACTION}" in
 	;;	
 
 	"get")	
-		batocera-settings -command load -key audio.device	
+		batocera-settings -r audio.device	
 	;;	
 
 	"set")	

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-vim3
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-vim3
@@ -14,7 +14,7 @@ case "${ACTION}" in
 	;;	
 
 	"get")	
-		batocera-settings -command load -key audio.device	
+		batocera-settings -r audio.device	
 	;;	
 
 	"set")	

--- a/package/batocera/core/batocera-bluetooth/S32bluetooth.template
+++ b/package/batocera/core/batocera-bluetooth/S32bluetooth.template
@@ -7,7 +7,7 @@ case "$1" in
     start)
         # Restores old settings saved in userdata
         batocera-bluetooth restore
-        enabled="$(batocera-settings -command load -key controllers.bluetooth.enabled)"
+        enabled="$(batocera-settings -r controllers.bluetooth.enabled)"
         [ "$enabled" == "1" ] || exit 0
         # soft unblock bluetooth
         rfkill unblock bluetooth
@@ -41,8 +41,8 @@ case "$1" in
             esac
         done
 
-        btaddr="$(batocera-settings -command load -key bluetooth.adapter)"
-        settings_version="$(batocera-settings -command load -key controllers.ps3.driver)"
+        btaddr="$(batocera-settings -r bluetooth.adapter)"
+        settings_version="$(batocera-settings -r controllers.ps3.driver)"
         if [ "$settings_version" != "bluez" ]
 	then
             BLUETOOTHD_ARGS="--noplugin=sixaxis"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-config
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-config
@@ -44,7 +44,7 @@ echo "---- batocera-config ----" >> $log
 
 if [ "$command" == "getRootPassword" ]; then
     # security disabled, force the default one without changing boot configuration
-    securityenabled="`$systemsetting  -command load -key system.security.enabled`"
+    securityenabled="`$systemsetting -r system.security.enabled`"
     if [ "$securityenabled" != "1" ];then
 	echo "linux"
 	exit 0
@@ -66,7 +66,7 @@ if [ "$command" == "setRootPassword" ]; then
     PASSWD=${2}
 
     # security disabled, don't change
-    securityenabled="`$systemsetting  -command load -key system.security.enabled`"
+    securityenabled="`$systemsetting -r system.security.enabled`"
     if [ "$securityenabled" != "1" ];then
 	exit 0
     fi
@@ -173,13 +173,13 @@ if [ "$command" == "module" ];then
 fi
 
 if [ "$command" == "canupdate" ];then
-	updatetype="`$systemsetting  -command load -key updates.type`"
+	updatetype="`$systemsetting -r updates.type`"
 	if test "${updatetype}" != "stable" -a "${updatetype}" != "unstable" -a "${updatetype}" != "beta"
 	then
 		# force a default value in case the value is removed or miswritten
 		updatetype="stable"
 	fi
-	settingsupdateurl="`$systemsetting  -command load -key updates.url`"
+	settingsupdateurl="`$systemsetting -r updates.url`"
 
 	# customizable upgrade url website
 	if test -n "${settingsupdateurl}"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-hybrid-nvidia
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-hybrid-nvidia
@@ -23,7 +23,7 @@ echo "Stopping ES..."
 mount -o remount,rw /boot
 
 echo "Activating Nvidia driver"
-batocera-settings /boot/batocera-boot.conf --command uncomment --key nvidia-driver
+batocera-settings -f /boot/batocera-boot.conf -w nvidia-driver -v true
 
 echo "Writing NVidia Xconf..."
 cat > /userdata/system/99-nvidia.conf <<_EOF_

--- a/package/batocera/core/batocera-scripts/scripts/batocera-install
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-install
@@ -4,7 +4,7 @@ updateurl="https://updates.batocera.org"
 systemsetting="batocera-settings"
 
 # customizable upgrade url website
-settingsupdateurl=$($systemsetting -command load -key updates.url)
+settingsupdateurl=$($systemsetting -r updates.url)
 test -n "${settingsupdateurl}" && updateurl="${settingsupdateurl}"
 
 IMGFOLDER="/userdata/system/installs"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-kodilauncher
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-kodilauncher
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 systemsetting="batocera-settings"
-WAITMODE="`$systemsetting  -command load -key kodi.network.waitmode`"
+WAITMODE="`$systemsetting -r kodi.network.waitmode`"
 
 # if the mode is required or wish,
 # kodi waits for the network before starting
 # in fact, it waits that an ip is available (such as a db service for example)
 if test "${WAITMODE}" = "required" -o "${WAITMODE}" = "wish"
 then
-    WAITTIME="`$systemsetting  -command load -key kodi.network.waittime`"
-    WAITHOST="`$systemsetting  -command load -key kodi.network.waithost`"
+    WAITTIME="`$systemsetting -r kodi.network.waittime`"
+    WAITHOST="`$systemsetting -r kodi.network.waithost`"
 
     DOCONT=1
     NWAITED=0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
@@ -65,8 +65,8 @@ updateurl="https://updates.batocera.org"
 systemsetting="/usr/bin/batocera-settings"
 
 arch=$(cat /usr/share/batocera/batocera.arch)
-updatetype=$($systemsetting -command load -key updates.type)
-settingsupdateurl=$($systemsetting -command load -key updates.url)
+updatetype=$($systemsetting -r updates.type)
+settingsupdateurl=$($systemsetting -r updates.url)
 
 # customizable upgrade url website
 test -n "${settingsupdateurl}" && updateurl="${settingsupdateurl}"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -45,7 +45,7 @@ do_disable() {
 }
 
 do_start() {
-    settingsWlan="$(batocera-settings -command load -key wifi.enabled)"
+    settingsWlan="$(batocera-settings -r wifi.enabled)"
     if [ "$settingsWlan" != "1" ];then
         return 0
     fi

--- a/package/batocera/core/batocera-splash/S29splashscreencontrol
+++ b/package/batocera/core/batocera-splash/S29splashscreencontrol
@@ -45,7 +45,7 @@ case $1 in
         [[ $PID == $(pgrep -f "sleep infinity") ]] && picture=1 || picture=0
 
         # Read Config and set some defaults
-        splash_setting=$(batocera-settings -command load -key splash.screen.length)
+        splash_setting=$(batocera-settings -r splash.screen.length)
         [[ -z $splash_setting ]] && splash_setting=auto
         [[ ${splash_setting,,} == auto && $ARCH =~ rpi(1|2|3) ]] && splash_setting=$ARCH
             

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -9,10 +9,10 @@ fi
 
 case "$1" in
 	start)
-		enabled="`batocera-settings -command load -key system.es.atstartup`"
+		enabled="`batocera-settings -r system.es.atstartup`"
 		if [ "$enabled" != "0" ];then
 			batocera-resolution minTomaxResolution-secure
-			settings_lang="`batocera-settings -command load -key system.language`"
+			settings_lang="`batocera-settings -r system.language`"
 			cd /userdata # es need a PWD
 			HOME=/userdata/system LANG="${settings_lang}.UTF-8" %BATOCERA_EMULATIONSTATION_PREFIX% %BATOCERA_EMULATIONSTATION_CMD% %BATOCERA_EMULATIONSTATION_ARGS% %BATOCERA_EMULATIONSTATION_POSTFIX%
 		fi

--- a/package/batocera/utils/gpicase/batocera-gpicase-install
+++ b/package/batocera/utils/gpicase/batocera-gpicase-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CONFIGFILE=/boot/config.txt
-CONFIG="$(batocera-settings "$CONFIGFILE" --command load --key force_gpi_defaults)"
+CONFIG="$(batocera-settings -f "$CONFIGFILE" -r force_gpi_defaults)"
 CONFIGERR=$?
 [[ $CONFIGERR -eq  12 || $CONFIG -eq 1 ]] || exit 0
 

--- a/package/batocera/utils/roshambo-case/S14roshambo
+++ b/package/batocera/utils/roshambo-case/S14roshambo
@@ -1,6 +1,6 @@
 #! /bin/sh
 
-enabled=`batocera-settings --command load --key roshambo.enabled`
+enabled=`batocera-settings -r roshambo.enabled`
 
 case "$1" in
 	start)

--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -10,12 +10,12 @@ devices="ATX_RASPI_R2_6 REMOTEPIBOARD_2003 REMOTEPIBOARD_2005 MAUSBERRY WITTYPI 
 
 # Read current config, if no key is set in batocera.conf then try to use
 # default value setted by udev-rule
-powerswitch="$(batocera-settings --command load --key system.power.switch)"
+powerswitch="$(batocera-settings -r system.power.switch)"
 if [ $? -ne 0 ] && [ -f /var/run/powerswitch-by-udevrule ]; then
     powerswitch="$(cat /var/run/powerswitch-by-udevrule)"
 fi
 # Read if a GPIO joypad is needed (to init on selected archs)
-gpiopad="$(batocera-settings --command load --key controllers.gpio.enabled)"
+gpiopad="$(batocera-settings -r controllers.gpio.enabled)"
 
 # Carry out specific functions when asked to by the system
 case "$1" in

--- a/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
+++ b/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
@@ -24,7 +24,7 @@ function powerdevice_dialog()
     local switch cmd button #dialog variabels
     local currentswitch #show current switch
 
-    currentswitch=$(batocera-settings --command load --key system.power.switch)
+    currentswitch=$(batocera-settings -r system.power.switch)
     [[ -z $currentswitch || $currentswitch == "#" ]] && currentswitch="disabled"
 
     powerdevices=(
@@ -483,7 +483,7 @@ case "$CONFVALUE" in
 
         # Write values and display MsgBox
         [[ -n $switch ]] || { echo "Abort! Nothing changed...."; exit 1;}
-        batocera-settings --command write --key system.power.switch --value "$switch"
+        batocera-settings -w system.power.switch -v "$switch"
         [[ $? -eq 0 ]] && info_msg="No error! Everything went okay!" || info_msg="An error occurred!"
         dialog --backtitle "BATOCERA Power Switch Selection Toolkit" \
                --title " STATUS OF NEW VALUE " \


### PR DESCRIPTION
So that we don't have to support "classic" style args anymore