### PR TITLE
sort devices by name

### DIFF
--- a/board/batocera/patches/sdl2/sdl2_input_p006_sort_devices.patch
+++ b/board/batocera/patches/sdl2/sdl2_input_p006_sort_devices.patch
@@ -1,8 +1,8 @@
 diff --git a/src/core/linux/SDL_udev.c b/src/core/linux/SDL_udev.c
-index 751e2ca..bec1485 100644
+index a22f825..da4672f 100644
 --- a/src/core/linux/SDL_udev.c
 +++ b/src/core/linux/SDL_udev.c
-@@ -191,12 +191,31 @@ SDL_UDEV_Quit(void)
+@@ -192,12 +192,76 @@ SDL_UDEV_Quit(void)
      }
  }
  
@@ -13,12 +13,57 @@ index 751e2ca..bec1485 100644
 +   struct udev_device *dev;
 +};
 +
++int isNumber(const char *s) {
++  int n;
++
++  if(strlen(s) == 0) {
++    return 0;
++  }
++
++  for(n=0; n<strlen(s); n++) {
++    if(!(s[n] == '0' || s[n] == '1' || s[n] == '2' || s[n] == '3' || s[n] == '4' ||
++	 s[n] == '5' || s[n] == '6' || s[n] == '7' || s[n] == '8' || s[n] == '9'))
++      return 0;
++  }
++  return 1;
++}
++
++// compare /dev/input/eventX and /dev/input/eventY where X and Y are numbers
++int strcmp_events(const char* x, const char* y) {
++
++  // find a common string
++  int n, common, is_number;
++  int a, b;
++
++  n=0;
++  while(x[n] == y[n] && x[n] != '\0' && y[n] != '\0') {
++    n++;
++  }
++  common = n;
++
++  // check if remaining string is a number
++  is_number = 1;
++  if(isNumber(x+common) == 0) is_number = 0;
++  if(isNumber(y+common) == 0) is_number = 0;
++
++  if(is_number == 1) {
++    a = atoi(x+common);
++    b = atoi(y+common);
++
++    if(a == b) return  0;
++    if(a < b)  return -1;
++    return 1;
++  } else {
++    return strcmp(x, y);
++  }
++}
++
 +/* Used for sorting devnodes to appear in the correct order */
 +static int sort_devnodes(const void *a, const void *b)
 +{
 +   const struct joypad_udev_entry *aa = a;
 +   const struct joypad_udev_entry *bb = b;
-+   return strcmp(aa->devnode, bb->devnode);
++   return strcmp_events(aa->devnode, bb->devnode);
 +}
 +
  void
@@ -35,7 +80,7 @@ index 751e2ca..bec1485 100644
      
      if (_this == NULL) {
          return;
-@@ -218,11 +237,28 @@ SDL_UDEV_Scan(void)
+@@ -219,11 +283,28 @@ SDL_UDEV_Scan(void)
          const char *path = _this->syms.udev_list_entry_get_name(item);
          struct udev_device *dev = _this->syms.udev_device_new_from_syspath(_this->udev, path);
          if (dev != NULL) {

--- a/package/batocera/emulators/dolphin-emu/001-padorder.patch
+++ b/package/batocera/emulators/dolphin-emu/001-padorder.patch
@@ -1,8 +1,8 @@
 diff --git a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
-index 029ea22..cd0d230 100644
+index 77f796b..f98a3e4 100644
 --- a/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
 +++ b/Source/Core/InputCommon/ControllerInterface/evdev/evdev.cpp
-@@ -369,11 +369,28 @@ void Init()
+@@ -376,11 +376,73 @@ void Init()
    StartHotplugThread();
  }
  
@@ -12,12 +12,57 @@ index 029ea22..cd0d230 100644
 +   struct udev_device *dev;
 +};
 +
