### PR TITLE
Enable RGA scaling option [don't merge, needs resync with ES]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -99,6 +99,11 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     else:
         retroarchConfig['video_smooth'] = 'false'
 
+    if system.isOptSet('rga_scaling') and system.getOptBoolean('rga_scaling') == True:
+        retroarchConfig['video_ctx_scaling'] = 'true'
+    else:
+        retroarchConfig['video_ctx_scaling'] = 'false'
+
     if 'shader' in renderConfig and renderConfig['shader'] != None:
         retroarchConfig['video_shader_enable'] = 'true'
         retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2,7 +2,7 @@
 # the aim is to display in es only the available options
 
 libretro:
-  features: [ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation]
+  features: [ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation, rga_scaling]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4]


### PR DESCRIPTION
ES option added to https://github.com/batocera-linux/batocera-emulationstation/pull/708
 
This enables RGA scaling on libretro-enabled emulators, which is effective on 8 and 16-bit systems on handheld screens like OGA. See the difference on this screenshot (it definitely looks sharper on the OGA screen). The options is "off" by default, same behavior as previous versions.

![RGA_Scaling](https://user-images.githubusercontent.com/21372356/101424080-426ffd80-38af-11eb-968e-19241fe36658.png)
