### PR TITLE
batocera-settings: Re-implement in C

### DIFF
--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -7,7 +7,8 @@
 BATOCERA_SCRIPTS_VERSION = 1.1
 BATOCERA_SCRIPTS_LICENSE = GPL
 BATOCERA_SCRIPTS_DEPENDENCIES = pciutils
-BATOCERA_SCRIPTS_SOURCE=
+BATOCERA_SCRIPTS_SITE=$(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/src
+BATOCERA_SCRIPTS_SITE_METHOD=local
 
 BATOCERA_SCRIPT_RESOLUTION_TYPE=basic
 ifeq ($(BR2_PACKAGE_RPI_USERLAND),y)
@@ -25,7 +26,7 @@ ifeq ($(BR2_PACKAGE_MALI_G31_GBM),y)
   BATOCERA_SCRIPT_RESOLUTION_TYPE=basic
 endif
 
-define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
+define BATOCERA_SCRIPTS_INSTALL_ALL
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/bluetooth/bluezutils.py            $(TARGET_DIR)/usr/lib/python2.7/ # any variable ?
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth       $(TARGET_DIR)/usr/bin/
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth-agent $(TARGET_DIR)/usr/bin/
@@ -60,6 +61,8 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/batocera-resolution.$(BATOCERA_SCRIPT_RESOLUTION_TYPE) $(TARGET_DIR)/usr/bin/batocera-resolution
 endef
 
+BATOCERA_SCRIPTS_POST_INSTALL_TARGET_HOOKS += BATOCERA_SCRIPTS_INSTALL_ALL
+
 define BATOCERA_SCRIPTS_INSTALL_XORG
 	mkdir -p $(TARGET_DIR)/etc/X11/xorg.conf.d
 	ln -fs /userdata/system/99-nvidia.conf $(TARGET_DIR)/etc/X11/xorg.conf.d/99-nvidia.conf
@@ -78,4 +81,4 @@ ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_ROCKCHIP_ANY),y)
   BATOCERA_SCRIPTS_POST_INSTALL_TARGET_HOOKS += BATOCERA_SCRIPTS_INSTALL_ROCKCHIP
 endif
 
-$(eval $(generic-package))
+$(eval $(meson-package))

--- a/package/batocera/core/batocera-scripts/src/.clang-format
+++ b/package/batocera/core/batocera-scripts/src/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/package/batocera/core/batocera-scripts/src/batocera_ascii.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_ascii.h
@@ -1,0 +1,21 @@
+#ifndef _BATOCERA_ASCII_H_
+#define _BATOCERA_ASCII_H_
+
+// Returns a pointer to the first non-leading whitespace.
+// Only ' ' and '\t' are considered whitespace.
+// Requires: begin <= end.
+static inline const char *skip_leading_whitespace(const char *begin, const char *end) {
+  while (begin != end && (*begin == ' ' || *begin == '\t')) ++begin;
+  return begin;
+}
+
+// Returns a pointer to the last non-whitespace.
+// Only ' ' and '\t' are considered whitespace.
+// Requires: begin <= end.
+static inline const char *skip_trailing_whitespace(const char *begin,
+                                            const char *end) {
+  while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t')) --end;
+  return end;
+}
+
+#endif  // _BATOCERA_ASCII_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_ascii.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_ascii.h
@@ -4,7 +4,8 @@
 // Returns a pointer to the first non-leading whitespace.
 // Only ' ' and '\t' are considered whitespace.
 // Requires: begin <= end.