++int isNumber(const char *s) {
++  int n;
++
++  if(strlen(s) == 0) {
++    return 0;
++  }
++
++  for(n=0; n<strlen(s); n++) {
++    if(!(s[n] == '0' || s[n] == '1' || s[n] == '2' || s[n] == '3' || s[n] == '4' ||
++	 s[n] == '5' || s[n] == '6' || s[n] == '7' || s[n] == '8' || s[n] == '9'))
++      return 0;
++  }
++  return 1;
++}
++
++// compare /dev/input/eventX and /dev/input/eventY where X and Y are numbers
++int strcmp_events(const char* x, const char* y) {
++
++  // find a common string
++  int n, common, is_number;
++  int a, b;
++
++  n=0;
++  while(x[n] == y[n] && x[n] != '\0' && y[n] != '\0') {
++    n++;
++  }
++  common = n;
++
++  // check if remaining string is a number
++  is_number = 1;
++  if(isNumber(x+common) == 0) is_number = 0;
++  if(isNumber(y+common) == 0) is_number = 0;
++
++  if(is_number == 1) {
++    a = atoi(x+common);
++    b = atoi(y+common);
++
++    if(a == b) return  0;
++    if(a < b)  return -1;
++    return 1;
++  } else {
++    return strcmp(x, y);
++  }
++}
++
 +/* Used for sorting devnodes to appear in the correct order */
 +static int sort_devnodes(const void *a, const void *b)
 +{
 +  const struct joypad_udev_entry *aa = (const struct joypad_udev_entry *) a;
 +  const struct joypad_udev_entry *bb = (const struct joypad_udev_entry *) b;
-+   return strcmp(aa->devnode, bb->devnode);
++   return strcmp_events(aa->devnode, bb->devnode);
 +}
 +
  void PopulateDevices()
@@ -31,7 +76,7 @@ index 029ea22..cd0d230 100644
  
    udev* const udev = udev_new();
    ASSERT_MSG(PAD, udev != nullptr, "Couldn't initialize libudev.");
-@@ -392,11 +409,24 @@ void PopulateDevices()
+@@ -399,11 +461,24 @@ void PopulateDevices()
  
      udev_device* dev = udev_device_new_from_syspath(udev, path);
  

--- a/package/batocera/emulators/retroarch/retroarch/000-input_sort_devices.patch
+++ b/package/batocera/emulators/retroarch/retroarch/000-input_sort_devices.patch
@@ -1,23 +1,68 @@
 diff --git a/input/drivers_joypad/udev_joypad.c b/input/drivers_joypad/udev_joypad.c
-index e60a8b2..03ba777 100644
+index 98bde28..9f221f4 100644
 --- a/input/drivers_joypad/udev_joypad.c
 +++ b/input/drivers_joypad/udev_joypad.c
-@@ -542,6 +542,14 @@ static void udev_joypad_poll(void)
+@@ -529,6 +529,59 @@ static void udev_joypad_poll(void)
     }
  }
  
++int isNumber(const char *s) {
++  int n;
++
++  if(strlen(s) == 0) {
++    return 0;
++  }
++
++  for(n=0; n<strlen(s); n++) {
++    if(!(s[n] == '0' || s[n] == '1' || s[n] == '2' || s[n] == '3' || s[n] == '4' ||
++	 s[n] == '5' || s[n] == '6' || s[n] == '7' || s[n] == '8' || s[n] == '9'))
++      return 0;
++  }
++  return 1;
++}
++
++// compare /dev/input/eventX and /dev/input/eventY where X and Y are numbers
++int strcmp_events(const char* x, const char* y) {
++
++  // find a common string
++  int n, common, is_number;
++  int a, b;
++
++  n=0;
++  while(x[n] == y[n] && x[n] != '\0' && y[n] != '\0') {
++    n++;
++  }
++  common = n;
++
++  // check if remaining string is a number
++  is_number = 1;
++  if(isNumber(x+common) == 0) is_number = 0;
++  if(isNumber(y+common) == 0) is_number = 0;
++
++  if(is_number == 1) {
++    a = atoi(x+common);
++    b = atoi(y+common);
++
++    if(a == b) return  0;
++    if(a < b)  return -1;
++    return 1;
++  } else {
++    return strcmp(x, y);
++  }
++}
++
 +/* Used for sorting devnodes to appear in the correct order */
 +static int sort_devnodes(const void *a, const void *b)
 +{
 +   const struct joypad_udev_entry *aa = (const struct joypad_udev_entry*)a;
 +   const struct joypad_udev_entry *bb = (const struct joypad_udev_entry*)b;
-+   return strcmp(aa->devnode, bb->devnode);
++   return strcmp_events(aa->devnode, bb->devnode);
 +}
 +
  static bool udev_joypad_init(void *data)
  {
     unsigned i;
-@@ -576,12 +584,32 @@ static bool udev_joypad_init(void *data)
+@@ -563,12 +616,32 @@ static bool udev_joypad_init(void *data)
     udev_enumerate_scan_devices(enumerate);
     devs = udev_enumerate_get_list_entry(enumerate);
  


### PR DESCRIPTION
yes, but event9 must be after event2 and before event event10
(actual sort was alpha sort event10 < event2 < event9) causing troubles for xinmo or some
special cases

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>