### PR TITLE
Some more cleanups for BATO30

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
@@ -21,14 +21,15 @@ getPer() {
 }
 
 do_versioncheck() {
-    echo "$1" | awk '{ $0=$(NF-1)$NF; gsub(/[^0-9]/,""); print }'
+    echo "$1" | awk '{ $0=$(NF-1)$NF; gsub(/[^0-9]/,""); print }' 2>/dev/null
 }
 
 do_wannaupdate() {
     local text; local to
     CUR_VER=$(cat /usr/share/batocera/batocera.version)
-    NET_VER=$(wget -q -O - "${DWD_HTTP_DIR}/batocera.version" | head -n1)
-    [ $? -ne 0 ] && return #Possible an update URL which is not valid 
+    NET_VER=$(wget -q -O - "${DWD_HTTP_DIR}/batocera.version")
+    [ $? -ne 0 ] && { echo "Something went wrong..."; return; } #Possible an update URL which is not valid
+    NET_VER=$(echo "$NET_VER" | head -n1)
     echo "Current Version installed:    $CUR_VER"
     echo "Version you want to download: $NET_VER"
     CUR_VER=$(do_versioncheck "$CUR_VER")
@@ -74,9 +75,6 @@ test -n "${settingsupdateurl}" && updateurl="${settingsupdateurl}"
 # force a default value in case the value is removed or miswritten
 test "${updatetype}" != "stable" -a "${updatetype}" != "unstable" -a "${updatetype}" != "beta" && updatetype="stable"
 
-# download directory
-mkdir -p /userdata/system/upgrade || exit 1
-
 # custom the url directory
 DWD_HTTP_DIR="${updateurl}/${arch}/${updatetype}/last"
 
@@ -110,8 +108,8 @@ do
     test $? -eq 0 || exit 1
     if test "${size}" -gt "${freespace}"
     then
-	echo "Not enough space on ${fs} to download the update"
-	exit 1
+        echo "Not enough space on ${fs} to download the update"
+        exit 1
     fi
 done
 
@@ -123,7 +121,6 @@ if [ $TERMINAL = 0 ]; then
     touch "/userdata/system/upgrade/boot.tar.xz"
     getPer "${size}" &
     GETPERPID=$!
-    mkdir -p "/userdata/system/upgrade" || exit 1
     curl -A "batocera-upgrade" -sfL "${url}" -o "/userdata/system/upgrade/boot.tar.xz" || exit 1
     kill -9 "${GETPERPID}"
     GETPERPID=
@@ -140,10 +137,10 @@ then
     CURRMD5=$(md5sum "/userdata/system/upgrade/boot.tar.xz" | sed -e s+' .*$'++)
     if test "${DISTMD5}" = "${CURRMD5}"
     then
-	echo "valid checksum."
+        echo "valid checksum."
     else
-	echo "invalid checksum. Got +${DISTMD5}+. Attempted +${CURRMD5}+."
-	exit 1
+        echo "invalid checksum. Got +${DISTMD5}+. Attempted +${CURRMD5}+."
+        exit 1
     fi
 else
     echo "no checksum found. don't check the file."
@@ -165,10 +162,10 @@ for BOOTFILE in ${BOOTFILES}
 do
     if test -e "/boot/${BOOTFILE}"
     then
-	if ! cp "/boot/${BOOTFILE}" "/boot/${BOOTFILE}.upgrade"
-	then
-	    exit 1
-	fi
+        if ! cp "/boot/${BOOTFILE}" "/boot/${BOOTFILE}.upgrade"
+        then
+            exit 1
+        fi
     fi
 done
 
@@ -184,10 +181,10 @@ for BOOTFILE in ${BOOTFILES}
 do
     if test -e "/boot/${BOOTFILE}.upgrade"
     then
-	if ! mv "/boot/${BOOTFILE}.upgrade" "/boot/${BOOTFILE}"
-	then
-	    echo "Outch" >&2
-	fi
+        if ! mv "/boot/${BOOTFILE}.upgrade" "/boot/${BOOTFILE}"
+        then
+            echo "Outch" >&2
+        fi
     fi
 done
 
@@ -204,5 +201,5 @@ rm -f "/userdata/system/upgrade/boot.tar.xz"
 rm -f "/userdata/system/upgrade/boot.tar.xz.md5"
 sync
 
-echo; echo "Done. Please reboot the sytem so that the changes take effect !"
+echo; echo "Done. Please reboot the system so that the changes take effect!"
 exit 0

--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -1,6 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
-NAME="S92switch"
 RUN="/usr/bin/rpi_gpioswitch"
 BTD_PID=$(pgrep -f "/bin/bash $RUN")
 
@@ -19,7 +18,7 @@ fi
 case "$1" in
     start)
         for i in $devices; do
-            if [ "$i" == "$powerswitch" ]; then
+            if [ "$i" = "$powerswitch" ]; then
                 $RUN start "$powerswitch" &
                 break
             fi

--- a/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
+++ b/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
@@ -390,15 +390,10 @@ case "$CONFVALUE" in
     "REMOTEPIBOARD_2005")
         msldigital_$1 14
     ;;
-    "PIN56ONOFF")
-        pin56_$1 onoff
-    ;;
-    "PIN56PUSH")
-        echo "will start pin56_$1"
-        pin56_$1 push
+    "PIN56PUSH"|"PIN56ONOFF")
+        pin56_$1
     ;;
     "PIN356ONOFFRESET")
-        echo "will start pin356_$1"
         pin356_$1 noparam
     ;;
     "RETROFLAG")
@@ -430,12 +425,12 @@ case "$CONFVALUE" in
     ;;
     --HELP|*)
         [[ $CONFVALUE == "--HELP" ]] || echo "Wrong argument given to 'start' or 'stop' parameter"
+        echo "Try: $(basename "$0") {start|stop} <value>"
         echo
-        echo "Try: rpi_gpioswitch.sh [start|stop] [value]"
+        echo -e -n "Valid values are:\t"
+        for i in $(seq 1 2 ${#powerdevices[@]}); do
+            echo -e -n "${powerdevices[i-1]}\n\t\t\t"
+        done
         echo
-        echo "Valid values are: REMOTEPIBOARD_2003, REMOTEPIBOARD_2005
-                  ATX_RASPI_R2_6, MAUSBERRY, ONOFFSHIM, RETROFLAG, RETROFLAG_GPI
-                  PIN56ONOFF, PIN56PUSH, PIN356ONOFFRESET, KINTARO, ARGONONE"
-        exit 1
     ;;
 esac

--- a/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
+++ b/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
@@ -16,7 +16,6 @@ define RPIGPIOSWITCH_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py $(TARGET_DIR)/usr/bin/rpi-retroflag-AdvancedSafeShutdown
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/rpigpioswitch/rpi-argonone.py                       $(TARGET_DIR)/usr/bin/rpi-argonone
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/rpigpioswitch/rpi-kintaro-SafeShutdown.py           $(TARGET_DIR)/usr/bin/rpi-kintaro-SafeShutdown
-	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/rpigpioswitch/rpi-gpio-init.py                      $(TARGET_DIR)/usr/bin/rpi-gpio-init
 	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/rpigpioswitch/S72gpioinput                          $(TARGET_DIR)/etc/init.d/S72gpioinput
 endef
 


### PR DESCRIPTION
Some more fixed:

- Better error handling with batocera-upgrade (ONLY SSH!)
- Some cleanups to batocera-upgrade (3 times creation of /userdata/system/upgrade)
- S92 is free from bash statements
- Some cleanups to rpi_gpioswitch 