-static inline const char *skip_leading_whitespace(const char *begin, const char *end) {
+static inline const char *skip_leading_whitespace(const char *begin,
+                                                  const char *end) {
   while (begin != end && (*begin == ' ' || *begin == '\t')) ++begin;
   return begin;
 }
@@ -13,7 +14,7 @@ static inline const char *skip_leading_whitespace(const char *begin, const char 
 // Only ' ' and '\t' are considered whitespace.
 // Requires: begin <= end.
 static inline const char *skip_trailing_whitespace(const char *begin,
-                                            const char *end) {
+                                                   const char *end) {
   while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t')) --end;
   return end;
 }

--- a/package/batocera/core/batocera-scripts/src/batocera_read_file.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_read_file.c
@@ -1,0 +1,29 @@
+#include "batocera_read_file.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+void batocera_read_file(const char *fname, char **out_data, size_t *out_size) {
+  FILE *f = fopen(fname, "rb");
+
+  if (f == NULL) {
+    perror(fname);
+    exit(EXIT_FAILURE);
+  }
+
+  fseek(f, 0, SEEK_END);
+  long fsize = ftell(f);
+  fseek(f, 0, SEEK_SET);
+
+  char *data = malloc(fsize + 1);
+  fread(data, fsize, 1, f);
+  if (ferror(f)) {
+    perror(fname);
+    exit(1);
+  }
+  fclose(f);
+  data[fsize] = 0;
+
+  *out_data = data;
+  *out_size = fsize;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_read_file.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_read_file.c
@@ -16,8 +16,7 @@ void batocera_read_file(const char *fname, char **out_data, size_t *out_size) {
   fseek(f, 0, SEEK_SET);
 
   char *data = malloc(fsize + 1);
-  fread(data, fsize, 1, f);
-  if (ferror(f)) {
+  if (fread(data, fsize, 1, f) != 1 && ferror(f)) {
     perror(fname);
     exit(1);
   }

--- a/package/batocera/core/batocera-scripts/src/batocera_read_file.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_read_file.h
@@ -1,0 +1,10 @@
+
+#ifndef _BATOCERA_READ_FILE_H_
+#define _BATOCERA_READ_FILE_H_
+
+#include <stddef.h>
+
+/* Reads the file. Exits on error. */
+void batocera_read_file(const char *fname, char **out_data, size_t *out_size);
+
+#endif  // _BATOCERA_READ_FILE_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_read_file.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_read_file.h
@@ -1,4 +1,3 @@
-
 #ifndef _BATOCERA_READ_FILE_H_
 #define _BATOCERA_READ_FILE_H_
 

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
@@ -1,0 +1,84 @@
+#include "batocera_settings_get.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *skip_whitespace(const char *begin, const char *end) {
+  while (begin != end && (*begin == ' ' || *begin == '\t'))
+    ++begin;
+  return begin;
+}
+
+static const char *skip_whitespace_end(const char *begin, const char *end) {
+  while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t'))
+    --end;
+  return end;
+}
+
+static struct batocera_settings_get_result_t
+batocera_settings_get_one(const char *config_contents, size_t config_size,
+                          const char *key, size_t key_size) {
+  struct batocera_settings_get_result_t result;
+  memset(&result, 0, sizeof(result));
+
+  const char *eof = config_contents + config_size;
+  const char *line_end = config_contents - 1;
+  size_t line_num = 0;
+  while (line_end < eof) {
+    ++line_num;
+    const char *line_begin = line_end + 1;
+    line_end = memchr(line_begin, '\n', eof - line_begin);
+    if (line_end == NULL)
+      line_end = eof;
+
+    const char *key_begin = skip_whitespace(line_begin, line_end);
+    if (key_begin == line_end || *key_begin == '#')
+      continue;
+
+    const char *eq_pos = memchr(key_begin, '=', line_end - key_begin);
+    if (eq_pos == NULL) {
+      const size_t err_size = 128 + (line_end - line_begin);
+      result.error = malloc(err_size);
+      result.error_size =
+          snprintf(result.error, err_size,
+                   "Invalid config file: key '%.*s' has no value on line %zu",
+                   (int)(line_end - line_begin), line_begin, line_num);
+      return result;
+    }
+    const char *key_end = skip_whitespace_end(key_begin, eq_pos);
+
+    if (key_end - key_begin != key_size ||
+        memcmp(key_begin, key, key_size) != 0)
+      continue;
+    result.key = key_begin;
+    result.key_size = key_size;
+
+    const char *value_begin = skip_whitespace(eq_pos + 1, line_end);
+    const char *value_end = line_end;
+    if (value_end > value_begin && (*(value_end - 1) == '\r'))
+      --value_end;
+
+    result.value = value_begin;
+    result.value_size = value_end - value_begin;
+    break; // returns the first found key
+  }
+  return result;
+}
+
+struct batocera_settings_get_result_t
+batocera_settings_get(const char *config_contents, size_t config_size,
+                      const char *keys[], size_t keys_size) {
+  for (size_t i = 0; i < keys_size; ++i) {
+    const char *key = keys[i];
+    const size_t key_size = strlen(keys[i]);
+    struct batocera_settings_get_result_t result =
+        batocera_settings_get_one(config_contents, config_size, key, key_size);
+    if (result.value != NULL)
+      return result;
+  }
+
+  struct batocera_settings_get_result_t result;
+  memset(&result, 0, sizeof(result));
+  return result;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
@@ -4,17 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char *skip_whitespace(const char *begin, const char *end) {
-  while (begin != end && (*begin == ' ' || *begin == '\t'))
-    ++begin;
-  return begin;
-}
-
-static const char *skip_whitespace_end(const char *begin, const char *end) {
-  while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t'))
-    --end;
-  return end;
-}
+#include "batocera_ascii.h"
 
 static struct batocera_settings_get_result_t
 batocera_settings_get_one(const char *config_contents, size_t config_size,
@@ -32,7 +22,7 @@ batocera_settings_get_one(const char *config_contents, size_t config_size,
     if (line_end == NULL)
       line_end = eof;
 
-    const char *key_begin = skip_whitespace(line_begin, line_end);
+    const char *key_begin = skip_leading_whitespace(line_begin, line_end);
     if (key_begin == line_end || *key_begin == '#')
       continue;
 
@@ -46,7 +36,7 @@ batocera_settings_get_one(const char *config_contents, size_t config_size,
                    (int)(line_end - line_begin), line_begin, line_num);
       return result;
     }
-    const char *key_end = skip_whitespace_end(key_begin, eq_pos);
+    const char *key_end = skip_trailing_whitespace(key_begin, eq_pos);
 
     if (key_end - key_begin != key_size ||
         memcmp(key_begin, key, key_size) != 0)
@@ -54,7 +44,7 @@ batocera_settings_get_one(const char *config_contents, size_t config_size,
     result.key = key_begin;
     result.key_size = key_size;
 
-    const char *value_begin = skip_whitespace(eq_pos + 1, line_end);
+    const char *value_begin = skip_leading_whitespace(eq_pos + 1, line_end);
     const char *value_end = line_end;
     if (value_end > value_begin && (*(value_end - 1) == '\r'))
       --value_end;

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get.c
@@ -6,9 +6,9 @@
 
 #include "batocera_ascii.h"
 
-static struct batocera_settings_get_result_t
-batocera_settings_get_one(const char *config_contents, size_t config_size,
-                          const char *key, size_t key_size) {
+static struct batocera_settings_get_result_t batocera_settings_get_one(
+    const char *config_contents, size_t config_size, const char *key,
+    size_t key_size) {
   struct batocera_settings_get_result_t result;
   memset(&result, 0, sizeof(result));
 
@@ -19,12 +19,10 @@ batocera_settings_get_one(const char *config_contents, size_t config_size,
     ++line_num;
     const char *line_begin = line_end + 1;
     line_end = memchr(line_begin, '\n', eof - line_begin);
-    if (line_end == NULL)
-      line_end = eof;
+    if (line_end == NULL) line_end = eof;
 
     const char *key_begin = skip_leading_whitespace(line_begin, line_end);
-    if (key_begin == line_end || *key_begin == '#')
-      continue;
+    if (key_begin == line_end || *key_begin == '#') continue;
 
     const char *eq_pos = memchr(key_begin, '=', line_end - key_begin);
     if (eq_pos == NULL) {
@@ -46,26 +44,24 @@ batocera_settings_get_one(const char *config_contents, size_t config_size,
 
     const char *value_begin = skip_leading_whitespace(eq_pos + 1, line_end);
     const char *value_end = line_end;
-    if (value_end > value_begin && (*(value_end - 1) == '\r'))
-      --value_end;
+    if (value_end > value_begin && (*(value_end - 1) == '\r')) --value_end;
 
     result.value = value_begin;
     result.value_size = value_end - value_begin;
-    break; // returns the first found key
+    break;  // returns the first found key
   }
   return result;
 }
 
-struct batocera_settings_get_result_t
-batocera_settings_get(const char *config_contents, size_t config_size,
-                      const char *keys[], size_t keys_size) {
+struct batocera_settings_get_result_t batocera_settings_get(
+    const char *config_contents, size_t config_size, const char *keys[],
+    size_t keys_size) {
   for (size_t i = 0; i < keys_size; ++i) {
     const char *key = keys[i];
     const size_t key_size = strlen(keys[i]);
     struct batocera_settings_get_result_t result =
         batocera_settings_get_one(config_contents, config_size, key, key_size);
-    if (result.value != NULL)
-      return result;
+    if (result.value != NULL) return result;
   }
 
   struct batocera_settings_get_result_t result;

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get.h
@@ -1,0 +1,20 @@
+#ifndef _BATOCERA_SETTINGS_GET_H_
+#define _BATOCERA_SETTINGS_GET_H_
+
+#include <stddef.h>
+
+struct batocera_settings_get_result_t {
+  const char *key;
+  size_t key_size;
+  const char *value;
+  size_t value_size;
+
+  // Owned if set and must be freed by the caller.
+  char *error;
+  size_t error_size;
+};
+
+struct batocera_settings_get_result_t
+batocera_settings_get(const char *config_contents, size_t config_size, const char *keys[], size_t keys_size);
+
+#endif  // _BATOCERA_SETTINGS_GET_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get.h
@@ -14,7 +14,8 @@ struct batocera_settings_get_result_t {
   size_t error_size;
 };
 
-struct batocera_settings_get_result_t
-batocera_settings_get(const char *config_contents, size_t config_size, const char *keys[], size_t keys_size);
+struct batocera_settings_get_result_t batocera_settings_get(
+    const char *config_contents, size_t config_size, const char *keys[],
+    size_t keys_size);
 
 #endif  // _BATOCERA_SETTINGS_GET_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
@@ -54,8 +54,7 @@ int main(int argc, char *argv[]) {
 
   fwrite(result.value, sizeof(char), result.value_size, stdout);
   fputc('\n', stderr);
-  if (ferror(stderr))
-    goto get_failed;
+  if (ferror(stderr)) goto get_failed;
 
   free(config_contents);
   return EXIT_SUCCESS;

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "batocera_read_file.h"
+#include "batocera_settings_get.h"
+
+static const char kUsage[] =
+    "batocera-settings-get [-f CONFIG_FILE] <key> [<key>...]\n\n"
+    "  Prints the value of the key or returns a non-zero exit status.\n"
+    "  If multiple keys are given, tries them in order until it finds a key "
+    "that exists.\n";
+
+int main(int argc, char *argv[]) {
+  if (argc < 2 || strcmp(argv[1], "--help") == 0) {
+    fwrite(kUsage, sizeof(char), sizeof(kUsage), stderr);
+    return EXIT_FAILURE;
+  }
+  size_t num_keys = argc - 1;
+  const char **keys = (const char **)argv + 1;
+  const char *config_path = "/userdata/system/batocera.conf";
+  if (argv[1][0] == '-' && argv[1][1] == 'f') {
+    if (argc < 3) {
+      const char message[] = "-f requires an argument\n";
+      fwrite(message, sizeof(char), sizeof(message), stderr);
+      return EXIT_FAILURE;
+    }
+    config_path = argv[2];
+    keys += 2;
+    num_keys -= 2;
+  }
+
+  if (num_keys == 0) {
+    const char message[] = "at least 1 key argument is required\n";
+    fwrite(message, sizeof(char), sizeof(message), stderr);
+    return EXIT_FAILURE;
+  }
+
+  char *config_contents;
+  size_t config_contents_size;
+  batocera_read_file(config_path, &config_contents, &config_contents_size);
+
+  struct batocera_settings_get_result_t result = batocera_settings_get(
+      config_contents, config_contents_size, keys, num_keys);
+  if (result.error != NULL) {
+    fwrite(result.error, sizeof(char), result.error_size, stderr);
+    free(result.error);
+    goto get_failed;
+  } else if (result.value == NULL) {
+    const char message[] = "not found\n";
+    fwrite(message, sizeof(char), sizeof(message), stderr);
+    goto get_failed;
+  }
+
+  fwrite(result.value, sizeof(char), result.value_size, stdout);
+  fputc('\n', stderr);
+  if (ferror(stderr))
+    goto get_failed;
+
+  free(config_contents);
+  return EXIT_SUCCESS;
+
+get_failed:
+  free(config_contents);
+  return EXIT_FAILURE;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
@@ -6,10 +6,11 @@
 #include "batocera_settings_get.h"
 
 static const char kUsage[] =
-    "batocera-settings-get [-f CONFIG_FILE] <key> [<key>...]\n\n"
-    "  Prints the value of the key or returns a non-zero exit status.\n"
-    "  If multiple keys are given, tries them in order until it finds a key "
-    "that exists.\n";
+    "Usage: batocera-settings-get [-f CONFIG_FILE] <KEY> [KEY]...\n\n"
+    "Prints the value of the key or returns a non-zero exit status.\n"
+    "If multiple keys are given, tries them in order until it finds a key"
+    " that exists.\n\n"
+    "By default, reads from /userdata/system/batocera.conf\n";
 
 int main(int argc, char *argv[]) {
   if (argc < 2 || strcmp(argv[1], "--help") == 0) {

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_get_main.c
@@ -48,14 +48,13 @@ int main(int argc, char *argv[]) {
     free(result.error);
     goto get_failed;
   } else if (result.value == NULL) {
-    const char message[] = "not found\n";
-    fwrite(message, sizeof(char), sizeof(message), stderr);
+    // Key not found.
     goto get_failed;
   }
 
   fwrite(result.value, sizeof(char), result.value_size, stdout);
-  fputc('\n', stderr);
-  if (ferror(stderr)) goto get_failed;
+  fputc('\n', stdout);
+  if (ferror(stdout)) goto get_failed;
 
   free(config_contents);
   return EXIT_SUCCESS;

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
@@ -29,10 +29,9 @@ static void write_kv(struct batocera_stringbuf *out, const char *key,
   batocera_stringbuf_append_line(out, value, value_size);
 }
 
-static struct batocera_settings_set_result_t
-batocera_settings_set_sized(const char *config_contents,
-                            size_t config_contents_size, const char *kvs[],
-                            size_t kvs_size, const size_t kvs_sizes[]) {
+static struct batocera_settings_set_result_t batocera_settings_set_sized(
+    const char *config_contents, size_t config_contents_size, const char *kvs[],
+    size_t kvs_size, const size_t kvs_sizes[]) {
   struct batocera_settings_set_result_t result;
   memset(&result, 0, sizeof(result));
 
@@ -49,8 +48,7 @@ batocera_settings_set_sized(const char *config_contents,
     const char *line_begin = line_end + 1;
     line_end = memchr(line_begin, '\n', eof - line_begin);
     if (line_end == NULL) {
-      if (line_begin == eof)
-        break;
+      if (line_begin == eof) break;
       line_end = eof;
     }
 
@@ -61,8 +59,7 @@ batocera_settings_set_sized(const char *config_contents,
     }
 
     const bool commented = *key_begin == '#';
-    if (commented)
-      ++key_begin;
+    if (commented) ++key_begin;
     if (key_begin == line_end) {
       batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
       continue;
@@ -107,12 +104,11 @@ batocera_settings_set_sized(const char *config_contents,
   return result;
 }
 
-struct batocera_settings_set_result_t
-batocera_settings_set(const char *config_contents, size_t config_contents_size,
-                      const char *kvs[], size_t kvs_size) {
+struct batocera_settings_set_result_t batocera_settings_set(
+    const char *config_contents, size_t config_contents_size, const char *kvs[],
+    size_t kvs_size) {
   size_t *kvs_sizes = malloc(sizeof(size_t) * kvs_size);
-  for (size_t i = 0; i < kvs_size; ++i)
-    kvs_sizes[i] = strlen(kvs[i]);
+  for (size_t i = 0; i < kvs_size; ++i) kvs_sizes[i] = strlen(kvs[i]);
 
   struct batocera_settings_set_result_t result = batocera_settings_set_sized(
       config_contents, config_contents_size, kvs, kvs_size, kvs_sizes);

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
@@ -59,7 +59,10 @@ static struct batocera_settings_set_result_t batocera_settings_set_sized(
     }
 
     const bool commented = *key_begin == '#';
-    if (commented) ++key_begin;
+    if (commented) {
+      ++key_begin;
+      key_begin = skip_leading_whitespace(key_begin, line_end);
+    }
     if (key_begin == line_end) {
       batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
       continue;

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
@@ -5,19 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "batocera_ascii.h"
 #include "batocera_stringbuf.h"
-
-static const char *skip_whitespace(const char *begin, const char *end) {
-  while (begin != end && (*begin == ' ' || *begin == '\t'))
-    ++begin;
-  return begin;
-}
-
-static const char *skip_whitespace_end(const char *begin, const char *end) {
-  while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t'))
-    --end;
-  return end;
-}
 
 static const size_t NOT_FOUND = -1;
 static size_t find_kv(const char *kvs[], size_t kvs_size,
@@ -65,7 +54,7 @@ batocera_settings_set_sized(const char *config_contents,
       line_end = eof;
     }
 
-    const char *key_begin = skip_whitespace(line_begin, line_end);
+    const char *key_begin = skip_leading_whitespace(line_begin, line_end);
     if (key_begin == line_end) {
       batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
       continue;
@@ -95,7 +84,7 @@ batocera_settings_set_sized(const char *config_contents,
       free(written);
       return result;
     }
-    const char *key_end = skip_whitespace_end(key_begin, eq_pos);
+    const char *key_end = skip_trailing_whitespace(key_begin, eq_pos);
 
     const size_t i = find_kv(kvs, kvs_size, kvs_sizes, key_begin, key_end);
     if (i == NOT_FOUND) {

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.c
@@ -1,0 +1,133 @@
+#include "batocera_settings_set.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "batocera_stringbuf.h"
+
+static const char *skip_whitespace(const char *begin, const char *end) {
+  while (begin != end && (*begin == ' ' || *begin == '\t'))
+    ++begin;
+  return begin;
+}
+
+static const char *skip_whitespace_end(const char *begin, const char *end) {
+  while (begin != end && (*(end - 1) == ' ' || *(end - 1) == '\t'))
+    --end;
+  return end;
+}
+
+static const size_t NOT_FOUND = -1;
+static size_t find_kv(const char *kvs[], size_t kvs_size,
+                      const size_t kvs_sizes[], const char *key_begin,
+                      const char *key_end) {
+  const size_t target_key_size = key_end - key_begin;
+  for (size_t i = 0; i < kvs_size; i += 2) {
+    if (target_key_size == kvs_sizes[i] &&
+        memcmp(key_begin, kvs[i], target_key_size) == 0) {
+      return i;
+    }
+  }
+  return NOT_FOUND;
+}
+
+static void write_kv(struct batocera_stringbuf *out, const char *key,
+                     size_t key_size, const char *value, size_t value_size) {
+  batocera_stringbuf_append(out, key, key_size);
+  batocera_stringbuf_append_char(out, '=');
+  batocera_stringbuf_append_line(out, value, value_size);
+}
+
+static struct batocera_settings_set_result_t
+batocera_settings_set_sized(const char *config_contents,
+                            size_t config_contents_size, const char *kvs[],
+                            size_t kvs_size, const size_t kvs_sizes[]) {
+  struct batocera_settings_set_result_t result;
+  memset(&result, 0, sizeof(result));
+
+  bool *written = malloc(kvs_size / 2 * sizeof(bool));
+
+  struct batocera_stringbuf out;
+  batocera_stringbuf_init(&out, config_contents_size);
+
+  const char *eof = config_contents + config_contents_size;
+  const char *line_end = config_contents - 1;
+  size_t line_num = 0;
+  while (line_end < eof) {
+    ++line_num;
+    const char *line_begin = line_end + 1;
+    line_end = memchr(line_begin, '\n', eof - line_begin);
+    if (line_end == NULL) {
+      if (line_begin == eof)
+        break;
+      line_end = eof;
+    }
+
+    const char *key_begin = skip_whitespace(line_begin, line_end);
+    if (key_begin == line_end) {
+      batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
+      continue;
+    }
+
+    const bool commented = *key_begin == '#';
+    if (commented)
+      ++key_begin;
+    if (key_begin == line_end) {
+      batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
+      continue;
+    }
+
+    const char *eq_pos = memchr(key_begin, '=', line_end - key_begin);
+    if (eq_pos == NULL) {
+      if (commented) {
+        batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
+        continue;
+      }
+      const size_t err_size = 128 + (line_end - line_begin);
+      result.error = malloc(err_size);
+      result.error_size =
+          snprintf(result.error, err_size,
+                   "Invalid config file: key '%.*s' has no value on line %zu",
+                   (int)(line_end - line_begin), line_begin, line_num);
+      free(out.data);
+      free(written);
+      return result;
+    }
+    const char *key_end = skip_whitespace_end(key_begin, eq_pos);
+
+    const size_t i = find_kv(kvs, kvs_size, kvs_sizes, key_begin, key_end);
+    if (i == NOT_FOUND) {
+      batocera_stringbuf_append_line(&out, line_begin, line_end - line_begin);
+      continue;
+    }
+    write_kv(&out, kvs[i], kvs_sizes[i], kvs[i + 1], kvs_sizes[i + 1]);
+    written[i / 2] = true;
+  }
+
+  for (size_t i = 0; i < kvs_size; i += 2) {
+    if (!written[i / 2]) {
+      write_kv(&out, kvs[i], kvs_sizes[i], kvs[i + 1], kvs_sizes[i + 1]);
+    }
+  }
+
+  result.contents = out.data;
+  result.contents_size = out.size;
+  free(written);
+  return result;
+}
+
+struct batocera_settings_set_result_t
+batocera_settings_set(const char *config_contents, size_t config_contents_size,
+                      const char *kvs[], size_t kvs_size) {
+  size_t *kvs_sizes = malloc(sizeof(size_t) * kvs_size);
+  for (size_t i = 0; i < kvs_size; ++i)
+    kvs_sizes[i] = strlen(kvs[i]);
+
+  struct batocera_settings_set_result_t result = batocera_settings_set_sized(
+      config_contents, config_contents_size, kvs, kvs_size, kvs_sizes);
+
+  free(kvs_sizes);
+  return result;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.h
@@ -12,7 +12,8 @@ struct batocera_settings_set_result_t {
   size_t error_size;
 };
 
-struct batocera_settings_set_result_t
-batocera_settings_set(const char *config_contents, size_t config_contents_size, const char *kvs[], size_t kvs_size);
+struct batocera_settings_set_result_t batocera_settings_set(
+    const char *config_contents, size_t config_contents_size, const char *kvs[],
+    size_t kvs_size);
 
 #endif  // _BATOCERA_SETTINGS_SET_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set.h
@@ -1,0 +1,18 @@
+#ifndef _BATOCERA_SETTINGS_SET_H_
+#define _BATOCERA_SETTINGS_SET_H_
+
+#include <stddef.h>
+
+struct batocera_settings_set_result_t {
+  char *contents;  // must be freed by the caller
+  size_t contents_size;
+
+  // Owned if set and must be freed by the caller.
+  char *error;
+  size_t error_size;
+};
+
+struct batocera_settings_set_result_t
+batocera_settings_set(const char *config_contents, size_t config_contents_size, const char *kvs[], size_t kvs_size);
+
+#endif  // _BATOCERA_SETTINGS_SET_H_

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set_main.c
@@ -1,0 +1,78 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "batocera_read_file.h"
+#include "batocera_settings_set.h"
+
+static const char kUsage[] =
+    "batocera-settings-set [-f CONFIG_FILE] <key> <value> [<key> "
+    "<value>...]\n\n"
+    "  Sets value(s) in the config file.\n"
+    "  If a commented key exists, will uncomment it and set the value in-place "
+    "instead of appending a new key\n";
+
+int main(int argc, char *argv[]) {
+  if (argc < 2 || strcmp(argv[1], "--help") == 0) {
+    fwrite(kUsage, sizeof(char), sizeof(kUsage), stderr);
+    return EXIT_FAILURE;
+  }
+  size_t kvs_size = argc - 1;
+  const char **kvs = (const char **)argv + 1;
+  const char *config_path = "/userdata/system/batocera.conf";
+  if (argv[1][0] == '-' && argv[1][1] == 'f') {
+    if (argc < 3) {
+      const char message[] = "-f requires an argument\n";
+      fwrite(message, sizeof(char), sizeof(message), stderr);
+      return EXIT_FAILURE;
+    }
+    config_path = argv[2];
+    kvs += 2;
+    kvs_size -= 2;
+  }
+
+  if (kvs_size == 0) {
+    const char message[] = "-f requires an argument\n";
+    fwrite(message, sizeof(char), sizeof(message), stderr);
+    return EXIT_FAILURE;
+  }
+
+  if (kvs_size % 2 != 0) {
+    const char message[] = "the number of key-value arguments must be even\n";
+    fwrite(message, sizeof(char), sizeof(message), stderr);
+    return EXIT_FAILURE;
+  }
+
+  char *config_contents;
+  size_t config_contents_size;
+  batocera_read_file(config_path, &config_contents, &config_contents_size);
+
+  struct batocera_settings_set_result_t result = batocera_settings_set(
+      config_contents, config_contents_size, kvs, kvs_size);
+  if (result.error != NULL) {
+    fwrite(result.error, sizeof(char), result.error_size, stderr);
+    free(result.error);
+    goto set_failed;
+  }
+
+  FILE *config_file = fopen(config_path, "w");
+  if (config_file == NULL) {
+    perror(config_path);
+    goto set_failed;
+  }
+  fwrite(result.contents, sizeof(char), result.contents_size, config_file);
+  if (ferror(config_file)) {
+    perror("write error");
+    goto set_failed;
+  }
+  fclose(config_file);
+
+  free(result.contents);
+  free(config_contents);
+  return EXIT_SUCCESS;
+
+set_failed:
+  free(result.contents);
+  free(config_contents);
+  return EXIT_FAILURE;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_settings_set_main.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_settings_set_main.c
@@ -6,11 +6,12 @@
 #include "batocera_settings_set.h"
 
 static const char kUsage[] =
-    "batocera-settings-set [-f CONFIG_FILE] <key> <value> [<key> "
-    "<value>...]\n\n"
-    "  Sets value(s) in the config file.\n"
-    "  If a commented key exists, will uncomment it and set the value in-place "
-    "instead of appending a new key\n";
+    "Usage: batocera-settings-set [-f CONFIG_FILE] <KEY> <VALUE> [KEY "
+    "VALUE]...\n\n"
+    "Sets value(s) in the config file.\n"
+    "If a commented key exists, will uncomment it and set the value in-place"
+    " instead of appending a new key\n\n"
+    "By default, writes to /userdata/system/batocera.conf\n";
 
 int main(int argc, char *argv[]) {
   if (argc < 2 || strcmp(argv[1], "--help") == 0) {

--- a/package/batocera/core/batocera-scripts/src/batocera_stringbuf.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_stringbuf.c
@@ -1,0 +1,46 @@
+#include "batocera_stringbuf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void batocera_stringbuf_init(struct batocera_stringbuf *buf, size_t capacity) {
+  buf->data = malloc(capacity * sizeof(char));
+  buf->size = 0;
+  buf->capacity = capacity;
+}
+
+static void ensure_capacity(struct batocera_stringbuf *buf, size_t capacity) {
+  if (buf->capacity >= capacity)
+    return;
+  size_t new_capacity = (2 * buf->capacity + 1) * sizeof(char);
+  if (new_capacity < capacity)
+    new_capacity = capacity;
+  char *new_buf = realloc(buf->data, new_capacity);
+  if (new_buf == NULL) {
+    perror("batocera_stringbuf_append");
+    exit(1);
+  }
+  buf->data = new_buf;
+  buf->capacity = new_capacity;
+}
+
+void batocera_stringbuf_append(struct batocera_stringbuf *buf, const char *str,
+                               size_t size) {
+  ensure_capacity(buf, buf->size + size);
+  memcpy(buf->data + buf->size, str, size * sizeof(char));
+  buf->size += size;
+}
+
+void batocera_stringbuf_append_line(struct batocera_stringbuf *buf,
+                                    const char *str, size_t size) {
+  ensure_capacity(buf, buf->size + size + 1);
+  memcpy(buf->data + buf->size, str, size * sizeof(char));
+  buf->data[buf->size + size] = '\n';
+  buf->size += size + 1;
+}
+
+void batocera_stringbuf_append_char(struct batocera_stringbuf *buf, char c) {
+  ensure_capacity(buf, buf->size + 1);
+  buf->data[buf->size++] = c;
+}

--- a/package/batocera/core/batocera-scripts/src/batocera_stringbuf.c
+++ b/package/batocera/core/batocera-scripts/src/batocera_stringbuf.c
@@ -11,11 +11,9 @@ void batocera_stringbuf_init(struct batocera_stringbuf *buf, size_t capacity) {
 }
 
 static void ensure_capacity(struct batocera_stringbuf *buf, size_t capacity) {
-  if (buf->capacity >= capacity)
-    return;
+  if (buf->capacity >= capacity) return;
   size_t new_capacity = (2 * buf->capacity + 1) * sizeof(char);
-  if (new_capacity < capacity)
-    new_capacity = capacity;
+  if (new_capacity < capacity) new_capacity = capacity;
   char *new_buf = realloc(buf->data, new_capacity);
   if (new_buf == NULL) {
     perror("batocera_stringbuf_append");

--- a/package/batocera/core/batocera-scripts/src/batocera_stringbuf.h
+++ b/package/batocera/core/batocera-scripts/src/batocera_stringbuf.h
@@ -1,0 +1,22 @@
+#ifndef _BATOCERA_STRINGBUF_H_
+#define _BATOCERA_STRINGBUF_H_
+
+#include <stddef.h>
+
+struct batocera_stringbuf {
+  char *data;
+  size_t size;
+  size_t capacity;
+};
+
+void batocera_stringbuf_init(struct batocera_stringbuf *buf, size_t capacity);
+
+void batocera_stringbuf_append(struct batocera_stringbuf *buf, const char *str,
+                               size_t size);
+
+void batocera_stringbuf_append_line(struct batocera_stringbuf *buf,
+                                    const char *str, size_t size);
+
+void batocera_stringbuf_append_char(struct batocera_stringbuf *buf, char c);
+
+#endif  // _BATOCERA_STRINGBUF_H_

--- a/package/batocera/core/batocera-scripts/src/meson.build
+++ b/package/batocera/core/batocera-scripts/src/meson.build
@@ -1,0 +1,3 @@
+project('batocera-scripts', 'c')
+executable('batocera-settings-get', ['batocera_settings_get_main.c', 'batocera_settings_get.c', 'batocera_read_file.c'], install: true)
+executable('batocera-settings-set', ['batocera_settings_set_main.c', 'batocera_settings_set.c', 'batocera_read_file.c', 'batocera_stringbuf.c'], install: true)

--- a/package/batocera/core/batocera-scripts/src/test/batocera-settings-test.sh
+++ b/package/batocera/core/batocera-scripts/src/test/batocera-settings-test.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+GET_BIN="$(dirname "$0")/../../src/build/batocera-settings-get"
+SET_BIN="$(dirname "$0")/../../src/build/batocera-settings-set"
+ORIG_CONF="$(dirname "$0")/batocera-test.conf"
+CONF=/tmp/batocera-settings-test.conf
+
+ERRORS=""
+
+# Arguments: <message>
+add_error() {
+  ERRORS="$ERRORS
+$1"
+}
+
+# Arguments: <key> <expected>
+expect_key() {
+  ACTUAL="$("$GET_BIN" -f "$CONF" "$1")"
+  if [ "$ACTUAL" != "$2" ]; then
+    add_error "Expected $1 to be $2, got $ACTUAL"
+  fi
+}
+
+# Arguments: <key> <value>
+write_key() {
+  "$SET_BIN" -f "$CONF" "$1" "$2" || add_error "write failed"
+}
+
+cp "$ORIG_CONF" "$CONF"
+
+# Read existing key
+expect_key kodi.enabled 1
+
+# Read commented key
+expect_key splash.screen.enabled ''
+
+# Read key that does not exist
+expect_key does.not.exist ''
+
+# Update existing key
+write_key kodi.enabled 2
+expect_key kodi.enabled 2
+
+# Uncomment key
+write_key splash.screen.enabled 1
+expect_key splash.screen.enabled 1
+
+# Write an entirely new key
+write_key totally.new.key 10
+expect_key totally.new.key 10
+
+if [ -n "$ERRORS" ]; then
+  echo >&2 "$ERRORS"
+  exit 1
+else
+  echo >&2 OK
+fi

--- a/package/batocera/core/batocera-scripts/src/test/batocera-test.conf
+++ b/package/batocera/core/batocera-scripts/src/test/batocera-test.conf
@@ -1,0 +1,30 @@
+# ------------ A - System Options ----------- #
+## batocera.linux security
+# enforce security
+# samba password required
+#system.security.enabled=0
+
+## Show or hide kodi in emulationstation (0,1)
+kodi.enabled=1
+## Start kodi at launch (0,1)
+kodi.atstartup=0
+## set x button shortcut (0,1)
+kodi.xbutton=1
+
+## Kodi can wait for a network component before starting
+## waithost is the ip or hostname that must answer to a ping to validate the availability
+## waittime is the maximum time waited when kodi boots
+## if waitmode is required, kodi will not start if the component is not available
+## if waitmode is wish, kodi will start if the component is not available
+## if waitmode is not set or has another value, kodi will start immediately
+#kodi.network.waitmode=required
+#kodi.network.waittime=10
+#kodi.network.waithost=192.168.0.50
+
+## Splashscreen is enabled per default set to 0 to disable
+## Set sound option to 0 to silence the video splash
+#splash.screen.enabled=1
+#splash.screen.sound=1
+
+#global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
+#global.ai_target_lang=


### PR DESCRIPTION
Re-implements `batocera-settings` in C, as two separate binaries for getting and setting the values.

```
Usage: batocera-settings-get [-f CONFIG_FILE] <KEY> [KEY]...

Prints the value of the key or returns a non-zero exit status.
If multiple keys are given, tries them in order until it finds a key that exists.

By default, reads from /userdata/system/batocera.conf
```

```
Usage: batocera-settings-set [-f CONFIG_FILE] <KEY> <VALUE> [KEY VALUE]...

Sets value(s) in the config file.
If a commented key exists, will uncomment it and set the value in-place instead of appending a new key

By default, writes to /userdata/system/batocera.conf
```

Note: This is safe to merge because this PR does not migrate any callers. That will be done in a separate PR.