### PR TITLE
Updates all LIBRETRO emulators CORE options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -34,13 +34,14 @@ def generateControllerConfig(system, playersControllers, rom):
 
 def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
     wiiMapping = {
-        'x':            'Buttons/2',    'b':        'Buttons/A',
-        'y':            'Buttons/1',    'a':        'Buttons/B',
-        'pageup':       'Buttons/-',    'pagedown': 'Buttons/+',
+        'x':            'Buttons/2',    'b':             'Buttons/A',
+        'y':            'Buttons/1',    'a':             'Buttons/B',
+        'pageup':       'Buttons/-',    'pagedown':      'Buttons/+',
         'select':       'Buttons/Home',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',
         'joystick1up':  'IR/Up',        'joystick1left': 'IR/Left',
-        'joystick2up':  'Tilt/Forward', 'joystick2left': 'Tilt/Left'
+        'joystick2up':  'Tilt/Forward', 'joystick2left': 'Tilt/Left',
+        'hotkey':       'Buttons/Hotkey'
     }
     wiiReverseAxes = {
         'IR/Up':        'IR/Down',
@@ -154,13 +155,14 @@ def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
 
 def generateControllerConfig_gamecube(system, playersControllers,rom):
     gamecubeMapping = {
-        'y':      'Buttons/B',  'b':        'Buttons/A',
-        'x':      'Buttons/Y',  'a':        'Buttons/X',
-        'pageup':     'Buttons/Z',  'start':    'Buttons/Start',
-        'l2': 'Triggers/L', 'r2': 'Triggers/R',
+        'y':            'Buttons/B',     'b':             'Buttons/A',
+        'x':            'Buttons/Y',     'a':             'Buttons/X',
+        'pageup':       'Buttons/Z',     'start':         'Buttons/Start',
+        'l2':           'Triggers/L',    'r2':            'Triggers/R',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',
-        'joystick1up': 'Main Stick/Up', 'joystick1left': 'Main Stick/Left',
-        'joystick2up': 'C-Stick/Up',    'joystick2left': 'C-Stick/Left', 'hotkey': 'Buttons/Hotkey'
+        'joystick1up':  'Main Stick/Up', 'joystick1left': 'Main Stick/Left',
+        'joystick2up':  'C-Stick/Up',    'joystick2left': 'C-Stick/Left',
+        'hotkey':       'Buttons/Hotkey'
     }
     gamecubeReverseAxes = {
         'Main Stick/Up':   'Main Stick/Down',
@@ -170,12 +172,12 @@ def generateControllerConfig_gamecube(system, playersControllers,rom):
     }
     # If joystick1up is missing on the pad, use up instead, and if l2/r2 is missing, use l1/r1
     gamecubeReplacements = {
-        'joystick1up': 'up',
-        'joystick1left': 'left',
-        'joystick1down': 'down',
+        'joystick1up':    'up',
+        'joystick1left':  'left',
+        'joystick1down':  'down',
         'joystick1right': 'right',
-        'l2': 'pageup',
-        'r2': 'pagedown'
+        'l2':             'pageup',
+        'r2':             'pagedown'
     }
 
     # This section allows a per ROM override of the default key options.
@@ -213,12 +215,12 @@ def generateHotkeys(playersControllers):
     f = codecs.open(configFileName, "w", encoding="utf_8_sig")
 
     hotkeysMapping = {
-        'a':  'Keys/Reset',                      'b': 'Keys/Toggle Pause',
-        'x':  'Keys/Load from selected slot',    'y': 'Keys/Save to selected slot',
-        'r2': None,                          'start': 'Keys/Exit',
+        'a':           'Keys/Reset',                    'b': 'Keys/Toggle Pause',
+        'x':           'Keys/Load from selected slot',  'y': 'Keys/Save to selected slot',
+        'r2':          None,                            'start': 'Keys/Exit',
         'pageup': 'Keys/Take Screenshot', 'pagedown': 'Keys/Toggle 3D Side-by-side',
         'up': 'Keys/Select State Slot 1', 'down': 'Keys/Select State Slot 2', 'left': None, 'right': None,
-        'joystick1up': None, 'joystick1left': None,
+        'joystick1up': None,    'joystick1left': None,
         'joystick2up': None,    'joystick2left': None
     }
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -9,82 +9,77 @@ from utils.logger import eslog
 
 # Create the controller configuration file
 def generateControllerConfig(system, playersControllers, rom):
+
     generateHotkeys(playersControllers)
     if system.name == "wii":
         if (system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') == False):
-            #Generate if hardcoded
+            # Generate if hardcoded
             generateControllerConfig_realwiimotes("WiimoteNew.ini", "Wiimote")
-            generateControllerConfig_gamecube(playersControllers,rom) # you can use the gamecube pads on the wii together with wiimotes
+            generateControllerConfig_gamecube(system, playersControllers,rom)           # You can use the gamecube pads on the wii together with wiimotes
         elif (system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') == True):
-            #Generate if hardcoded
-            generateControllerConfig_emulatedwiimotes(playersControllers, rom)
-            removeControllerConfig_gamecube() # because pads will already be used as emulated wiimotes
-        elif (".cc." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom):
-            #Generate if auto and name extensions are present
-            generateControllerConfig_emulatedwiimotes(playersControllers, rom)
-            removeControllerConfig_gamecube() # because pads will already be used as emulated wiimotes
+            # Generate if hardcoded
+            generateControllerConfig_emulatedwiimotes(system, playersControllers, rom)
+            removeControllerConfig_gamecube()                                           # Because pads will already be used as emulated wiimotes
+        elif (".cc." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom) or system.isOptSet("sideWiimote"):
+            # Generate if auto and name extensions are present
+            generateControllerConfig_emulatedwiimotes(system, playersControllers, rom)
+            removeControllerConfig_gamecube()                                           # Because pads will already be used as emulated wiimotes
         else:
             generateControllerConfig_realwiimotes("WiimoteNew.ini", "Wiimote")
-            generateControllerConfig_gamecube(playersControllers,rom) # you can use the gamecube pads on the wii together with wiimotes
+            generateControllerConfig_gamecube(system, playersControllers,rom)           # You can use the gamecube pads on the wii together with wiimotes
     elif system.name == "gamecube":
-        generateControllerConfig_gamecube(playersControllers,rom) #pass ROM name to allow for per ROM configuration
+        generateControllerConfig_gamecube(system, playersControllers,rom)               # Pass ROM name to allow for per ROM configuration
     else:
         raise ValueError("Invalid system name : '" + system.name + "'")
 
-def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
+def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
     wiiMapping = {
-        'x':      'Buttons/2',  'b':        'Buttons/A',
-        'y':      'Buttons/1',  'a':        'Buttons/B',
-        'pageup': 'Buttons/-',  'pagedown': 'Buttons/+',
-        'select':    'Buttons/Home',
+        'x':            'Buttons/2',    'b':        'Buttons/A',
+        'y':            'Buttons/1',    'a':        'Buttons/B',
+        'pageup':       'Buttons/-',    'pagedown': 'Buttons/+',
+        'select':       'Buttons/Home',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',
-        'joystick1up': 'IR/Up',    'joystick1left': 'IR/Left',
-        'joystick2up': 'Tilt/Forward', 'joystick2left': 'Tilt/Left'
+        'joystick1up':  'IR/Up',        'joystick1left': 'IR/Left',
+        'joystick2up':  'Tilt/Forward', 'joystick2left': 'Tilt/Left'
     }
     wiiReverseAxes = {
-        'IR/Up':      'IR/Down',
-        'IR/Left':    'IR/Right',
-        'Swing/Up':   'Swing/Down',
-        'Swing/Left': 'Swing/Right',
-        'Tilt/Left':  'Tilt/Right',
+        'IR/Up':        'IR/Down',
+        'IR/Left':      'IR/Right',
+        'Swing/Up':     'Swing/Down',
+        'Swing/Left':   'Swing/Right',
+        'Tilt/Left':    'Tilt/Right',
         'Tilt/Forward': 'Tilt/Backward',
-        'Nunchuk/Stick/Up' :  'Nunchuk/Stick/Down',
-        'Nunchuk/Stick/Left': 'Nunchuk/Stick/Right',
-        'Classic/Right Stick/Up' : 'Classic/Right Stick/Down',
-        'Classic/Right Stick/Left' : 'Classic/Right Stick/Right',
-        'Classic/Left Stick/Up' : 'Classic/Left Stick/Down',
-        'Classic/Left Stick/Left' : 'Classic/Left Stick/Right'
+        'Nunchuk/Stick/Up':         'Nunchuk/Stick/Down',
+        'Nunchuk/Stick/Left':       'Nunchuk/Stick/Right',
+        'Classic/Right Stick/Up':   'Classic/Right Stick/Down',
+        'Classic/Right Stick/Left': 'Classic/Right Stick/Right',
+        'Classic/Left Stick/Up':    'Classic/Left Stick/Down',
+        'Classic/Left Stick/Left':  'Classic/Left Stick/Right'
     }
 
     extraOptions = {}
     extraOptions["Source"] = "1"
 
-
-    # side wiimote
+    # Side wiimote
     # l2 for shaking actions
-    if ".side." in rom:
+    if (".side." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] != 'disabled' and system.config['controller_mode'] != 'cc'):
         extraOptions["Options/Sideways Wiimote"] = "1"
-        wiiMapping['x']   = 'Buttons/B'
-        wiiMapping['y'] = 'Buttons/A'
-        wiiMapping['a']   = 'Buttons/2'
-        wiiMapping['b'] = 'Buttons/1'
+        wiiMapping['x']  = 'Buttons/B'
+        wiiMapping['y']  = 'Buttons/A'
+        wiiMapping['a']  = 'Buttons/2'
+        wiiMapping['b']  = 'Buttons/1'
         wiiMapping['l2'] = 'Shake/X'
         wiiMapping['l2'] = 'Shake/Y'
         wiiMapping['l2'] = 'Shake/Z'
 
-
     # i: infrared, s: swing, t: tilt, n: nunchuk
     # 12 possible combinations : is si / it ti / in ni / st ts / sn ns / tn nt
 
-
-
-
-
     # i
-    if ".is." in rom or ".it." in rom or ".in." in rom:
+    if (".is." in rom or ".it." in rom or ".in." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] != 'disabled' and system.config['controller_mode'] != 'in' and system.config['controller_mode'] != 'cc'):
         wiiMapping['joystick1up']   = 'IR/Up'
         wiiMapping['joystick1left'] = 'IR/Left'
-    if ".si." in rom or ".ti." in rom or ".ni." in rom:
+    if (".si." in rom or ".ti." in rom or ".ni." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'in' and system.config['controller_mode'] != 'cc'):
         wiiMapping['joystick2up']   = 'IR/Up'
         wiiMapping['joystick2left'] = 'IR/Left'
 
@@ -92,7 +87,7 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
     if ".si." in rom or ".st." in rom or ".sn." in rom:
         wiiMapping['joystick1up']   = 'Swing/Up'
         wiiMapping['joystick1left'] = 'Swing/Left'
-    if ".is." in rom or ".ts." in rom or ".ns." in rom:
+    if (".is." in rom or ".ts." in rom or ".ns." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'is'):
         wiiMapping['joystick2up']   = 'Swing/Up'
         wiiMapping['joystick2left'] = 'Swing/Left'
 
@@ -100,12 +95,12 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
     if ".ti." in rom or ".ts." in rom or ".tn." in rom:
         wiiMapping['joystick1up']   = 'Tilt/Forward'
         wiiMapping['joystick1left'] = 'Tilt/Left'
-    if ".it." in rom or ".st." in rom or ".nt." in rom:
+    if (".it." in rom or ".st." in rom or ".nt." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'it'):
         wiiMapping['joystick2up']   = 'Tilt/Forward'
         wiiMapping['joystick2left'] = 'Tilt/Left'
 
     # n
-    if ".ni." in rom or ".ns." in rom or ".nt." in rom:
+    if (".ni." in rom or ".ns." in rom or ".nt." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'in'):
         extraOptions['Extension']   = 'Nunchuk'
         wiiMapping['l2'] = 'Nunchuk/Buttons/C'
         wiiMapping['r2'] = 'Nunchuk/Buttons/Z'
@@ -118,7 +113,8 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
         wiiMapping['joystick2up']   = 'Nunchuk/Stick/Up'
         wiiMapping['joystick2left'] = 'Nunchuk/Stick/Left'
 
-    if ".cc." in rom:  #Classic Controller Settings
+    # cc : Classic Controller Settings
+    if (".cc." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'cc'):
         extraOptions['Extension']   = 'Classic'
         wiiMapping['x'] = 'Classic/Buttons/X'
         wiiMapping['y'] = 'Classic/Buttons/Y'
@@ -139,9 +135,9 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
         wiiMapping['joystick2up'] = 'Classic/Right Stick/Up'
         wiiMapping['joystick2left'] = 'Classic/Right Stick/Left'
 
-    #This section allows a per ROM override of the default key options.
-    configname = rom + ".cfg"  #Define ROM configuration name
-    if os.path.isfile(configname): #file exists
+    # This section allows a per ROM override of the default key options.
+    configname = rom + ".cfg"       # Define ROM configuration name
+    if os.path.isfile(configname):  # File exists
         import ast
         with open(configname) as cconfig:
             line = cconfig.readline()
@@ -151,13 +147,12 @@ def generateControllerConfig_emulatedwiimotes(playersControllers, rom):
                 wiiMapping.update(res)
                 line = cconfig.readline()
 
-
     eslog.log("Extra Options: {}".format(extraOptions))
     eslog.log("Wii Mappings: {}".format(wiiMapping))
 
-    generateControllerConfig_any(playersControllers, "WiimoteNew.ini", "Wiimote", wiiMapping, wiiReverseAxes, None, extraOptions)
+    generateControllerConfig_any(system, playersControllers, "WiimoteNew.ini", "Wiimote", wiiMapping, wiiReverseAxes, None, extraOptions)
 
-def generateControllerConfig_gamecube(playersControllers,rom):
+def generateControllerConfig_gamecube(system, playersControllers,rom):
     gamecubeMapping = {
         'y':      'Buttons/B',  'b':        'Buttons/A',
         'x':      'Buttons/Y',  'a':        'Buttons/X',
@@ -173,7 +168,7 @@ def generateControllerConfig_gamecube(playersControllers,rom):
         'C-Stick/Up':      'C-Stick/Down',
         'C-Stick/Left':    'C-Stick/Right'
     }
-    # if joystick1up is missing on the pad, use up instead, and if l2/r2 is missing, use l1/r1
+    # If joystick1up is missing on the pad, use up instead, and if l2/r2 is missing, use l1/r1
     gamecubeReplacements = {
         'joystick1up': 'up',
         'joystick1left': 'left',
@@ -182,11 +177,10 @@ def generateControllerConfig_gamecube(playersControllers,rom):
         'l2': 'pageup',
         'r2': 'pagedown'
     }
-    
 
-    #This section allows a per ROM override of the default key options.
-    configname = rom + ".cfg"  #Define ROM configuration name
-    if os.path.isfile(configname): #file exists
+    # This section allows a per ROM override of the default key options.
+    configname = rom + ".cfg"       # Define ROM configuration name
+    if os.path.isfile(configname):  # File exists
         import ast
         with open(configname) as cconfig:
             line = cconfig.readline()
@@ -196,8 +190,7 @@ def generateControllerConfig_gamecube(playersControllers,rom):
                 gamecubeMapping.update(res)
                 line = cconfig.readline()
 
-
-    generateControllerConfig_any(playersControllers, "GCPadNew.ini", "GCPad", gamecubeMapping, gamecubeReverseAxes, gamecubeReplacements)
+    generateControllerConfig_any(system, playersControllers, "GCPadNew.ini", "GCPad", gamecubeMapping, gamecubeReverseAxes, gamecubeReplacements)
 
 def removeControllerConfig_gamecube():
     configFileName = "{}/{}".format(batoceraFiles.dolphinConfig, "GCPadNew.ini")
@@ -235,7 +228,7 @@ def generateHotkeys(playersControllers):
             f.write("[Hotkeys1]" + "\n")
             f.write("Device = evdev/0/" + pad.realName.strip() + "\n")
 
-            # search the hotkey button
+            # Search the hotkey button
             hotkey = None
             if "hotkey" not in pad.inputs:
                 return
@@ -251,31 +244,29 @@ def generateHotkeys(playersControllers):
                 if input.name in hotkeysMapping:
                     keyname = hotkeysMapping[input.name]
 
-                # write the configuration for this key
+                # Write the configuration for this key
                 if keyname is not None:
                     write_key(f, keyname, input.type, input.id, input.value, pad.nbaxes, False, hotkey.id)
                     
                 #else:
                 #    f.write("# undefined key: name="+input.name+", type="+input.type+", id="+str(input.id)+", value="+str(input.value)+"\n")
-                
-
 
         nplayer += 1
 
     f.write
     f.close()
 
-def generateControllerConfig_any(playersControllers, filename, anyDefKey, anyMapping, anyReverseAxes, anyReplacements, extraOptions = {}):
+def generateControllerConfig_any(system, playersControllers, filename, anyDefKey, anyMapping, anyReverseAxes, anyReplacements, extraOptions = {}):
     configFileName = "{}/{}".format(batoceraFiles.dolphinConfig, filename)
     f = codecs.open(configFileName, "w", encoding="utf_8_sig")
     nplayer = 1
     nsamepad = 0
 
-    # in case of two pads having the same name, dolphin wants a number to handle this
+    # In case of two pads having the same name, dolphin wants a number to handle this
     double_pads = dict()
 
     for playercontroller, pad in sorted(playersControllers.items()):
-        # handle x pads having the same name
+        # Handle x pads having the same name
         if pad.configName in double_pads:
             nsamepad = double_pads[pad.configName]
         else:
@@ -287,9 +278,9 @@ def generateControllerConfig_any(playersControllers, filename, anyDefKey, anyMap
         for opt in extraOptions:
             f.write(opt + " = " + extraOptions[opt] + "\n")
 
-        # recompute the mapping according to available buttons on the pads and the available replacements
+        # Recompute the mapping according to available buttons on the pads and the available replacements
         currentMapping = anyMapping
-        # apply replacements
+        # Apply replacements
         if anyReplacements is not None:
             for x in anyReplacements:
             	if x not in pad.inputs and x in currentMapping:
@@ -310,14 +301,15 @@ def generateControllerConfig_any(playersControllers, filename, anyDefKey, anyMap
             if input.name in currentMapping:
                 keyname = currentMapping[input.name]
 
-            # write the configuration for this key
+            # Write the configuration for this key
             if keyname is not None:
                 write_key(f, keyname, input.type, input.id, input.value, pad.nbaxes, False, None)
                 if 'Triggers' in keyname and input.type == 'axis':
                     write_key(f, keyname + '-Analog', input.type, input.id, input.value, pad.nbaxes, False, None)
-            # write the 2nd part
+            # Write the 2nd part
             if input.name in { "joystick1up", "joystick1left", "joystick2up", "joystick2left"} and keyname is not None:
                 write_key(f, anyReverseAxes[keyname], input.type, input.id, input.value, pad.nbaxes, True, None)
+            # DualShock Motion control
             if system.isOptSet("dsmotion") and system.getOptBoolean("dsmotion") == True:
                 f.write("IMUGyroscope/Pitch Up = `Gyro X-`\n")
                 f.write("IMUGyroscope/Pitch Down = `Gyro X+`\n")
@@ -332,11 +324,13 @@ def generateControllerConfig_any(playersControllers, filename, anyDefKey, anyMap
                 f.write("IMUAccelerometer/Backward = `Accel Z+`\n")
                 f.write("IMUAccelerometer/Up = `Accel Y-`\n")
                 f.write("IMUAccelerometer/Down = `Accel Y+`\n")
+            # Mouse to emulate Wiimote
             if system.isOptSet("mouseir") and system.getOptBoolean("mouseir") == True:
                 f.write("IR/Up = `Cursor Y-`\n")
                 f.write("IR/Down = `Cursor Y+`\n")
                 f.write("IR/Left = `Cursor X-`\n")
                 f.write("IR/Right = `Cursor X+`\n")
+            # Rumble option
             if system.isOptSet("rumble") and system.getOptBoolean("rumble") == True:
                 f.write("Rumble/Motor = Weak\n")
 
@@ -352,11 +346,11 @@ def write_key(f, keyname, input_type, input_id, input_value, input_global_id, re
     if input_type == "button":
         f.write("Button " + str(input_id))
     elif input_type == "hat":
-        if input_value == "1" or input_value == "4": # up or down
+        if input_value == "1" or input_value == "4":        # up or down
             f.write("Axis " + str(int(input_global_id)+1))
         else:
             f.write("Axis " + str(input_global_id))
-        if input_value == "1" or input_value == "8": # up or left
+        if input_value == "1" or input_value == "8":        # up or left
             f.write("-")
         else:
             f.write("+")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -86,10 +86,10 @@ class DolphinGenerator(Generator):
         dolphinSettings.set("Core", "GameCubeLanguage", getGameCubeLangFromEnvironment())
 
         # Enable MMU
-        if system.isOptSet("enable_mmu") and not system.getOptBoolean("enable_mmu"):
-            dolphinSettings.set("Core", "MMU", '"False"')
-        else:
+        if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu"):
             dolphinSettings.set("Core", "MMU", '"True"')
+        else:
+            dolphinSettings.set("Core", "MMU", '"False"')
 
         # Backend - Default OpenGL
         if system.isOptSet("gfxbackend") and system.getOptBoolean("gfxbackend") == 'Vulkan':
@@ -135,7 +135,7 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Settings", "ShowFPS", '"False"')
 
-        # HiResTextures - Default On
+        # HiResTextures
         if system.isOptSet('hires_textures') and not system.getOptBoolean('hires_textures'):
             dolphinGFXSettings.set("Settings", "HiresTextures",      '"False"')
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"False"')
@@ -143,7 +143,7 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "HiresTextures",      '"True"')
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"True"')
             
-        # Widescreen Hack - Default Off
+        # Widescreen Hack
         if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
             # Prefer Cheats than Hack 
             if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'))):
@@ -181,25 +181,25 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
                 dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")  
 
-        # Internal resolution settings - Default 1X
+        # Internal resolution settings
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
         else:
             dolphinGFXSettings.set("Settings", "InternalResolution", '"1"')
 
-        # VSync - Default On
+        # VSync
         if system.isOptSet('vsync'):
             dolphinGFXSettings.set("Hardware", "VSync", system.getOptBoolean('vsync'))
         else:
             dolphinGFXSettings.set("Hardware", "VSync", '"True"')
 
-        # Anisotropic filtering - Auto 0
+        # Anisotropic filtering
         if system.isOptSet('anisotropic_filtering'):
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", system.config["anisotropic_filtering"])
         else:
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", '"0"')
 
-		# Anti aliasing - Auto 0
+		# Anti aliasing
         if system.isOptSet('antialiasing'):
             dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -15,20 +15,21 @@ class DolphinGenerator(Generator):
         if not os.path.exists(os.path.dirname(batoceraFiles.dolphinIni)):
             os.makedirs(os.path.dirname(batoceraFiles.dolphinIni))
 
-        # dir required for saves
+        # Dir required for saves
         if not os.path.exists(batoceraFiles.dolphinData + "/StateSaves"):
             os.makedirs(batoceraFiles.dolphinData + "/StateSaves")
 
         dolphinControllers.generateControllerConfig(system, playersControllers, rom)
 
-        # dolphin.ini
+        ## dolphin.ini ##
+
         dolphinSettings = ConfigParser.ConfigParser()
         # To prevent ConfigParser from converting to lower case
         dolphinSettings.optionxform = str
         if os.path.exists(batoceraFiles.dolphinIni):
             dolphinSettings.read(batoceraFiles.dolphinIni)
 
-        # sections
+        # Sections
         if not dolphinSettings.has_section("General"):
             dolphinSettings.add_section("General")
         if not dolphinSettings.has_section("Core"):
@@ -38,31 +39,31 @@ class DolphinGenerator(Generator):
         if not dolphinSettings.has_section("Analytics"):
             dolphinSettings.add_section("Analytics")
 
-        # draw or not FPS
+        # Draw or not FPS
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
-            dolphinSettings.set("General", "ShowLag", '"True"')
+            dolphinSettings.set("General", "ShowLag",        '"True"')
             dolphinSettings.set("General", "ShowFrameCount", '"True"')
         else:
-            dolphinSettings.set("General", "ShowLag", '"False"')
+            dolphinSettings.set("General", "ShowLag",        '"False"')
             dolphinSettings.set("General", "ShowFrameCount", '"False"')
 
-        # don't ask about statistics
+        # Don't ask about statistics
         dolphinSettings.set("Analytics", "PermissionAsked", '"True"')
 
         # PanicHandlers displaymessages
-        dolphinSettings.set("Interface", "UsePanicHandlers", '"False"')
+        dolphinSettings.set("Interface", "UsePanicHandlers",        '"False"')
         dolphinSettings.set("Interface", "OnScreenDisplayMessages", '"True"')
 
-        # don't confirm at stop
+        # Don't confirm at stop
         dolphinSettings.set("Interface", "ConfirmStop", '"False"')
 
-        # Cheats - Default Off
-        if system.isOptSet("enable_cheats"):
-            dolphinSettings.set("Core", "EnableCheats", system.config['enable_cheats'])
+        # Enable Cheats
+        if system.isOptSet("enable_cheats") and system.getOptBoolean("enable_cheats"):
+            dolphinSettings.set("Core", "EnableCheats", '"True"')
         else:
             dolphinSettings.set("Core", "EnableCheats", '"False"')
 
-        # speed up disc transfert rate
+        # Speed up disc transfert rate
         if system.isOptSet("enable_fastdisc") and system.getOptBoolean("enable_fastdisc"):
             dolphinSettings.set("Core", "FastDiscSpeed", '"True"')
         else:
@@ -80,42 +81,43 @@ class DolphinGenerator(Generator):
         else:
             dolphinSettings.set("Core", "SyncGPU", '"False"')
 
-        # language (for gamecube at least)
+        # Language (for gamecube at least)
         dolphinSettings.set("Core", "SelectedLanguage", getGameCubeLangFromEnvironment())
         dolphinSettings.set("Core", "GameCubeLanguage", getGameCubeLangFromEnvironment())
 
-        # Enable MMU - Default On
-        if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu"):
-            dolphinSettings.set("Core", "MMU", '"True"')
-        else:
+        # Enable MMU
+        if system.isOptSet("enable_mmu") and not system.getOptBoolean("enable_mmu"):
             dolphinSettings.set("Core", "MMU", '"False"')
+        else:
+            dolphinSettings.set("Core", "MMU", '"True"')
 
-        # backend - Default
-        if system.isOptSet("gfxbackend"):
-            dolphinSettings.set("Core", "GFXBackend", system.config["gfxbackend"])
+        # Backend - Default OpenGL
+        if system.isOptSet("gfxbackend") and system.getOptBoolean("gfxbackend") == 'Vulkan':
+            dolphinSettings.set("Core", "GFXBackend", '"Vulkan"')
         else:
             dolphinSettings.set("Core", "GFXBackend", '"OGL"')
 
-        # wiimote scanning
+        # Wiimote scanning
         dolphinSettings.set("Core", "WiimoteContinuousScanning", '"True"')
 
-        # gamecube pads forced as standard pad
+        # Gamecube pads forced as standard pad
         dolphinSettings.set("Core", "SIDevice0", '"6"')
         dolphinSettings.set("Core", "SIDevice1", '"6"')
         dolphinSettings.set("Core", "SIDevice2", '"6"')
         dolphinSettings.set("Core", "SIDevice3", '"6"')
 
-        # save dolphin.ini
+        # Save dolphin.ini
         with open(batoceraFiles.dolphinIni, 'w') as configfile:
             dolphinSettings.write(configfile)
 
-        # gfx.ini
+        ## gfx.ini ##
+
         dolphinGFXSettings = ConfigParser.ConfigParser()
         # To prevent ConfigParser from converting to lower case
         dolphinGFXSettings.optionxform = str
         dolphinGFXSettings.read(batoceraFiles.dolphinGfxIni)
 
-        #Add Default Sections
+        # Add Default Sections
         if not dolphinGFXSettings.has_section("Settings"):
             dolphinGFXSettings.add_section("Settings")
         if not dolphinGFXSettings.has_section("Hacks"):
@@ -127,7 +129,7 @@ class DolphinGenerator(Generator):
             
         dolphinGFXSettings.set("Settings", "AspectRatio", getGfxRatioFromConfig(system.config, gameResolution))
 
-        # show fps
+        # Show fps
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
             dolphinGFXSettings.set("Settings", "ShowFPS", '"True"')
         else:
@@ -135,19 +137,23 @@ class DolphinGenerator(Generator):
 
         # HiResTextures - Default On
         if system.isOptSet('hires_textures') and not system.getOptBoolean('hires_textures'):
-            dolphinGFXSettings.set("Settings", "HiresTextures", '"False"')
+            dolphinGFXSettings.set("Settings", "HiresTextures",      '"False"')
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"False"')
         else:
-            dolphinGFXSettings.set("Settings", "HiresTextures", '"True"')
+            dolphinGFXSettings.set("Settings", "HiresTextures",      '"True"')
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"True"')
             
-        # widescreen hack but only if enable cheats is not enabled - Default Off
-        if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack') and (not system.isOptSet('enable_cheats') or not system.getOptBoolean('enable_cheats'))):
-            dolphinGFXSettings.set("Settings", "wideScreenHack", '"True"')
+        # Widescreen Hack - Default Off
+        if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
+            # Prefer Cheats than Hack 
+            if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'))):
+                dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
+            else
+                dolphinGFXSettings.set("Settings", "wideScreenHack", '"True"')
         else:
-            dolphinGFXSettings.remove_option("Settings", '"wideScreenHack"')
+            dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
 
-        # various performance hacks - Default Off
+        # Various performance hacks - Default Off
         if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
             dolphinGFXSettings.set("Hacks", "BBoxEnable", '"False"')
             dolphinGFXSettings.set("Hacks", "DeferEFBCopies", '"True"')
@@ -174,38 +180,36 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "ArbitraryMipmapDetection")
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
                 dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")  
-  
-        # internal resolution settings - Default 1X
+
+        # Internal resolution settings - Default 1X
         if system.isOptSet('internalresolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internalresolution"])
         else:
             dolphinGFXSettings.set("Settings", "InternalResolution", '"1"')
 
-        # vsync - Default
+        # VSync - Default On
         if system.isOptSet('vsync'):
             dolphinGFXSettings.set("Hardware", "VSync", system.getOptBoolean('vsync'))
         else:
             dolphinGFXSettings.set("Hardware", "VSync", '"True"')
-            
 
-  
-        # anisotropic filtering - Auto 0
+        # Anisotropic filtering - Auto 0
         if system.isOptSet('anisotropic_filtering'):
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", system.config["anisotropic_filtering"])
         else:
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", '"0"')
-			
-		# anti aliasing - Auto 0
+
+		# Anti aliasing - Auto 0
         if system.isOptSet('antialiasing'):
             dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:
             dolphinGFXSettings.set("Settings", "MSAA", '"0"')
-			
-		# save gfx.ini
+
+		# Save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:
             dolphinGFXSettings.write(configfile)
 
-        # update SYSCONF
+        # Update SYSCONF
         try:
             dolphinSYSCONF.update(system.config, batoceraFiles.dolphinSYSCONF, gameResolution)
         except Exception:
@@ -217,6 +221,7 @@ class DolphinGenerator(Generator):
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
 
+
 def getGfxRatioFromConfig(config, gameResolution):
     # 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:
@@ -226,9 +231,8 @@ def getGfxRatioFromConfig(config, gameResolution):
             return 1
     return 0
 
-# seem to be only for the gamecube. However, while this is not in a gamecube section
-# it may be used for something else, so set it anyway
-
+# Seem to be only for the gamecube. However, while this is not in a gamecube section
+# It may be used for something else, so set it anyway
 def getGameCubeLangFromEnvironment():
     lang = environ['LANG'][:5]
     availableLanguages = { "en_US": 0, "de_DE": 1, "fr_FR": 2, "es_ES": 3, "it_IT": 4, "nl_NL": 5 }

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -142,13 +142,13 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Settings", "HiresTextures",      '"True"')
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", '"True"')
-            
+
         # Widescreen Hack
-        if (system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
+        if system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
             # Prefer Cheats than Hack 
-            if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'))):
+            if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
                 dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
-            else
+            else:
                 dolphinGFXSettings.set("Settings", "wideScreenHack", '"True"')
         else:
             dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -25,14 +25,16 @@ ratioIndexes = ["4/3", "16/9", "16/10", "16/15", "21/9", "1/1", "2/1", "3/2", "3
                 "8/7", "19/12", "19/14", "30/17", "32/9", "config", "squarepixel", "core", "custom"]
 
 # Define the libretro device type corresponding to the libretro cores, when needed.
-coreToP1Device = {'cap32': '513', '81': '257', 'fuse': '513'};
-coreToP2Device = {'fuse': '513'};
+coreToP1Device = {'atari800': '513', 'cap32': '513', '81': '259', 'fuse': '769'};
+coreToP2Device = {'atari800': '513', 'fuse': '513'};
 
 # Define systems compatible with retroachievements
 systemToRetroachievements = {'atari2600', 'atari7800', 'atarijaguar', 'colecovision', 'nes', 'snes', 'virtualboy', 'n64', 'sg1000', 'mastersystem', 'megadrive', 'segacd', 'sega32x', 'saturn', 'pcengine', 'pcenginecd', 'supergrafx', 'psx', 'mame', 'hbmame', 'fbneo', 'neogeo', 'lightgun', 'apple2', 'lynx', 'wswan', 'wswanc', 'gb', 'gbc', 'gba', 'nds', 'pokemini', 'gamegear', 'ngp', 'ngpc'}; 
 
 # Define systems not compatible with rewind option
-systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'odyssey2', 'mame', 'hbmame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn', 'fbneo'};
+#systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'odyssey2', 'mame', 'hbmame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn', 'fbneo'};
+# TOTO: Select goog list
+systemNoRewind = {'saturn'};
 
 # Define systems not compatible with run-ahead option (warning: this option is CPU intensive!)
 systemNoRunahead = {'sega32x', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};
@@ -68,7 +70,7 @@ def fast_image_size(image_file):
 # take a system, and returns a dict of retroarch.cfg compatible parameters
 def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     # Create/update retroarch-core-options.cfg
-    libretroOptions.generateCoreSettings(batoceraFiles.retroarchCoreCustom, system)
+    libretroOptions.generateCoreSettings(batoceraFiles.retroarchCoreCustom, system, rom)
 
     # Create/update hatari.cfg
     if system.name == 'atarist':
@@ -154,22 +156,19 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['savestate_directory'] = batoceraFiles.savesDir + system.name
     retroarchConfig['savefile_directory'] = batoceraFiles.savesDir + system.name
 
+    # Devices choices
     retroarchConfig['input_libretro_device_p1'] = '1'
     retroarchConfig['input_libretro_device_p2'] = '1'
 
     if(system.config['core'] in coreToP1Device):
         retroarchConfig['input_libretro_device_p1'] = coreToP1Device[system.config['core']]
-
     if(system.config['core'] in coreToP2Device):
         retroarchConfig['input_libretro_device_p2'] = coreToP2Device[system.config['core']]
 
     if len(controllers) > 2 and (system.config['core'] == 'snes9x_next' or system.config['core'] == 'snes9x'):
         retroarchConfig['input_libretro_device_p2'] = '257'
 
-    if system.config['core'] == 'atari800':
-        retroarchConfig['input_libretro_device_p1'] = '513'
-        retroarchConfig['input_libretro_device_p2'] = '513'
-
+    # Retroachievements
     retroarchConfig['cheevos_enable'] = 'false'
     retroarchConfig['cheevos_hardcore_mode_enable'] = 'false'
     retroarchConfig['cheevos_leaderboards_enable'] = 'false'
@@ -224,10 +223,6 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     # forced values (so that if the config is not correct, fix it)
     if system.config['core'] == 'tgbdual':
         retroarchConfig['aspect_ratio_index'] = str(ratioIndexes.index("core")) # reset each time in this function
-
-    # Virtual keyboard for Amstrad CPC (select+start)
-    if system.config['core'] == 'cap32':
-        retroarchConfig['cap32_combokey'] = 'y'
 
     # Disable internal image viewer (ES does it, and pico-8 won't load .p8.png)
     retroarchConfig['builtin_imageviewer_enable'] = 'false'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -32,9 +32,8 @@ coreToP2Device = {'atari800': '513', 'fuse': '513'};
 systemToRetroachievements = {'atari2600', 'atari7800', 'atarijaguar', 'colecovision', 'nes', 'snes', 'virtualboy', 'n64', 'sg1000', 'mastersystem', 'megadrive', 'segacd', 'sega32x', 'saturn', 'pcengine', 'pcenginecd', 'supergrafx', 'psx', 'mame', 'hbmame', 'fbneo', 'neogeo', 'lightgun', 'apple2', 'lynx', 'wswan', 'wswanc', 'gb', 'gbc', 'gba', 'nds', 'pokemini', 'gamegear', 'ngp', 'ngpc'}; 
 
 # Define systems not compatible with rewind option
-#systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'odyssey2', 'mame', 'hbmame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn', 'fbneo'};
-# TOTO: Select goog list
-systemNoRewind = {'saturn'};
+systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'hbmame', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'saturn'};
+# 'odyssey2', 'mame', 'neogeocd', 'fbneo'
 
 # Define systems not compatible with run-ahead option (warning: this option is CPU intensive!)
 systemNoRunahead = {'sega32x', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'neogeocd', 'saturn'};

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -148,20 +148,39 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             retroarchConfig['input_libretro_device_p1'] = systemToP1Device[system.name]
             retroarchConfig['input_libretro_device_p2'] = systemToP2Device[system.name]
 
-    ## PlayStation controlers
+    ## PlayStation controller
     if (system.config['core'] == 'mednafen_psx'):               # Madnafen
-        # Controller 1 Type
         if system.isOptSet('beetle_psx_Controller1'):
             retroarchConfig['input_libretro_device_p1'] = system.config['beetle_psx_Controller1']
-        # Controller 2 Type
         if system.isOptSet('beetle_psx_Controller2'):
             retroarchConfig['input_libretro_device_p2'] = system.config['beetle_psx_Controller2']
     if (system.config['core'] == 'pcsx_rearmed'):               # PCSX Rearmed
         if system.isOptSet('controller1_pcsx'):
             retroarchConfig['input_libretro_device_p1'] = system.config['controller1_pcsx']
-        # Controller 2 Type
         if system.isOptSet('controller2_pcsx'):
             retroarchConfig['input_libretro_device_p2'] = system.config['controller2_pcsx']
+
+    ## Sega Megadrive controller
+    if system.config['core'] == 'genesisplusgx' and system.name == 'megadrive':
+        if system.isOptSet('controller1_md'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['controller1_md']
+        else:
+            retroarchConfig['input_libretro_device_p1'] = '513' # 6 button
+        if system.isOptSet('controller2_md'):
+            retroarchConfig['input_libretro_device_p2'] = system.config['controller2_md']
+        else:
+            retroarchConfig['input_libretro_device_p2'] = '513' # 6 button
+
+    ## Sega Mastersystem controller
+    if system.config['core'] == 'genesisplusgx' and system.name == 'mastersystem':
+        if system.isOptSet('controller1_ms'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['controller1_ms']
+        else:
+            retroarchConfig['input_libretro_device_p1'] = '769'
+        if system.isOptSet('controller2_ms'):
+            retroarchConfig['input_libretro_device_p2'] = system.config['controller2_ms']
+        else:
+            retroarchConfig['input_libretro_device_p2'] = '769'
 
 
     # Smooth option

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -195,8 +195,25 @@ def generateCoreSettings(retroarchCore, system, rom):
     if (system.config['core'] == 'o2em'):
         # Virtual keyboard transparency
         coreSettings.save('o2em_vkb_transparency ', '"20%"')
-    
-    # MAME 2003+
+
+    # MAME 0.225
+    if (system.config['core'] == 'mame'):
+        # Lightgun mode
+        coreSettings.save('mame_lightgun_mode', '"lightgun"')
+        # Enable cheats
+        coreSettings.save('mame_cheats_enable', '"enabled"')
+        # CPU Overclock
+        if system.isOptSet('mame_cpu_overclock'):
+            coreSettings.save('mame_cpu_overclock', system.config['mame_cpu_overclock'])
+        else:
+            coreSettings.save('mame_cpu_overclock', '"default"')
+        # Video Resolution
+        if system.isOptSet('mame_altres'):
+            coreSettings.save('mame_altres', system.config['mame_altres'])
+        else:
+            coreSettings.save('mame_altres', '"640x480"')
+
+    # MAME 2003 Plus
     if (system.config['core'] == 'mame078plus'):
         # Skip Disclaimer and Warnings
         coreSettings.save('mame2003-plus_skip_disclaimer', '"enabled"')
@@ -398,7 +415,7 @@ def generateCoreSettings(retroarchCore, system, rom):
             coreSettings.save('sgx_nospritelimit', system.config['sgx_nospritelimit'])
         else:
             coreSettings.save('sgx_nospritelimit', '"enabled"')
-        
+
     # Nec PC-FX
     if (system.config['core'] == 'pcfx'):
         # Remove 16-sprites-per-scanline hardware limit
@@ -747,7 +764,7 @@ def generateCoreSettings(retroarchCore, system, rom):
         else:
             coreSettings.save('snes9x_2010_overclock', '"10 MHz (Default)"')
 
-    # TODO: Add CORE options for BSnes on PC
+    # TODO: Add CORE options for BSnes and PocketSNES
     
     # Nintendo Virtual Boy
     if (system.config['core'] == 'vb'):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -140,7 +140,9 @@ def generateCoreSettings(retroarchCore, system, rom):
             coreSettings.save('vice_physical_keyboard_pass_through', system.config['keyboard_pass_through'])
         else:
             coreSettings.save('vice_physical_keyboard_pass_through', '"disabled"')
-            
+
+    # TODO: Add core options for C128 / C16Plus4 / Vic20 / Pet
+
     # Commodore AMIGA
     if (system.config['core'] == 'puae'):
         # Show Video Options
@@ -425,8 +427,8 @@ def generateCoreSettings(retroarchCore, system, rom):
             coreSettings.save('pcfx_nospritelimit', '"enabled"')
 
     # Nintendo 3DS
+    # TODO: Add CORE Options for 3DS
     if (system.config['core'] == 'citra'):
-        # TODO: Add CORE Options for 3DS
         # Set OpenGL rendering
         if not os.path.exists(batoceraFiles.CONF + "/retroarch/3ds.cfg"):
             f = open(batoceraFiles.CONF + "/retroarch/3ds.cfg", "w")
@@ -441,49 +443,39 @@ def generateCoreSettings(retroarchCore, system, rom):
         # .htc files must be placed in 'Mupen64plus/cache'
         coreSettings.save('mupen64plus-txHiresEnable', '"True"')
         # Video 4:3 Resolution
-        if system.isOptSet('43screensize'):
-            coreSettings.save('mupen64plus-43screensize', system.config['43screensize'])
+        if system.isOptSet('mupen64plus-43screensize') and system.config['mupen64plus-43screensize'] != '320x240':
+            coreSettings.save('mupen64plus-43screensize', system.config['mupen64plus-43screensize'])
         else:
             coreSettings.save('mupen64plus-43screensize', '"320x240"')
         # Video 16:9 Resolution
-        if system.isOptSet('169screensize'):
-            coreSettings.save('mupen64plus-169screensize', system.config['169screensize'])
+        if system.isOptSet('mupen64plus-169screensize') and system.config['mupen64plus-169screensize'] != '640x360':
+            coreSettings.save('mupen64plus-169screensize', system.config['mupen64plus-169screensize'])
         else:
             coreSettings.save('mupen64plus-169screensize', '"640x360"')
         # Widescreen Hack
-        if system.isOptSet('aspect'):
-            coreSettings.save('mupen64plus-aspect', '"' + system.config['aspect'] + '"')
-            #if (system.config['aspect'] != '4:3'):
-                # Auto Config System
-                # TODO: Update this trick with a beter solution
-                #system.save('ratio', '16/9')
-                #system.save('bezel', 'none')
-                
-                #retroarchConfig['aspect_ratio_index'] = '"16/9"')
-                #retroarchConfig['video_aspect_ratio_auto'] = 'false'
-                #retroarchConfig['input_overlay_enable'] = "false"
-                #retroarchConfig['video_message_pos_x']  = 0.05
-                #retroarchConfig['video_message_pos_y']  = 0.05
+        # Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+        if system.isOptSet('mupen64plus-aspect') and system.isOptSet('ratio') and system.isOptSet('bezel') and system.config['mupen64plus-aspect'] == '16:9 adjusted' and system.config["ratio"] == "16/9" and system.config["bezel"] == "none":
+            coreSettings.save('mupen64plus-aspect', '"16:9 adjusted"')
         else:
             coreSettings.save('mupen64plus-aspect', '"4:3"')
         # Bilinear Filtering
-        if system.isOptSet('BilinearMode'):
-            coreSettings.save('mupen64plus-BilinearMode', system.config['BilinearMode'])
+        if system.isOptSet('mupen64plus-BilinearMode') and system.config['mupen64plus-BilinearMode'] == '3point':
+            coreSettings.save('mupen64plus-BilinearMode', '"3point"')
         else:
             coreSettings.save('mupen64plus-BilinearMode', '"standard"')
         # Anti-aliasing (MSA)
-        if system.isOptSet('MultiSampling'):
-            coreSettings.save('mupen64plus-MultiSampling', system.config['MultiSampling'])
+        if system.isOptSet('mupen64plus-MultiSampling') and system.config['mupen64plus-MultiSampling'] != '0':
+            coreSettings.save('mupen64plus-MultiSampling', system.config['mupen64plus-MultiSampling'])
         else:
             coreSettings.save('mupen64plus-MultiSampling', '"0"')
         # Texture Filtering
-        if system.isOptSet('Texture_filter'):
-            coreSettings.save('mupen64plus-txFilterMode', '"' + system.config['Texture_filter'] + '"')
+        if system.isOptSet('mupen64plus-txFilterMode') and system.config['mupen64plus-txFilterMode'] != 'None':
+            coreSettings.save('mupen64plus-txFilterMode', '"' + system.config['mupen64plus-txFilterMode'] + '"')
         else:
             coreSettings.save('mupen64plus-txFilterMode', '"None"')
         # Texture Enhancement
-        if system.isOptSet('Texture_Enhancement'):
-            coreSettings.save('mupen64plus-txEnhancementMode', '"' + system.config['Texture_Enhancement'] + '"')
+        if system.isOptSet('mupen64plus-txEnhancementMode') and system.config['mupen64plus-txEnhancementMode'] != 'None':
+            coreSettings.save('mupen64plus-txEnhancementMode', '"' + system.config['mupen64plus-txEnhancementMode'] + '"')
         else:
             coreSettings.save('mupen64plus-txEnhancementMode', '"None"')
 
@@ -577,7 +569,6 @@ def generateCoreSettings(retroarchCore, system, rom):
         # GB / GBC: Use Super Game Boy borders
         if system.isOptSet('sgb_borders') and system.config['sgb_borders'] == "True":
             coreSettings.save('mgba_sgb_borders', '"ON"')
-            # TODO: Maybe autoswitch on a good FULLSCREEN BEZEL
         else:
             coreSettings.save('mgba_sgb_borders', '"OFF"')
         # GB / GBC: Color Correction
@@ -613,7 +604,6 @@ def generateCoreSettings(retroarchCore, system, rom):
         else:
             coreSettings.save('vbam_palettes', '"black and white"')
         # GB / GBC: Use Super Game Boy borders
-        # TODO: Maybe autoswitch on a good FULLSCREEN BEZEL
         if system.isOptSet('showborders_gb') and system.name == 'gb':
             coreSettings.save('vbam_showborders', system.config['showborders_gb'])
             # Force SGB mode, "sgb2" is same
@@ -825,58 +815,50 @@ def generateCoreSettings(retroarchCore, system, rom):
         coreSettings.save('reicast_lightgun3_crosshair', '"Green"')
         coreSettings.save('reicast_lightgun4_crosshair', '"White"')
         # Video resolution 
-        if system.isOptSet('internal_resolution_flycast'):
-            coreSettings.save('reicast_internal_resolution', system.config['internal_resolution_flycast'])
+        if system.isOptSet('reicast_internal_resolution'):
+            coreSettings.save('reicast_internal_resolution', system.config['reicast_internal_resolution'])
         else:
             coreSettings.save('reicast_internal_resolution', '"640x480"')
         # Textures Mip-mapping (blur)
-        if system.isOptSet('mipmapping'):
-            coreSettings.save('reicast_mipmapping', system.config['mipmapping'])
+        if system.isOptSet('reicast_mipmapping'):
+            coreSettings.save('reicast_mipmapping', system.config['reicast_mipmapping'])
         else:
             coreSettings.save('reicast_mipmapping', '"disabled"')
         # Anisotropic Filtering
-        if system.isOptSet('anisotropic_filtering'):
-            coreSettings.save('reicast_anisotropic_filtering', system.config['anisotropic_filtering'])
+        if system.isOptSet('reicast_anisotropic_filtering'):
+            coreSettings.save('reicast_anisotropic_filtering', system.config['reicast_anisotropic_filtering'])
         else:
             coreSettings.save('reicast_anisotropic_filtering', '"off"')
         # Texture Upscaling (xBRZ)
-        if system.isOptSet('texture_upscaling'):
-            coreSettings.save('reicast_texupscale', '"' + system.config['texture_upscaling'] + '"')
+        if system.isOptSet('reicast_texupscale'):
+            coreSettings.save('reicast_texupscale', '"' + system.config['reicast_texupscale'] + '"')
         else:
             coreSettings.save('reicast_texupscale', '"off"')
         # Render to Texture Upscaling
-        if system.isOptSet('render_to_texture_upscaling'):
-            coreSettings.save('reicast_render_to_texture_upscaling', system.config['render_to_texture_upscaling'])
+        if system.isOptSet('reicast_render_to_texture_upscaling'):
+            coreSettings.save('reicast_render_to_texture_upscaling', system.config['reicast_render_to_texture_upscaling'])
         else:
             coreSettings.save('reicast_render_to_texture_upscaling', '"1x"')
         # Frame Skip
-        if system.isOptSet('frame_skipping'):
-            coreSettings.save('reicast_frame_skipping', system.config['frame_skipping'])
+        if system.isOptSet('reicast_frame_skipping'):
+            coreSettings.save('reicast_frame_skipping', system.config['reicast_frame_skipping'])
         else:
             coreSettings.save('reicast_frame_skipping', '"disabled"')
         # Force Windows CE Mode
-        if system.isOptSet('force_wince'):
-            coreSettings.save('reicast_force_wince', system.config['force_wince'])
+        if system.isOptSet('reicast_force_wince'):
+            coreSettings.save('reicast_force_wince', system.config['reicast_force_wince'])
         else:
             coreSettings.save('reicast_force_wince', '"disabled"')
-        # Widescreen Hack
-        if system.isOptSet('widescreen_hack_flycast'):
-            coreSettings.save('reicast_widescreen_hack', system.config['widescreen_hack_flycast'])
-            if (system.config['widescreen_hack_flycast'] == 'enabled'):
-                # Auto Config System
-                #system.config["ratio"] == "16/9"
-                #system.config["bezel"] == "none"
-                # Prefer Hack from Cheat
-                coreSettings.save('reicast_widescreen_cheats', '"disabled"')
-        else:
-            coreSettings.save('reicast_widescreen_hack', '"disabled"')
         # Widescreen Cheat
-        if system.isOptSet('widescreen_cheats'):
-            coreSettings.save('reicast_widescreen_cheats', system.config['widescreen_cheats'])
-            #if (system.config['widescreen_cheats'] == 'enabled'):
-                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
+        if system.isOptSet('reicast_widescreen_cheats') and system.isOptSet('ratio') and system.isOptSet('bezel') and system.config['reicast_widescreen_cheats'] == 'enabled' and system.config["ratio"] == "16/9" and system.config["bezel"] == "none":
+            coreSettings.save('reicast_widescreen_cheats', '"enabled"')
         else:
             coreSettings.save('reicast_widescreen_cheats', '"disabled"')
+        # Widescreen Hack (prefer Cheat)
+        if system.isOptSet('reicast_widescreen_hack') and system.isOptSet('ratio') and system.isOptSet('bezel') and system.isOptSet('reicast_widescreen_cheats') and system.config['reicast_widescreen_hack'] == 'enabled' and system.config["ratio"] == "16/9" and system.config["bezel"] == "none" and system.config['reicast_widescreen_cheats'] == 'disabled':
+            coreSettings.save('reicast_widescreen_hack',   '"enabled"')
+        else:
+            coreSettings.save('reicast_widescreen_hack',   '"disabled"')
 
         ## Atomiswave / Naomi
         
@@ -1097,40 +1079,38 @@ def generateCoreSettings(retroarchCore, system, rom):
     # Sony PSX
     if (system.config['core'] == 'mednafen_psx'):
         # CPU Frequency Scaling (Overclock)
-        if system.isOptSet('beetlepsx_cpu_freq'):
-            coreSettings.save('beetle_psx_cpu_freq_scale', system.config['beetlepsx_cpu_freq'])
+        if system.isOptSet('beetle_psx_cpu_freq_scale'):
+            coreSettings.save('beetle_psx_cpu_freq_scale', system.config['beetle_psx_cpu_freq_scale'])
         else:
             coreSettings.save('beetle_psx_cpu_freq_scale', '"100%(native)"')
         # Show official Bootlogo
-        if system.isOptSet('skip_bios_psx'):
-            coreSettings.save('beetle_psx_skip_bios', system.config['skip_bios_psx'])
+        if system.isOptSet('beetle_psx_skip_bios'):
+            coreSettings.save('beetle_psx_skip_bios', system.config['beetle_psx_skip_bios'])
         else:
             coreSettings.save('beetle_psx_skip_bios', '"disabled"')
         # Video Resolution
-        if system.isOptSet('internal_resolution_mednafen'):
-            coreSettings.save('beetle_psx_internal_resolution', system.config['internal_resolution_mednafen'])
+        if system.isOptSet('beetle_psx_internal_resolution'):
+            coreSettings.save('beetle_psx_internal_resolution', system.config['beetle_psx_internal_resolution'])
         else:
             coreSettings.save('beetle_psx_internal_resolution', '"1x(native)"')
         # Widescreen Hack
-        if system.isOptSet('widescreen_hack_mednafen'):
-            coreSettings.save('beetle_psx_widescreen_hack', system.config['widescreen_hack_mednafen'])
-            #if (system.config['widescreen_hack_mednafen'] == 'enabled'):
-                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
+        if system.isOptSet('beetle_psx_widescreen_hack') and system.isOptSet('ratio') and system.isOptSet('bezel') and system.config['beetle_psx_widescreen_hack'] == 'enabled' and system.config["ratio"] == "16/9" and system.config["bezel"] == "none":
+            coreSettings.save('beetle_psx_widescreen_hack', '"enabled"')
         else:
             coreSettings.save('beetle_psx_widescreen_hack', '"disabled"')
         # Frame Duping (Speedup)
-        if system.isOptSet('frame_duping'):
-            coreSettings.save('beetle_psx_frame_duping', system.config['frame_duping'])
+        if system.isOptSet('beetle_psx_frame_duping'):
+            coreSettings.save('beetle_psx_frame_duping', system.config['beetle_psx_frame_duping'])
         else:
             coreSettings.save('beetle_psx_frame_duping', '"disabled"') 
         # CPU Dynarec (Speedup)
-        if system.isOptSet('cpu_dynarec'):
-            coreSettings.save('beetle_psx_cpu_dynarec', system.config['cpu_dynarec'])
+        if system.isOptSet('beetle_psx_cpu_dynarec'):
+            coreSettings.save('beetle_psx_cpu_dynarec', system.config['beetle_psx_cpu_dynarec'])
         else:
             coreSettings.save('beetle_psx_cpu_dynarec', '"disabled"')
         # Dynarec Code Invalidation
-        if system.isOptSet('dynarec_invalidate'):
-            coreSettings.save('beetle_psx_dynarec_invalidate', system.config['dynarec_invalidate'])
+        if system.isOptSet('beetle_psx_dynarec_invalidate'):
+            coreSettings.save('beetle_psx_dynarec_invalidate', system.config['beetle_psx_dynarec_invalidate'])
         else:
             coreSettings.save('beetle_psx_dynarec_invalidate', '"full"')
         # Multitap
@@ -1149,49 +1129,46 @@ def generateCoreSettings(retroarchCore, system, rom):
             coreSettings.save('beetle_psx_enable_multitap_port2', '"disabled"')
 
     if (system.config['core'] == 'duckstation'):
-        coreSettings.save('duckstation_Display.AspectRatio', '"4:3"')
-        
         # Show official Bootlogo
-        if system.isOptSet('PatchFastBoot'):
-            coreSettings.save('duckstation_BIOS.PatchFastBoot', system.config['PatchFastBoot'])
+        if system.isOptSet('duckstation_PatchFastBoot'):
+            coreSettings.save('duckstation_BIOS.PatchFastBoot', system.config['duckstation_PatchFastBoot'])
         else:
             coreSettings.save('duckstation_BIOS.PatchFastBoot', '"false"')
         # Video Resolution
-        if system.isOptSet('resolution_scale'):
-            coreSettings.save('duckstation_GPU.ResolutionScale', system.config['resolution_scale'])
+        if system.isOptSet('duckstation_resolution_scale'):
+            coreSettings.save('duckstation_GPU.ResolutionScale', system.config['duckstation_resolution_scale'])
         else:
             coreSettings.save('duckstation_GPU.ResolutionScale', '"1"')
         # Anti-aliasing (MSAA/SSAA)
-        if system.isOptSet('antialiasing'):
-            coreSettings.save('duckstation_GPU.MSAA', system.config['antialiasing'])
+        if system.isOptSet('duckstation_antialiasing'):
+            coreSettings.save('duckstation_GPU.MSAA', system.config['duckstation_antialiasing'])
         else:
             coreSettings.save('duckstation_GPU.MSAA', '"1"')
         # Texture Filtering
-        if system.isOptSet('texture_filtering'):
-            coreSettings.save('duckstation_GPU.TextureFilter', system.config['texture_filtering'])
+        if system.isOptSet('duckstation_texture_filtering'):
+            coreSettings.save('duckstation_GPU.TextureFilter', system.config['duckstation_texture_filtering'])
         else:
             coreSettings.save('duckstation_GPU.TextureFilter', '"Nearest"')
         # Widescreen Hack
-        if system.isOptSet('widescreen_hack_duckstation'):
-            coreSettings.save('duckstation_GPU.WidescreenHack', system.config['widescreen_hack_duckstation'])
-            if (system.config['widescreen_hack_duckstation'] == 'true'):
-                coreSettings.save('duckstation_Display.AspectRatio', '"16:9"')
-                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
+        if system.isOptSet('duckstation_widescreen_hack') and system.isOptSet('ratio') and system.isOptSet('bezel') and system.config['duckstation_widescreen_hack'] == 'true' and system.config["ratio"] == "16/9" and system.config["bezel"] == "none":
+            coreSettings.save('duckstation_GPU.WidescreenHack',  '"true"')
+            coreSettings.save('duckstation_Display.AspectRatio', '"16:9"')
         else:
-            coreSettings.save('duckstation_GPU.WidescreenHack', '"false"')
+            coreSettings.save('duckstation_GPU.WidescreenHack',  '"false"')
+            coreSettings.save('duckstation_Display.AspectRatio', '"4:3"')
          # Crop Mode
         if system.isOptSet('duckstation_CropMode'):
             coreSettings.save('duckstation_Display.CropMode', system.config['duckstation_CropMode'])
         else:
             coreSettings.save('duckstation_Display.CropMode', '"Overscan"')
         # Controller 1 Type
-        if system.isOptSet('Controller1'):
-            coreSettings.save('duckstation_Controller1.Type', system.config['Controller1'])
+        if system.isOptSet('duckstation_Controller1'):
+            coreSettings.save('duckstation_Controller1.Type', system.config['duckstation_Controller1'])
         else:
             coreSettings.save('duckstation_Controller1.Type', '"DigitalController"')
         # Controller 2 Type
-        if system.isOptSet('Controller2'):
-            coreSettings.save('duckstation_Controller2.Type', system.config['Controller2'])
+        if system.isOptSet('duckstation_Controller2'):
+            coreSettings.save('duckstation_Controller2.Type', system.config['duckstation_Controller2'])
         else:
             coreSettings.save('duckstation_Controller2.Type', '"DigitalController"')
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -5,7 +5,7 @@ import ConfigParser
 from settings.unixSettings import UnixSettings
 import batoceraFiles
 
-def generateCoreSettings(retroarchCore, system):
+def generateCoreSettings(retroarchCore, system, rom):
     # retroarch-core-options.cfg
     if not os.path.exists(os.path.dirname(retroarchCore)):
         os.makedirs(os.path.dirname(retroarchCore))
@@ -18,22 +18,269 @@ def generateCoreSettings(retroarchCore, system):
         os.remove(retroarchCore)
         coreSettings = UnixSettings(retroarchCore, separator=' ')
 
+
+    # Amstrad CPC / GX4000
+    if (system.config['core'] == 'cap32'):
+        # Virtual Keyboard by default (select+start) change to (start+Y)
+        coreSettings.save('cap32_combokey', '"y"')
+        # Auto Select Model
+        if (system.name == 'gx4000'):
+            coreSettings.save('cap32_model', '"6128+"')
+        elif system.isOptSet('cap32_model'):
+            coreSettings.save('cap32_model', '"' + system.config['cap32_model'] + '"')
+        else:
+            coreSettings.save('cap32_model', '"6128"')
+        # Ram size
+        if system.isOptSet('cap32_ram'):
+            coreSettings.save('cap32_ram', '"' + system.config['cap32_ram'] + '"')
+        else:
+            coreSettings.save('cap32_ram', '"128"')
+
     # Atari 800 and 5200
     if (system.config['core'] == 'atari800'):
+    
         if (system.name == 'atari800'):
-            coreSettings.save('atari800_system',    '"130XE (128K)"')
-            coreSettings.save('RAM_SIZE',           '"64"')
-            coreSettings.save('STEREO_POKEY',       '"1"')
-            coreSettings.save('BUILTIN_BASIC',      '"1"')
-        else:
-            coreSettings.save('atari800_system',    '"5200"')
-            coreSettings.save('RAM_SIZE',           '"16"')
-            coreSettings.save('STEREO_POKEY',       '"0"')
-            coreSettings.save('BUILTIN_BASIC',      '"0"')
+            # Select Atari 800
+            # Let user overide Atari System
+            if system.isOptSet('atari800_system'):
+                coreSettings.save('atari800_system', '"' + system.config['atari800_system'] + '"')
+            else:
+                coreSettings.save('atari800_system', '"130XE (128K)"')
+            # Video Standard
+            if system.isOptSet('atari800_ntscpal'):
+                coreSettings.save('atari800_ntscpal', system.config['atari800_ntscpal'])
+            else:
+                coreSettings.save('atari800_ntscpal', '"NTSC"')
+            # SIO Acceleration
+            if system.isOptSet('atari800_sioaccel'):
+                coreSettings.save('atari800_sioaccel', system.config['atari800_sioaccel'])
+            else:
+                coreSettings.save('atari800_sioaccel', '"enabled"')
+            # Hi-Res Artifacting
+            if system.isOptSet('atari800_artifacting'):
+                coreSettings.save('atari800_artifacting', system.config['atari800_artifacting'])
+            else:
+                coreSettings.save('atari800_artifacting', '"disabled"')
+            # Internal resolution
+            if system.isOptSet('atari800_resolution'):
+                coreSettings.save('atari800_resolution', system.config['atari800_resolution'])
+            else:
+                coreSettings.save('atari800_resolution', '"336x240"')
+            
+            # WARNING: Now we must stop to use "atari800.cfg" because core options crush them
 
-    # Colecovision and MSX
+        else:
+            # Select Atari 5200
+            coreSettings.save('atari800_system', '"5200"')
+            # Joy Hack (for robotron)
+            if system.isOptSet('atari800_opt2'):
+                coreSettings.save('atari800_opt2', system.config['atari800_opt2'])
+            else:
+                coreSettings.save('atari800_opt2', '"disabled"')
+
+    # Atari Jaguar
+    if (system.config['core'] == 'virtualjaguar'):
+        # Fast Blitter (Older, Faster, Less compatible)
+        if system.isOptSet('usefastblitter'):
+            coreSettings.save('virtualjaguar_usefastblitter', system.config['usefastblitter'])
+        else:
+            coreSettings.save('virtualjaguar_usefastblitter', '"enabled"')
+        # Show Bios Bootlogo
+        if system.isOptSet('bios_vj'):
+            coreSettings.save('virtualjaguar_bios', system.config['bios_vj'])
+        else:
+            coreSettings.save('virtualjaguar_bios', '"enabled"')
+        # Doom Res Hack
+        if system.isOptSet('doom_res_hack'):
+            coreSettings.save('virtualjaguar_doom_res_hack', system.config['doom_res_hack'])
+        else:
+            coreSettings.save('virtualjaguar_doom_res_hack', '"disabled"')
+
+    # Atari Lynx
+    if (system.config['core'] == 'handy'):
+        # Display rotation
+        # Set this option to start game at 'None' because it crash the emulator
+        coreSettings.save('handy_rot', '"None"')
+
+    # Commodore 64
+    if (system.config['core'] == 'vice_x64'):
+        
+        # Activate Jiffydos
+        coreSettings.save('vice_jiffydos',          '"enabled"')
+        # Enable Datasette Hotkeys
+        coreSettings.save('vice_datasette_hotkeys', '"enabled"')
+        # Not Read 'vicerc'
+        coreSettings.save('vice_read_vicerc',       '"disabled"')
+        # Makes [2nd Fire] press [Up]
+        coreSettings.save('vice_retropad_options',  '"jump"')
+        # Select Joystick Type
+        coreSettings.save('vice_Controller',        '"joystick"')
+        # Aspect Ratio
+        if system.isOptSet('aspect_ratio'):
+            coreSettings.save('vice_aspect_ratio', system.config['aspect_ratio'])
+        else:
+            coreSettings.save('vice_aspect_ratio', '"pal"')
+        # Zoom Mode
+        if system.isOptSet('zoom_mode_c64'):
+            coreSettings.save('vice_zoom_mode', system.config['zoom_mode_c64'])
+        else:
+            coreSettings.save('vice_zoom_mode', '"medium"')
+        # External palette
+        if system.isOptSet('external_palette'):
+            coreSettings.save('vice_external_palette', system.config['external_palette'])
+        else:
+            coreSettings.save('vice_external_palette', '"colodore"')
+        # Select Joystick Port
+        if system.isOptSet('JoyPort'):
+            coreSettings.save('vice_JoyPort', '"' + system.config['JoyPort'] + '"')
+        else:
+            coreSettings.save('vice_JoyPort', '"port 1"')
+        # Keyboard Pass-through for Pad2Key
+        if system.isOptSet('keyboard_pass_through'):
+            coreSettings.save('vice_physical_keyboard_pass_through', system.config['keyboard_pass_through'])
+        else:
+            coreSettings.save('vice_physical_keyboard_pass_through', '"disabled"')
+            
+    # Commodore AMIGA
+    if (system.config['core'] == 'puae'):
+        # Show Video Options
+        coreSettings.save('puae_video_options_display ', '"enabled"')
+        # Video Resolution
+        if system.isOptSet('video_resolution'):
+            coreSettings.save('puae_video_resolution', system.config['video_resolution'])
+        else:
+            coreSettings.save('puae_video_resolution', '"auto"')
+        # Zoom Mode    
+        if system.isOptSet('zoom_mode'):
+            coreSettings.save('puae_zoom_mode', system.config['zoom_mode'])
+        else:
+            coreSettings.save('puae_zoom_mode', '"auto"')
+        # Standard Video    
+        if system.isOptSet('video_standard'):
+            coreSettings.save('puae_video_standard', system.config['video_standard'])
+        else:
+            coreSettings.save('puae_video_standard', '"PAL"')
+        # 2P Gamepad Mapping (Keyrah)
+        if system.isOptSet('keyrah_mapping'):
+            coreSettings.save('puae_keyrah_keypad_mappings', system.config['keyrah_mapping'])
+        else:
+            coreSettings.save('puae_keyrah_keypad_mappings', '"enabled"')
+        # Mouse Speed    
+        if system.isOptSet('mouse_speed'):
+            coreSettings.save('puae_mouse_speed', system.config['mouse_speed'])
+        else:
+            coreSettings.save('puae_mouse_speed', '"200"')
+        # Whdload Launcher
+        if system.isOptSet('whdload'):
+            coreSettings.save('puae_use_whdload_prefs', system.config['whdload'])
+        else:
+            coreSettings.save('puae_use_whdload_prefs', '"config"')
+        # Jump on B
+        if system.isOptSet('pad_options'):
+            coreSettings.save('puae_retropad_options', system.config['pad_options'])
+        else:
+            coreSettings.save('puae_retropad_options', '"jump"')
+        # Disable Emulator Joystick for Pad2Key
+        if system.isOptSet('disable_joystick'):
+            coreSettings.save('puae_physical_keyboard_pass_through', system.config['disable_joystick'])
+        else:
+            coreSettings.save('puae_physical_keyboard_pass_through', '"disabled"')
+        # Frameskip
+        if system.isOptSet('gfx_framerate'):
+            coreSettings.save('puae_gfx_framerate', system.config['gfx_framerate'])
+        else:
+            coreSettings.save('puae_gfx_framerate', '"disabled"')
+    
+    # Magnavox - Odyssey2 / Phillips Videopac+
+    if (system.config['core'] == 'o2em'):
+        # Virtual keyboard transparency
+        coreSettings.save('o2em_vkb_transparency ', '"20%"')
+    
+    # MAME 2003+
+    if (system.config['core'] == 'mame078plus'):
+        # Skip Disclaimer and Warnings
+        coreSettings.save('mame2003-plus_skip_disclaimer', '"enabled"')
+        coreSettings.save('mame2003-plus_skip_warnings',   '"enabled"')
+        # Control Mapping
+        if system.isOptSet('mame2003-plus_analog'):
+            coreSettings.save('mame2003-plus_analog', system.config['mame2003-plus_analog'])
+        else:
+            coreSettings.save('mame2003-plus_analog', '"digital"')
+        # Frameskip
+        if system.isOptSet('mame2003-plus_frameskip'):
+            coreSettings.save('mame2003-plus_frameskip', system.config['mame2003-plus_frameskip'])
+        else:
+            coreSettings.save('mame2003-plus_frameskip', '"0"')
+        # Input interface
+        if system.isOptSet('mame2003-plus_input_interface'):
+            coreSettings.save('mame2003-plus_input_interface', system.config['mame2003-plus_input_interface'])
+        else:
+            coreSettings.save('mame2003-plus_input_interface', '"retropad"')
+        # TATE Mode
+        if system.isOptSet('mame2003-plus_tate_mode'):
+            coreSettings.save('mame2003-plus_tate_mode', system.config['mame2003-plus_tate_mode'])
+        else:
+            coreSettings.save('mame2003-plus_tate_mode', '"disabled"')
+        # NEOGEO Bios
+        if system.isOptSet('mame2003-plus_neogeo_bios'):
+            coreSettings.save('mame2003-plus_neogeo_bios', system.config['mame2003-plus_neogeo_bios'])
+        else:
+            coreSettings.save('mame2003-plus_neogeo_bios', '"unibios33"')
+
+    # MAME 2010
+    if (system.config['core'] == 'mame0139'):
+        # Skip Gameinfo / Nagscreen / Disclamers
+        coreSettings.save('mame_current_skip_gameinfo',    '"enabled"')
+        coreSettings.save('mame_current_skip_nagscreen',   '"enabled"')
+        coreSettings.save('mame_current_skip_warnings',    '"enabled"')
+        # Frameskip
+        if system.isOptSet('mame_current_frame_skip'):
+            coreSettings.save('mame_current_frame_skip', system.config['mame_current_frame_skip'])
+        else:
+            coreSettings.save('mame_current_frame_skip', '"0"')
+        # Enable autofire
+        if system.isOptSet('mame_current_turbo_button'):
+            coreSettings.save('mame_current_turbo_button', '"' + system.config['mame_current_turbo_button'] + '"')
+        else:
+            coreSettings.save('mame_current_turbo_button', '"disabled"')
+        # Set autofire pulse speed
+        if system.isOptSet('mame_current_turbo_delay'):
+            coreSettings.save('mame_current_turbo_delay', system.config['mame_current_turbo_delay'])
+        else:
+            coreSettings.save('mame_current_turbo_delay', '"medium"')
+
+    # TODO: Add CORE options for MAME / iMame4all and HbMame
+
+    # MB Vectrex 
+    if (system.config['core'] == 'vecx'):
+        # Res Multiplier
+        if system.isOptSet('res_multi'):
+            coreSettings.save('vecx_res_multi', system.config['res_multi'])
+        else:
+            coreSettings.save('vecx_res_multi', '"1"')
+
+    # Microsoft DOS
+    if (system.config['core'] == 'dosbox'):
+        # Active PC Speaker
+        coreSettings.save('dosbox_svn_pcspeaker', '"true"')
+        # Show Advenced Options
+        coreSettings.save('dosbox_svn_adv_options', '"true"')
+        # CPU Cycles Auto (must use 'bat' files for specific games)
+        coreSettings.save('dosbox_svn_cpu_cycles_mode', '"auto"')
+        # Timing Mode (FPS)
+        if system.isOptSet('core_timing'):
+            coreSettings.save('dosbox_svn_core_timing', system.config['core_timing'])
+        else:
+            coreSettings.save('dosbox_svn_core_timing', '"external"')
+        # Video Filter
+        if system.isOptSet('filter'):
+            coreSettings.save('dosbox_svn_scaler', system.config['filter'])
+        else:
+            coreSettings.save('dosbox_svn_scaler', '"none"')
+
+    # Microsoft MSX and Colecovision
     if (system.config['core'] == 'bluemsx'):
-        coreSettings.save('bluemsx_overscan', '"enabled"')
+        # Auto Select Core
         if (system.name == 'colecovision'):
             coreSettings.save('bluemsx_msxtype', '"ColecoVision"')
         elif (system.name == 'msx1'):
@@ -44,111 +291,175 @@ def generateCoreSettings(retroarchCore, system):
             coreSettings.save('bluemsx_msxtype', '"MSX2+"')
         elif (system.name == 'msxturbor'):
             coreSettings.save('bluemsx_msxtype', '"MSXturboR"')
+        # Forces cropping of overscanned frames
+        if system.name == 'colecovision' or system.name == 'msx1':
+            coreSettings.save('bluemsx_overscan', '"enabled"')
+        else:
+            coreSettings.save('bluemsx_overscan', '"MSX2"')
+        # Reduce Sprite Flickering
+        if system.isOptSet('bluemsx_nospritelimits') and system.config['bluemsx_nospritelimits'] == "False":
+            coreSettings.save('bluemsx_nospritelimits', '"OFF"')
+        else:
+            coreSettings.save('bluemsx_nospritelimits', '"ON"')
 
+    # Nec PC Engine / CD
+    if system.config['core'] == 'pce_fast':
+        # Remove 16-sprites-per-scanline hardware limit
+        if system.isOptSet('pce_nospritelimit'):
+            coreSettings.save('pce_nospritelimit', system.config['pce_nospritelimit'])
+        else:
+            coreSettings.save('pce_nospritelimit', '"enabled"')
+
+    # Nec PC-8800
+    if system.config['core'] == 'quasi88':
+        # PC Model
+        if system.isOptSet('q88_basic_mode'):
+            coreSettings.save('q88_basic_mode', '"' + system.config['q88_basic_mode'] + '"')
+        else:
+            coreSettings.save('q88_basic_mode', '"N88 V2"')
+        # CPU clock (Overclock)
+        if system.isOptSet('q88_cpu_clock'):
+            coreSettings.save('q88_cpu_clock', '"' + system.config['q88_cpu_clock'] + '"')
+        else:
+            coreSettings.save('q88_cpu_clock', '"4"')
+        # Use PCG-8100
+        if system.isOptSet('q88_pcg-8100'):
+            coreSettings.save('q88_pcg-8100', system.config['q88_pcg-8100'])
+        else:
+            coreSettings.save('q88_pcg-8100', '"disabled"')
+    
+    # Nec PC-9800
+    # https://github.com/AZO234/NP2kai/blob/6e8f651a72c2ece37cc52e17cdaf4fdb87a6b2f9/sdl/libretro/libretro_core_options.h
+    if system.config['core'] == 'np2kai':
+        # Use the American keyboard
+        coreSettings.save('np2kai_keyboard', '"Us"')
+        # Fast memcheck at startup
+        coreSettings.save('np2kai_FastMC', '"ON"')
+        # Sound Generator: Use "fmgen" for enhanced sound rendering, not "Default"
+        #coreSettings.save('np2kai_usefmgen', '"fmgen"')
+        # PC Model
+        if system.isOptSet('np2kai_model'):
+            coreSettings.save('np2kai_model', '"' + system.config['np2kai_model'] + '"')
+        else:
+            coreSettings.save('np2kai_model', '"PC-9801VX"')
+        # CPU Feature
+        if system.isOptSet('np2kai_cpu_feature'):
+            coreSettings.save('np2kai_cpu_feature', '"' + system.config['np2kai_cpu_feature'] + '"')
+        else:
+            coreSettings.save('np2kai_cpu_feature', '"Intel 80386"')
+        # CPU Clock Multiplier
+        if system.isOptSet('np2kai_clk_mult'):
+            coreSettings.save('np2kai_clk_mult', '"' + system.config['np2kai_clk_mult'] + '"')
+        else:
+            coreSettings.save('np2kai_clk_mult', '"4"')
+        # RAM Size
+        if system.isOptSet('np2kai_ExMemory'):
+            coreSettings.save('np2kai_ExMemory', '"' + system.config['np2kai_ExMemory'] + '"')
+        else:
+            coreSettings.save('np2kai_ExMemory', '"3"')
+        # GDC
+        if system.isOptSet('np2kai_gdc'):
+            coreSettings.save('np2kai_gdc', '"' + system.config['np2kai_gdc'] + '"')
+        else:
+            coreSettings.save('np2kai_gdc', '"uPD7220"')
+        # Remove Scanlines (255 lines)
+        if system.isOptSet('np2kai_skipline') and system.config['np2kai_skipline'] != "Full 255 lines":
+            if system.config['np2kai_skipline'] == "True":
+                coreSettings.save('np2kai_skipline', '"ON"')
+            else:
+                coreSettings.save('np2kai_skipline', '"OFF"')
+        else:
+            coreSettings.save('np2kai_skipline', '"Full 255 lines"')
+        # Real Palettes
+        if system.isOptSet('np2kai_realpal') and system.config['np2kai_realpal'] == "True":
+            coreSettings.save('np2kai_realpal', '"ON"')
+        else:
+            coreSettings.save('np2kai_realpal', '"OFF"')
+        # Sound Board
+        if system.isOptSet('np2kai_SNDboard'):
+            coreSettings.save('np2kai_SNDboard', '"' + system.config['np2kai_SNDboard'] + '"')
+        else:
+            coreSettings.save('np2kai_SNDboard', '"PC9801-26K + 86"')
+        # JAST SOUND
+        if system.isOptSet('np2kai_jast_snd') and system.config['np2kai_jast_snd'] == "True":
+            coreSettings.save('np2kai_jast_snd', '"ON"')
+        else:
+            coreSettings.save('np2kai_jast_snd', '"OFF"')
+        # Joypad to Keyboard Mapping
+        if system.isOptSet('np2kai_joymode'):
+            coreSettings.save('np2kai_joymode', '"' + system.config['np2kai_joymode'] + '"')
+        else:
+            coreSettings.save('np2kai_joymode', '"Arrows"')
+    
+    # Nec PC Engine SuperGrafx
+    if (system.config['core'] == 'mednafen_supergrafx'):
+        # Remove 16-sprites-per-scanline hardware limit
+        if system.isOptSet('sgx_nospritelimit'):
+            coreSettings.save('sgx_nospritelimit', system.config['sgx_nospritelimit'])
+        else:
+            coreSettings.save('sgx_nospritelimit', '"enabled"')
+        
+    # Nec PC-FX
+    if (system.config['core'] == 'pcfx'):
+        # Remove 16-sprites-per-scanline hardware limit
+        if system.isOptSet('pcfx_nospritelimit'):
+            coreSettings.save('pcfx_nospritelimit', system.config['pcfx_nospritelimit'])
+        else:
+            coreSettings.save('pcfx_nospritelimit', '"enabled"')
+
+    # Nintendo 3DS
     if (system.config['core'] == 'citra'):
+        # TODO: Add CORE Options for 3DS
+        # Set OpenGL rendering
         if not os.path.exists(batoceraFiles.CONF + "/retroarch/3ds.cfg"):
             f = open(batoceraFiles.CONF + "/retroarch/3ds.cfg", "w")
             f.write("video_driver = \"glcore\"\n")
             f.close()
 
-    if (system.config['core'] == 'tgbdual'):
-        coreSettings.save('tgbdual_audio_output',       '"Game Boy #1"')
-        coreSettings.save('tgbdual_gblink_enable',      '"enabled"')
-        coreSettings.save('tgbdual_screen_placement',   '"left-right"')
-        coreSettings.save('tgbdual_single_screen_mp',   '"both players"')
-        coreSettings.save('tgbdual_switch_screens',     '"normal"')
-
-    if (system.config['core'] == 'gambatte'):
-        if 'colorization' in system.renderconfig and system.renderconfig['colorization'] != None:
-            coreSettings.save('gambatte_gb_colorization',     '"internal"')
-            coreSettings.save('gambatte_gb_internal_palette', '"' + system.renderconfig['colorization'] + '"')
-        else:
-            coreSettings.save('gambatte_gb_colorization',     '"disabled"')
-
-    if (system.config['core'] == 'desmume'):
-        coreSettings.save('desmume_pointer_device_r',   '"emulated"')
-        # multisampling aa
-        if system.isOptSet('multisampling'):
-            coreSettings.save('desmume_gfx_multisampling', system.config['multisampling'])
-        else:
-            coreSettings.save('desmume_gfx_multisampling', '"disabled"')
-        # texture smoothing
-        if system.isOptSet('texture_smoothing'):
-            coreSettings.save('desmume_gfx_texture_smoothing', system.config['texture_smoothing'])
-        else:
-            coreSettings.save('desmume_gfx_texture_smoothing', '"disabled"')
-        # texture scaling (xBrz)
-        if system.isOptSet('texture_scaling'):
-            coreSettings.save('desmume_gfx_texture_scaling', system.config['texture_scaling'])
-        else:
-            coreSettings.save('desmume_gfx_texture_scaling', '"1"')
-
-    if (system.config['core'] == 'mame078'):
-        coreSettings.save('mame2003_skip_disclaimer',   '"enabled"')
-        coreSettings.save('mame2003_skip_warnings',     '"enabled"')
-
-    if (system.config['core'] == 'mame078plus'):
-        coreSettings.save('mame2003-plus_skip_disclaimer',  '"enabled"')
-        coreSettings.save('mame2003-plus_skip_warnings',    '"enabled"')
-        coreSettings.save('mame2003-plus_analog',           '"digital"')
-
-    if (system.config['core'] == 'puae'):
-        coreSettings.save('puae_video_options_display ',    '"enabled"')
-        # video resolution
-        if system.isOptSet('video_resolution'):
-            coreSettings.save('puae_video_resolution', system.config['video_resolution'])
-        else:
-            coreSettings.save('puae_video_resolution', '"auto"')
-        # zoom mode	
-        if system.isOptSet('zoom_mode'):
-            coreSettings.save('puae_zoom_mode', system.config['zoom_mode'])
-        else:
-            coreSettings.save('puae_zoom_mode', '"auto"')
-        # standard video	
-        if system.isOptSet('video_standard'):
-            coreSettings.save('puae_video_standard', system.config['video_standard'])
-        else:
-            coreSettings.save('puae_video_standard', '"PAL"')
-        # keypad mapping 2p	
-        if system.isOptSet('keyrah_mapping'):
-            coreSettings.save('puae_keyrah_keypad_mappings', system.config['keyrah_mapping'])
-        else:
-            coreSettings.save('puae_keyrah_keypad_mappings', '"enabled"')
-        # mouse speed	
-        if system.isOptSet('mouse_speed'):
-            coreSettings.save('puae_mouse_speed', system.config['mouse_speed'])
-        else:
-            coreSettings.save('puae_mouse_speed', '"200"')
-        # whdload	
-        if system.isOptSet('whdload'):
-            coreSettings.save('puae_use_whdload_prefs', system.config['whdload'])
-        else:
-            coreSettings.save('puae_use_whdload_prefs', '"config"')
-        # retropad options	
-        if system.isOptSet('pad_options'):
-            coreSettings.save('puae_retropad_options', system.config['pad_options'])
-        else:
-            coreSettings.save('puae_retropad_options', '"jump"')
-
-    if (system.config['core'] == 'pce'):
-        coreSettings.save('pce_keepaspect', '"enabled"')
-        coreSettings.save('pce_nospritelimit', '"enabled"')
-
-    if (system.config['core'] == 'pce_fast'):
-        coreSettings.save('pce_keepaspect', '"enabled"')
-
+    # Nintendo 64
     if (system.config['core'] == 'mupen64plus-next'):
-        # BilinearMode
+        # Threaded Rendering
+        coreSettings.save('mupen64plus-ThreadedRenderer', '"True"')
+        # Use High-Res Textures Pack
+        # .htc files must be placed in 'Mupen64plus/cache'
+        coreSettings.save('mupen64plus-txHiresEnable', '"True"')
+        # Video 4:3 Resolution
+        if system.isOptSet('43screensize'):
+            coreSettings.save('mupen64plus-43screensize', system.config['43screensize'])
+        else:
+            coreSettings.save('mupen64plus-43screensize', '"320x240"')
+        # Video 16:9 Resolution
+        if system.isOptSet('169screensize'):
+            coreSettings.save('mupen64plus-169screensize', system.config['169screensize'])
+        else:
+            coreSettings.save('mupen64plus-169screensize', '"640x360"')
+        # Widescreen Hack
+        if system.isOptSet('aspect'):
+            coreSettings.save('mupen64plus-aspect', '"' + system.config['aspect'] + '"')
+            #if (system.config['aspect'] != '4:3'):
+                # Auto Config System
+                # TODO: Update this trick with a beter solution
+                #system.save('ratio', '16/9')
+                #system.save('bezel', 'none')
+                
+                #retroarchConfig['aspect_ratio_index'] = '"16/9"')
+                #retroarchConfig['video_aspect_ratio_auto'] = 'false'
+                #retroarchConfig['input_overlay_enable'] = "false"
+                #retroarchConfig['video_message_pos_x']  = 0.05
+                #retroarchConfig['video_message_pos_y']  = 0.05
+        else:
+            coreSettings.save('mupen64plus-aspect', '"4:3"')
+        # Bilinear Filtering
         if system.isOptSet('BilinearMode'):
             coreSettings.save('mupen64plus-BilinearMode', system.config['BilinearMode'])
         else:
             coreSettings.save('mupen64plus-BilinearMode', '"standard"')
-        # multisampling aa
+        # Anti-aliasing (MSA)
         if system.isOptSet('MultiSampling'):
             coreSettings.save('mupen64plus-MultiSampling', system.config['MultiSampling'])
         else:
             coreSettings.save('mupen64plus-MultiSampling', '"0"')
-        # Texture filter
+        # Texture Filtering
         if system.isOptSet('Texture_filter'):
             coreSettings.save('mupen64plus-txFilterMode', '"' + system.config['Texture_filter'] + '"')
         else:
@@ -159,188 +470,837 @@ def generateCoreSettings(retroarchCore, system):
         else:
             coreSettings.save('mupen64plus-txEnhancementMode', '"None"')
 
+    if (system.config['core'] == 'parallel_n64'):
+        # Video Resolution
+        if system.isOptSet('screensize'):
+            coreSettings.save('parallel-n64-screensize', system.config['screensize'])
+        else:
+            coreSettings.save('parallel-n64-screensize', '"320x240"')
+        # Texture Filtering
+        if system.isOptSet('filtering'):
+            coreSettings.save('parallel-n64-filtering', system.config['filtering'])
+        else:
+            coreSettings.save('parallel-n64-filtering', '"automatic"')
+
+    # Nintendo DS
+    if (system.config['core'] == 'desmume'):
+        # Emulate Stylus on Right Stick
+        coreSettings.save('desmume_pointer_device_r', '"emulated"')
+        # Internal Resolution
+        if system.isOptSet('internal_resolution_desmume'):
+            coreSettings.save('desmume_internal_resolution', system.config['internal_resolution_desmume'])
+        else:
+            coreSettings.save('desmume_internal_resolution', '"256x192"')
+        # Anti-aliasing (MSAA)
+        if system.isOptSet('multisampling'):
+            coreSettings.save('desmume_gfx_multisampling', system.config['multisampling'])
+        else:
+            coreSettings.save('desmume_gfx_multisampling', '"disabled"')
+        # Texture Smoothing
+        if system.isOptSet('texture_smoothing'):
+            coreSettings.save('desmume_gfx_texture_smoothing', system.config['texture_smoothing'])
+        else:
+            coreSettings.save('desmume_gfx_texture_smoothing', '"disabled"')
+        # Textures Upscaling (XBRZ)
+        if system.isOptSet('texture_scaling'):
+            coreSettings.save('desmume_gfx_texture_scaling', system.config['texture_scaling'])
+        else:
+            coreSettings.save('desmume_gfx_texture_scaling', '"1"')
+        # Frame Skip
+        if system.isOptSet('frameskip_desmume'):
+            coreSettings.save('desmume_frameskip', system.config['frameskip_desmume'])
+        else:
+            coreSettings.save('desmume_frameskip', '"0"')
+        # Screen Layout
+        if system.isOptSet('screens_layout'):
+            coreSettings.save('desmume_screens_layout', '"' + system.config['screens_layout'] + '"')
+        else:
+            coreSettings.save('desmume_screens_layout', '"top/bottom"')
+
+    # Nintendo Gameboy (Dual Screen) / GB Color (Dual Screen) 
+    if (system.config['core'] == 'tgbdual'):
+        # Emulates two Game Boy units
+        coreSettings.save('tgbdual_gblink_enable',    '"enabled"')
+        # Displays the selected player screens
+        coreSettings.save('tgbdual_single_screen_mp', '"both players"')
+        # Switches the screen layout
+        coreSettings.save('tgbdual_screen_placement', '"left-right"')
+        # Switch Game Boy sound
+        coreSettings.save('tgbdual_audio_output',     '"Game Boy #1"')
+        # Switches the player screens
+        coreSettings.save('tgbdual_switch_screens',   '"normal"')
+
+    # Nintendo Gameboy / GB Color / GB Advance
+    if (system.config['core'] == 'gambatte'):
+        # GB / GBC: Use official Bootlogo
+        if system.isOptSet('gb_bootloader'):
+            coreSettings.save('gambatte_gb_bootloader', system.config['gb_bootloader'])
+        else:
+            coreSettings.save('gambatte_gb_bootloader', '"enabled"')
+        # GB: Colorisation of GB games
+        # TODO: Update to use new "es_features" system
+        if 'colorization' in system.renderconfig and system.renderconfig['colorization'] != None:
+            coreSettings.save('gambatte_gb_colorization',     '"internal"')
+            coreSettings.save('gambatte_gb_internal_palette', '"' + system.renderconfig['colorization'] + '"')
+        else:
+            coreSettings.save('gambatte_gb_colorization',     '"disabled"')
+        # GB / GBC: Interframe Blending (LCD ghosting effects)
+        if system.isOptSet('mix_frames'):
+            coreSettings.save('gambatte_mix_frames', system.config['mix_frames'])
+        else:
+            coreSettings.save('gambatte_mix_frames', '"disabled"')
+
+    if (system.config['core'] == 'mgba'):
+        # Skip BIOS intro
+        if system.isOptSet('skip_bios_mgba') and system.config['skip_bios_mgba'] == "True":
+            coreSettings.save('mgba_skip_bios', '"ON"')
+        else:
+            coreSettings.save('mgba_skip_bios', '"OFF"')
+        
+        # GB / GBC: Use Super Game Boy borders
+        if system.isOptSet('sgb_borders') and system.config['sgb_borders'] == "True":
+            coreSettings.save('mgba_sgb_borders', '"ON"')
+            # TODO: Maybe autoswitch on a good FULLSCREEN BEZEL
+        else:
+            coreSettings.save('mgba_sgb_borders', '"OFF"')
+        # GB / GBC: Color Correction
+        if system.isOptSet('color_correction') and system.config['color_correction'] != "False":
+            coreSettings.save('mgba_color_correction', system.config['color_correction'])
+        else:
+            coreSettings.save('mgba_color_correction', '"OFF"')
+        
+        # GBA: Solar sensor level, Boktai 1: The Sun is in Your Hand
+        if system.isOptSet('solar_sensor_level'):
+            coreSettings.save('mgba_solar_sensor_level', system.config['solar_sensor_level'])
+        else:
+            coreSettings.save('mgba_solar_sensor_level', '"0"')
+        # GBA: Frameskip
+        if system.isOptSet('frameskip_mgba'):
+            coreSettings.save('mgba_frameskip', system.config['frameskip_mgba'])
+        else:
+            coreSettings.save('mgba_frameskip', '"0"')
+
+    if (system.config['core'] == 'vba-m'):
+        # GB / GBC / GBA: Auto select fine hardware mode
+        # Emulator AUTO mode not working fine
+        if system.name == 'gb':
+            coreSettings.save('vbam_gbHardware', '"gb"')
+        elif system.name == 'gbc':
+            coreSettings.save('vbam_gbHardware', '"gbc"')
+        else:
+            coreSettings.save('vbam_gbHardware', '"gba"')
+
+        # GB: Colorisation of GB games
+        if system.isOptSet('palettes'):
+            coreSettings.save('vbam_palettes', '"' + system.config['palettes'] + '"')
+        else:
+            coreSettings.save('vbam_palettes', '"black and white"')
+        # GB / GBC: Use Super Game Boy borders
+        # TODO: Maybe autoswitch on a good FULLSCREEN BEZEL
+        if system.isOptSet('showborders_gb') and system.name == 'gb':
+            coreSettings.save('vbam_showborders', system.config['showborders_gb'])
+            # Force SGB mode, "sgb2" is same
+            coreSettings.save('vbam_gbHardware', '"sgb"')
+        elif system.isOptSet('showborders_gbc') and system.name == 'gbc':
+            coreSettings.save('vbam_showborders', system.config['showborders_gbc'])
+            # Force SGB mode, "sgb2" is same
+            coreSettings.save('vbam_gbHardware', '"sgb"')
+        else:
+            coreSettings.save('vbam_showborders', '"disabled"')
+        # GB / GBC: Color Correction
+        if system.isOptSet('gbcoloroption_gb') and system.name == 'gb':
+            coreSettings.save('vbam_gbcoloroption', system.config['gbcoloroption_gb'])
+        elif system.isOptSet('gbcoloroption_gbc') and system.name == 'gbc':
+            coreSettings.save('vbam_gbcoloroption', system.config['gbcoloroption_gbc'])
+        else:
+            coreSettings.save('vbam_gbcoloroption', '"disabled"')
+
+        # GBA: Solar sensor level, Boktai 1: The Sun is in Your Hand
+        if system.isOptSet('solarsensor'):
+            coreSettings.save('vbam_solarsensor', system.config['solarsensor'])
+        else:
+            coreSettings.save('vbam_solarsensor', '"0"')
+        # GBA: Sensor Sensitivity (Gyroscope) (%)
+        if system.isOptSet('gyro_sensitivity'):
+            coreSettings.save('vbam_gyro_sensitivity', system.config['gyro_sensitivity'])
+        else:
+            coreSettings.save('vbam_gyro_sensitivity', '"10"')
+        # GBA: Sensor Sensitivity (Tilt) (%)
+        if system.isOptSet('tilt_sensitivity'):
+            coreSettings.save('vbam_tilt_sensitivity', system.config['tilt_sensitivity'])
+        else:
+            coreSettings.save('vbam_tilt_sensitivity', '"10"')
+
+    # Nintendo NES / Famicom Disk System
+    if (system.config['core'] == 'nestopia'):
+        # Reduce Sprite Flickering
+        if system.isOptSet('nestopia_nospritelimit') and system.config['nestopia_nospritelimit'] == "disabled":
+            coreSettings.save('nestopia_nospritelimit', '"disabled"')
+            coreSettings.save('nestopia_overscan_h', '"disabled"')
+            coreSettings.save('nestopia_overscan_v', '"disabled"')
+        else:
+            coreSettings.save('fceumm_nospritelimit', '"enabled"')
+            coreSettings.save('nestopia_overscan_h', '"enabled"')
+            coreSettings.save('nestopia_overscan_v', '"enabled"')
+        # Palette Choice
+        if system.isOptSet('nestopia_palette'):
+            coreSettings.save('nestopia_palette', system.config['nestopia_palette'])
+        else:
+            coreSettings.save('nestopia_palette', '"consumer"')
+        # NTSC Filter
+        if system.isOptSet('nestopia_blargg_ntsc_filter'):
+            coreSettings.save('nestopia_blargg_ntsc_filter', system.config['nestopia_blargg_ntsc_filter'])
+        else:
+            coreSettings.save('nestopia_blargg_ntsc_filter', '"disabled"')
+        # CPU Overclock
+        if system.isOptSet('nestopia_overclock'):
+            coreSettings.save('nestopia_overclock', system.config['nestopia_overclock'])
+        else:
+            coreSettings.save('nestopia_overclock', '"1x"')
+        # 4 Player Adapter
+        if system.isOptSet('nestopia_select_adapter'):
+            coreSettings.save('nestopia_select_adapter', system.config['nestopia_select_adapter'])
+        else:
+            coreSettings.save('nestopia_select_adapter', '"auto"')
+
+    if (system.config['core'] == 'fceumm'):
+        # Reduce Sprite Flickering
+        if system.isOptSet('fceumm_nospritelimit') and system.config['fceumm_nospritelimit'] == "disabled":
+            coreSettings.save('fceumm_nospritelimit', '"disabled"')
+            coreSettings.save('fceumm_overscan_h', '"disabled"')
+            coreSettings.save('fceumm_overscan_v', '"disabled"')
+        else:
+            coreSettings.save('fceumm_nospritelimit', '"enabled"')
+            coreSettings.save('fceumm_overscan_h', '"enabled"')
+            coreSettings.save('fceumm_overscan_v', '"enabled"')
+        # Palette Choice
+        if system.isOptSet('fceumm_palette'):
+            coreSettings.save('fceumm_palette', system.config['fceumm_palette'])
+        else:
+            coreSettings.save('fceumm_palette', '"default"')
+        # NTSC Filter
+        if system.isOptSet('fceumm_ntsc_filter'):
+            coreSettings.save('fceumm_ntsc_filter', system.config['fceumm_ntsc_filter'])
+        else:
+            coreSettings.save('fceumm_ntsc_filter', '"disabled"')
+        # Sound Quality
+        if system.isOptSet('fceumm_sndquality'):
+            coreSettings.save('fceumm_sndquality', '"' + system.config['fceumm_sndquality'] + '"')
+        else:
+            coreSettings.save('fceumm_sndquality', '"Low"')
+        # PPU Overclocking
+        if system.isOptSet('fceumm_overclocking'):
+            coreSettings.save('fceumm_overclocking', system.config['fceumm_overclocking'])
+        else:
+            coreSettings.save('fceumm_overclocking', '"disabled"')
+
+    # Nintendo Pokemon Mini
+    if (system.config['core'] == 'pokemini'):
+        # LCD Filter
+        if system.isOptSet('pokemini_lcdfilter'):
+            coreSettings.save('pokemini_lcdfilter', system.config['pokemini_lcdfilter'])
+        else:
+            coreSettings.save('pokemini_lcdfilter', '"dotmatrix"')
+        # LCD Ghosting Effects
+        if system.isOptSet('pokemini_lcdmode'):
+            coreSettings.save('pokemini_lcdmode', system.config['pokemini_lcdmode'])
+        else:
+            coreSettings.save('pokemini_lcdmode', '"analog"')
+
+    # Nintendo SNES
+    if (system.config['core'] == 'snes9x'):
+        # Reduce sprite flickering (Hack, Unsafe)
+        if system.isOptSet('reduce_sprite_flicker'):
+            coreSettings.save('snes9x_reduce_sprite_flicker', system.config['reduce_sprite_flicker'])
+        else:
+            coreSettings.save('snes9x_reduce_sprite_flicker', '"enabled"')
+        # Reduce Slowdown (Hack, Unsafe)
+        if system.isOptSet('reduce_slowdown'):
+            coreSettings.save('snes9x_overclock_cycles', system.config['reduce_slowdown'])
+        else:
+            coreSettings.save('snes9x_overclock_cycles', '"disabled"')
+        # SuperFX Overclocking
+        if system.isOptSet('overclock_superfx'):
+            coreSettings.save('snes9x_overclock_superfx', system.config['overclock_superfx'])
+        else:
+            coreSettings.save('snes9x_overclock_superfx', '"100%"')
+        # Hi-Res Blending
+        if system.isOptSet('hires_blend'):
+            coreSettings.save('snes9x_hires_blend', system.config['hires_blend'])
+        else:
+            coreSettings.save('snes9x_hires_blend', '"disabled"')
+            
+    if (system.config['core'] == 'snes9x_next'):
+        # Reduce sprite flickering (Hack, Unsafe)
+        if system.isOptSet('2010_reduce_sprite_flicker'):
+            coreSettings.save('snes9x_2010_reduce_sprite_flicker', system.config['2010_reduce_sprite_flicker'])
+        else:
+            coreSettings.save('snes9x_2010_reduce_sprite_flicker', '"enabled"')
+        # Reduce Slowdown (Hack, Unsafe)
+        if system.isOptSet('2010_reduce_slowdown'):
+            coreSettings.save('snes9x_2010_overclock_cycles', system.config['2010_reduce_slowdown'])
+        else:
+            coreSettings.save('snes9x_2010_overclock_cycles', '"disabled"')
+        # SuperFX Overclocking
+        if system.isOptSet('2010_overclock_superfx'):
+            coreSettings.save('snes9x_2010_overclock', '"' + system.config['2010_overclock_superfx'] + '"')
+        else:
+            coreSettings.save('snes9x_2010_overclock', '"10 MHz (Default)"')
+
+    # TODO: Add CORE options for BSnes on PC
+    
+    # Nintendo Virtual Boy
     if (system.config['core'] == 'vb'):
-        # 2D color mode
+        # 2D Color Mode
         if system.isOptSet('2d_color_mode'):
             coreSettings.save('vb_color_mode', '"' + system.config['2d_color_mode'] + '"')
         else:
             coreSettings.save('vb_color_mode', '"black & red"')
-        # 3D color mode
+        # 3D Glasses Color Mode
         if system.isOptSet('3d_color_mode'):
             coreSettings.save('vb_anaglyph_preset', '"' + system.config['3d_color_mode'] + '"')
         else:
             coreSettings.save('vb_anaglyph_preset', '"disabled"')
 
-    if (system.config['core'] == 'picodrive'):
-        coreSettings.save('picodrive_input1',   '"6 button pad"')
-        coreSettings.save('picodrive_input2',   '"6 button pad"')
-        coreSettings.save('picodrive_sprlim',    '"enabled"')
-
-    if (system.config['core'] == '81'):
-        coreSettings.save('81_sound',   '"Zon X-81"')
-
-    if (system.config['core'] == 'cap32'):
-        if (system.name == 'gx4000'):
-            coreSettings.save('cap32_model',    '"6128+"')
-        else:
-            coreSettings.save('cap32_model',    '"6128"')
-
-    if (system.config['core'] == 'fuse'):
-        coreSettings.save('fuse_machine',   '"Spectrum 128K"')
-
+    # Panasonic 3DO
     if (system.config['core'] == 'opera'):
-        coreSettings.save('opera_dsp_threaded',   '"enabled"')
-
-    if (system.config['core'] == 'virtualjaguar'):
-        coreSettings.save('virtualjaguar_usefastblitter',   '"enabled"')
-
-    if (system.config['core'] == 'vice'):
-        coreSettings.save('vice_Controller',    '"joystick"')
-        coreSettings.save('vice_datasette_hotkeys',    '"enabled"')
-        coreSettings.save('vice_read_vicerc',    '"disabled"')
-        coreSettings.save('vice_retropad_options',    '"jump"')
-        coreSettings.save('vice_JoyPort',       '"port_1"')
-        # aspect ratio
-        if system.isOptSet('aspect_ratio'):
-            coreSettings.save('vice_aspect_ratio', system.config['aspect_ratio'])
+        # Audio Process on separate CPU thread
+        coreSettings.save('opera_dsp_threaded', '"enabled"')
+        # High Resolution (640x480)
+        if system.isOptSet('high_resolution'):
+            coreSettings.save('opera_high_resolution', system.config['high_resolution'])
         else:
-            coreSettings.save('vice_aspect_ratio', '"pal"')
-        # zoom mode
-        if system.isOptSet('zoom_mode'):
-            coreSettings.save('vice_zoom_mode', system.config['zoom_mode'])
+            coreSettings.save('opera_high_resolution', '"enabled"')
+        # CPU Overclock
+        if system.isOptSet('cpu_overclock'):
+            coreSettings.save('opera_cpu_overclock', '"' + system.config['cpu_overclock'] + '"')
         else:
-            coreSettings.save('vice_zoom_mode', '"medium"')
-        # external palette
-        if system.isOptSet('external_palette'):
-            coreSettings.save('vice_external_palette', system.config['external_palette'])
+            coreSettings.save('opera_cpu_overclock', '"1.0x (12.50Mhz)"')
+        # Active Input Devices Fix
+        if system.isOptSet('active_devices'):
+            coreSettings.save('opera_active_devices', system.config['active_devices'])
         else:
-            coreSettings.save('vice_external_palette', '"colodore"')
+            coreSettings.save('opera_active_devices', '"1"')
+        # Additional game fixes
+        coreSettings.save('opera_hack_timing_1',    '"disabled"')
+        coreSettings.save('opera_hack_timing_3',    '"disabled"')
+        coreSettings.save('opera_hack_timing_5',    '"disabled"')
+        coreSettings.save('opera_hack_timing_6',    '"disabled"')
+        if system.isOptSet('game_fixes_opera') and system.config['game_fixes_opera'] != 'disabled':
+            if system.config['game_fixes_opera'] == 'timing_hack1':
+                coreSettings.save('opera_hack_timing_1',        '"enabled"')
+            elif system.config['game_fixes_opera'] == 'timing_hack3':
+                coreSettings.save('opera_hack_timing_3',        '"enabled"')
+            elif system.config['game_fixes_opera'] == 'timing_hack5':
+                coreSettings.save('opera_hack_timing_5',        '"enabled"')
+            elif system.config['game_fixes_opera'] == 'timing_hack6':
+                coreSettings.save('opera_hack_timing_6',        '"enabled"')
 
-    if (system.config['core'] == 'theodore'):
-        coreSettings.save('theodore_autorun',   '"enabled"')
+    # TODO: Add ScummVM CORE Options
 
-    if (system.config['core'] == 'genesisplusgx'):
-        coreSettings.save('genesis_plus_gx_no_sprite_limit',    '"enabled"')
-
-    if (system.config['core'] == 'snes9x_next'):
-        coreSettings.save('snes9x_2010_reduce_sprite_flicker',       '"enabled"')
-        # reduce slowdown
-        if system.isOptSet('reduce_slowdown'):
-            coreSettings.save('snes9x_2010_overclock_cycles', system.config['reduce_slowdown'])
-        else:
-            coreSettings.save('snes9x_2010_overclock_cycles', '"compatible"')
-
-    if (system.config['core'] == 'yabasanshiro'):
-        # resolution mode
-        if system.isOptSet('resolution_mode'):
-            coreSettings.save('yabasanshiro_resolution_mode', system.config['resolution_mode'])
-        else:
-            coreSettings.save('yabasanshiro_resolution_mode', '"original"')
-
-    if (system.config['core'] == 'nestopia'):
-        coreSettings.save('nestopia_nospritelimit',    '"enabled"')
-        coreSettings.save('nestopia_overscan_h',    '"enabled"')
-        coreSettings.save('nestopia_overscan_v',    '"enabled"')
-        # palette
-        if system.isOptSet('palette'):
-            coreSettings.save('nestopia_palette', system.config['palette'])
-        else:
-            coreSettings.save('nestopia_palette', '"consumer"')
-
-    if (system.config['core'] == 'fceumm'):
-        coreSettings.save('fceumm_nospritelimit',    '"enabled"')
-
+    # Sega Dreamcast / Atomiswave / Naomi
     if (system.config['core'] == 'flycast'):
-        coreSettings.save('reicast_threaded_rendering',   '"enabled"')
-        coreSettings.save('reicast_mipmapping',   '"disabled"')
-        # widescreen hack
-        if system.isOptSet('widescreen_hack'):
-            coreSettings.save('reicast_widescreen_hack', system.config['widescreen_hack'])
+        # Threaded Rendering
+        coreSettings.save('reicast_threaded_rendering',  '"enabled"')
+        # Crossbar Colors
+        coreSettings.save('reicast_lightgun1_crosshair', '"Red"')
+        coreSettings.save('reicast_lightgun2_crosshair', '"Blue"')
+        coreSettings.save('reicast_lightgun3_crosshair', '"Green"')
+        coreSettings.save('reicast_lightgun4_crosshair', '"White"')
+        # Video resolution 
+        if system.isOptSet('internal_resolution_flycast'):
+            coreSettings.save('reicast_internal_resolution', system.config['internal_resolution_flycast'])
         else:
-            coreSettings.save('reicast_widescreen_hack', '"disabled"')
-        # anisotropic filtering
+            coreSettings.save('reicast_internal_resolution', '"640x480"')
+        # Textures Mip-mapping (blur)
+        if system.isOptSet('mipmapping'):
+            coreSettings.save('reicast_mipmapping', system.config['mipmapping'])
+        else:
+            coreSettings.save('reicast_mipmapping', '"disabled"')
+        # Anisotropic Filtering
         if system.isOptSet('anisotropic_filtering'):
             coreSettings.save('reicast_anisotropic_filtering', system.config['anisotropic_filtering'])
         else:
             coreSettings.save('reicast_anisotropic_filtering', '"off"')
-        # texture upscaling (xBRZ)
+        # Texture Upscaling (xBRZ)
         if system.isOptSet('texture_upscaling'):
-            coreSettings.save('reicast_texupscale', system.config['texture_upscaling'])
+            coreSettings.save('reicast_texupscale', '"' + system.config['texture_upscaling'] + '"')
         else:
             coreSettings.save('reicast_texupscale', '"off"')
-        # render to texture upscaling
+        # Render to Texture Upscaling
         if system.isOptSet('render_to_texture_upscaling'):
             coreSettings.save('reicast_render_to_texture_upscaling', system.config['render_to_texture_upscaling'])
         else:
             coreSettings.save('reicast_render_to_texture_upscaling', '"1x"')
+        # Frame Skip
+        if system.isOptSet('frame_skipping'):
+            coreSettings.save('reicast_frame_skipping', system.config['frame_skipping'])
+        else:
+            coreSettings.save('reicast_frame_skipping', '"disabled"')
+        # Force Windows CE Mode
+        if system.isOptSet('force_wince'):
+            coreSettings.save('reicast_force_wince', system.config['force_wince'])
+        else:
+            coreSettings.save('reicast_force_wince', '"disabled"')
+        # Widescreen Hack
+        if system.isOptSet('widescreen_hack_flycast'):
+            coreSettings.save('reicast_widescreen_hack', system.config['widescreen_hack_flycast'])
+            if (system.config['widescreen_hack_flycast'] == 'enabled'):
+                # Auto Config System
+                #system.config["ratio"] == "16/9"
+                #system.config["bezel"] == "none"
+                # Prefer Hack from Cheat
+                coreSettings.save('reicast_widescreen_cheats', '"disabled"')
+        else:
+            coreSettings.save('reicast_widescreen_hack', '"disabled"')
+        # Widescreen Cheat
+        if system.isOptSet('widescreen_cheats'):
+            coreSettings.save('reicast_widescreen_cheats', system.config['widescreen_cheats'])
+            #if (system.config['widescreen_cheats'] == 'enabled'):
+                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
+        else:
+            coreSettings.save('reicast_widescreen_cheats', '"disabled"')
 
-    if (system.config['core'] == 'dosbox'):
-        coreSettings.save('dosbox_svn_pcspeaker', '"true"')
+        ## Atomiswave / Naomi
+        
+        # Screen Orientation
+        if system.isOptSet('screen_rotation_atomiswave') and system.name == 'atomiswave':
+            coreSettings.save('reicast_screen_rotation', system.config['screen_rotation_atomiswave'])
+        elif system.isOptSet('screen_rotation_naomi') and system.name == 'naomi':
+                coreSettings.save('reicast_screen_rotation', system.config['screen_rotation_naomi'])
+        else:
+            coreSettings.save('reicast_screen_rotation', '"horizontal"')
 
+    # Sega SG1000 / Master System / Game Gear / Megadrive / Mega CD
+    if (system.config['core'] == 'genesisplusgx'):
+        # Allows each game to have its own one brm file for save without lack of space
+        coreSettings.save('genesis_plus_gx_bram', '"per game"')
+        # Reduce sprite flickering
+        if system.isOptSet('gpgx_no_sprite_limit'):
+            coreSettings.save('genesis_plus_gx_no_sprite_limit', system.config['gpgx_no_sprite_limit'])
+        else:
+            coreSettings.save('genesis_plus_gx_no_sprite_limit', '"enabled"')
+        # Blargg NTSC filter
+        if system.isOptSet('gpgx_blargg_filter_md') and system.name == 'megadrive':
+            coreSettings.save('genesis_plus_gx_blargg_ntsc_filter', system.config['gpgx_blargg_filter_md'])
+        elif system.isOptSet('gpgx_blargg_filter_ms') and system.name == 'mastersystem':
+            coreSettings.save('genesis_plus_gx_blargg_ntsc_filter', system.config['gpgx_blargg_filter_ms'])
+        else:
+            coreSettings.save('genesis_plus_gx_blargg_ntsc_filter', '"Off"')
+        # Show Lightgun Crosshair
+        if system.isOptSet('gun_cursor_md') and system.name == 'megadrive':
+            coreSettings.save('genesis_plus_gx_gun_cursor', system.config['gun_cursor_md'])
+        elif system.isOptSet('gun_cursor_ms') and system.name == 'mastersystem':
+            coreSettings.save('genesis_plus_gx_gun_cursor', system.config['gun_cursor_ms'])
+        else:
+            coreSettings.save('genesis_plus_gx_gun_cursor', '"disabled"')
+
+        # Master System FM (YM2413)
+        # system.name == 'mastersystem'
+        if system.isOptSet('ym2413'):
+            coreSettings.save('genesis_plus_gx_ym2413', system.config['ym2413'])
+        else:
+            coreSettings.save('genesis_plus_gx_ym2413', '"auto"')
+
+        # Game Gear LCD Ghosting Filter
+        # system.name == 'gamegear'
+        if system.isOptSet('lcd_filter'):
+            coreSettings.save('genesis_plus_gx_lcd_filter', system.config['lcd_filter'])
+        else:
+            coreSettings.save('genesis_plus_gx_lcd_filter', '"disabled"')
+        # Game Gear Extended Screen
+        if system.isOptSet('gg_extra'):
+            coreSettings.save('genesis_plus_gx_gg_extra', system.config['gg_extra'])
+        else:
+            coreSettings.save('genesis_plus_gx_gg_extra', '"disabled"')
+    
+    # Sega 32X (Sega Megadrive / MegaCD / Master System)
+    if system.config['core'] == 'picodrive':
+        # 6 Button Controller
+        coreSettings.save('picodrive_input1', '"6 button pad"')
+        coreSettings.save('picodrive_input2', '"6 button pad"')
+        # Reduce sprite flickering
+        if system.isOptSet('picodrive_sprlim') and system.config['picodrive_sprlim'] == 'disabled':
+            coreSettings.save('picodrive_sprlim',   '"disabled"')
+            coreSettings.save('picodrive_overscan', '"disabled"')
+        else:
+            coreSettings.save('picodrive_sprlim',   '"enabled"')
+            coreSettings.save('picodrive_overscan', '"enabled"')
+
+        # Sega MegaCD
+        # Emulate the Backup RAM Cartridge for games save (ex: Shining Force CD)
+        if system.name == 'segacd':
+            coreSettings.save('picodrive_ramcart', '"enabled"')
+        else:
+            coreSettings.save('picodrive_ramcart', '"disabled"')
+
+    # Sega Saturn
+    if (system.config['core'] == 'yabasanshiro'):
+        # Video Resolution
+        if system.isOptSet('resolution_mode'):
+            coreSettings.save('yabasanshiro_resolution_mode', system.config['resolution_mode'])
+        else:
+            coreSettings.save('yabasanshiro_resolution_mode', '"original"')
+        # Multitap
+        if system.isOptSet('multitap_yabasanshiro') and system.config['multitap_yabasanshiro'] != 'disabled':
+            if system.config['multitap_yabasanshiro'] == 'port1':
+                coreSettings.save('yabasanshiro_multitap_port1', '"enabled"')
+                coreSettings.save('yabasanshiro_multitap_port2', '"disabled"')
+            elif system.config['multitap_yabasanshiro'] == 'port2':
+                coreSettings.save('yabasanshiro_multitap_port1', '"disabled"')
+                coreSettings.save('yabasanshiro_multitap_port2', '"enabled"')
+            elif system.config['multitap_yabasanshiro'] == 'port12':
+                coreSettings.save('yabasanshiro_multitap_port1', '"enabled"')
+                coreSettings.save('yabasanshiro_multitap_port2', '"enabled"')
+        else:
+            coreSettings.save('yabasanshiro_multitap_port1', '"disabled"')
+            coreSettings.save('yabasanshiro_multitap_port2', '"disabled"')
+
+    # TODO: Add CORE options for Beetle-saturn and Kronos
+
+    # Sharp X68000
     if (system.config['core'] == 'px68k'):
+        # To auto launch HDD games
         coreSettings.save('px68k_disk_path', '"disabled"')
+        # CPU Speed (Overclock)
+        if system.isOptSet('px68k_cpuspeed'):
+            coreSettings.save('px68k_cpuspeed', '"' + system.config['px68k_cpuspeed'] + '"')
+        else:
+            coreSettings.save('px68k_cpuspeed', '"33Mhz (OC)"')
+        # RAM Size
+        if system.isOptSet('px68k_ramsize'):
+            coreSettings.save('px68k_ramsize', '"' + system.config['px68k_ramsize'] + '"')
+        else:
+            coreSettings.save('px68k_ramsize', '"2MB"')
+        # Frame Skip
+        if system.isOptSet('px68k_frameskip'):
+                coreSettings.save('px68k_frameskip', '"' + system.config['px68k_frameskip'] + '"')
+        else:
+            coreSettings.save('px68k_frameskip', '"Full Frame"')
+        # Joypad Type for two players
+        if system.isOptSet('px68k_joytype'):
+            coreSettings.save('px68k_joytype1', '"' + system.config['px68k_joytype'] + '"')
+            coreSettings.save('px68k_joytype2', '"' + system.config['px68k_joytype'] + '"')
+        else:
+            coreSettings.save('px68k_joytype1', '"Default (2 Buttons)"')
+            coreSettings.save('px68k_joytype2', '"Default (2 Buttons)"')
 
+    # Sinclair ZX81
+    if (system.config['core'] == '81'):
+        # Tape Fast Load
+        coreSettings.save('81_fast_load', '"enabled"')
+        # Enables sound emulatio
+        coreSettings.save('81_sound',     '"Zon X-81"')
+        # Colorisation (Chroma 81)
+        if system.isOptSet('81_chroma_81'):
+            coreSettings.save('81_chroma_81', system.config['81_chroma_81'])
+        else:
+            coreSettings.save('81_chroma_81', '"enabled"')
+        # High Resolution
+        if system.isOptSet('81_highres'):
+            coreSettings.save('81_highres', system.config['81_highres'])
+        else:
+            coreSettings.save('81_highres', '"WRX"')
+
+    # Sinclair ZX Spectrum
+    if (system.config['core'] == 'fuse'):
+        # The most common configuration same as ZX Spectrum+
+        coreSettings.save('fuse_machine',   '"Spectrum 128K"')
+        # Zoom, Hide Video Border
+        if system.isOptSet('fuse_hide_border'):
+            coreSettings.save('fuse_hide_border', system.config['fuse_hide_border'])
+        else:
+            coreSettings.save('fuse_hide_border', '"disabled"')
+
+    # SNK Neogeo AES MVS / Neogeo CD
+    if (system.config['core'] == 'fbneo'):
+        # Diagnostic input
+        coreSettings.save('fbneo-diagnostic-input', '"Start + L + R"')
+        # CPU Clock
+        if system.isOptSet('fbneo-cpu-speed-adjust'):
+            coreSettings.save('fbneo-cpu-speed-adjust', system.config['fbneo-cpu-speed-adjust'])
+        else:
+            coreSettings.save('fbneo-cpu-speed-adjust', '"100%"')
+        # Frameskip
+        if system.isOptSet('fbneo-frameskip'):
+            coreSettings.save('fbneo-frameskip', system.config['fbneo-frameskip'])
+        else:
+            coreSettings.save('fbneo-frameskip', '"0"')
+        # Crosshair (Lightgun)
+        if system.isOptSet('fbneo-lightgun-hide-crosshair'):
+            coreSettings.save('fbneo-lightgun-hide-crosshair', system.config['fbneo-lightgun-hide-crosshair'])
+        else:
+            coreSettings.save('fbneo-lightgun-hide-crosshair', '"disabled"')
+
+        # NEOGEO
+        if system.name == 'neogeo':
+            # Neogeo Mode
+            romBase = os.path.splitext(os.path.basename(rom))[0] # filename without extension
+            if system.isOptSet('fbneo-neogeo-mode-switch'):
+                coreSettings.save("fbneo-neogeo-mode", '"DIPSWITCH"')
+                if system.config['fbneo-neogeo-mode-switch'] == 'MVS Asia/Europe':
+                    coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",  '"MVS Asia/Europe ver. 5 (1 slot)"')
+                elif system.config['fbneo-neogeo-mode-switch'] == 'MVS USA':
+                    coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",  '"MVS USA ver. 5 (2 slot)"')
+                elif system.config['fbneo-neogeo-mode-switch'] == 'MVS Japan':
+                    coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",  '"MVS Japan ver. 5 (? slot)"')
+                elif system.config['fbneo-neogeo-mode-switch'] == 'AES Asia':
+                    coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",  '"AES Asia"')
+                elif system.config['fbneo-neogeo-mode-switch'] == 'AES Japan':
+                    coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",  '"AES Japan"')
+                else:
+                    coreSettings.save("fbneo-neogeo-mode", '"UNIBIOS"')
+            else:
+                coreSettings.save("fbneo-neogeo-mode",     '"UNIBIOS"')
+                #coreSettings.save("fbneo-dipswitch-" + romBase + "-BIOS",      '"Universe BIOS ver. 4.0"')
+            # Memory card mode
+            if system.isOptSet('fbneo-memcard-mode'):
+                coreSettings.save('fbneo-memcard-mode', system.config['fbneo-memcard-mode'])
+            else:
+                coreSettings.save('fbneo-memcard-mode', '"per-game"')
+
+    # SNK Neogeo CD
+    if (system.config['core'] == 'neocd'):
+        # Console region
+        if system.isOptSet('neocd_region'):
+            coreSettings.save('neocd_region', system.config['neocd_region'])
+        else:
+            coreSettings.save('neocd_region', '"Japan"')
+        # BIOS Select
+        if system.isOptSet('neocd_bios'):
+            coreSettings.save('neocd_bios', '"' + system.config['neocd_bios'] + '"')
+        else:
+            coreSettings.save('neocd_bios', '"CDZ"')
+        # Per-Game saves
+        if system.isOptSet('neocd_per_content_saves') and system.config['neocd_per_content_saves'] == "False":
+            coreSettings.save('neocd_per_content_saves', '"Off"')
+        else:
+            coreSettings.save('neocd_per_content_saves', '"On"')
+
+    # Sony PSX
     if (system.config['core'] == 'mednafen_psx'):
-        coreSettings.save('beetle_psx_hw_cpu_freq_scale',   '"110%"')
-        # internal resolution
-        if system.isOptSet('internal_resolution'):
-            coreSettings.save('beetle_psx_hw_internal_resolution', system.config['internal_resolution'])
+        # CPU Frequency Scaling (Overclock)
+        if system.isOptSet('beetlepsx_cpu_freq'):
+            coreSettings.save('beetle_psx_cpu_freq_scale', system.config['beetlepsx_cpu_freq'])
         else:
-            coreSettings.save('beetle_psx_hw_internal_resolution', '"1x(native)"')
-        # texture filtering
-        if system.isOptSet('texture_filtering'):
-            coreSettings.save('beetle_psx_hw_filter', system.config['texture_filtering'])
+            coreSettings.save('beetle_psx_cpu_freq_scale', '"100%(native)"')
+        # Show official Bootlogo
+        if system.isOptSet('skip_bios_psx'):
+            coreSettings.save('beetle_psx_skip_bios', system.config['skip_bios_psx'])
         else:
-            coreSettings.save('beetle_psx_hw_filter', '"nearest"')
-        # widescreen hack
-        if system.isOptSet('widescreen_hack'):
-            coreSettings.save('beetle_psx_hw_widescreen_hack', system.config['widescreen_hack'])
+            coreSettings.save('beetle_psx_skip_bios', '"disabled"')
+        # Video Resolution
+        if system.isOptSet('internal_resolution_mednafen'):
+            coreSettings.save('beetle_psx_internal_resolution', system.config['internal_resolution_mednafen'])
         else:
-            coreSettings.save('beetle_psx_hw_widescreen_hack', '"disabled"')
+            coreSettings.save('beetle_psx_internal_resolution', '"1x(native)"')
+        # Widescreen Hack
+        if system.isOptSet('widescreen_hack_mednafen'):
+            coreSettings.save('beetle_psx_widescreen_hack', system.config['widescreen_hack_mednafen'])
+            #if (system.config['widescreen_hack_mednafen'] == 'enabled'):
+                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
+        else:
+            coreSettings.save('beetle_psx_widescreen_hack', '"disabled"')
+        # Frame Duping (Speedup)
+        if system.isOptSet('frame_duping'):
+            coreSettings.save('beetle_psx_frame_duping', system.config['frame_duping'])
+        else:
+            coreSettings.save('beetle_psx_frame_duping', '"disabled"') 
+        # CPU Dynarec (Speedup)
+        if system.isOptSet('cpu_dynarec'):
+            coreSettings.save('beetle_psx_cpu_dynarec', system.config['cpu_dynarec'])
+        else:
+            coreSettings.save('beetle_psx_cpu_dynarec', '"disabled"')
+        # Dynarec Code Invalidation
+        if system.isOptSet('dynarec_invalidate'):
+            coreSettings.save('beetle_psx_dynarec_invalidate', system.config['dynarec_invalidate'])
+        else:
+            coreSettings.save('beetle_psx_dynarec_invalidate', '"full"')
+        # Multitap
+        if system.isOptSet('multitap_mednafen') and system.config['multitap_mednafen'] != 'disabled':
+            if system.config['multitap_mednafen'] == 'port1':
+                coreSettings.save('beetle_psx_enable_multitap_port1', '"enabled"')
+                coreSettings.save('beetle_psx_enable_multitap_port2', '"disabled"')
+            elif system.config['multitap_mednafen'] == 'port2':
+                coreSettings.save('beetle_psx_enable_multitap_port1', '"disabled"')
+                coreSettings.save('beetle_psx_enable_multitap_port2', '"enabled"')
+            elif system.config['multitap_mednafen'] == 'port12':
+                coreSettings.save('beetle_psx_enable_multitap_port1', '"enabled"')
+                coreSettings.save('beetle_psx_enable_multitap_port2', '"enabled"')
+        else:
+            coreSettings.save('beetle_psx_enable_multitap_port1', '"disabled"')
+            coreSettings.save('beetle_psx_enable_multitap_port2', '"disabled"')
 
     if (system.config['core'] == 'duckstation'):
-        # resolution scale (default 1)
+        coreSettings.save('duckstation_Display.AspectRatio', '"4:3"')
+        
+        # Show official Bootlogo
+        if system.isOptSet('PatchFastBoot'):
+            coreSettings.save('duckstation_BIOS.PatchFastBoot', system.config['PatchFastBoot'])
+        else:
+            coreSettings.save('duckstation_BIOS.PatchFastBoot', '"false"')
+        # Video Resolution
         if system.isOptSet('resolution_scale'):
             coreSettings.save('duckstation_GPU.ResolutionScale', system.config['resolution_scale'])
         else:
             coreSettings.save('duckstation_GPU.ResolutionScale', '"1"')
-        # multisampling antialiasing (default 1x)
+        # Anti-aliasing (MSAA/SSAA)
         if system.isOptSet('antialiasing'):
             coreSettings.save('duckstation_GPU.MSAA', system.config['antialiasing'])
         else:
             coreSettings.save('duckstation_GPU.MSAA', '"1"')
-        # texture filtering (default nearest)
+        # Texture Filtering
         if system.isOptSet('texture_filtering'):
             coreSettings.save('duckstation_GPU.TextureFilter', system.config['texture_filtering'])
         else:
             coreSettings.save('duckstation_GPU.TextureFilter', '"Nearest"')
-        # widescreen hack (default off)
-        if system.isOptSet('widescreen_hack'):
-            coreSettings.save('duckstation_GPU.WidescreenHack', system.config['widescreen_hack'])
+        # Widescreen Hack
+        if system.isOptSet('widescreen_hack_duckstation'):
+            coreSettings.save('duckstation_GPU.WidescreenHack', system.config['widescreen_hack_duckstation'])
+            if (system.config['widescreen_hack_duckstation'] == 'true'):
+                coreSettings.save('duckstation_Display.AspectRatio', '"16:9"')
+                # TODO: Auto configure to remove BEZEL and switch RATIO to 16/9
         else:
             coreSettings.save('duckstation_GPU.WidescreenHack', '"false"')
+         # Crop Mode
+        if system.isOptSet('duckstation_CropMode'):
+            coreSettings.save('duckstation_Display.CropMode', system.config['duckstation_CropMode'])
+        else:
+            coreSettings.save('duckstation_Display.CropMode', '"Overscan"')
+        # Controller 1 Type
+        if system.isOptSet('Controller1'):
+            coreSettings.save('duckstation_Controller1.Type', system.config['Controller1'])
+        else:
+            coreSettings.save('duckstation_Controller1.Type', '"DigitalController"')
+        # Controller 2 Type
+        if system.isOptSet('Controller2'):
+            coreSettings.save('duckstation_Controller2.Type', system.config['Controller2'])
+        else:
+            coreSettings.save('duckstation_Controller2.Type', '"DigitalController"')
 
     if (system.config['core'] == 'pcsx_rearmed'):
-        for n in range(1, 8+1):
-            val = coreSettings.load('pcsx_rearmed_pad{}type'.format(n))
-            if val == '"none"' or val == "" or val is None:
-                coreSettings.save('pcsx_rearmed_pad{}type'.format(n), '"standard"')
-        # force multitap no value / auto to disable
-        # only let enabled when it is forced while previous values enable it
-        val = coreSettings.load('pcsx_rearmed_multitap1')
-        if val == '"auto"' or val == "" or val is None:
+        # Display Games Hack Options
+        coreSettings.save('pcsx_rearmed_show_gpu_peops_settings', '"enabled"')
+        # Display Multitap/Gamepad Options
+        coreSettings.save('pcsx_rearmed_show_other_input_settings', '"enabled"')
+        
+        # Show Bios Bootlogo (Breaks some games)
+        if system.isOptSet('show_bios_bootlogo'):
+            coreSettings.save('pcsx_rearmed_show_bios_bootlogo', system.config['show_bios_bootlogo'])
+        else:
+            coreSettings.save('pcsx_rearmed_show_bios_bootlogo', '"enabled"')
+        # Frameskip
+        if system.isOptSet('frameskip_pcsx'):
+            coreSettings.save('pcsx_rearmed_frameskip', system.config['frameskip_pcsx'])
+        else:
+            coreSettings.save('pcsx_rearmed_frameskip', '"0"')
+        # Enhanced resolution at the cost of lower performance
+        # Speed hack causes game glitches.
+        if system.isOptSet('neon_enhancement') and system.config['neon_enhancement'] != 'disabled':
+            if system.config['neon_enhancement'] == 'enabled':
+                coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"enabled"')
+                coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"disabled"')
+            elif system.config['neon_enhancement'] == 'enabled_with_speedhack':
+                coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"enabled"')
+                coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"enabled"')
+        else:
+            coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"disabled"')
+            coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"disabled"')
+        # Multitap
+        if system.isOptSet('multitap_pcsx') and system.config['multitap_pcsx'] != 'disabled':
+            if system.config['multitap_pcsx'] == 'port1':
+                coreSettings.save('pcsx_rearmed_multitap1', '"enabled"')
+                coreSettings.save('pcsx_rearmed_multitap2', '"disabled"')
+            elif system.config['multitap_pcsx'] == 'port2':
+                coreSettings.save('pcsx_rearmed_multitap1', '"disabled"')
+                coreSettings.save('pcsx_rearmed_multitap2', '"enabled"')
+            elif system.config['multitap_pcsx'] == 'port12':
+                coreSettings.save('pcsx_rearmed_multitap1', '"enabled"')
+                coreSettings.save('pcsx_rearmed_multitap2', '"enabled"')
+        else:
             coreSettings.save('pcsx_rearmed_multitap1', '"disabled"')
-        val = coreSettings.load('pcsx_rearmed_multitap2')
-        if val == '"auto"' or val == "" or val is None:
             coreSettings.save('pcsx_rearmed_multitap2', '"disabled"')
+        # Additional game fixes
+        coreSettings.save('pcsx_rearmed_idiablofix',                    '"disabled"')
+        coreSettings.save('pcsx_rearmed_pe2_fix',                       '"disabled"')
+        coreSettings.save('pcsx_rearmed_inuyasha_fix',                  '"disabled"')
+        coreSettings.save('pcsx_rearmed_gpu_peops_odd_even_bit',        '"disabled"')
+        coreSettings.save('pcsx_rearmed_gpu_peops_expand_screen_width', '"disabled"')
+        coreSettings.save('pcsx_rearmed_gpu_peops_ignore_brightness',   '"disabled"')
+        coreSettings.save('pcsx_rearmed_gpu_peops_lazy_screen_update',  '"disabled"')
+        coreSettings.save('pcsx_rearmed_gpu_peops_repeated_triangles',  '"disabled"')
+        if system.isOptSet('game_fixes_pcsx') and system.config['game_fixes_pcsx'] != 'disabled':
+            if system.config['game_fixes_pcsx'] == 'Diablo_Music_Fix':
+                coreSettings.save('pcsx_rearmed_idiablofix',                    '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Parasite_Eve':
+                coreSettings.save('pcsx_rearmed_pe2_fix',                       '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'InuYasha_Sengoku':
+                coreSettings.save('pcsx_rearmed_inuyasha_fix',                  '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Chrono_Chross':
+                coreSettings.save('pcsx_rearmed_gpu_peops_odd_even_bit',        '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Capcom_fighting':
+                coreSettings.save('pcsx_rearmed_gpu_peops_expand_screen_width', '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Lunar':
+                coreSettings.save('pcsx_rearmed_gpu_peops_ignore_brightness',   '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Pandemonium':
+                coreSettings.save('pcsx_rearmed_gpu_peops_lazy_screen_update',  '"enabled"')
+            elif system.config['game_fixes_pcsx'] == 'Dark_Forces':
+                coreSettings.save('pcsx_rearmed_gpu_peops_repeated_triangles',  '"enabled"')
 
-    # custom : allow the user to configure directly retroarchcore.cfg via batocera.conf via lines like : snes.retroarchcore.opt=val
+    # Thomson MO5 / TO7
+    if (system.config['core'] == 'theodore'):
+        # Auto run games
+        coreSettings.save('theodore_autorun',   '"enabled"')
+    
+    ## PORTs
+    
+    # DOOM
+    if (system.config['core'] == 'prboom'):
+        # Internal resolution
+        if system.isOptSet('prboom-resolution'):
+            coreSettings.save('prboom-resolution', system.config['prboom-resolution'])
+        else:
+            coreSettings.save('prboom-resolution', '"320x200"')
+
+    # QUAKE
+    if (system.config['core'] == 'tyrquake'):
+        # Resolution
+        if system.isOptSet('tyrquake_resolution'):
+            coreSettings.save('tyrquake_resolution', system.config['tyrquake_resolution'])
+        else:
+            coreSettings.save('tyrquake_resolution', '"640x480"')
+        # Frame rate
+        if system.isOptSet('tyrquake_framerate'):
+            coreSettings.save('tyrquake_framerate', system.config['tyrquake_framerate'])
+        else:
+            coreSettings.save('tyrquake_framerate', '"Auto"')
+        # Rumble
+        if system.isOptSet('tyrquake_rumble'):
+            coreSettings.save('tyrquake_rumble', system.config['tyrquake_rumble'])
+        else:
+            coreSettings.save('tyrquake_rumble', '"disabled"')
+
+    # BONBERMAN
+    if (system.config['core'] == 'mrboom'):
+        # Team mode
+        if system.isOptSet('mrboom-aspect'):
+            coreSettings.save('mrboom-aspect', system.config['mrboom-aspect'])
+        else:
+            coreSettings.save('mrboom-aspect', '"Native"')
+        # Monsters
+        if system.isOptSet('mrboom-nomonster') and system.config['mrboom-nomonster'] == "True":
+            coreSettings.save('mrboom-nomonster', '"ON"')
+        else:
+            coreSettings.save('mrboom-nomonster', '"OFF"')
+
+
+
+    # Custom : Allow the user to configure directly retroarchcore.cfg via batocera.conf via lines like : snes.retroarchcore.opt=val
     for user_config in system.config:
         if user_config[:14] == "retroarchcore.":
             coreSettings.save(user_config[14:], system.config[user_config])
 
     coreSettings.write()
-
 
 def generateHatariConf(hatariConf):
     hatariConfig = ConfigParser.ConfigParser()
@@ -348,11 +1308,6 @@ def generateHatariConf(hatariConf):
     hatariConfig.optionxform = str
     if os.path.exists(hatariConf):
         hatariConfig.read(hatariConf)
-
-    # Screen section
-    if not hatariConfig.has_section("Screen"):
-        hatariConfig.add_section("Screen")
-    hatariConfig.set("Screen", "bAllowOverscan", "FALSE")
 
     # update the configuration file
     if not os.path.exists(os.path.dirname(hatariConf)):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -884,15 +884,15 @@ def generateCoreSettings(coreSettings, system, rom):
         else:
             coreSettings.save('genesis_plus_gx_gun_cursor', '"disabled"')
 
-        # Master System FM (YM2413)
         # system.name == 'mastersystem'
+        # Master System FM (YM2413)
         if system.isOptSet('ym2413'):
             coreSettings.save('genesis_plus_gx_ym2413', system.config['ym2413'])
         else:
             coreSettings.save('genesis_plus_gx_ym2413', '"auto"')
 
-        # Game Gear LCD Ghosting Filter
         # system.name == 'gamegear'
+        # Game Gear LCD Ghosting Filter
         if system.isOptSet('lcd_filter'):
             coreSettings.save('genesis_plus_gx_lcd_filter', system.config['lcd_filter'])
         else:
@@ -905,9 +905,6 @@ def generateCoreSettings(coreSettings, system, rom):
     
     # Sega 32X (Sega Megadrive / MegaCD / Master System)
     if system.config['core'] == 'picodrive':
-        # 6 Button Controller
-        coreSettings.save('picodrive_input1', '"6 button pad"')
-        coreSettings.save('picodrive_input2', '"6 button pad"')
         # Reduce sprite flickering
         if system.isOptSet('picodrive_sprlim') and system.config['picodrive_sprlim'] == 'disabled':
             coreSettings.save('picodrive_sprlim',   '"disabled"')
@@ -915,6 +912,16 @@ def generateCoreSettings(coreSettings, system, rom):
         else:
             coreSettings.save('picodrive_sprlim',   '"enabled"')
             coreSettings.save('picodrive_overscan', '"enabled"')
+        # 6 Button Controller 1
+        if system.isOptSet('picodrive_controller1'):
+            coreSettings.save('picodrive_sprlim', '"' + system.config['picodrive_controller1'] + '"')
+        else:
+            coreSettings.save('picodrive_input1', '"6 button pad"')
+        # 6 Button Controller 2
+        if system.isOptSet('picodrive_controller2'):
+            coreSettings.save('picodrive_input2', '"' + system.config['picodrive_controller2'] + '"')
+        else:
+            coreSettings.save('picodrive_input2', '"6 button pad"')
 
         # Sega MegaCD
         # Emulate the Backup RAM Cartridge for games save (ex: Shining Force CD)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -5,19 +5,7 @@ import ConfigParser
 from settings.unixSettings import UnixSettings
 import batoceraFiles
 
-def generateCoreSettings(retroarchCore, system, rom):
-    # retroarch-core-options.cfg
-    if not os.path.exists(os.path.dirname(retroarchCore)):
-        os.makedirs(os.path.dirname(retroarchCore))
-
-    try:
-        coreSettings = UnixSettings(retroarchCore, separator=' ')
-    except UnicodeError:
-        # invalid retroarch-core-options.cfg
-        # remove it and try again
-        os.remove(retroarchCore)
-        coreSettings = UnixSettings(retroarchCore, separator=' ')
-
+def generateCoreSettings(coreSettings, system, rom):
 
     # Amstrad CPC / GX4000
     if (system.config['core'] == 'cap32'):
@@ -809,6 +797,8 @@ def generateCoreSettings(retroarchCore, system, rom):
     if (system.config['core'] == 'flycast'):
         # Threaded Rendering
         coreSettings.save('reicast_threaded_rendering',  '"enabled"')
+        # Enable controller force feedback
+        coreSettings.save('reicast_enable_purupuru',  '"enabled"')
         # Crossbar Colors
         coreSettings.save('reicast_lightgun1_crosshair', '"Red"')
         coreSettings.save('reicast_lightgun2_crosshair', '"Blue"')
@@ -1113,6 +1103,8 @@ def generateCoreSettings(retroarchCore, system, rom):
             coreSettings.save('beetle_psx_dynarec_invalidate', system.config['beetle_psx_dynarec_invalidate'])
         else:
             coreSettings.save('beetle_psx_dynarec_invalidate', '"full"')
+        # Analog Stick self calibration
+        coreSettings.save('beetle_psx_analog_calibration', '"enabled"')
         # Multitap
         if system.isOptSet('multitap_mednafen') and system.config['multitap_mednafen'] != 'disabled':
             if system.config['multitap_mednafen'] == 'port1':
@@ -1177,7 +1169,9 @@ def generateCoreSettings(retroarchCore, system, rom):
         coreSettings.save('pcsx_rearmed_show_gpu_peops_settings', '"enabled"')
         # Display Multitap/Gamepad Options
         coreSettings.save('pcsx_rearmed_show_other_input_settings', '"enabled"')
-        
+        # Enable Vibration
+        coreSettings.save('pcsx_rearmed_vibration', '"enabled"')
+
         # Show Bios Bootlogo (Breaks some games)
         if system.isOptSet('show_bios_bootlogo'):
             coreSettings.save('pcsx_rearmed_show_bios_bootlogo', system.config['show_bios_bootlogo'])

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7,6 +7,7 @@ libretro:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4]
       prompt: GRAPHICS BACKEND
+      label:  Choose your graphics rendering
       choices:
         "OpenGL": opengl
         "Vulkan": vulkan
@@ -14,16 +15,101 @@ libretro:
   cores:
     '81':
       features: [netplay, rewind, autosave, padtokeyboard]
+      cfeatures:
+            81_chroma_81:
+                prompt: COLORISATION
+                label:  Enable the Chroma 81 interface
+                choices:
+                    "Automatic": automatic
+                    "Off":       disabled
+                    "On":        enabled
+            81_highres:
+                prompt: HIGH RESOLUTION
+                label:  Enables WRX high resolution module
+                choices:
+                    "Automatic": automatic
+                    "Off":       none
+                    "On":        WRX
     atari800:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [                           padtokeyboard]
+      systems:
+            atari800:
+                cfeatures:
+                    atari800_system:
+                        prompt: ATARI SYSTEM
+                        label:  Choose what Atari System to emulate
+                        choices:
+                            "400/600XL/800 (48K) (OS B)": 400/800 (OS B)
+                            "800XL/1200XL/XEGS (64K)":    800XL (64K)
+                            "130XE (128K)":               130XE (128K)
+                    atari800_ntscpal:
+                        prompt: VIDEO STANDARD
+                        label:  Switch frequency and resolution by region
+                        choices:
+                            "NTSC":    NTSC
+                            "PAL":     PAL
+                    atari800_sioaccel:
+                        prompt: SIO ACCELERATION
+                        label:  Speeds up file loading. A few games will not load
+                        choices:
+                            "Off":     disabled
+                            "On":      enabled
+                    atari800_artifacting:
+                        prompt: HI-RES ARTIFACTING
+                        label:  Artificial color filters to mimic actual hardware
+                        choices:
+                            "Off":     disabled
+                            "On":      enabled
+                    atari800_resolution:
+                        prompt: INTERNAL RESOLUTION
+                        label:  Enables alternate resolutions for some games
+                        choices:
+                            "336x240": 336x240
+                            "320x240": 320x240
+                            "384x240": 384x240
+                            "384x272": 384x272
+                            "384x288": 384x288
+                            "400x300": 400x300
+            atari5200:
+                cfeatures:
+                    atari800_opt2:
+                        prompt: JOY HACK (FOR ROBOTRON)
+                        label:  Treats the second analog stick as joystick 2
+                        choices:
+                            "Off":     disabled
+                            "On":      enabled
     beetle-saturn:
       features: [netplay,         autosave]
     bluemsx:
       features: [         rewind, autosave, padtokeyboard]
+      cfeatures:
+            bluemsx_nospritelimits:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Remove the 4 sprite per line limit
+                choices:
+                    "Off": OFF
+                    "On":  ON
     bsnes:
       features: [netplay, rewind, autosave]
     cap32:
       features: [netplay, rewind, autosave, padtokeyboard]
+      cfeatures:
+            cap32_model:
+                prompt: CPC MODEL
+                label:  Choose which Amstrad CPC model to emulate
+                choices:
+                    "464":   464
+                    "6128":  6128
+                    "6128+": 6128+
+            cap32_ram:
+                prompt: RAM SIZE
+                label:  CPC physical RAM size in kB
+                choices:
+                    "64":    64
+                    "128":   128
+                    "192+":  192
+                    "512":   512
+                    "576+":  576
     citra:
       features: [         rewind, autosave]
     daphne:
@@ -31,19 +117,36 @@ libretro:
     desmume:
       features: [netplay, rewind, autosave]
       cfeatures:
+            internal_resolution_desmume:
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "256x192":   256x192
+                    "512x384":   512x384
+                    "768x576":   768x576
+                    "1024x768":  1024x768
+                    "1280x960":  1280x960
+                    "1536x1152": 1536x1152
+                    "1792x1344": 1792x1344
+                    "2048x1536": 2048x1536
+                    "2304x1728": 2304x1728
+                    "2560x1920": 2560x1920
             texture_scaling:
                 prompt: TEXTURES UPSCALING (XBRZ)
+                label:  Upscaling textures resolution on 3D objetcs
                 choices:
                     "Off": 1
                     "2x":  2
                     "4x":  4
             texture_smoothing:
                 prompt: TEXTURES SMOOTHING
+                label:  Smooths out textures on 3D objetcs
                 choices:
                     "Off": disabled
                     "On":  enabled
             multisampling:
-                prompt: MULTISAMPLING AA
+                prompt: ANTI-ALIASING (MSAA)
+                label:  Smooth out jagged edges on 3D objetcs polygons 
                 choices:
                     "Off": disabled
                     "2x":  2
@@ -51,62 +154,296 @@ libretro:
                     "8x":  8
                     "16x": 16
                     "32x": 32
+            screens_layout:
+                prompt: SCREEN LAYOUT
+                label:  Allows you to arrange the DS screens
+                choices:
+                    "top/bottom":    top/bottom
+                    "bottom/top":    bottom/top
+                    "left/right":    left/right
+                    "right/left":    right/left
+                    "top only":      top only
+                    "bottom only":   bottom only
+                    "quick switch":  quick switch
+                    "hybrid/top":    hybrid/top
+                    "hybrid/bottom": hybrid/bottom
+            frameskip_desmume:
+                prompt: FRAME SKIP
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "Off": 0
+                    "1":   1
+                    "2":   2
+                    "3":   3
+                    "4":   4
+                    "5":   5
+                    "6":   6
+                    "7":   7
+                    "8":   8
+                    "9":   9
     devilutionx:
       features: [ ]
     dolphin:
       features: [ ]
     dosbox:
-      features: [ padtokeyboard ]
+      features: [padtokeyboard]
+      cfeatures:
+            core_timing:
+                prompt: CPU TIMING MODE (FPS)
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "internal (fixed 60fps)":  internal_fixed
+                    "internal (variable fps)": internal_variable
+                    "external (variable fps)": external
+            filter:
+                prompt: VIDEO FILTER
+                label:  Apply to achieve some kind of visual effect
+                choices:
+                    "Off":         none
+                    "normal2x":    normal2x
+                    "normal3x":    normal3x
+                    "advmame2x":   advmame2x
+                    "advmame3x":   advmame3x
+                    "advinterp2x": advinterp2x
+                    "advinterp3x": advinterp3x
+                    "hq2x":        hq2x
+                    "hq3x":        hq3x
+                    "2xai":        2xai
+                    "super2xai":   super2xai
+                    "supereagle":  supereagle
+                    "tv2x":        tv2x
+                    "tv3x":        tv3x
+                    "rgb2x":       rgb2x
+                    "rgb3x":       rgb3x
+                    "scan2x":      scan2x
+                    "scan3x":      scan3x
     duckstation:
       features: [ ]
       cfeatures:
+            PatchFastBoot:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show BIOS animation when starting content
+                choices:
+                    "Off":        "true"
+                    "On":         "false"
             resolution_scale:
-                prompt:  INTERNAL RESOLUTION
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
-                    "native":   1
-                    "2x":       2
-                    "3x/720p":  3
-                    "4x":       4
-                    "5x/1080p": 5
-                    "6x/1440p": 6
-                    "7x":       7
-                    "8x":       8
-                    "9x":       9
+                    "1x(native)": 1
+                    "2x":         2
+                    "3x/720p":    3
+                    "4x":         4
+                    "5x/1080p":   5
+                    "6x/1440p":   6
+                    "7x":         7
+                    "8x":         8
+                    "9x":         9
             antialiasing:
-                prompt:  MSAA/SSAA
+                prompt: ANTI-ALIASING (MSAA/SSAA)
+                label:  Smooth out jagged edges on 3D objetcs polygons 
                 choices:
-                    "Off":      1
-                    "2x msaa":  2
-                    "4x msaa":  4
-                    "8x msaa":  8
-                    "16x msaa": 16
-                    "32x msaa": 32
-                    "2x ssaa":  2-ssaa
-                    "4x ssaa":  4-ssaa
-                    "8x ssaa":  8-ssaa
-                    "16x ssaa": 16-ssaa
-                    "32x ssaa": 32-ssaa
+                    "Off":        1
+                    "2x msaa":    2
+                    "4x msaa":    4
+                    "8x msaa":    8
+                    "16x msaa":   16
+                    "32x msaa":   32
+                    "2x ssaa":    2-ssaa
+                    "4x ssaa":    4-ssaa
+                    "8x ssaa":    8-ssaa
+                    "16x ssaa":   16-ssaa
+                    "32x ssaa":   32-ssaa
             texture_filtering:
-                prompt:  TEXTURE FILTER
+                prompt: TEXTURE FILTERING
+                label:  Smooths out textures on 3D objetcs
                 choices:
-                    "nearest":   Nearest
-                    "bilinear":  Bilinear
-                    "jinc2":     JINC2
-                    "xBR":       xBR
-            widescreen_hack:
+                    "nearest":    Nearest
+                    "bilinear":   Bilinear
+                    "jinc2":      JINC2
+                    "xBR":        xBR
+            widescreen_hack_duckstation:
                 prompt: WIDESCREEN HACK
+                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
                 choices:
-                    "Off":  false
-                    "On":   true
+                    "Off":        "false"
+                    "On":         "true"
+            duckstation_CropMode:
+                prompt: CROP MODE
+                label:  Changes how much of the image is cropped
+                choices:
+                    "Off":                "None"
+                    "Only Overscan Area": "Overscan"
+                    "All Borders":        "Borders"
+            Controller1:
+                prompt: CONTROLLER 1 TYPE
+                label:  Sets the type of controller for slot 1
+                choices:
+                    "None":                          None
+                    "Digital Controller":            DigitalController
+                    "Analog Controller (DualShock)": AnalogController
+                    "Namco GunCon":                  NamcoGunCon
+                    "PlayStation Mouse":             PlayStationMouse
+                    "NeGcon":                        NeGcon
+            Controller2:
+                prompt: CONTROLLER 2 TYPE
+                label:  Sets the type of controller for slot 2
+                choices:
+                    "None":                          None
+                    "Digital Controller":            DigitalController
+                    "Analog Controller (DualShock)": AnalogController
+                    "Namco GunCon":                  NamcoGunCon
+                    "PlayStation Mouse":             PlayStationMouse
+                    "NeGcon":                        NeGcon
     fbneo:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            fbneo-cpu-speed-adjust:
+                prompt: CPU CLOCK
+                label:  Can fix native slowdowns in some games
+                choices:
+                    "30%":        30%
+                    "40%":        40%
+                    "50%":        50%
+                    "60%":        60%
+                    "70%":        70%
+                    "80%":        80%
+                    "90%":        90%
+                    "100%":       100%
+                    "110%":       110%
+                    "120%":       120%
+                    "130%":       130%
+                    "140%":       140%
+                    "150%":       150%
+                    "160%":       160%
+                    "170%":       170%
+                    "180%":       180%
+                    "190%":       190%
+                    "200%":       200%
+            fbneo-frameskip:
+                prompt: FRAMESKIP
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "No skipping":                         0
+                    "Skip rendering of 1 frames out of 2": 1
+                    "Skip rendering of 2 frames out of 3": 2
+                    "Skip rendering of 3 frames out of 4": 3
+                    "Skip rendering of 4 frames out of 5": 4
+            fbneo-lightgun-hide-crosshair:
+                prompt: CROSSHAIR (LIGHTGUN)
+                label:  Show crosshair if you play with a lightgun device
+                choices:
+                    "Off":                                enabled
+                    "On":                                 disabled
+      systems:
+            neogeo:
+                cfeatures:
+                    fbneo-neogeo-mode-switch:
+                        prompt: NEOGEO MODE
+                        label:  Load appropriate Bios depending on your choice
+                        choices:
+                            "Console AES World":                   AES Asia
+                            "Console AES Japan":                   AES Japan
+                            "Arcade MVS Europe":                   MVS Asia/Europe
+                            "Arcade MVS USA":                      MVS USA
+                            "Arcade MVS Japan":                    MVS Japan
+                            "Arcade Universe BIOS (Cheats)":       Universe BIOS
+                    fbneo-memcard-mode:
+                        prompt: MEMORY CARD MODE
+                        label:  Change the behavior for the memory card
+                        choices:
+                            "Off":                                disabled
+                            "Shared":                             shared
+                            "Per-game":                           per-game
     fceumm:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            fceumm_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Removes 8-sprites-per-scanline hardware limit
+                choices:
+                    "Off":                  disabled
+                    "On":                   enabled
+            fceumm_palette:
+                prompt: COLOR PALETTE
+                label:  Choose which color palette is going to be used
+                choices:
+                    "default":              default
+                    "asqrealc":             asqrealc
+                    "nintendo-vc":          nintendo-vc
+                    "rgb":                  rgb
+                    "yuv-v3":               yuv-v3
+                    "unsaturated-final":    unsaturated-final
+                    "sony-cxa2025as-us":    sony-cxa2025as-us
+                    "pal":                  pal
+                    "bmf-final2":           bmf-final2
+                    "bmf-final3":           bmf-final3
+                    "smooth-fbx":           smooth-fbx
+                    "composite-direct-fbx": composite-direct-fbx
+                    "pvm-style-d93-fbx":    pvm-style-d93-fbx
+                    "ntsc-hardware-fbx":    ntsc-hardware-fbx
+                    "nes-classic-fbx-fs":   nes-classic-fbx-fs
+                    "nescap":               nescap
+                    "wavebeam":             wavebeam
+                    "custom":               custom
+            fceumm_ntsc_filter:
+                prompt: NTSC FILTER
+                label:  Enable blargg NTSC video filters
+                choices:
+                    "Off":                                    disabled
+                    "Composite (color bleeding + artifacts)": composite
+                    "SVideo (color bleeding only)":           svideo
+                    "RGB (crisp image)":                      rgb
+            fceumm_sndquality:
+                prompt: SOUND QUALITY (HIGHTER DEVICES)
+                label:  High sound quality for games using expansion audio
+                choices:
+                    "Low":                  Low
+                    "High":                 High
+                    "Very High":            Very High
+            fceumm_overclocking:
+                prompt: PPU OVERCLOCKING
+                label:  Minimize ingame slowdowns of some games (Contra Force)
+                choices:
+                    "disabled":             disabled
+                    "2x-Postrender":        2x-Postrender
+                    "2x-VBlank":            2x-VBlank
     flycast:
       features: [         rewind, autosave]
       cfeatures:
+            internal_resolution_flycast:
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "640x480":    640x480
+                    "1280x960":   1280x960
+                    "1920x1440":  1920x1440
+                    "2560x1920":  2560x1920
+                    "3200x2400":  3200x2400
+                    "3840x2880":  3840x2880
+                    "4480x3360":  4480x3360
+                    "5120x3840":  5120x3840
+                    "5760x4320":  5760x4320
+                    "6400x4800":  6400x4800
+                    "7040x5280":  7040x5280
+                    "7680x5760":  7680x5760
+                    "8320x6240":  8320x6240
+                    "8960x6720":  8960x6720
+                    "9600x7200":  9600x7200
+                    "10240x7680": 10240x7680
+                    "10880x8160": 10880x8160
+                    "11520x8640": 11520x8640
+                    "12160x9120": 12160x9120
+                    "12800x9600": 12800x9600
+            mipmapping:
+                prompt: TEXTURES MIP-MAPPING (BLUR)
+                label:  Smooths out textures on 3D objetcs
+                choices:
+                    "Off": disabled
+                    "On":  enabled
             anisotropic_filtering:
                 prompt: ANISOTROPIC FILTERING
+                label:  Enhance the quality with on perspective textures
                 choices:
                     "Off": off
                     "2x":  2
@@ -115,6 +452,7 @@ libretro:
                     "16x": 16
             texture_upscaling:
                 prompt: TEXTURES UPSCALING (XBRZ)
+                label:  Upscaling 2D pixel art graphics (2D Games Only)
                 choices:
                     "Off": off
                     "2x":  2x
@@ -122,25 +460,151 @@ libretro:
                     "6x":  6x
             render_to_texture_upscaling:
                 prompt: RENDER TO TEXTURES UPSCALING
+                label:  Upscaling textures resolution on 3D objetcs
                 choices:
                     "Off": 1x
                     "2x":  2x
                     "3x":  3x
                     "4x":  4x
                     "8x":  8x
-            widescreen_hack:
-                prompt: WIDESCREEN HACK
+            frame_skipping:
+                prompt: FRAME SKIP
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "Off": disabled
+                    "1":   1
+                    "2":   2
+                    "3":   3
+                    "4":   4
+                    "5":   5
+                    "6":   6
+            force_wince:
+                prompt: FORCE WINDOWS CE MODE
+                label:  Enable full MMU emulation for Windows CE games
                 choices:
                     "Off": disabled
                     "On":  enabled
+            widescreen_hack_flycast:
+                prompt: WIDESCREEN HACK
+                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+                choices:
+                    "Off": disabled
+                    "On":  enabled
+            widescreen_cheats:
+                prompt: WIDESCREEN CHEAT
+                label:  Same as HACK but with a specific setting by game
+                choices:
+                    "Off": disabled
+                    "On":  enabled
+      systems:
+            atomiswave:
+                cfeatures:
+                    screen_rotation_atomiswave:
+                        prompt: SCREEN ORIENTATION
+                        label:  Rotate screen for some arcade games
+                        choices:
+                            "Horizontal": horizontal
+                            "Vertical":   vertical
+            naomi:
+                cfeatures:
+                    screen_rotation_naomi:
+                        prompt: SCREEN ORIENTATION
+                        label:  Rotate screen for some arcade games
+                        choices:
+                            "Horizontal": horizontal
+                            "Vertical":   vertical
     freeintv:
       features: [padtokeyboard]
     fuse:
       features: [         rewind, autosave, padtokeyboard]
+      cfeatures:
+            fuse_hide_border:
+                prompt: ZOOM (HIDES BORDER)
+                label:  Making the game occupy the entire screen area
+                choices:
+                    "Off":  disabled
+                    "On":   enabled
     gambatte:
       features: [         rewind, autosave, colorization]
+      cfeatures:
+            gb_bootloader:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show BIOS animation when starting content
+                choices:
+                    "Off":                     disabled
+                    "On":                      enabled
+            mix_frames:
+                prompt: GHOSTING EFFECT
+                label:  Simulation of LCD ghosting effects
+                choices:
+                    "Off":                     disabled
+                    "Simple (Accurate)":       mix
+                    "Simple (Fast)":           mix_fast
+                    "LCD Ghosting (Accurate)": lcd_ghosting
+                    "LCD Ghosting (Fast)":     lcd_ghosting_fast
     genesisplusgx:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            gpgx_no_sprite_limit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Reduce sprite flickering when enabled
+                choices:
+                    "Off":                disabled
+                    "On":                 enabled
+      systems:
+            megadrive:
+                cfeatures:
+                    gpgx_blargg_filter_md:
+                        prompt: NTSC FILTER
+                        label:  Enable blargg NTSC video filters
+                        choices:
+                            "Off":                                    Off
+                            "Composite (color bleeding + artifacts)": composite
+                            "SVideo (color bleeding only)":           svideo
+                            "RGB (crisp image)":                      rgb
+                    gun_cursor_md:
+                        prompt: SHOW LIGHTGUN CROSSHAIR
+                        label:  Shows crosshairs for Menacer and Justifiers devices
+                        choices:
+                            "Off":        disabled
+                            "On":         enabled
+            mastersystem:
+                cfeatures:
+                    gpgx_blargg_filter_ms:
+                        prompt: NTSC FILTER
+                        label:  Enable blargg NTSC video filters
+                        choices:
+                            "Off":                                    Off
+                            "Composite (color bleeding + artifacts)": composite
+                            "SVideo (color bleeding only)":           svideo
+                            "RGB (crisp image)":                      rgb
+                    gun_cursor_ms:
+                        prompt: SHOW LIGHTGUN CROSSHAIR
+                        label:  Shows crosshairs for Light Phaser device
+                        choices:
+                            "Off":        disabled
+                            "On":         enabled
+                    ym2413:
+                        prompt: FM CHIP (YM2413)
+                        label:  Enhanced sound output support for compatible games
+                        choices:
+                            "Automatic":  automatic
+                            "Off":        disabled
+                            "On":         enabled
+            gamegear:
+                cfeatures:
+                    lcd_filter:
+                        prompt: LCD GHOSTING FILTER
+                        label:  Simulate the movement blur effect on old LCD screen
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
+                    gg_extra:
+                        prompt: EXTENDED SCREEN
+                        label:  Extend the game screen area like on a Master System
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
     gpsp:
       features: [         rewind, autosave]
     gw:
@@ -161,8 +625,75 @@ libretro:
       features: [netplay, rewind, autosave]
     mame0139:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            mame_current_frame_skip:
+                prompt: FRAMSKIP
+                label:  Skip frames to improve performance (smoothless)
+                choices:
+                    "Off":            0
+                    "1":              1
+                    "2":              2
+                    "3":              3
+                    "4":              4
+                    "Automatic":      automatic
+            mame_current_turbo_button:
+                prompt: AUTOFIRE
+                label:  Choice the buton to enable Autofire
+                choices:
+                    "Off":            disabled
+                    "button 1":       button 1
+                    "button 2":       button 2
+                    "R2 to button 1": R2 to button 1 mapping
+                    "R2 to button 2": R2 to button 2 mapping
+            mame_current_turbo_delay:
+                prompt: AUTOFIRE PULSE SPEED
+                label:  Choose the fire speed for Autofire 
+                choices:
+                    "slow":           slow
+                    "medium":         medium
+                    "fast":           fast
     mame078plus:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            mame2003-plus_analog:
+                prompt: CONTROL MAPPING
+                label:  Choose from Analog and Digital controller
+                choices:
+                    "Analog":       analog
+                    "Digital":      digital
+            mame2003-plus_frameskip:
+                prompt: FRAMSKIP
+                label:  Skip frames to improve performance (smoothless)
+                choices:
+                    "Off":          0
+                    "1":            1
+                    "2":            2
+                    "3":            3
+                    "4":            4
+                    "5":            5
+            mame2003-plus_input_interface:
+                prompt: INPUT INTERFACE
+                label:  Use input directly sends by keyboard to the core
+                choices:
+                    "retropad":     retropad
+                    "keyboard":     keyboard
+                    "simultaneous": simultaneous
+            mame2003-plus_tate_mode:
+                prompt: TATE MODE
+                label:  Rotating display to vertical mode rendering
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
+            mame2003-plus_neogeo_bios:
+                prompt: NEOGEO MODE
+                label:  Manually specify your choice of Neo Geo BIOS
+                choices:
+                    "Console AES World":                   asia-aes
+                    "Arcade MVS Europe":                   euro
+                    "Arcade MVS USA":                      us
+                    "Arcade MVS Japan":                    japan
+                    "Arcade Universe BIOS 4.0 (Cheats)":   unibios40
+                    "Arcade Universe BIOS 3.3 (Cheats)":   unibios33
     mednafen_lynx:
       features: [netplay, rewind, autosave]
     mednafen_ngp:
@@ -170,56 +701,233 @@ libretro:
     mednafen_psx:
       features: [         rewind, autosave]
       cfeatures:
-            internal_resolution:
-                prompt: INTERNAL RESOLUTION
+            skip_bios_psx:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show BIOS animation when starting content
+                choices:
+                    "Off":        enabled
+                    "On":         disabled
+            beetlepsx_cpu_freq:
+                prompt: OVERCLOCKING (HEAVY CPU)
+                label:  Can eliminate slowdown and improve frame rates
+                choices:
+                    "50%":          50%
+                    "60%":          60%
+                    "70%":          70%
+                    "80%":          80%
+                    "90%":          90%
+                    "100%(native)": 100%(native)
+                    "110%":         110%
+                    "120%":         120%
+                    "130%":         130%
+                    "140%":         140%
+                    "150%":         150%
+                    "160%":         160%
+                    "170%":         170%
+                    "180%":         180%
+                    "190%":         190%
+                    "200%":         200%
+                    "250%":         250%
+                    "300%":         300%
+                    "350%":         350%
+                    "4000%":        400%
+                    "450%":         450%
+                    "500%":         500%
+                    "550%":         550%
+                    "600%":         600%
+                    "650%":         650%
+                    "700%":         700%
+                    "750%":         750%
+            internal_resolution_mednafen:
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "1x(native)": 1x(native)
                     "2x":         2x
                     "4x":         4x
                     "8x":         8x
                     "16x":        16x
-            texture_filtering:
-                prompt: TEXTURE FILTERING
-                choices:
-                    "Nearest":    nearest
-                    "SABR":       SABR
-                    "xBR":        xBR
-                    "Bilinear":   bilinear
-                    "3-Point":    3-point
-                    "JINC2":      JINC2
-            widescreen_hack:
+            widescreen_hack_mednafen:
                 prompt: WIDESCREEN HACK
+                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
                 choices:
                     "Off":        disabled
                     "On":         enabled
+            frame_duping:
+                prompt: FRAME DUPING (SPEEDDUP)
+                label:  Small performance increase (may lost anim. frames)
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
+            cpu_dynarec:
+                prompt: CPU DYNAREC (SPEEDDUP)
+                label:  Much faster than interpreter (but may have bugs)
+                choices:
+                    "Desabled (Beatle Interpreter": disabled
+                    "Max Performance":              execute
+                    "Cycle Timing Check":           execute_once
+                    "Lightrec Interpreter":         run_interpreter
+            dynarec_invalidate:
+                prompt: DYNAREC CODE INVALIDATION
+                label:  Some games require DMA Only (for CPU Dynarec)
+                choices:
+                    "Full":                         full
+                    "DMA Only (Slightly Faster)":   dma
+            multitap_mednafen:
+                prompt: ENABLE MULTITAP
+                label:  Allowing 5-8 player support in games
+                choices:
+                    "Off":              disabled
+                    "Port1":            port1
+                    "Port2":            port2
+                    "Port1+2":          port12
     mednafen_supergrafx:
       features: [netplay, rewind, autosave]
     mednafen_wswan:
       features: [netplay, rewind, autosave]
     mgba:
       features: [         rewind, autosave]
+      cfeatures:
+            skip_bios_mgba:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show BIOS animation when starting content
+                choices:
+                    "Off": ON
+                    "On":  OFF
+      systems:
+            gb:
+                cfeatures:
+                    sgb_borders:
+                        prompt: SUPER GB BORDERS
+                        label:  Only for Super Game Boy enhanced games
+                        choices:
+                            "Off": OFF
+                            "On":  ON
+                    color_correction:
+                        prompt: COLOR CORRECTION
+                        label:  Adjusts output colors to feel real hardware
+                        choices:
+                            "Off": OFF
+                            "On":  GBA
+            gbc:
+                cfeatures:
+                    sgb_borders:
+                        prompt: SUPER GB BORDERS
+                        label:  Only for Super Game Boy enhanced games
+                        choices:
+                            "Off": OFF
+                            "On":  ON
+                    color_correction:
+                        prompt: COLOR CORRECTION
+                        label:  Adjusts output colors to feel real hardware
+                        label:  
+                        choices:
+                            "Off": OFF
+                            "On":  GBC
+            gba:
+                cfeatures:
+                    solar_sensor_level:
+                        prompt: SOLAR SENSOR LEVEL
+                        label: Only for games that employed it (for Boktai)
+                        choices:
+                            "0":  0
+                            "1":  1
+                            "2":  2
+                            "3":  3
+                            "4":  4
+                            "5":  5
+                            "6":  6
+                            "7":  7
+                            "8":  8
+                            "9":  9
+                            "10": 10
+                    frameskip_mgba:
+                        prompt: FRAMESKIP
+                        label:  Skip frames to improve performance (smoothless)
+                        choices:
+                            "0":  0
+                            "1":  1
+                            "2":  2
+                            "3":  3
+                            "4":  4
+                            "5":  5
+                            "6":  6
+                            "7":  7
+                            "8":  8
+                            "9":  9
+                            "10": 10
     mrboom:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            mrboom-aspect:
+                prompt: TEAM MODE
+                label:  Choose the Team mode color
+                choices:
+                    "Selfie": Native
+                    "Color":  Color
+                    "Sex":    Sex
+                    "Skynet": Skynet
+            mrboom-nomonster:
+                prompt: MONSTERS
+                label:  Enable or disable monsters on battle
+                choices:
+                    "Off":    OFF
+                    "On":     ON
     mupen64plus-next:
       features: [         rewind, autosave]
       cfeatures:
+            43screensize:
+                prompt: VIDEO 4:3 RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "320x240":   320x240
+                    "640x480":   640x480
+                    "960x720":   960x720
+                    "1280x960":  1280x960
+                    "1600x1200": 1600x1200
+                    "1920x1440": 1920x1440
+                    "2240x1680": 2240x1680
+                    "2560x1920": 2560x1920
+                    "3200x2400": 3200x2400
+                    "3520x2640": 3520x2640
+                    "3840x2880": 3840x2880
+            169screensize:
+                prompt: VIDEO 16:9 RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "640x360":   640x360
+                    "960x540":   960x540
+                    "1280x720":  1280x720
+                    "1920x1080": 1920x1080
+                    "2560x1440": 2560x1440
+                    "3840x2160": 3840x2160
+                    "7680x4320": 7680x4320
+            aspect:
+                prompt: WIDESCREEN HACK
+                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+                choices:
+                    "Off":       4:3
+                    "On":        16:9 adjusted
             BilinearMode:
                 prompt: BILINEAR FILTERING
+                label:  Filter to gradually switch colors
                 choices:
                     "standard":   standard
                     "3 point":    3point
             MultiSampling:
-                prompt: MSAA LEVEL
+                prompt: ANTI-ALIASING (MSAA)
+                label:  Smooth out jagged edges on 3D objetcs polygons 
                 choices:
-                    "off":        0
+                    "Off":        0
                     "2x":         2
                     "4x":         4
                     "8x":         8
                     "16x":        16
             Texture_filter:
-                prompt: TEXTURE FILTER
+                prompt: TEXTURE FILTERING
+                label:  Smooths out textures on 3D objetcs
                 choices:
-                    "off":        None
+                    "Off":        None
                     "Smooth 1":   Smooth filtering 1
                     "Smooth 2":   Smooth filtering 2
                     "Smooth 3":   Smooth filtering 3
@@ -227,9 +935,10 @@ libretro:
                     "Sharp 1":    Sharp filtering 1
                     "Sharp 2":    Sharp filtering 2
             Texture_Enhancement:
-                prompt: Texture Enhancement
+                prompt: TEXTURE ENHANCEMENT (XBRZ)
+                label:  Scales up a nearest-neighbor version of the texture
                 choices:
-                    "off":        None
+                    "Off":        None
                     "As Is":      As Is
                     "X2":         X2
                     "X2SAI":      X2SAI
@@ -244,12 +953,40 @@ libretro:
                     "5xBRZ":      5xBRZ
                     "6xBRZ":      6xBRZ
     neocd:
-      features: [                 autosave]
+      features: [         rewind, autosave]
+      cfeatures:
+            neocd_region:
+                prompt: CONSOLE REGION
+                label:  Change language of some games
+                choices:
+                    "Japan":        Japan
+                    "USA":          USA
+                    "Europe":       Europe
+            neocd_bios:
+                prompt: BIOS SELECT
+                label:  CD Universe Bios not include cheats
+                choices:
+                    "CDZ":          CDZ
+                    "CDZ (MAME)":   CDZ (MAME)
+                    "Universe 3.2": Universe 3.2
+            neocd_per_content_saves:
+                prompt: PER-GAME SAVES
+                label:  Use one save file per-game
+                choices:
+                    "Off":          Off
+                    "On":           On
     nestopia:
       features: [netplay, rewind, autosave]
       cfeatures:
-            palette:
+            nestopia_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Removes 8-sprites-per-scanline hardware limi
+                choices:
+                    "Off":                  disabled
+                    "On":                   enabled
+            nestopia_palette:
                 prompt: COLOR PALETTE
+                label:  Choose which color palette is going to be used
                 choices:
                     "consumer":             consumer
                     "cxa2025as":            cxa2025as
@@ -261,42 +998,342 @@ libretro:
                     "pvm-style-d93-fbx":    pvm-style-d93-fbx
                     "ntsc-hardware-fbx":    ntsc-hardware-fbx
                     "nes-classic-fbx-fs":   nes-classic-fbx-fs
-                    "raw":                  raw
                     "custom":               custom
-    tic80:
-      features: [                 autosave]
-    retro8:
-      features: [ ]
-    quasi88:
-      features: [netplay, rewind, autosave, padtokeyboard]
+            nestopia_blargg_ntsc_filter:
+                prompt: NTSC FILTER
+                label:  Enable blargg NTSC video filters
+                choices:
+                    "Off":                                    disabled
+                    "Composite (color bleeding + artifacts)": composite
+                    "SVideo (color bleeding only)":           svideo
+                    "RGB (crisp image)":                      rgb
+            nestopia_overclock:
+                prompt: CPU OVERCLOCK
+                label:  Minimize ingame slowdowns of some games (Contra Force)
+                choices:
+                    "Off":                  1x
+                    "2x":                   2x
+            nestopia_select_adapter:
+                prompt: 4 PLAYER ADAPTER
+                label:  Manually select a 4 Player Adapter for some games
+                choices:
+                    "Autodetect":           auto
+                    "ntsc":                 ntsc
+                    "famicom":              famicom
     np2kai:
       features: [netplay, rewind, autosave, padtokeyboard]
+      cfeatures:
+            np2kai_model:
+                prompt: PC MODEL
+                label:  Selects the correct PC model being emulated
+                choices:
+                    "PC-286":    PC-286
+                    "PC-9801VM": PC-9801VM
+                    "PC-9801VX": PC-9801VX
+            np2kai_cpu_feature:
+                prompt: CPU FEATURE
+                label:  Select the processor model
+                choices:
+                    "Intel 80386":         Intel 80386
+                    "Intel i486DX":        Intel i486DX
+                    "Intel Pentium (MMX)": Intel MMX Pentium
+                    "Intel Pentium 2":     Intel Pentium II
+                    "Intel Pentium 3":     Intel Pentium III
+                    "Intel Pentium 4":     Intel Pentium 4
+                    "Neko Processor II":   Neko Processor II
+            np2kai_clk_mult:
+                prompt: CPU CLOCK MULTIPLIER
+                label:  Recommended to use somewhere between a 4x and 8x
+                choices:
+                    "2x":        2
+                    "4x":        4
+                    "5x":        5
+                    "6x":        6
+                    "8x":        8
+                    "10x":       10
+                    "12x":       12
+                    "16x":       16
+                    "20x":       20
+                    "24x":       24
+                    "30x":       30
+                    "36x":       36
+                    "40x":       40
+                    "42x":       42
+                    "52x":       52
+                    "64x":       64
+                    "76x":       76
+                    "88x":       88
+                    "100x":      100
+            np2kai_ExMemory:
+                prompt: RAM SIZE
+                label:  Select memory required by game, 13 Mo recommanded
+                choices:
+                    "1 Mo":      1
+                    "3 Mo":      2
+                    "7 Mo":      7
+                    "11 Mo":     11
+                    "13 Mo":     13
+                    "16 Mo":     16
+                    "32 Mo":     32
+                    "64 Mo":     64
+                    "120 Mo":    120
+                    "230 Mo":    230
+                    "512 Mo":    512
+                    "1024 Mo":   1024
+            np2kai_gdc:
+                prompt: GDC
+                label:  Graphic Display Controller model
+                choices:
+                    "uPD7220":   uPD7220
+                    "uPD72020":  uPD72020
+            np2kai_skipline:
+                prompt: REMOVE SCANLINES
+                label:  (Off) will show Black Scanline in older games (Graphically designed to use scanlines)
+                choices:
+                    "Full 255 lines": Full 255 lines
+                    "Off":            OFF
+                    "On":             ON
+            np2kai_realpal:
+                prompt: REAL PALETTES
+                label:  Some games only working correctly with this (Apros)
+                choices:
+                    "Off":       OFF
+                    "On":        ON
+            np2kai_SNDboard:
+                prompt: SOUND BOARD
+                label:  Choose 26K for old games and 86K for newer games
+                choices:
+                    "None":                                             None
+                    "PC9801-14":                                        PC9801-14
+                    "PC9801-26K":                                       PC9801-26K
+                    "PC9801-26K + 86":                                  PC9801-26K + 86
+                    "PC9801-86":                                        PC9801-86
+                    "PC9801-86 + 118(B460)":                            PC9801-86 + 118(B460)
+                    "PC9801-86 + 118(B460) + Sound Blaster 16":         PC9801-86 + 118(B460) + Sound Blaster 16
+                    "PC9801-86 + Mate-X PCM(B460)":                     PC9801-86 + Mate-X PCM(B460)
+                    "PC9801-86 + Mate-X PCM(B460) + Sound Blaster 16":  PC9801-86 + Mate-X PCM(B460) + Sound Blaster 16
+                    "PC9801-86 + Chibi-oto":                            PC9801-86 + Chibi-oto
+                    "PC9801-86 + Speek Board":                          PC9801-86 + Speak Board
+                    "PC9801-86 + Sound Blaster 16":                     PC9801-86 + Sound Blaster 16
+                    "PC9801-118":                                       PC9801-118
+                    "PC9801-118 + Sound Blaster 16":                    PC9801-118 + Sound Blaster 16
+                    "AMD-98":                                           AMD-98
+                    "Chibi-oto":                                        Chibi-oto
+                    "Sound Blaster 16":                                 Sound Blaster 16
+                    "Speak Board":                                      Speak Board
+                    "Spark Board":                                      Spark Board
+                    "Sound Orchestra":                                  Sound Orchestra
+                    "Sound Orchestra-V":                                Sound Orchestra-V
+                    "Little Orchestra L":                               Little Orchestra L
+                    "Multimedia Orchestra":                             Multimedia Orchestra
+                    "Mate-X PCM(B460)":                                 Mate-X PCM
+                    "Mate-X PCM + Sound Blaster 16":                    Mate-X PCM + Sound Blaster 16
+                    "Otomi-chanx2":                                     Otomi-chanx2
+                    "Otomi-chanx2 + 86":                                Otomi-chanx2 + 86
+                    "WaveStar":                                         WaveStar
+            np2kai_jast_snd:
+                prompt: JAST SOUND
+                label:  To have music and not only sound in games (Owl-Zoo)
+                choices:
+                    "Off":                          OFF
+                    "On":                           ON
+            np2kai_joymode:
+                prompt: Joypad D-pad Mapping
+                label:  Emulate a keyboard/mouse/joypad on your gamepad
+                choices:
+                    "Off":                          OFF
+                    "Mouse":                        Mouse
+                    "Arrows":                       Arrows
+                    "Arrows 3button":               Arrows 3button
+                    "Keypad":                       Keypad
+                    "Keypad 3button":               Keypad 3button
+                    "Manual keyboard":              Manual Keyboard
+                    "Atari Joypad":                 Atari Joypad
     nxengine:
       features: [ ]
     o2em:
       features: [                 autosave]
     opera:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            high_resolution:
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "320x240":         disabled
+                    "640x480":         enabled
+            cpu_overclock:
+                prompt: CPU OVERCLOCK
+                label:  Improve frame rates in many games (like NFS)
+                choices:
+                    "1.0x (12.50Mhz)": 1.0x (12.50Mhz)
+                    "1.1x (13.75Mhz)": 1.1x (13.75Mhz)
+                    "1.2x (15.00Mhz)": 1.2x (15.00Mhz)
+                    "1.5x (18.75Mhz)": 1.5x (18.75Mhz)
+                    "1.6x (20.00Mhz)": 1.6x (20.00Mhz)
+                    "1.8x (22.50Mhz)": 1.8x (22.50Mhz)
+                    "2.0x (25.00Mhz)": 2.0x (25.00Mhz)
+            active_devices:
+                prompt: ACTIVE INPUT DEVICES FIX
+                label:  Fixing a possible bug with controller detection
+                choices:
+                    "1":               1
+                    "2":               2
+                    "3":               3
+                    "4":               4
+                    "5":               5
+                    "6":               6
+                    "7":               7
+                    "8":               8
+            game_fixes_opera:
+                prompt: ADDITIONAL GAME FIXES
+                label:  Enable these options to fix them games
+                choices:
+                    "Off":               disabled
+                    "Alone in the Dark": timing_hack6
+                    "Crash'n Burn":      timing_hack1
+                    "Dinopark Tycoon":   timing_hack3
+                    "Microcosm":         timing_hack5
     parallel_n64:
       features: [         rewind, autosave]
+      cfeatures:
+            screensize:
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
+                choices:
+                    "320x240":   320x240
+                    "640x480":   640x480
+                    "960x720":   960x720
+                    "1280x960":  1280x960
+                    "1440x1080": 1440x1080
+                    "1600x1200": 1600x1200
+                    "1920x1440": 1920x1440
+                    "2240x1680": 2240x1680
+                    "2880x2160": 2880x2160
+                    "5760x4320": 5760x4320
+            filtering:
+                prompt: TEXTURE FILTERING
+                label:  Smooths out textures on 3D objetcs
+                choices:
+                    "Automatic":   automatic
+                    "N64 3-point": N64 3-point
+                    "Bilinear":    bilinear
+                    "Nearest":     nearest
     pce:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            pce_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Remove 16-sprites-per-scanline hardware limit
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
     pce_fast:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            sgx_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Remove 16-sprites-per-scanline hardware limit
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
     pcfx:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            pcfx_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Remove 16-sprites-per-scanline hardware limit
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
     pcsx_rearmed:
       features: [         rewind, autosave]
+      cfeatures:
+            show_bios_bootlogo:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show animation when starting (Breaks some games)
+                choices:
+                    "Off":              disabled
+                    "On":               enabled
+            frameskip_pcsx:
+                prompt: FRAMESKIP
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "Off":              0
+                    "1":                1
+                    "2":                2
+                    "3":                3
+            neon_enhancement:
+                prompt: ENHANCED RESOLUTION (SLOWER)
+                label:  Double the resolution (Speed hack causes glitches)
+                choices:
+                    "Off":              disabled
+                    "On":               enabled
+                    "On (Speed hack)":  enabled_with_speedhack
+            multitap_pcsx:
+                prompt: ENABLE MULTITAP
+                label:  Allowing 5-8 player support in games
+                choices:
+                    "Off":              disabled
+                    "Port1":            port1
+                    "Port2":            port2
+                    "Port1+2":          port12
+            game_fixes_pcsx:
+                prompt: ADDITIONAL GAME FIXES
+                label:  Enable these options to fix them games
+                choices:
+                    "Off":                                  disabled
+                    "Capcom VS games Expand Screen Width":  Capcom_fighting
+                    "Chrono Chross Odd/Even Bit Hack":      Chrono_Chross
+                    "Dark Forces Flat Tex Triangles Fix":   Dark_Forces
+                    "Diablo Music Fix":                     Diablo_Music_Fix
+                    "Lunar Ignore Brightness Color Fix":    Lunar
+                    "InuYasha Sengoku Battle Fix":          InuYasha_Sengoku
+                    "Pandemonium 2 Lazy Screen Update Fix": Pandemonium
+                    "Parasite Eve 2/Vandal Hearts 1&2 Fix": Parasite_Eve
     picodrive:
       features: [netplay, rewind, autosave]
+      cfeatures:
+            picodrive_sprlim:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Reduce sprite flickering when enabled
+                choices:
+                    "Off":          disabled
+                    "On":           enabled
     pocketsnes:
       features: [netplay, rewind, autosave]
     pokemini:
       features: [         rewind, autosave]
+      cfeatures:
+            pokemini_lcdfilter:
+                prompt: LCD FILTER
+                label:  Produces a clean LCD effect
+                choices:
+                    "Off":  none
+                    "On":   dotmatrix
+            pokemini_lcdmode:
+                prompt: LCD GHOSTING EFFECTS
+                label:  Emulate liquid crystal display
+                choices:
+                    "Off":  3shades
+                    "On":   analog
     ppsspp:
       features: [         rewind, autosave]
     prboom:
       features: [         rewind, autosave]
+      cfeatures:
+            prboom-resolution:
+                prompt: VIDEO RESOLUTION
+                label:  Smooth out jagged edges on 3D objetcs polygons
+                choices:
+                    "320x200":    320x200
+                    "640x400":    640x400
+                    "960x600":    960x600
+                    "1280x800":   1280x800
+                    "1600x1000":  1600x1000
+                    "1920x1200":  1920x1200
+                    "2240x1400":  2240x1400
+                    "2560x1600":  2560x1600
     prosystem:
       features: [         rewind, autosave]
     puae:
@@ -304,29 +1341,34 @@ libretro:
       cfeatures:
             video_resolution:
                 prompt: VIDEO RESOLUTION
+                label:  Increase video to Hi Resolution
                 choices:
                     "360p":       lores
                     "720p":       hires
                     "1440p":      superhires
             video_standard:
                 prompt: VIDEO STANDARD
+                label:  Switch frequency and resolution by region
                 choices:
-                    "pal":        PAL
-                    "ntsc":       NTSC
+                    "PAL 50Hz - 288/576px":        PAL
+                    "NTSC 60Hz - 240/480px":       NTSC
             zoom_mode:
                 prompt: ZOOM MODE
+                label:  Crops the borders to fit various host screens
                 choices:
-                    "deactivate": none
+                    "Off":        none
                     "medium":     medium
                     "large":      large
                     "larger":     larger
             keyrah_mapping:
-                prompt: KEYRAH 2P MAPPING
+                prompt: 2P GAMEPAD MAPPING (KEYRAH)
+                label:  Keypad to joyport mappings for 2 players
                 choices:
-                    "On":         enabled
                     "Off":        disabled
+                    "On":         enabled
             mouse_speed:
                 prompt: MOUSE SPEED
+                label:  Affects mouse speed globally.
                 choices:
                     "original":   100
                     "50%":        50
@@ -336,52 +1378,244 @@ libretro:
                     "170%":       170
                     "200%":       200
             whdload:
-                prompt: WHDLOAD
+                prompt: WHDLOAD LAUNCHER
+                label:  Enable launching pre-installed WHDLoad installs
                 choices:
-                    "On":         config
                     "Off":        disabled
+                    "On":         config
             pad_options:
                 prompt: JUMP ON B
+                label:  Makes second fire button press up
                 choices:
-                    "On":         jump
                     "Off":        disabled
+                    "On":         jump
+            disable_joystick:
+                prompt: DISABLE EMULATOR JOYSTICK
+                label:  Passes all physical keyboard events for Pad2Key
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
+            gfx_framerate:
+                prompt: FRAMESKIP
+                label:  Skip frames to improve performance (Smoothless)
+                choices:
+                    "Off":        disabled
+                    "1":          1
+                    "2":          2
     px68k:
       features: [padtokeyboard]
+      cfeatures:
+            px68k_cpuspeed:
+                prompt: CPU SPEED (OVERCLOCK)
+                label:  Can be used to slow down games that run too fast
+                choices:
+                    "10Mhz":              10Mhz
+                    "16Mhz":              16Mhz
+                    "25Mhz":              25Mhz
+                    "33Mhz (Overclock)":  33Mhz (OC)
+                    "66Mhz (Overclock)":  66Mhz (OC)
+                    "100Mhz (Overclock)": 100Mhz (OC)
+                    "150Mhz (Overclock)": 150Mhz (OC)
+                    "200Mhz (Overclock)": 200Mhz (OC)
+            px68k_ramsize:
+                prompt: RAM SIZE
+                label:  Amount of RAM used
+                choices:
+                    "1MB":                1MB
+                    "2MB":                2MB
+                    "3MB":                3MB
+                    "4MB":                4MB
+                    "5MB":                5MB
+                    "6MB":                6MB
+                    "7MB":                7MB
+                    "8MB":                8MB
+                    "9MB":                9MB
+                    "10MB":               10MB
+                    "11MB":               11MB
+                    "12MB":               12MB
+            px68k_frameskip:
+                prompt: FRAME SKIP
+                label:  Improve performance at the expense of smoothness
+                choices:
+                    "Full Frame":         Full Frame
+                    "1/2 Frame":          1/2 Frame
+                    "1/3 Frame":          1/3 Frame
+                    "1/4 Frame":          1/4 Frame
+                    "1/5 Frame":          1/5 Frame
+                    "1/6 Frame":          1/6 Frame
+                    "1/8 Frame1":         1/8 Frame1
+                    "16 Frame":           16 Frame
+                    "1/32 Frame":         1/32 Frame
+                    "1/60 Frame":         1/60 Frame
+                    "Auto Frame Skip":    Auto Frame Skip
+            px68k_joytype:
+                prompt: TWO PLAYERS JOYPAD TYPE
+                label:  Choose your Joypad type with 2 or 8 buttons
+                choices:
+                    "Default (2 Buttons)":       Default (2 Buttons)
+                    "Megadrive (8 Buttons)":     CPSF-MD (8 Buttons)
+                    "Super Famicom (8 Buttons)": CPSF-SFC (8 Buttons)
+    quasi88:
+      features: [netplay, rewind, autosave, padtokeyboard]
+      cfeatures:
+            q88_basic_mode:
+                prompt: PC MODEL
+                label:  Selects the correct PC model being emulated
+                choices:
+                    "N88 BASIC V2":         N88 V2
+                    "N88 BASIC V1H":        N88 V1H
+                    "N88 BASIC V1S":        N88 V1S
+                    "N BASIC":              N
+            q88_cpu_clock:
+                prompt: CPU CLOCK (OVERCLOCK)
+                label:  Many games run so fast, reduce slowdown on Ys series
+                choices:
+                    "1 MHz (Underclock)":   1
+                    "2 MHz (Underclock)":   2
+                    "4 MHz (NEC uPD780)":   4
+                    "8 MHz (NEC uPID7008)": 8
+                    "16 MHz (Overclock)":   16
+                    "32 MHz (Overclock)":   32
+                    "64 MHz (Overclock)":   64
+            q88_pcg-8100:
+                prompt: USE PCG-8100
+                label:  Emulate the PCG-8100 required for some games
+                choices:
+                    "Off":                  disabled
+                    "On":                   enabled
+    retro8:
+      features: [ ]
     scummvm:
       features: [padtokeyboard]
     snes9x:
       features: [netplay, rewind, autosave]
       cfeatures:
-            reduce_slowdown:
-                prompt: REDUCE SLOWDOWN
+            reduce_sprite_flicker:
+                prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
+                label:  Increase number of sprites that can be drawn
                 choices:
-                    "off":        disabled
+                    "Off":        disabled
+                    "On":         enabled
+            reduce_slowdown:
+                prompt: REDUCE SLOWDOWN (HACK, UNSTABLE)
+                label:  Overclock SNES CPU for Gradius 3, Super R-Type
+                choices:
+                    "Off":        disabled
                     "light":      light
                     "compatible": compatible
                     "max":        max
+            overclock_superfx:
+                prompt: SUPER-FX OVERCLOCKING
+                label:  Improve performance on slow devices or cause errors
+                choices:
+                    "50%":        50%
+                    "60%":        60%
+                    "70%":        70%
+                    "80%":        80%
+                    "90%":        90%
+                    "100%":       100%
+                    "150%":       150%
+                    "200%":       200%
+                    "250%":       250%
+                    "300%":       300%
+                    "350%":       350%
+                    "400%":       400%
+                    "450%":       450%
+                    "500%":       500%
+            hires_blend:
+                prompt: HI-RES BLENDING
+                label:  Required for some games effectc (Kirby's Dream Land)
+                choices:
+                    "Off":        disabled
+                    "Merge":      merge
+                    "Blur":       blur
     snes9x_next:
       features: [netplay, rewind, autosave]
       cfeatures:
-            reduce_slowdown:
-                prompt: REDUCE SLOWDOWN
+            2010_reduce_sprite_flicker:
+                prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
+                label:  Increase number of sprites that can be drawn
                 choices:
-                    "off":        disabled
+                    "Off":        disabled
+                    "On":         enabled
+            2010_reduce_slowdown:
+                prompt: REDUCE SLOWDOWN (HACK, UNSTABLE)
+                label:  Overclock SNES CPU for Gradius 3, Super R-Type
+                choices:
+                    "Off":        disabled
                     "light":      light
                     "compatible": compatible
                     "max":        max
+            2010_overclock_superfx:
+                prompt: SUPER-FX OVERCLOCKING
+                label:  Improve performance on slow devices or cause errors
+                choices:
+                    "5 MHz (Underclock)":   5 MHz (Underclock)
+                    "8 MHz (Underclock)":   8 MHz (Underclock)
+                    "9 MHz (Underclock)":   9 MHz (Underclock)
+                    "10 MHz (Default)":     10 MHz (Default)
+                    "11 MHz":               11 MHz
+                    "12 MHz":               12 MHz
+                    "13 MHz":               13 MHz
+                    "14 MHz":               14 MHz
+                    "15 MHz":               15 MHz
+                    "20 MHz":               20 MHz
+                    "30 MHz":               30 MHz
+                    "40 MHz":               40 MHz
     stella:
       features: [netplay, rewind, autosave]
     tgbdual:
       features: [netplay, rewind, autosave]
     theodore:
       features: [netplay, rewind, autosave, padtokeyboard]
+    tic80:
+      features: [padtokeyboard]
     tyrquake:
       features: [padtokeyboard]
+      features: [         rewind, autosave]
+      cfeatures:
+            tyrquake_resolution:
+                prompt: VIDEO RESOLUTION
+                label:  Smooth out jagged edges on 3D objetcs polygons
+                choices:
+                    "320x240":    320x240
+                    "640x480":    640x480
+                    "960x720":    960x720
+                    "1024x768":   1024x768
+                    "1280x720":   1280x720
+                    "1920x1080":  1920x1080
+            tyrquake_framerate:
+                prompt: FRAMERATE
+                label:  Modify framerate
+                choices:
+                    "Automatic":  Automatic
+                    "10fps":      10fps
+                    "15fps":      15fps
+                    "20fps":      20fps
+                    "25fps":      25fps
+                    "30fps":      30fps
+                    "40fps":      40fps
+                    "50fps":      50fps
+                    "60fps":      60fps
+                    "75fps":      75fps
+                    "90fps":      90fps
+                    "100fps":     100fps
+                    "120fps":     120fps
+                    "144fps":     144fps
+                    "155fps":     155fps
+                    "160fps":     160fps
+            tyrquake_rumble:
+                prompt: RUMBLE
+                label:  Enables joypad rumble
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
     vb:
       features: [netplay, rewind, autosave]
       cfeatures:
             2d_color_mode:
-                prompt: 2D COLOR MODE
+                prompt: COLOR PALETTE (2D)
+                label:  Choose which color palette to use
                 choices:
                     "original":            black & red
                     "black/white":         black & white
@@ -392,9 +1626,10 @@ libretro:
                     "black/magenta":       black & magenta
                     "black/yellow":        black & yellow
             3d_color_mode:
-                prompt: 3D GLASSES COLOR MODE
+                prompt: ANAGLYPH PRESET (3D)
+                label:  Choose the color of your 3D glasses
                 choices:
-                    "off":                 disabled
+                    "Off":                 disabled
                     "red/blue":            red & blue
                     "red/cyan":            red & cyan
                     "red/electric cyan":   red & electric cyan
@@ -402,13 +1637,136 @@ libretro:
                     "yellow/blue":         yellow & blue
     vba-m:
       features: [         rewind, autosave]
+      systems:
+            gb:
+                cfeatures:
+                    palettes:
+                        prompt: COLORISATION
+                        label:  Set Game Boy palettes to use
+                        choices:
+                            "original gameboy": original gameboy
+                            "black and white":  black and white
+                            "gba sp":           gba sp
+                            "blue sea":         blue sea
+                            "dark knight":      dark knight
+                            "green forest":     green forest
+                            "hot desert":       hot desert
+                            "pink dreams":      pink dreams
+                            "weird colors":     weird colors
+                    gbcoloroption_gb:
+                        prompt: COLOR CORRECTION
+                        label:  Adjusts output colors to feel real hardware
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
+                    showborders_gb:
+                        prompt: SUPER GB BORDERS
+                        label:  Only for Super Game Boy enhanced games
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
+            gbc:
+                cfeatures:
+                    gbcoloroption_gbc:
+                        prompt: COLOR CORRECTION
+                        label:  Adjusts output colors to feel real hardware
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
+                    showborders_gbc:
+                        prompt: SUPER GB BORDERS
+                        label:  Only for Super Game Boy enhanced games
+                        choices:
+                            "Off":       disabled
+                            "On":        enabled
+            gba:
+                cfeatures:
+                    solarsensor:
+                        prompt: SOLAR SENSOR LEVEL
+                        label: Only for games that employed it (for Boktai)
+                        choices:
+                            "0":  0
+                            "1":  1
+                            "2":  2
+                            "3":  3
+                            "4":  4
+                            "5":  5
+                            "6":  6
+                            "7":  7
+                            "8":  8
+                            "9":  9
+                            "10": 10
+                    gyro_sensitivity:
+                        prompt: SENSOR SENSITIVITY (GYROSCOPE)
+                        label: For Gyro-enabled games (bind on left analog)
+                        choices:
+                            "10":  10
+                            "15":  15
+                            "20":  20
+                            "25":  25
+                            "30":  30
+                            "35":  35
+                            "40":  40
+                            "45":  45
+                            "50":  50
+                            "55":  55
+                            "60":  60
+                            "65":  65
+                            "70":  70
+                            "75":  75
+                            "80":  80
+                            "85":  85
+                            "90":  90
+                            "95":  95
+                            "100": 100
+                            "105": 105
+                            "110": 110
+                            "115": 115
+                            "120": 120
+                    tilt_sensitivity:
+                        prompt: SENSOR SENSITIVITY (TILT)
+                        label: For Gyro-enabled games (bind on right analog)
+                        choices:
+                            "10":  10
+                            "15":  15
+                            "20":  20
+                            "25":  25
+                            "30":  30
+                            "35":  35
+                            "40":  40
+                            "45":  45
+                            "50":  50
+                            "55":  55
+                            "60":  60
+                            "65":  65
+                            "70":  70
+                            "75":  75
+                            "80":  80
+                            "85":  85
+                            "90":  90
+                            "95":  95
+                            "100": 100
+                            "105": 105
+                            "110": 110
+                            "115": 115
+                            "120": 120
     vecx:
       features: [         rewind, autosave]
+      cfeatures:
+            res_multi:
+                prompt: RESOLUTION MULTIPLIER
+                label:  Resolution multipliers to smooth vectors
+                choices:
+                    "Off":  1
+                    "2":    2
+                    "3":    3
+                    "4":    4
     vice_x64:
       features: [         rewind, autosave, padtokeyboard]
       cfeatures:
             external_palette:
                 prompt: EXTERNAL PALETTE
+                label:  Choose the most accurate colors
                 choices:
                     "default":          default
                     "colodore":         colodore
@@ -429,16 +1787,30 @@ libretro:
                     "vice":             vice
             aspect_ratio:
                 prompt: ASPECT RATIO
+                label:  Switch frequency and resolution by region
                 choices:
-                    "pal":              pal
-                    "ntsc":             ntsc
-            zoom_mode:
+                    "PAL 50Hz - 312/576px":     pal
+                    "NTSC 60Hz - 262/492px":    ntsc
+            zoom_mode_c64:
                 prompt: ZOOM MODE
+                label:  Crops the borders to fit various host screens
                 choices:
-                    "deactivate":       none
+                    "Off":              none
                     "small":            small
                     "medium":           medium
                     "maximum":          maximum
+            JoyPort:
+                prompt: JOYSTICK PORT
+                label:  Choose to use Joystick on port 1 or 2
+                choices:
+                    "Port 1":           Port 1
+                    "Port 2":           Port 2
+            keyboard_pass_through:
+                prompt: KEYBOARD PASS-THROUGH
+                label:  Passes all physical keyboard events for Pad2Key
+                choices:
+                    "Off":              disabled
+                    "On":               enabled
     vice_x64sc:
       features: [         rewind, autosave, padtokeyboard]
     vice_xplus4:
@@ -451,11 +1823,31 @@ libretro:
       features: [         rewind, autosave, padtokeyboard]
     virtualjaguar:
       features: [padtokeyboard]
+      cfeatures:
+            usefastblitter:
+                prompt: FAST BLITTER (LESS COMPATIBLE)
+                label:  Use the older and less compatible faster blitter
+                choices:
+                    "Off":      disabled
+                    "On":       enabled
+            bios_vj:
+                prompt: SHOW BIOS BOOTLOGO
+                label:  Show animation when starting (Breaks some games)
+                choices:
+                    "Off":      disabled
+                    "On":       enabled
+            doom_res_hack:
+                prompt: DOOM RES HACK
+                label:  Enable for Doom to run at its correct resolution
+                choices:
+                    "Off":      disabled
+                    "On":       enabled
     yabasanshiro:
       features: [         rewind, autosave]
       cfeatures:
             resolution_mode:
-                prompt: RESOLUTION MODE
+                prompt: VIDEO RESOLUTION
+                label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "original": original
                     "2x":       2x
@@ -463,9 +1855,38 @@ libretro:
                     "720p":     720p
                     "1080p":    1080p
                     "4k":       4k
+            multitap_yabasanshiro:
+                prompt: ENABLE MULTITAP
+                label:  Allowing 7-12 player support in games
+                choices:
+                    "Off":              disabled
+                    "Port1":            port1
+                    "Port2":            port2
+                    "Port1+2":          port12
+
+# Standalones
 
 amiberry:
   features: [ratio, padtokeyboard]
+
+cannonball:
+  features: [ratio]
+  cfeatures:
+    highResolution:
+      prompt: HIGH RESOLUTION
+      label:  Increase video to Hi Resolution
+      choices:
+        "Off": 0
+        "On":  1
+cemu:
+  features: [emulated_wiimotes]
+  cfeatures:
+    gfxbackend:
+      prompt: GRAPHICS BACKEND
+      label:  Choose your graphics rendering
+      choices:
+        OpenGL: OpenGL
+        Vulkan: Vulkan
 
 citra:
   features: [ratio, rewind, screen_layout]
@@ -478,11 +1899,13 @@ dolphin:
   cfeatures:
         perf_hacks:
             prompt: PERFORMANCE HACKS
+            label:  Increase emulator performance
             choices:
                 "Off": 0
                 "On":  1
         anisotropic_filtering:
             prompt: ANISOTROPIC FILTERING
+            label:  Enhance the quality with on perspective textures
             choices:
                 "Off": 0
                 "2x":  1
@@ -491,16 +1914,19 @@ dolphin:
                 "16x": 4
         dual_core:
             prompt: DUAL CORE
+            label:  Usually not much faster than single core mode
             choices:
                 "Off": 0
                 "On":  1
         gpu_sync:
             prompt: GPU SYNC
+            label:  Speed Hack for dual core mode to fix some glitches
             choices:
                 "Off": 0
                 "On":  1
         antialiasing:
-            prompt: ANTIALIASING
+            prompt: ANTI-ALIASING
+            label:  Smooth out jagged edges on 3D objetcs polygons
             choices:
                 "Off": 0
                 "2x":  2
@@ -508,37 +1934,44 @@ dolphin:
                 "8x":  8
         hires_textures:
             prompt: HIRES TEXTURES
+            label:  Permit to use HD Texture Pack
             choices:
                 "Off": 0
                 "On":  1
         widescreen_hack:
             prompt: WIDESCREEN HACK
+            label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
             choices:
                 "Off": 0
                 "On":  1
         enable_cheats:
             prompt: ENABLE CHEATS
+            label:  To use game cheats or 16/9 Aspect Ratio Fix codes
             choices:
                 "Off": 0
                 "On":  1
         enable_mmu:
             prompt: MEMORY MANAGEMENT UNIT
+            label:  Allow many games to boot and work properly
             choices:
                 "Off": 0
                 "On":  1
         enable_fastdisc:
             prompt: FAST DISK SPEED
+            label:  Speed up disc speed to remoe any loading
             choices:
                 "Off": 0
                 "On":  1
         vsync:
             prompt: VSYNC
+            label:  Fix the heavy screen tearing in games (heavy CPU)
             choices:
                 "Off": 0
                 "On":  1
         gfxbackend:
             archs_include: [x86, x86_64, rpi4]
             prompt: GRAPHICS BACKEND
+            label:  Choose your graphics rendering
             choices:
                 "OpenGL": OGL
                 "Vulkan": Vulkan
@@ -570,11 +2003,17 @@ dosbox_staging:
 dosbox-x:
   features: [ratio, padtokeyboard]
 
+flycast:
+  features: [ratio]
+
 fsuae:
   features: [ratio, padtokeyboard]
 
 linapple:
   features: [ratio, padtokeyboard]
+
+melonds:
+  features: []
 
 moonlight:
   features: [ratio]
@@ -582,11 +2021,36 @@ moonlight:
 mupen64plus:
   features: [ratio]
 
+openbor:
+  cfeatures:
+    ratio:
+      prompt: SCREEN RATIO
+      label:  Stretch games to Full Screen but distorted
+      choices:
+        "Normal":         0
+        "Stretch":        1
+    filter:
+      prompt: VIDEO FILTER
+      label:  Apply to achieve some kind of visual effect
+      choices:
+        "Simple 2x":      0
+        "Bilinear":       1
+        "2xSaI":          2
+        "Super 2xSaI":    3
+        "Super Eagle":    4
+        "Advance Mame2x": 5
+        "Lq2x":           6
+        "Hq2x":           7
+        "ScanLines":      8
+        "ScanLines TV":   9
+        "TV 2x":          10
+        "Dot Matrix":     11
 pcsx2:
   features: [ratio, fullboot, internal_resolution]
   cfeatures:
         anisotropic_filtering:
             prompt: ANISOTROPIC FILTERING
+            label:  Enhance the quality with on perspective textures
             choices:
                 "Off": 0
                 "2x":  2
@@ -594,7 +2058,8 @@ pcsx2:
                 "8x":  8
                 "16x": 16
         skipdraw:
-            prompt: SKIPDRAW
+            prompt: SKIPDRAW HACK
+            label:  Skip frames to improve performance (Smoothless)
             choices:
                 "Off": 0
                 "1":   1
@@ -603,12 +2068,15 @@ pcsx2:
                 "4":   4
                 "5":   5
         align_sprite:
-            prompt: ALIGN SPRITE
+            prompt: ALIGN SPRITE (HACK)
+            label:  Remove lines in Internal Resolution (Soul Calibur)
+            label:  
             choices:
                 "Off": 0
                 "On":  1
         vsync:
             prompt: VSYNC
+            label:  Fix the heavy screen tearing in games (heavy CPU)
             choices:
                 "Off": 0
                 "On":  1
@@ -618,146 +2086,110 @@ ppsspp:
   cfeatures:
         frameskip:
             prompt: FRAME SKIP
+            label:  Skip frames to improve performance (Smoothless)
             choices:
                 "Off": 0
                 "On":  1
 reicast:
   features: [ratio]
 
-flycast:
-  features: [ratio]
+rpcs3:
+  features: []
+  cfeatures:
+    gui:
+      prompt: GRAPHICAL USER INTERFACE
+      label:  Display the user interface
+      choices:
+        "Off":      0
+        "On":       1
+    gfxbackend:
+      prompt: GRAPHICS BACKEND
+      label:  Choose your graphics rendering
+      choices:
+        "OpenGL":   OpenGL
+        "Vulkan":   Vulkan
 
 scummvm:
   features: [ratio, padtokeyboard]
 
 vice:
   features: [ratio, padtokeyboard]
-openbor:
-  cfeatures:
-    ratio:
-      prompt: RATIO
-      choices:
-        Normal:  0
-        Stretch: 1
-    filter:
-      prompt: FILTER
-      choices:
-        Simple 2x:      0
-        Bilinear:       1
-        2xSaI:          2
-        Super 2xSaI:    3
-        Super Eagle:    4
-        Advance Mame2x: 5
-        Lq2x:           6
-        Hq2x:           7
-        ScanLines:      8
-        ScanLines TV:   9
-        TV 2x:         10
-        Dot Matrix:    11
-
-cannonball:
-  features: [ratio]
-  cfeatures:
-    highResolution:
-      prompt: HIGH RESOLUTION
-      choices:
-        Off: 0
-        On:  1
-cemu:
-  features: [emulated_wiimotes]
-  cfeatures:
-    gfxbackend:
-      prompt: GRAPHICS BACKEND
-      choices:
-        OpenGL: OpenGL
-        Vulkan: Vulkan
-
-
-melonds:
-  features: []
-
-rpcs3:
-  features: []
-  cfeatures:
-    gui:
-      prompt: Display user interface
-      choices:
-        Off: 0
-        On:  1
-    gfxbackend:
-      prompt: GRAPHICS BACKEND
-      choices:
-        OpenGL: OpenGL
-        Vulkan: Vulkan
 
 mame:
   features: []
   cfeatures:
     video:
-      prompt: Video engine
+      prompt: GRAPHICS BACKEND
+      label:  Choose your graphics rendering
       choices:
-        "BGFX": bgfx
-        "Accel": accel
-        "OpenGL": opengl
-
+        "BGFX":          bgfx
+        "Accel":         accel
+        "OpenGL":        opengl
     bgfxbackend:
       archs_include: [x86, x86_64, rpi4]
-      prompt: BGFX backend
+      prompt: BGFX BACKEND
+      label:  Choose your graphics API
       choices:
-        "Auto": auto
-        "OpenGL": opengl
-        "OpenGLES": gles
-        "Vulkan": vulkan
-
+        "Automatic"      auto
+        "OpenGL":        opengl
+        "OpenGLES":      gles
+        "Vulkan":        vulkan
     rotation:
-      prompt: Rotation
+      prompt: TATE MODE
+      label:  Rotating display to vertical mode rendering
       choices:
-        "Disabled": null
-        "AutoCW90": autoror
-        "AutoCW270": autorol
-
+        "Disabled":      null
+        "Rotate 90":     autoror
+        "Rotate 270":    autorol
     bgfxshaders:
-      prompt: Shaders
+      prompt: VIDEO FILTER
+      label:  Apply to achieve some kind of visual effect
       choices:
-        "None": null
-        "CrtGeom": crt-geom
+        "None":          null
+        "CrtGeom":       crt-geom
         "CrtGeomDeluxe": crt-geom-deluxe
-        "SuperEagle": eagle
-        "HLSL": hlsl
-        "HQ2X": hq2x
-        "HQ3X": hq3x
-        "HQ4X": hq4x
+        "SuperEagle":    eagle
+        "HLSL":          hlsl
+        "HQ2X":          hq2x
+        "HQ3X":          hq3x
+        "HQ4X":          hq4x
 
 wine:
   features: [padtokeyboard]
   cfeatures:
     dxvk:
-      prompt: dxvk
+      prompt: DXVK
+      label:  Direct-X to Vulkan
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1
     dxvk_hud:
-      prompt: dxvk hud
+      prompt: DXVK HUD
+      label:  Show information overlay
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1
     esync:
-      prompt: esync
+      prompt: ESYNC
+      label:  ESync
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1
     fsync:
-      prompt: fsync
+      prompt: FSYNC
+      label:  FSync
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1
     pba:
-      prompt: pba
+      prompt: PBA
+      label:  Persistent Buffer Allocator
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1
     virtual_desktop:
-      prompt: virtual desktop
+      prompt: VIRTUAL DESKTOP
+      label:  Using a virtual desktop to fix the resolution
       choices:
-        Off: 0
-        On:  1
+        "Off": 0
+        "On":  1

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1872,21 +1872,21 @@ amiberry:
 cannonball:
   features: [ratio]
   cfeatures:
-    highResolution:
-      prompt: HIGH RESOLUTION
-      label:  Increase video to Hi Resolution
-      choices:
-        "Off": 0
-        "On":  1
+        highResolution:
+            prompt: HIGH RESOLUTION
+            label:  Increase video to Hi Resolution
+            choices:
+                "Off": 0
+                "On":  1
 cemu:
   features: [emulated_wiimotes]
   cfeatures:
-    gfxbackend:
-      prompt: GRAPHICS BACKEND
-      label:  Choose your graphics rendering
-      choices:
-        OpenGL: OpenGL
-        Vulkan: Vulkan
+        gfxbackend:
+            prompt: GRAPHICS BACKEND
+            label:  Choose your graphics rendering
+            choices:
+                "OpenGL": OpenGL
+                "Vulkan": Vulkan
 
 citra:
   features: [ratio, rewind, screen_layout]
@@ -2096,18 +2096,18 @@ reicast:
 rpcs3:
   features: []
   cfeatures:
-    gui:
-      prompt: GRAPHICAL USER INTERFACE
-      label:  Display the user interface
-      choices:
-        "Off":      0
-        "On":       1
-    gfxbackend:
-      prompt: GRAPHICS BACKEND
-      label:  Choose your graphics rendering
-      choices:
-        "OpenGL":   OpenGL
-        "Vulkan":   Vulkan
+        gui:
+            prompt: GRAPHICAL USER INTERFACE
+            label:  Display the user interface
+            choices:
+                "Off":      0
+                "On":       1
+        gfxbackend:
+            prompt: GRAPHICS BACKEND
+            label:  Choose your graphics rendering
+            choices:
+                "OpenGL":   OpenGL
+                "Vulkan":   Vulkan
 
 scummvm:
   features: [ratio, padtokeyboard]
@@ -2118,78 +2118,78 @@ vice:
 mame:
   features: []
   cfeatures:
-    video:
-      prompt: GRAPHICS BACKEND
-      label:  Choose your graphics rendering
-      choices:
-        "BGFX":          bgfx
-        "Accel":         accel
-        "OpenGL":        opengl
-    bgfxbackend:
-      archs_include: [x86, x86_64, rpi4]
-      prompt: BGFX BACKEND
-      label:  Choose your graphics API
-      choices:
-        "Automatic"      auto
-        "OpenGL":        opengl
-        "OpenGLES":      gles
-        "Vulkan":        vulkan
-    rotation:
-      prompt: TATE MODE
-      label:  Rotating display to vertical mode rendering
-      choices:
-        "Disabled":      null
-        "Rotate 90":     autoror
-        "Rotate 270":    autorol
-    bgfxshaders:
-      prompt: VIDEO FILTER
-      label:  Apply to achieve some kind of visual effect
-      choices:
-        "None":          null
-        "CrtGeom":       crt-geom
-        "CrtGeomDeluxe": crt-geom-deluxe
-        "SuperEagle":    eagle
-        "HLSL":          hlsl
-        "HQ2X":          hq2x
-        "HQ3X":          hq3x
-        "HQ4X":          hq4x
+        video:
+            prompt: GRAPHICS BACKEND
+            label:  Choose your graphics rendering
+            choices:
+                "BGFX":          bgfx
+                "Accel":         accel
+                "OpenGL":        opengl
+        bgfxbackend:
+            archs_include: [x86, x86_64, rpi4]
+            prompt: BGFX BACKEND
+            label:  Choose your graphics API
+            choices:
+                "Automatic":     auto
+                "OpenGL":        opengl
+                "OpenGLES":      gles
+                "Vulkan":        vulkan
+        rotation:
+            prompt: TATE MODE
+            label:  Rotating display to vertical mode rendering
+            choices:
+                "Disabled":      null
+                "Rotate 90":     autoror
+                "Rotate 270":    autorol
+        bgfxshaders:
+            prompt: VIDEO FILTER
+            label:  Apply to achieve some kind of visual effect
+            choices:
+                "None":          null
+                "CrtGeom":       crt-geom
+                "CrtGeomDeluxe": crt-geom-deluxe
+                "SuperEagle":    eagle
+                "HLSL":          hlsl
+                "HQ2X":          hq2x
+                "HQ3X":          hq3x
+                "HQ4X":          hq4x
 
 wine:
   features: [padtokeyboard]
   cfeatures:
-    dxvk:
-      prompt: DXVK
-      label:  Direct-X to Vulkan
-      choices:
-        "Off": 0
-        "On":  1
-    dxvk_hud:
-      prompt: DXVK HUD
-      label:  Show information overlay
-      choices:
-        "Off": 0
-        "On":  1
-    esync:
-      prompt: ESYNC
-      label:  ESync
-      choices:
-        "Off": 0
-        "On":  1
-    fsync:
-      prompt: FSYNC
-      label:  FSync
-      choices:
-        "Off": 0
-        "On":  1
-    pba:
-      prompt: PBA
-      label:  Persistent Buffer Allocator
-      choices:
-        "Off": 0
-        "On":  1
-    virtual_desktop:
-      prompt: VIRTUAL DESKTOP
-      label:  Using a virtual desktop to fix the resolution
-      choices:
-        "Off": 0
-        "On":  1
+        dxvk:
+            prompt: DXVK
+            label:  Converts the DirectX calls from 9 to 12 in Vulkan
+            choices:
+                "Off": 0
+                "On":  1
+        dxvk_hud:
+            prompt: DXVK HUD
+            label:  See your FPS and version of Vulkan API and Driver
+            choices:
+                "Off": 0
+                "On":  1
+        esync:
+            prompt: ESYNC
+            label:  Can increase performance for games that stress CPU
+            choices:
+                "Off": 0
+                "On":  1
+        fsync:
+            prompt: FSYNC
+            label:  Can improving frame rates and responsiveness
+            choices:
+                "Off": 0
+                "On":  1
+        pba:
+            prompt: PBA
+            label:  Vastly improving the speed of buffer maps
+            choices:
+                "Off": 0
+                "On":  1
+        virtual_desktop:
+            prompt: VIRTUAL DESKTOP
+            label:  Define the resolution and a new dedicated window
+            choices:
+                "Off": 0
+                "On":  1

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2,7 +2,7 @@
 # the aim is to display in es only the available options
 
 libretro:
-  features: [ratio, smooth, shaders, pixel_perfect, decoration, latency_reduction, game_translation]
+  features: [ratio, smooth, shaders, pixel_perfect, decoration, game_translation]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4]
@@ -14,7 +14,7 @@ libretro:
 
   cores:
     '81':
-      features: [netplay, rewind, autosave, padtokeyboard]
+      features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             81_chroma_81:
                 prompt: COLORISATION
@@ -31,7 +31,7 @@ libretro:
                     "Off":       none
                     "On":        WRX
     atari800:
-      features: [                           padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
       systems:
             atari800:
                 cfeatures:
@@ -79,9 +79,9 @@ libretro:
                             "Off":     disabled
                             "On":      enabled
     beetle-saturn:
-      features: [netplay,         autosave]
+      features: [netplay,         autosave, latency_reduction]
     bluemsx:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             bluemsx_nospritelimits:
                 prompt: REDUCE SPRITE FLICKERING
@@ -90,9 +90,9 @@ libretro:
                     "Off": OFF
                     "On":  ON
     bsnes:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     cap32:
-      features: [netplay, rewind, autosave, padtokeyboard]
+      features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             cap32_model:
                 prompt: CPC MODEL
@@ -111,11 +111,11 @@ libretro:
                     "512":   512
                     "576+":  576
     citra:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
     daphne:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
     desmume:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             internal_resolution_desmume:
                 prompt: VIDEO RESOLUTION
@@ -186,7 +186,7 @@ libretro:
     dolphin:
       features: [ ]
     dosbox:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
       cfeatures:
             core_timing:
                 prompt: CPU TIMING MODE (FPS)
@@ -218,7 +218,7 @@ libretro:
                     "scan2x":      scan2x
                     "scan3x":      scan3x
     duckstation:
-      features: [ ]
+      features: [                 autosave, latency_reduction]
       cfeatures:
             PatchFastBoot:
                 prompt: SHOW BIOS BOOTLOGO
@@ -296,7 +296,7 @@ libretro:
                     "PlayStation Mouse":             PlayStationMouse
                     "NeGcon":                        NeGcon
     fbneo:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             fbneo-cpu-speed-adjust:
                 prompt: CPU CLOCK
@@ -356,7 +356,7 @@ libretro:
                             "Shared":                             shared
                             "Per-game":                           per-game
     fceumm:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             fceumm_nospritelimit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -409,7 +409,7 @@ libretro:
                     "2x-Postrender":        2x-Postrender
                     "2x-VBlank":            2x-VBlank
     flycast:
-      features: [         rewind, autosave]
+      features: [                 autosave]
       cfeatures:
             internal_resolution_flycast:
                 prompt: VIDEO RESOLUTION
@@ -514,9 +514,9 @@ libretro:
                             "Horizontal": horizontal
                             "Vertical":   vertical
     freeintv:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
     fuse:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [                 autosave, latency_reduction, padtokeyboard]
       cfeatures:
             fuse_hide_border:
                 prompt: ZOOM (HIDES BORDER)
@@ -525,7 +525,7 @@ libretro:
                     "Off":  disabled
                     "On":   enabled
     gambatte:
-      features: [         rewind, autosave, colorization]
+      features: [         rewind, autosave, latency_reduction, colorization]
       cfeatures:
             gb_bootloader:
                 prompt: SHOW BIOS BOOTLOGO
@@ -543,7 +543,7 @@ libretro:
                     "LCD Ghosting (Accurate)": lcd_ghosting
                     "LCD Ghosting (Fast)":     lcd_ghosting_fast
     genesisplusgx:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             gpgx_no_sprite_limit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -606,25 +606,69 @@ libretro:
                             "Off":       disabled
                             "On":        enabled
     gpsp:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
     gw:
-      features: [ ]
+      features: [                           latency_reduction]
     handy:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     hatari:
-      features: [                 autosave, padtokeyboard]
+      features: [                 autosave, latency_reduction, padtokeyboard]
     imame4all:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     kronos:
       features: [                 autosave]
     lutro:
       features: [ ]
     mame:
-      features: [netplay, rewind, autosave]
+      features: [netplay,         autosave, latency_reduction]
+      cfeatures:
+            mame_cpu_overclock:
+                prompt: CPU OVERCLOCK
+                label:  Minimize ingame slowdowns of some games
+                choices:
+                    "default":        default
+                    "30":             30
+                    "35":             35
+                    "40":             40
+                    "45":             45
+                    "50":             50
+                    "55":             55
+                    "60":             60
+                    "65":             65
+                    "70":             70
+                    "75":             75
+                    "80":             80
+                    "85":             85
+                    "90":             90
+                    "95":             95
+                    "100":            100
+                    "105":            105
+                    "110":            110
+                    "115":            115
+                    "120":            120
+                    "125":            125
+                    "130":            130
+                    "135":            135
+                    "140":            140
+                    "145":            145
+                    "150":            150
+            mame_altres:
+                prompt: VIDEO RESOLUTION
+                label:  Increase video to Highter Resolution
+                choices:
+                    "640x480":        640x480
+                    "800x600":        800x600
+                    "960x720":        960x720
+                    "1024x768":       1024x768
+                    "1280x720":       1280x720
+                    "1600x800":       1600x800
+                    "1920x1080":      1920x1080
+                    "2560x1440":      2560x1440
+                    "3840x2160":      3840x2160
     hbmame:
-      features: [netplay, rewind, autosave]
+      features: [netplay,         autosave, latency_reduction]
     mame0139:
-      features: [netplay, rewind, autosave]
+      features: [netplay,         autosave, latency_reduction]
       cfeatures:
             mame_current_frame_skip:
                 prompt: FRAMSKIP
@@ -653,7 +697,7 @@ libretro:
                     "medium":         medium
                     "fast":           fast
     mame078plus:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             mame2003-plus_analog:
                 prompt: CONTROL MAPPING
@@ -695,11 +739,11 @@ libretro:
                     "Arcade Universe BIOS 4.0 (Cheats)":   unibios40
                     "Arcade Universe BIOS 3.3 (Cheats)":   unibios33
     mednafen_lynx:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     mednafen_ngp:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     mednafen_psx:
-      features: [         rewind, autosave]
+      features: [                 autosave, latency_reduction]
       cfeatures:
             skip_bios_psx:
                 prompt: SHOW BIOS BOOTLOGO
@@ -782,11 +826,18 @@ libretro:
                     "Port2":            port2
                     "Port1+2":          port12
     mednafen_supergrafx:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
+      cfeatures:
+            sgx_nospritelimit:
+                prompt: REDUCE SPRITE FLICKERING
+                label:  Remove 16-sprites-per-scanline hardware limit
+                choices:
+                    "Off":        disabled
+                    "On":         enabled
     mednafen_wswan:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     mgba:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
       cfeatures:
             skip_bios_mgba:
                 prompt: SHOW BIOS BOOTLOGO
@@ -857,7 +908,7 @@ libretro:
                             "9":  9
                             "10": 10
     mrboom:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             mrboom-aspect:
                 prompt: TEAM MODE
@@ -874,7 +925,7 @@ libretro:
                     "Off":    OFF
                     "On":     ON
     mupen64plus-next:
-      features: [         rewind, autosave]
+      features: [                 autosave]
       cfeatures:
             43screensize:
                 prompt: VIDEO 4:3 RESOLUTION
@@ -976,7 +1027,7 @@ libretro:
                     "Off":          Off
                     "On":           On
     nestopia:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             nestopia_nospritelimit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -1150,11 +1201,11 @@ libretro:
                     "Manual keyboard":              Manual Keyboard
                     "Atari Joypad":                 Atari Joypad
     nxengine:
-      features: [ ]
+      features: [                           latency_reduction]
     o2em:
-      features: [                 autosave]
+      features: [         rewind, autosave, latency_reduction]
     opera:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             high_resolution:
                 prompt: VIDEO RESOLUTION
@@ -1195,7 +1246,7 @@ libretro:
                     "Dinopark Tycoon":   timing_hack3
                     "Microcosm":         timing_hack5
     parallel_n64:
-      features: [         rewind, autosave]
+      features: [                 autosave]
       cfeatures:
             screensize:
                 prompt: VIDEO RESOLUTION
@@ -1220,7 +1271,7 @@ libretro:
                     "Bilinear":    bilinear
                     "Nearest":     nearest
     pce:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             pce_nospritelimit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -1229,7 +1280,7 @@ libretro:
                     "Off":        disabled
                     "On":         enabled
     pce_fast:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             sgx_nospritelimit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -1238,7 +1289,7 @@ libretro:
                     "Off":        disabled
                     "On":         enabled
     pcfx:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             pcfx_nospritelimit:
                 prompt: REDUCE SPRITE FLICKERING
@@ -1247,7 +1298,7 @@ libretro:
                     "Off":        disabled
                     "On":         enabled
     pcsx_rearmed:
-      features: [         rewind, autosave]
+      features: [                 autosave, latency_reduction]
       cfeatures:
             show_bios_bootlogo:
                 prompt: SHOW BIOS BOOTLOGO
@@ -1292,7 +1343,7 @@ libretro:
                     "Pandemonium 2 Lazy Screen Update Fix": Pandemonium
                     "Parasite Eve 2/Vandal Hearts 1&2 Fix": Parasite_Eve
     picodrive:
-      features: [netplay, rewind, autosave]
+      features: [netplay,         autosave]
       cfeatures:
             picodrive_sprlim:
                 prompt: REDUCE SPRITE FLICKERING
@@ -1301,9 +1352,9 @@ libretro:
                     "Off":          disabled
                     "On":           enabled
     pocketsnes:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     pokemini:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
       cfeatures:
             pokemini_lcdfilter:
                 prompt: LCD FILTER
@@ -1318,9 +1369,9 @@ libretro:
                     "Off":  3shades
                     "On":   analog
     ppsspp:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
     prboom:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
       cfeatures:
             prboom-resolution:
                 prompt: VIDEO RESOLUTION
@@ -1335,7 +1386,7 @@ libretro:
                     "2240x1400":  2240x1400
                     "2560x1600":  2560x1600
     prosystem:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
     puae:
       features: [         rewind, autosave, padtokeyboard]
       cfeatures:
@@ -1403,7 +1454,7 @@ libretro:
                     "1":          1
                     "2":          2
     px68k:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
       cfeatures:
             px68k_cpuspeed:
                 prompt: CPU SPEED (OVERCLOCK)
@@ -1456,7 +1507,7 @@ libretro:
                     "Megadrive (8 Buttons)":     CPSF-MD (8 Buttons)
                     "Super Famicom (8 Buttons)": CPSF-SFC (8 Buttons)
     quasi88:
-      features: [netplay, rewind, autosave, padtokeyboard]
+      features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             q88_basic_mode:
                 prompt: PC MODEL
@@ -1484,11 +1535,11 @@ libretro:
                     "Off":                  disabled
                     "On":                   enabled
     retro8:
-      features: [ ]
+      features: [                           latency_reduction]
     scummvm:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
     snes9x:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             reduce_sprite_flicker:
                 prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
@@ -1530,7 +1581,7 @@ libretro:
                     "Merge":      merge
                     "Blur":       blur
     snes9x_next:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             2010_reduce_sprite_flicker:
                 prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
@@ -1563,15 +1614,15 @@ libretro:
                     "30 MHz":               30 MHz
                     "40 MHz":               40 MHz
     stella:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     tgbdual:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
     theodore:
-      features: [netplay, rewind, autosave, padtokeyboard]
+      features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
     tic80:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
     tyrquake:
-      features: [padtokeyboard]
+      features: [                           latency_reduction, padtokeyboard]
       features: [         rewind, autosave]
       cfeatures:
             tyrquake_resolution:
@@ -1611,7 +1662,7 @@ libretro:
                     "Off":        disabled
                     "On":         enabled
     vb:
-      features: [netplay, rewind, autosave]
+      features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             2d_color_mode:
                 prompt: COLOR PALETTE (2D)
@@ -1636,7 +1687,7 @@ libretro:
                     "green/magenta":       green & magenta
                     "yellow/blue":         yellow & blue
     vba-m:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
       systems:
             gb:
                 cfeatures:
@@ -1751,7 +1802,7 @@ libretro:
                             "115": 115
                             "120": 120
     vecx:
-      features: [         rewind, autosave]
+      features: [         rewind, autosave, latency_reduction]
       cfeatures:
             res_multi:
                 prompt: RESOLUTION MULTIPLIER
@@ -1762,7 +1813,7 @@ libretro:
                     "3":    3
                     "4":    4
     vice_x64:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             external_palette:
                 prompt: EXTERNAL PALETTE
@@ -1812,17 +1863,17 @@ libretro:
                     "Off":              disabled
                     "On":               enabled
     vice_x64sc:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
     vice_xplus4:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
     vice_x128:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
     vice_xvic:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
     vice_xpet:
-      features: [         rewind, autosave, padtokeyboard]
+      features: [         rewind, autosave, latency_reduction, padtokeyboard]
     virtualjaguar:
-      features: [padtokeyboard]
+      features: [                 autosave, latency_reduction, padtokeyboard]
       cfeatures:
             usefastblitter:
                 prompt: FAST BLITTER (LESS COMPATIBLE)
@@ -1843,7 +1894,7 @@ libretro:
                     "Off":      disabled
                     "On":       enabled
     yabasanshiro:
-      features: [         rewind, autosave]
+      features: [                 autosave]
       cfeatures:
             resolution_mode:
                 prompt: VIDEO RESOLUTION

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -220,13 +220,13 @@ libretro:
     duckstation:
       features: [                 autosave, latency_reduction]
       cfeatures:
-            PatchFastBoot:
+            duckstation_PatchFastBoot:
                 prompt: SHOW BIOS BOOTLOGO
                 label:  Show BIOS animation when starting content
                 choices:
                     "Off":        "true"
                     "On":         "false"
-            resolution_scale:
+            duckstation_resolution_scale:
                 prompt: VIDEO RESOLUTION
                 label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
@@ -239,7 +239,7 @@ libretro:
                     "7x":         7
                     "8x":         8
                     "9x":         9
-            antialiasing:
+            duckstation_antialiasing:
                 prompt: ANTI-ALIASING (MSAA/SSAA)
                 label:  Smooth out jagged edges on 3D objetcs polygons 
                 choices:
@@ -254,7 +254,7 @@ libretro:
                     "8x ssaa":    8-ssaa
                     "16x ssaa":   16-ssaa
                     "32x ssaa":   32-ssaa
-            texture_filtering:
+            duckstation_texture_filtering:
                 prompt: TEXTURE FILTERING
                 label:  Smooths out textures on 3D objetcs
                 choices:
@@ -262,9 +262,9 @@ libretro:
                     "bilinear":   Bilinear
                     "jinc2":      JINC2
                     "xBR":        xBR
-            widescreen_hack_duckstation:
+            duckstation_widescreen_hack:
                 prompt: WIDESCREEN HACK
-                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+                label:  You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":        "false"
                     "On":         "true"
@@ -275,7 +275,7 @@ libretro:
                     "Off":                "None"
                     "Only Overscan Area": "Overscan"
                     "All Borders":        "Borders"
-            Controller1:
+            duckstation_Controller1:
                 prompt: CONTROLLER 1 TYPE
                 label:  Sets the type of controller for slot 1
                 choices:
@@ -285,7 +285,7 @@ libretro:
                     "Namco GunCon":                  NamcoGunCon
                     "PlayStation Mouse":             PlayStationMouse
                     "NeGcon":                        NeGcon
-            Controller2:
+            duckstation_Controller2:
                 prompt: CONTROLLER 2 TYPE
                 label:  Sets the type of controller for slot 2
                 choices:
@@ -411,7 +411,7 @@ libretro:
     flycast:
       features: [                 autosave]
       cfeatures:
-            internal_resolution_flycast:
+            reicast_internal_resolution:
                 prompt: VIDEO RESOLUTION
                 label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
@@ -435,13 +435,13 @@ libretro:
                     "11520x8640": 11520x8640
                     "12160x9120": 12160x9120
                     "12800x9600": 12800x9600
-            mipmapping:
+            reicast_mipmapping:
                 prompt: TEXTURES MIP-MAPPING (BLUR)
                 label:  Smooths out textures on 3D objetcs
                 choices:
                     "Off": disabled
                     "On":  enabled
-            anisotropic_filtering:
+            reicast_anisotropic_filtering:
                 prompt: ANISOTROPIC FILTERING
                 label:  Enhance the quality with on perspective textures
                 choices:
@@ -450,7 +450,7 @@ libretro:
                     "4x":  4
                     "8x":  8
                     "16x": 16
-            texture_upscaling:
+            reicast_texupscale:
                 prompt: TEXTURES UPSCALING (XBRZ)
                 label:  Upscaling 2D pixel art graphics (2D Games Only)
                 choices:
@@ -458,7 +458,7 @@ libretro:
                     "2x":  2x
                     "4x":  4x
                     "6x":  6x
-            render_to_texture_upscaling:
+            reicast_render_to_texture_upscaling:
                 prompt: RENDER TO TEXTURES UPSCALING
                 label:  Upscaling textures resolution on 3D objetcs
                 choices:
@@ -467,7 +467,7 @@ libretro:
                     "3x":  3x
                     "4x":  4x
                     "8x":  8x
-            frame_skipping:
+            reicast_frame_skipping:
                 prompt: FRAME SKIP
                 label:  Skip frames to improve performance (Smoothless)
                 choices:
@@ -478,21 +478,21 @@ libretro:
                     "4":   4
                     "5":   5
                     "6":   6
-            force_wince:
+            reicast_force_wince:
                 prompt: FORCE WINDOWS CE MODE
                 label:  Enable full MMU emulation for Windows CE games
                 choices:
                     "Off": disabled
                     "On":  enabled
-            widescreen_hack_flycast:
-                prompt: WIDESCREEN HACK
-                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+            reicast_widescreen_cheats:
+                prompt: WIDESCREEN CHEAT (PRIORITY)
+                label:  You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off": disabled
                     "On":  enabled
-            widescreen_cheats:
-                prompt: WIDESCREEN CHEAT
-                label:  Same as HACK but with a specific setting by game
+            reicast_widescreen_hack:
+                prompt: WIDESCREEN HACK
+                label:  You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off": disabled
                     "On":  enabled
@@ -745,13 +745,13 @@ libretro:
     mednafen_psx:
       features: [                 autosave, latency_reduction]
       cfeatures:
-            skip_bios_psx:
+            beetle_psx_skip_bios:
                 prompt: SHOW BIOS BOOTLOGO
                 label:  Show BIOS animation when starting content
                 choices:
                     "Off":        enabled
                     "On":         disabled
-            beetlepsx_cpu_freq:
+            beetle_psx_cpu_freq_scale:
                 prompt: OVERCLOCKING (HEAVY CPU)
                 label:  Can eliminate slowdown and improve frame rates
                 choices:
@@ -782,7 +782,7 @@ libretro:
                     "650%":         650%
                     "700%":         700%
                     "750%":         750%
-            internal_resolution_mednafen:
+            beetle_psx_internal_resolution:
                 prompt: VIDEO RESOLUTION
                 label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
@@ -791,19 +791,19 @@ libretro:
                     "4x":         4x
                     "8x":         8x
                     "16x":        16x
-            widescreen_hack_mednafen:
+            beetle_psx_widescreen_hack:
                 prompt: WIDESCREEN HACK
-                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+                label:  You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":        disabled
                     "On":         enabled
-            frame_duping:
+            beetle_psx_frame_duping:
                 prompt: FRAME DUPING (SPEEDDUP)
                 label:  Small performance increase (may lost anim. frames)
                 choices:
                     "Off":        disabled
                     "On":         enabled
-            cpu_dynarec:
+            beetle_psx_cpu_dynarec:
                 prompt: CPU DYNAREC (SPEEDDUP)
                 label:  Much faster than interpreter (but may have bugs)
                 choices:
@@ -811,7 +811,7 @@ libretro:
                     "Max Performance":              execute
                     "Cycle Timing Check":           execute_once
                     "Lightrec Interpreter":         run_interpreter
-            dynarec_invalidate:
+            beetle_psx_dynarec_invalidate:
                 prompt: DYNAREC CODE INVALIDATION
                 label:  Some games require DMA Only (for CPU Dynarec)
                 choices:
@@ -927,7 +927,7 @@ libretro:
     mupen64plus-next:
       features: [                 autosave]
       cfeatures:
-            43screensize:
+            mupen64plus-43screensize:
                 prompt: VIDEO 4:3 RESOLUTION
                 label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
@@ -942,7 +942,7 @@ libretro:
                     "3200x2400": 3200x2400
                     "3520x2640": 3520x2640
                     "3840x2880": 3840x2880
-            169screensize:
+            mupen64plus-169screensize:
                 prompt: VIDEO 16:9 RESOLUTION
                 label:  Improve the fidelity of 3D models (unaffect 2D)
                 choices:
@@ -953,19 +953,19 @@ libretro:
                     "2560x1440": 2560x1440
                     "3840x2160": 3840x2160
                     "7680x4320": 7680x4320
-            aspect:
+            mupen64plus-aspect:
                 prompt: WIDESCREEN HACK
-                label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+                label:  You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":       4:3
                     "On":        16:9 adjusted
-            BilinearMode:
+            mupen64plus-BilinearMode:
                 prompt: BILINEAR FILTERING
                 label:  Filter to gradually switch colors
                 choices:
                     "standard":   standard
                     "3 point":    3point
-            MultiSampling:
+            mupen64plus-MultiSampling:
                 prompt: ANTI-ALIASING (MSAA)
                 label:  Smooth out jagged edges on 3D objetcs polygons 
                 choices:
@@ -974,7 +974,7 @@ libretro:
                     "4x":         4
                     "8x":         8
                     "16x":        16
-            Texture_filter:
+            mupen64plus-txFilterMode:
                 prompt: TEXTURE FILTERING
                 label:  Smooths out textures on 3D objetcs
                 choices:
@@ -985,7 +985,7 @@ libretro:
                     "Smooth 4":   Smooth filtering 4
                     "Sharp 1":    Sharp filtering 1
                     "Sharp 2":    Sharp filtering 2
-            Texture_Enhancement:
+            mupen64plus-txEnhancementMode:
                 prompt: TEXTURE ENHANCEMENT (XBRZ)
                 label:  Scales up a nearest-neighbor version of the texture
                 choices:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -568,6 +568,34 @@ libretro:
                         choices:
                             "Off":        disabled
                             "On":         enabled
+                    controller1_md:
+                        prompt:      CONTROLLER 1 TYPE
+                        description: Select 3 or 6 button controller, mouse or Multitap
+                        choices:
+                            #"None":                          0
+                            "Joypad Auto":                   1
+                            "Joypad 3 Button":               257
+                            "Joypad 6 Button":               513
+                            "Joypad 3 Button + 4-WayPlay":   1025
+                            "Joypad 6 Button + 4-WayPlay":   1281
+                            "Joypad 3 Button + Teamplayer":  1537
+                            "Joypad 6 Button + Teamplayer":  1793
+                            #"XE-1AP":                        773
+                            "Mouse":                         2
+                    controller2_md:
+                        prompt:      CONTROLLER 2 TYPE
+                        description: Select 3 or 6 button controller, mouse or Multitap
+                        choices:
+                            #"None":                          0
+                            "Joypad Auto":                   1
+                            "Joypad 3 Button":               257
+                            "Joypad 6 Button":               513
+                            "Joypad 3 Button + 4-WayPlay":   1025
+                            "Joypad 6 Button + 4-WayPlay":   1281
+                            "Joypad 3 Button + Teamplayer":  1537
+                            "Joypad 6 Button + Teamplayer":  1793
+                            #"XE-1AP":                        773
+                            "Mouse":                         2
             mastersystem:
                 cfeatures:
                     gpgx_blargg_filter_ms:
@@ -578,12 +606,6 @@ libretro:
                             "Composite (color bleeding + artifacts)": composite
                             "SVideo (color bleeding only)":           svideo
                             "RGB (crisp image)":                      rgb
-                    gun_cursor_ms:
-                        prompt:      SHOW LIGHTGUN CROSSHAIR
-                        description: Shows crosshairs for Light Phaser device
-                        choices:
-                            "Off":        disabled
-                            "On":         enabled
                     ym2413:
                         prompt:      FM CHIP (YM2413)
                         description: Enhanced sound output support for compatible games
@@ -591,6 +613,36 @@ libretro:
                             "Automatic":  automatic
                             "Off":        disabled
                             "On":         enabled
+                    gun_cursor_ms:
+                        prompt:      SHOW LIGHTGUN CROSSHAIR
+                        description: Shows crosshairs for Light Phaser device
+                        choices:
+                            "Off":        disabled
+                            "On":         enabled
+                    controller1_ms:
+                        prompt:      CONTROLLER 1 TYPE
+                        description: Select 2 button controller, Lightgun or Multitap
+                        choices:
+                            #"None":                          0
+                            #"Joypad Auto":                   1
+                            "Joypad 2 Button":               769
+                            "Joypad 2 Button + Master Tap":  2049
+                            "Light Phaser":                  260
+                            "Paddle Control":                261
+                            #"Sports Pad":                    517
+                            #"Graphic Board":                 262
+                    controller2_ms:
+                        prompt:      CONTROLLER 2 TYPE
+                        description: Select 2 button controller, Lightgun or Multitap
+                        choices:
+                            #"None":                          0
+                            #"Joypad Auto":                   1
+                            "Joypad 2 Button":               769
+                            "Joypad 2 Button + Master Tap":  2049
+                            "Light Phaser":                  260
+                            "Paddle Control":                261
+                            #"Sports Pad":                    517
+                            #"Graphic Board":                 262
             gamegear:
                 cfeatures:
                     lcd_filter:
@@ -829,28 +881,28 @@ libretro:
                 prompt:      CONTROLLER 1 TYPE
                 description: Use DualShock type for games with Rumble mode
                 choices:
-                    "None":                          0
+                    #"None":                          0
                     "Digital Controller":            1
-                    "Analog Controller":             261
+                    #"Analog Controller":             261
                     "Analog Controller (DualShock)": 517
-                    "Analog Joystick":               773
+                    #"Analog Joystick":               773
                     "Namco GunCon":                  260
-                    "Justifier":                     516
-                    "PlayStation Mouse":             258
                     "NeGcon":                        1029
+                    #"Justifier":                     516
+                    "PlayStation Mouse":             258
             beetle_psx_Controller2:
                 prompt:      CONTROLLER 2 TYPE
                 description: Use DualShock type for games with Rumble mode
                 choices:
-                    "None":                          0
+                    #"None":                          0
                     "Digital Controller":            1
-                    "Analog Controller":             261
+                    #"Analog Controller":             261
                     "Analog Controller (DualShock)": 517
-                    "Analog Joystick":               773
+                    #"Analog Joystick":               773
                     "Namco GunCon":                  260
-                    "Justifier":                     516
-                    "PlayStation Mouse":             258
                     "NeGcon":                        1029
+                    #"Justifier":                     516
+                    "PlayStation Mouse":             258
     mednafen_supergrafx:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
@@ -1372,24 +1424,24 @@ libretro:
                 prompt:      CONTROLLER 1 TYPE
                 description: Use DualShock type for games with Rumble mode
                 choices:
-                    "None":                          0
+                    #"None":                          0
                     "Digital Controller":            1
-                    "Analog Controller":             261
+                    #"Analog Controller":             261
                     "Analog Controller (DualShock)": 517
                     "Namco GunCon":                  260
-                    "PlayStation Mouse":             258
                     "NeGcon":                        773
+                    "PlayStation Mouse":             258
             controller2_pcsx:
                 prompt:      CONTROLLER 2 TYPE
                 description: Use DualShock type for games with Rumble mode
                 choices:
-                    "None":                          0
+                    #"None":                          0
                     "Digital Controller":            1
-                    "Analog Controller":             261
+                    #"Analog Controller":             261
                     "Analog Controller (DualShock)": 517
                     "Namco GunCon":                  260
-                    "PlayStation Mouse":             258
                     "NeGcon":                        773
+                    "PlayStation Mouse":             258
     picodrive:
       features: [netplay,         autosave]
       cfeatures:
@@ -1397,8 +1449,20 @@ libretro:
                 prompt:      REDUCE SPRITE FLICKERING
                 description: Reduce sprite flickering when enabled
                 choices:
-                    "Off":          disabled
-                    "On":           enabled
+                    "Off":             disabled
+                    "On":              enabled
+            picodrive_controller1:
+                prompt:      CONTROLLER 1 TYPE
+                description: Select 3 or 6 button controller
+                choices:
+                    "Joypad 3 Button": 3 button pad
+                    "Joypad 6 Button": 6 button pad
+            picodrive_controller2:
+                prompt:      CONTROLLER 2 TYPE
+                description: Select 3 or 6 button controller
+                choices:
+                    "Joypad 3 Button": 3 button pad
+                    "Joypad 6 Button": 6 button pad
     pocketsnes:
       features: [netplay, rewind, autosave, latency_reduction]
     pokemini:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1996,6 +1996,13 @@ daphne:
 dolphin:
   features: [ratio, internal_resolution]
   cfeatures:
+        gfxbackend:
+            archs_include: [x86, x86_64, rpi4]
+            prompt:      GRAPHICS BACKEND
+            description: Choose your graphics rendering
+            choices:
+                "OpenGL": OGL
+                "Vulkan": Vulkan
         perf_hacks:
             prompt:      PERFORMANCE HACKS
             description: Increase emulator performance
@@ -2067,25 +2074,21 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
-        gfxbackend:
-            archs_include: [x86, x86_64, rpi4]
-            prompt:      GRAPHICS BACKEND
-            description: Choose your graphics rendering
-            choices:
-                "OpenGL": OGL
-                "Vulkan": Vulkan
         dsmotion:
-            prompt: DUALSHOCK MOTION
-            choices:
-                "Off": 0
-                "On":  1
-        rumble:
-            prompt: RUMBLE
+            prompt:      DUALSHOCK MOTION CONTROL
+            description: Emulate Wii pointer with your controller Gyroscope
             choices:
                 "Off": 0
                 "On":  1
         mouseir:
-            prompt: USE MOUSE AS IR
+            prompt:      MOUSE AS IR WIIMOTE
+            description: Emulate the Wiimote IR control with a mouse
+            choices:
+                "Off": 0
+                "On":  1
+        rumble:
+            prompt:      ENABLE RUMBLE
+            description: To use vibration on games with Rumble mode
             choices:
                 "Off": 0
                 "On":  1
@@ -2093,6 +2096,17 @@ dolphin:
   systems:
     wii:
         features: [emulated_wiimotes]
+        cfeatures:
+            controller_mode:
+                prompt:      GAMEPAD CONTROLLER MODE
+                description: Use gamepad with L2 for Shake and more on right stick
+                choices:
+                    "Off":                       disabled
+                    "Classic Controller":        cc
+                    "Wiimote Sideway":           side
+                    "Wiimote Sideway + Swing":   is
+                    "Wiimote Sideway + Tilt":    it
+                    "Wiimote Sideway + Nunchuk": in
 dosbox:
   features: [ratio, padtokeyboard]
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1991,7 +1991,7 @@ dolphin:
                 "On":  1
         widescreen_hack:
             prompt: WIDESCREEN HACK
-            label:  Increases from 4:3 to 16:9 in 3D games (bad for 2D)
+            label:  You must use a 16/9 RATIO to work
             choices:
                 "Off": 0
                 "On":  1

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6,8 +6,8 @@ libretro:
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4]
-      prompt: GRAPHICS BACKEND
-      label:  Choose your graphics rendering
+      prompt:      GRAPHICS BACKEND
+      description: Choose your graphics rendering
       choices:
         "OpenGL": opengl
         "Vulkan": vulkan
@@ -17,15 +17,15 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             81_chroma_81:
-                prompt: COLORISATION
-                label:  Enable the Chroma 81 interface
+                prompt:      COLORISATION
+                description: Enable the Chroma 81 interface
                 choices:
                     "Automatic": automatic
                     "Off":       disabled
                     "On":        enabled
             81_highres:
-                prompt: HIGH RESOLUTION
-                label:  Enables WRX high resolution module
+                prompt:      HIGH RESOLUTION
+                description: Enables WRX high resolution module
                 choices:
                     "Automatic": automatic
                     "Off":       none
@@ -36,33 +36,33 @@ libretro:
             atari800:
                 cfeatures:
                     atari800_system:
-                        prompt: ATARI SYSTEM
-                        label:  Choose what Atari System to emulate
+                        prompt:      ATARI SYSTEM
+                        description: Choose what Atari System to emulate
                         choices:
                             "400/600XL/800 (48K) (OS B)": 400/800 (OS B)
                             "800XL/1200XL/XEGS (64K)":    800XL (64K)
                             "130XE (128K)":               130XE (128K)
                     atari800_ntscpal:
-                        prompt: VIDEO STANDARD
-                        label:  Switch frequency and resolution by region
+                        prompt:      VIDEO STANDARD
+                        description: Switch frequency and resolution by region
                         choices:
                             "NTSC":    NTSC
                             "PAL":     PAL
                     atari800_sioaccel:
-                        prompt: SIO ACCELERATION
-                        label:  Speeds up file loading. A few games will not load
+                        prompt:      SIO ACCELERATION
+                        description: Speeds up file loading. A few games will not load
                         choices:
                             "Off":     disabled
                             "On":      enabled
                     atari800_artifacting:
-                        prompt: HI-RES ARTIFACTING
-                        label:  Artificial color filters to mimic actual hardware
+                        prompt:      HI-RES ARTIFACTING
+                        description: Artificial color filters to mimic actual hardware
                         choices:
                             "Off":     disabled
                             "On":      enabled
                     atari800_resolution:
-                        prompt: INTERNAL RESOLUTION
-                        label:  Enables alternate resolutions for some games
+                        prompt:      INTERNAL RESOLUTION
+                        description: Enables alternate resolutions for some games
                         choices:
                             "336x240": 336x240
                             "320x240": 320x240
@@ -73,8 +73,8 @@ libretro:
             atari5200:
                 cfeatures:
                     atari800_opt2:
-                        prompt: JOY HACK (FOR ROBOTRON)
-                        label:  Treats the second analog stick as joystick 2
+                        prompt:      JOY HACK (FOR ROBOTRON)
+                        description: Treats the second analog stick as joystick 2
                         choices:
                             "Off":     disabled
                             "On":      enabled
@@ -84,8 +84,8 @@ libretro:
       features: [         rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             bluemsx_nospritelimits:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Remove the 4 sprite per line limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Remove the 4 sprite per line limit
                 choices:
                     "Off": OFF
                     "On":  ON
@@ -95,15 +95,15 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             cap32_model:
-                prompt: CPC MODEL
-                label:  Choose which Amstrad CPC model to emulate
+                prompt:      CPC MODEL
+                description: Choose which Amstrad CPC model to emulate
                 choices:
                     "464":   464
                     "6128":  6128
                     "6128+": 6128+
             cap32_ram:
-                prompt: RAM SIZE
-                label:  CPC physical RAM size in kB
+                prompt:      RAM SIZE
+                description: CPC physical RAM size in kB
                 choices:
                     "64":    64
                     "128":   128
@@ -118,8 +118,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             internal_resolution_desmume:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "256x192":   256x192
                     "512x384":   512x384
@@ -132,21 +132,21 @@ libretro:
                     "2304x1728": 2304x1728
                     "2560x1920": 2560x1920
             texture_scaling:
-                prompt: TEXTURES UPSCALING (XBRZ)
-                label:  Upscaling textures resolution on 3D objetcs
+                prompt:      TEXTURES UPSCALING (XBRZ)
+                description: Upscaling textures resolution on 3D objetcs
                 choices:
                     "Off": 1
                     "2x":  2
                     "4x":  4
             texture_smoothing:
-                prompt: TEXTURES SMOOTHING
-                label:  Smooths out textures on 3D objetcs
+                prompt:      TEXTURES SMOOTHING
+                description: Smooths out textures on 3D objetcs
                 choices:
                     "Off": disabled
                     "On":  enabled
             multisampling:
-                prompt: ANTI-ALIASING (MSAA)
-                label:  Smooth out jagged edges on 3D objetcs polygons 
+                prompt:      ANTI-ALIASING (MSAA)
+                description: Smooth out jagged edges on 3D objetcs polygons 
                 choices:
                     "Off": disabled
                     "2x":  2
@@ -155,8 +155,8 @@ libretro:
                     "16x": 16
                     "32x": 32
             screens_layout:
-                prompt: SCREEN LAYOUT
-                label:  Allows you to arrange the DS screens
+                prompt:      SCREEN LAYOUT
+                description: Allows you to arrange the DS screens
                 choices:
                     "top/bottom":    top/bottom
                     "bottom/top":    bottom/top
@@ -168,8 +168,8 @@ libretro:
                     "hybrid/top":    hybrid/top
                     "hybrid/bottom": hybrid/bottom
             frameskip_desmume:
-                prompt: FRAME SKIP
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      FRAME SKIP
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "Off": 0
                     "1":   1
@@ -189,15 +189,15 @@ libretro:
       features: [                           latency_reduction, padtokeyboard]
       cfeatures:
             core_timing:
-                prompt: CPU TIMING MODE (FPS)
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      CPU TIMING MODE (FPS)
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "internal (fixed 60fps)":  internal_fixed
                     "internal (variable fps)": internal_variable
                     "external (variable fps)": external
             filter:
-                prompt: VIDEO FILTER
-                label:  Apply to achieve some kind of visual effect
+                prompt:      VIDEO FILTER
+                description: Apply to achieve some kind of visual effect
                 choices:
                     "Off":         none
                     "normal2x":    normal2x
@@ -221,14 +221,14 @@ libretro:
       features: [                 autosave, latency_reduction]
       cfeatures:
             duckstation_PatchFastBoot:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show BIOS animation when starting content
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show BIOS animation when starting content
                 choices:
                     "Off":        "true"
                     "On":         "false"
             duckstation_resolution_scale:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "1x(native)": 1
                     "2x":         2
@@ -240,8 +240,8 @@ libretro:
                     "8x":         8
                     "9x":         9
             duckstation_antialiasing:
-                prompt: ANTI-ALIASING (MSAA/SSAA)
-                label:  Smooth out jagged edges on 3D objetcs polygons 
+                prompt:      ANTI-ALIASING (MSAA/SSAA)
+                description: Smooth out jagged edges on 3D objetcs polygons 
                 choices:
                     "Off":        1
                     "2x msaa":    2
@@ -255,29 +255,29 @@ libretro:
                     "16x ssaa":   16-ssaa
                     "32x ssaa":   32-ssaa
             duckstation_texture_filtering:
-                prompt: TEXTURE FILTERING
-                label:  Smooths out textures on 3D objetcs
+                prompt:      TEXTURE FILTERING
+                description: Smooths out textures on 3D objetcs
                 choices:
                     "nearest":    Nearest
                     "bilinear":   Bilinear
                     "jinc2":      JINC2
                     "xBR":        xBR
             duckstation_widescreen_hack:
-                prompt: WIDESCREEN HACK
-                label:  You must use a 16/9 RATIO and disable BEZEL
+                prompt:      WIDESCREEN HACK
+                description: You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":        "false"
                     "On":         "true"
             duckstation_CropMode:
-                prompt: CROP MODE
-                label:  Changes how much of the image is cropped
+                prompt:      CROP MODE
+                description: Changes how much of the image is cropped
                 choices:
                     "Off":                "None"
                     "Only Overscan Area": "Overscan"
                     "All Borders":        "Borders"
             duckstation_Controller1:
-                prompt: CONTROLLER 1 TYPE
-                label:  Sets the type of controller for slot 1
+                prompt:      CONTROLLER 1 TYPE
+                description: Use DualShock type for games with Rumble mode
                 choices:
                     "None":                          None
                     "Digital Controller":            DigitalController
@@ -286,8 +286,8 @@ libretro:
                     "PlayStation Mouse":             PlayStationMouse
                     "NeGcon":                        NeGcon
             duckstation_Controller2:
-                prompt: CONTROLLER 2 TYPE
-                label:  Sets the type of controller for slot 2
+                prompt:      CONTROLLER 2 TYPE
+                description: Use DualShock type for games with Rumble mode
                 choices:
                     "None":                          None
                     "Digital Controller":            DigitalController
@@ -299,8 +299,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             fbneo-cpu-speed-adjust:
-                prompt: CPU CLOCK
-                label:  Can fix native slowdowns in some games
+                prompt:      CPU CLOCK
+                description: Can fix native slowdowns in some games
                 choices:
                     "30%":        30%
                     "40%":        40%
@@ -321,8 +321,8 @@ libretro:
                     "190%":       190%
                     "200%":       200%
             fbneo-frameskip:
-                prompt: FRAMESKIP
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      FRAMESKIP
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "No skipping":                         0
                     "Skip rendering of 1 frames out of 2": 1
@@ -330,8 +330,8 @@ libretro:
                     "Skip rendering of 3 frames out of 4": 3
                     "Skip rendering of 4 frames out of 5": 4
             fbneo-lightgun-hide-crosshair:
-                prompt: CROSSHAIR (LIGHTGUN)
-                label:  Show crosshair if you play with a lightgun device
+                prompt:      CROSSHAIR (LIGHTGUN)
+                description: Show crosshair if you play with a lightgun device
                 choices:
                     "Off":                                enabled
                     "On":                                 disabled
@@ -339,8 +339,8 @@ libretro:
             neogeo:
                 cfeatures:
                     fbneo-neogeo-mode-switch:
-                        prompt: NEOGEO MODE
-                        label:  Load appropriate Bios depending on your choice
+                        prompt:      NEOGEO MODE
+                        description: Load appropriate Bios depending on your choice
                         choices:
                             "Console AES World":                   AES Asia
                             "Console AES Japan":                   AES Japan
@@ -349,8 +349,8 @@ libretro:
                             "Arcade MVS Japan":                    MVS Japan
                             "Arcade Universe BIOS (Cheats)":       Universe BIOS
                     fbneo-memcard-mode:
-                        prompt: MEMORY CARD MODE
-                        label:  Change the behavior for the memory card
+                        prompt:      MEMORY CARD MODE
+                        description: Change the behavior for the memory card
                         choices:
                             "Off":                                disabled
                             "Shared":                             shared
@@ -359,14 +359,14 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             fceumm_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Removes 8-sprites-per-scanline hardware limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Removes 8-sprites-per-scanline hardware limit
                 choices:
                     "Off":                  disabled
                     "On":                   enabled
             fceumm_palette:
-                prompt: COLOR PALETTE
-                label:  Choose which color palette is going to be used
+                prompt:      COLOR PALETTE
+                description: Choose which color palette is going to be used
                 choices:
                     "default":              default
                     "asqrealc":             asqrealc
@@ -387,23 +387,23 @@ libretro:
                     "wavebeam":             wavebeam
                     "custom":               custom
             fceumm_ntsc_filter:
-                prompt: NTSC FILTER
-                label:  Enable blargg NTSC video filters
+                prompt:      NTSC FILTER
+                description: Enable blargg NTSC video filters
                 choices:
                     "Off":                                    disabled
                     "Composite (color bleeding + artifacts)": composite
                     "SVideo (color bleeding only)":           svideo
                     "RGB (crisp image)":                      rgb
             fceumm_sndquality:
-                prompt: SOUND QUALITY (HIGHTER DEVICES)
-                label:  High sound quality for games using expansion audio
+                prompt:      SOUND QUALITY (HIGHTER DEVICES)
+                description: High sound quality for games using expansion audio
                 choices:
                     "Low":                  Low
                     "High":                 High
                     "Very High":            Very High
             fceumm_overclocking:
-                prompt: PPU OVERCLOCKING
-                label:  Minimize ingame slowdowns of some games (Contra Force)
+                prompt:      PPU OVERCLOCKING
+                description: Minimize ingame slowdowns of some games (Contra Force)
                 choices:
                     "disabled":             disabled
                     "2x-Postrender":        2x-Postrender
@@ -412,8 +412,8 @@ libretro:
       features: [                 autosave]
       cfeatures:
             reicast_internal_resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "640x480":    640x480
                     "1280x960":   1280x960
@@ -436,14 +436,14 @@ libretro:
                     "12160x9120": 12160x9120
                     "12800x9600": 12800x9600
             reicast_mipmapping:
-                prompt: TEXTURES MIP-MAPPING (BLUR)
-                label:  Smooths out textures on 3D objetcs
+                prompt:      TEXTURES MIP-MAPPING (BLUR)
+                description: Smooths out textures on 3D objetcs
                 choices:
                     "Off": disabled
                     "On":  enabled
             reicast_anisotropic_filtering:
-                prompt: ANISOTROPIC FILTERING
-                label:  Enhance the quality with on perspective textures
+                prompt:      ANISOTROPIC FILTERING
+                description: Enhance the quality with on perspective textures
                 choices:
                     "Off": off
                     "2x":  2
@@ -451,16 +451,16 @@ libretro:
                     "8x":  8
                     "16x": 16
             reicast_texupscale:
-                prompt: TEXTURES UPSCALING (XBRZ)
-                label:  Upscaling 2D pixel art graphics (2D Games Only)
+                prompt:      TEXTURES UPSCALING (XBRZ)
+                description: Upscaling 2D pixel art graphics (2D Games Only)
                 choices:
                     "Off": off
                     "2x":  2x
                     "4x":  4x
                     "6x":  6x
             reicast_render_to_texture_upscaling:
-                prompt: RENDER TO TEXTURES UPSCALING
-                label:  Upscaling textures resolution on 3D objetcs
+                prompt:      RENDER TO TEXTURES UPSCALING
+                description: Upscaling textures resolution on 3D objetcs
                 choices:
                     "Off": 1x
                     "2x":  2x
@@ -468,8 +468,8 @@ libretro:
                     "4x":  4x
                     "8x":  8x
             reicast_frame_skipping:
-                prompt: FRAME SKIP
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      FRAME SKIP
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "Off": disabled
                     "1":   1
@@ -479,20 +479,20 @@ libretro:
                     "5":   5
                     "6":   6
             reicast_force_wince:
-                prompt: FORCE WINDOWS CE MODE
-                label:  Enable full MMU emulation for Windows CE games
+                prompt:      FORCE WINDOWS CE MODE
+                description: Enable full MMU emulation for Windows CE games
                 choices:
                     "Off": disabled
                     "On":  enabled
             reicast_widescreen_cheats:
-                prompt: WIDESCREEN CHEAT (PRIORITY)
-                label:  You must use a 16/9 RATIO and disable BEZEL
+                prompt:      WIDESCREEN CHEAT (PRIORITY)
+                description: You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off": disabled
                     "On":  enabled
             reicast_widescreen_hack:
-                prompt: WIDESCREEN HACK
-                label:  You must use a 16/9 RATIO and disable BEZEL
+                prompt:      WIDESCREEN HACK
+                description: You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off": disabled
                     "On":  enabled
@@ -500,16 +500,16 @@ libretro:
             atomiswave:
                 cfeatures:
                     screen_rotation_atomiswave:
-                        prompt: SCREEN ORIENTATION
-                        label:  Rotate screen for some arcade games
+                        prompt:      SCREEN ORIENTATION
+                        description: Rotate screen for some arcade games
                         choices:
                             "Horizontal": horizontal
                             "Vertical":   vertical
             naomi:
                 cfeatures:
                     screen_rotation_naomi:
-                        prompt: SCREEN ORIENTATION
-                        label:  Rotate screen for some arcade games
+                        prompt:      SCREEN ORIENTATION
+                        description: Rotate screen for some arcade games
                         choices:
                             "Horizontal": horizontal
                             "Vertical":   vertical
@@ -519,8 +519,8 @@ libretro:
       features: [                 autosave, latency_reduction, padtokeyboard]
       cfeatures:
             fuse_hide_border:
-                prompt: ZOOM (HIDES BORDER)
-                label:  Making the game occupy the entire screen area
+                prompt:      ZOOM (HIDES BORDER)
+                description: Making the game occupy the entire screen area
                 choices:
                     "Off":  disabled
                     "On":   enabled
@@ -528,14 +528,14 @@ libretro:
       features: [         rewind, autosave, latency_reduction, colorization]
       cfeatures:
             gb_bootloader:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show BIOS animation when starting content
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show BIOS animation when starting content
                 choices:
                     "Off":                     disabled
                     "On":                      enabled
             mix_frames:
-                prompt: GHOSTING EFFECT
-                label:  Simulation of LCD ghosting effects
+                prompt:      GHOSTING EFFECT
+                description: Simulation of LCD ghosting effects
                 choices:
                     "Off":                     disabled
                     "Simple (Accurate)":       mix
@@ -546,8 +546,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             gpgx_no_sprite_limit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Reduce sprite flickering when enabled
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Reduce sprite flickering when enabled
                 choices:
                     "Off":                disabled
                     "On":                 enabled
@@ -555,38 +555,38 @@ libretro:
             megadrive:
                 cfeatures:
                     gpgx_blargg_filter_md:
-                        prompt: NTSC FILTER
-                        label:  Enable blargg NTSC video filters
+                        prompt:      NTSC FILTER
+                        description: Enable blargg NTSC video filters
                         choices:
                             "Off":                                    Off
                             "Composite (color bleeding + artifacts)": composite
                             "SVideo (color bleeding only)":           svideo
                             "RGB (crisp image)":                      rgb
                     gun_cursor_md:
-                        prompt: SHOW LIGHTGUN CROSSHAIR
-                        label:  Shows crosshairs for Menacer and Justifiers devices
+                        prompt:      SHOW LIGHTGUN CROSSHAIR
+                        description: Shows crosshairs for Menacer and Justifiers devices
                         choices:
                             "Off":        disabled
                             "On":         enabled
             mastersystem:
                 cfeatures:
                     gpgx_blargg_filter_ms:
-                        prompt: NTSC FILTER
-                        label:  Enable blargg NTSC video filters
+                        prompt:      NTSC FILTER
+                        description: Enable blargg NTSC video filters
                         choices:
                             "Off":                                    Off
                             "Composite (color bleeding + artifacts)": composite
                             "SVideo (color bleeding only)":           svideo
                             "RGB (crisp image)":                      rgb
                     gun_cursor_ms:
-                        prompt: SHOW LIGHTGUN CROSSHAIR
-                        label:  Shows crosshairs for Light Phaser device
+                        prompt:      SHOW LIGHTGUN CROSSHAIR
+                        description: Shows crosshairs for Light Phaser device
                         choices:
                             "Off":        disabled
                             "On":         enabled
                     ym2413:
-                        prompt: FM CHIP (YM2413)
-                        label:  Enhanced sound output support for compatible games
+                        prompt:      FM CHIP (YM2413)
+                        description: Enhanced sound output support for compatible games
                         choices:
                             "Automatic":  automatic
                             "Off":        disabled
@@ -594,14 +594,14 @@ libretro:
             gamegear:
                 cfeatures:
                     lcd_filter:
-                        prompt: LCD GHOSTING FILTER
-                        label:  Simulate the movement blur effect on old LCD screen
+                        prompt:      LCD GHOSTING FILTER
+                        description: Simulate the movement blur effect on old LCD screen
                         choices:
                             "Off":       disabled
                             "On":        enabled
                     gg_extra:
-                        prompt: EXTENDED SCREEN
-                        label:  Extend the game screen area like on a Master System
+                        prompt:      EXTENDED SCREEN
+                        description: Extend the game screen area like on a Master System
                         choices:
                             "Off":       disabled
                             "On":        enabled
@@ -623,8 +623,8 @@ libretro:
       features: [netplay,         autosave, latency_reduction]
       cfeatures:
             mame_cpu_overclock:
-                prompt: CPU OVERCLOCK
-                label:  Minimize ingame slowdowns of some games
+                prompt:      CPU OVERCLOCK
+                description: Minimize ingame slowdowns of some games
                 choices:
                     "default":        default
                     "30":             30
@@ -653,8 +653,8 @@ libretro:
                     "145":            145
                     "150":            150
             mame_altres:
-                prompt: VIDEO RESOLUTION
-                label:  Increase video to Highter Resolution
+                prompt:      VIDEO RESOLUTION
+                description: Increase video to Highter Resolution
                 choices:
                     "640x480":        640x480
                     "800x600":        800x600
@@ -671,8 +671,8 @@ libretro:
       features: [netplay,         autosave, latency_reduction]
       cfeatures:
             mame_current_frame_skip:
-                prompt: FRAMSKIP
-                label:  Skip frames to improve performance (smoothless)
+                prompt:      FRAMSKIP
+                description: Skip frames to improve performance (smoothless)
                 choices:
                     "Off":            0
                     "1":              1
@@ -681,8 +681,8 @@ libretro:
                     "4":              4
                     "Automatic":      automatic
             mame_current_turbo_button:
-                prompt: AUTOFIRE
-                label:  Choice the buton to enable Autofire
+                prompt:      AUTOFIRE
+                description: Choice the buton to enable Autofire
                 choices:
                     "Off":            disabled
                     "button 1":       button 1
@@ -690,8 +690,8 @@ libretro:
                     "R2 to button 1": R2 to button 1 mapping
                     "R2 to button 2": R2 to button 2 mapping
             mame_current_turbo_delay:
-                prompt: AUTOFIRE PULSE SPEED
-                label:  Choose the fire speed for Autofire 
+                prompt:      AUTOFIRE PULSE SPEED
+                description: Choose the fire speed for Autofire 
                 choices:
                     "slow":           slow
                     "medium":         medium
@@ -700,14 +700,14 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             mame2003-plus_analog:
-                prompt: CONTROL MAPPING
-                label:  Choose from Analog and Digital controller
+                prompt:      CONTROL MAPPING
+                description: Choose from Analog and Digital controller
                 choices:
                     "Analog":       analog
                     "Digital":      digital
             mame2003-plus_frameskip:
-                prompt: FRAMSKIP
-                label:  Skip frames to improve performance (smoothless)
+                prompt:      FRAMSKIP
+                description: Skip frames to improve performance (smoothless)
                 choices:
                     "Off":          0
                     "1":            1
@@ -716,21 +716,21 @@ libretro:
                     "4":            4
                     "5":            5
             mame2003-plus_input_interface:
-                prompt: INPUT INTERFACE
-                label:  Use input directly sends by keyboard to the core
+                prompt:      INPUT INTERFACE
+                description: Use input directly sends by keyboard to the core
                 choices:
                     "retropad":     retropad
                     "keyboard":     keyboard
                     "simultaneous": simultaneous
             mame2003-plus_tate_mode:
-                prompt: TATE MODE
-                label:  Rotating display to vertical mode rendering
+                prompt:      TATE MODE
+                description: Rotating display to vertical mode rendering
                 choices:
                     "Off":        disabled
                     "On":         enabled
             mame2003-plus_neogeo_bios:
-                prompt: NEOGEO MODE
-                label:  Manually specify your choice of Neo Geo BIOS
+                prompt:      NEOGEO MODE
+                description: Manually specify your choice of Neo Geo BIOS
                 choices:
                     "Console AES World":                   asia-aes
                     "Arcade MVS Europe":                   euro
@@ -746,14 +746,14 @@ libretro:
       features: [                 autosave, latency_reduction]
       cfeatures:
             beetle_psx_skip_bios:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show BIOS animation when starting content
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show BIOS animation when starting content
                 choices:
                     "Off":        enabled
                     "On":         disabled
             beetle_psx_cpu_freq_scale:
-                prompt: OVERCLOCKING (HEAVY CPU)
-                label:  Can eliminate slowdown and improve frame rates
+                prompt:      OVERCLOCKING (HEAVY CPU)
+                description: Can eliminate slowdown and improve frame rates
                 choices:
                     "50%":          50%
                     "60%":          60%
@@ -783,8 +783,8 @@ libretro:
                     "700%":         700%
                     "750%":         750%
             beetle_psx_internal_resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "1x(native)": 1x(native)
                     "2x":         2x
@@ -792,45 +792,71 @@ libretro:
                     "8x":         8x
                     "16x":        16x
             beetle_psx_widescreen_hack:
-                prompt: WIDESCREEN HACK
-                label:  You must use a 16/9 RATIO and disable BEZEL
+                prompt:      WIDESCREEN HACK
+                description: You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":        disabled
                     "On":         enabled
             beetle_psx_frame_duping:
-                prompt: FRAME DUPING (SPEEDDUP)
-                label:  Small performance increase (may lost anim. frames)
+                prompt:      FRAME DUPING (SPEEDDUP)
+                description: Small performance increase (may lost anim. frames)
                 choices:
                     "Off":        disabled
                     "On":         enabled
             beetle_psx_cpu_dynarec:
-                prompt: CPU DYNAREC (SPEEDDUP)
-                label:  Much faster than interpreter (but may have bugs)
+                prompt:      CPU DYNAREC (SPEEDDUP)
+                description: Much faster than interpreter (but may have bugs)
                 choices:
                     "Desabled (Beatle Interpreter": disabled
                     "Max Performance":              execute
                     "Cycle Timing Check":           execute_once
                     "Lightrec Interpreter":         run_interpreter
             beetle_psx_dynarec_invalidate:
-                prompt: DYNAREC CODE INVALIDATION
-                label:  Some games require DMA Only (for CPU Dynarec)
+                prompt:      DYNAREC CODE INVALIDATION
+                description: Some games require DMA Only (for CPU Dynarec)
                 choices:
                     "Full":                         full
                     "DMA Only (Slightly Faster)":   dma
             multitap_mednafen:
-                prompt: ENABLE MULTITAP
-                label:  Allowing 5-8 player support in games
+                prompt:      ENABLE MULTITAP
+                description: Allowing 5-8 player support in games
                 choices:
                     "Off":              disabled
-                    "Port1":            port1
-                    "Port2":            port2
-                    "Port1+2":          port12
+                    "Port 1":           port1
+                    "Port 2":           port2
+                    "Port 1+2":         port12
+            beetle_psx_Controller1:
+                prompt:      CONTROLLER 1 TYPE
+                description: Use DualShock type for games with Rumble mode
+                choices:
+                    "None":                          0
+                    "Digital Controller":            1
+                    "Analog Controller":             261
+                    "Analog Controller (DualShock)": 517
+                    "Analog Joystick":               773
+                    "Namco GunCon":                  260
+                    "Justifier":                     516
+                    "PlayStation Mouse":             258
+                    "NeGcon":                        1029
+            beetle_psx_Controller2:
+                prompt:      CONTROLLER 2 TYPE
+                description: Use DualShock type for games with Rumble mode
+                choices:
+                    "None":                          0
+                    "Digital Controller":            1
+                    "Analog Controller":             261
+                    "Analog Controller (DualShock)": 517
+                    "Analog Joystick":               773
+                    "Namco GunCon":                  260
+                    "Justifier":                     516
+                    "PlayStation Mouse":             258
+                    "NeGcon":                        1029
     mednafen_supergrafx:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             sgx_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Remove 16-sprites-per-scanline hardware limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Remove 16-sprites-per-scanline hardware limit
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -840,8 +866,8 @@ libretro:
       features: [         rewind, autosave, latency_reduction]
       cfeatures:
             skip_bios_mgba:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show BIOS animation when starting content
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show BIOS animation when starting content
                 choices:
                     "Off": ON
                     "On":  OFF
@@ -849,37 +875,37 @@ libretro:
             gb:
                 cfeatures:
                     sgb_borders:
-                        prompt: SUPER GB BORDERS
-                        label:  Only for Super Game Boy enhanced games
+                        prompt:      SUPER GB BORDERS
+                        description: Only for Super Game Boy enhanced games
                         choices:
                             "Off": OFF
                             "On":  ON
                     color_correction:
-                        prompt: COLOR CORRECTION
-                        label:  Adjusts output colors to feel real hardware
+                        prompt:      COLOR CORRECTION
+                        description: Adjusts output colors to feel real hardware
                         choices:
                             "Off": OFF
                             "On":  GBA
             gbc:
                 cfeatures:
                     sgb_borders:
-                        prompt: SUPER GB BORDERS
-                        label:  Only for Super Game Boy enhanced games
+                        prompt:      SUPER GB BORDERS
+                        description: Only for Super Game Boy enhanced games
                         choices:
                             "Off": OFF
                             "On":  ON
                     color_correction:
-                        prompt: COLOR CORRECTION
-                        label:  Adjusts output colors to feel real hardware
-                        label:  
+                        prompt:      COLOR CORRECTION
+                        description: Adjusts output colors to feel real hardware
+                        description: 
                         choices:
                             "Off": OFF
                             "On":  GBC
             gba:
                 cfeatures:
                     solar_sensor_level:
-                        prompt: SOLAR SENSOR LEVEL
-                        label: Only for games that employed it (for Boktai)
+                        prompt:      SOLAR SENSOR LEVEL
+                        description: Only for games that employed it (for Boktai)
                         choices:
                             "0":  0
                             "1":  1
@@ -893,8 +919,8 @@ libretro:
                             "9":  9
                             "10": 10
                     frameskip_mgba:
-                        prompt: FRAMESKIP
-                        label:  Skip frames to improve performance (smoothless)
+                        prompt:      FRAMESKIP
+                        description: Skip frames to improve performance (smoothless)
                         choices:
                             "0":  0
                             "1":  1
@@ -911,16 +937,16 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             mrboom-aspect:
-                prompt: TEAM MODE
-                label:  Choose the Team mode color
+                prompt:      TEAM MODE
+                description: Choose the Team mode color
                 choices:
                     "Selfie": Native
                     "Color":  Color
                     "Sex":    Sex
                     "Skynet": Skynet
             mrboom-nomonster:
-                prompt: MONSTERS
-                label:  Enable or disable monsters on battle
+                prompt:      MONSTERS
+                description: Enable or disable monsters on battle
                 choices:
                     "Off":    OFF
                     "On":     ON
@@ -928,8 +954,8 @@ libretro:
       features: [                 autosave]
       cfeatures:
             mupen64plus-43screensize:
-                prompt: VIDEO 4:3 RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO 4:3 RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "320x240":   320x240
                     "640x480":   640x480
@@ -943,8 +969,8 @@ libretro:
                     "3520x2640": 3520x2640
                     "3840x2880": 3840x2880
             mupen64plus-169screensize:
-                prompt: VIDEO 16:9 RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO 16:9 RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "640x360":   640x360
                     "960x540":   960x540
@@ -954,20 +980,20 @@ libretro:
                     "3840x2160": 3840x2160
                     "7680x4320": 7680x4320
             mupen64plus-aspect:
-                prompt: WIDESCREEN HACK
-                label:  You must use a 16/9 RATIO and disable BEZEL
+                prompt:      WIDESCREEN HACK
+                description: You must use a 16/9 RATIO and disable BEZEL
                 choices:
                     "Off":       4:3
                     "On":        16:9 adjusted
             mupen64plus-BilinearMode:
-                prompt: BILINEAR FILTERING
-                label:  Filter to gradually switch colors
+                prompt:      BILINEAR FILTERING
+                description: Filter to gradually switch colors
                 choices:
                     "standard":   standard
                     "3 point":    3point
             mupen64plus-MultiSampling:
-                prompt: ANTI-ALIASING (MSAA)
-                label:  Smooth out jagged edges on 3D objetcs polygons 
+                prompt:      ANTI-ALIASING (MSAA)
+                description: Smooth out jagged edges on 3D objetcs polygons 
                 choices:
                     "Off":        0
                     "2x":         2
@@ -975,8 +1001,8 @@ libretro:
                     "8x":         8
                     "16x":        16
             mupen64plus-txFilterMode:
-                prompt: TEXTURE FILTERING
-                label:  Smooths out textures on 3D objetcs
+                prompt:      TEXTURE FILTERING
+                description: Smooths out textures on 3D objetcs
                 choices:
                     "Off":        None
                     "Smooth 1":   Smooth filtering 1
@@ -986,8 +1012,8 @@ libretro:
                     "Sharp 1":    Sharp filtering 1
                     "Sharp 2":    Sharp filtering 2
             mupen64plus-txEnhancementMode:
-                prompt: TEXTURE ENHANCEMENT (XBRZ)
-                label:  Scales up a nearest-neighbor version of the texture
+                prompt:      TEXTURE ENHANCEMENT (XBRZ)
+                description: Scales up a nearest-neighbor version of the texture
                 choices:
                     "Off":        None
                     "As Is":      As Is
@@ -1007,22 +1033,22 @@ libretro:
       features: [         rewind, autosave]
       cfeatures:
             neocd_region:
-                prompt: CONSOLE REGION
-                label:  Change language of some games
+                prompt:      CONSOLE REGION
+                description: Change language of some games
                 choices:
                     "Japan":        Japan
                     "USA":          USA
                     "Europe":       Europe
             neocd_bios:
-                prompt: BIOS SELECT
-                label:  CD Universe Bios not include cheats
+                prompt:      BIOS SELECT
+                description: CD Universe Bios not include cheats
                 choices:
                     "CDZ":          CDZ
                     "CDZ (MAME)":   CDZ (MAME)
                     "Universe 3.2": Universe 3.2
             neocd_per_content_saves:
-                prompt: PER-GAME SAVES
-                label:  Use one save file per-game
+                prompt:      PER-GAME SAVES
+                description: Use one save file per-game
                 choices:
                     "Off":          Off
                     "On":           On
@@ -1030,14 +1056,14 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             nestopia_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Removes 8-sprites-per-scanline hardware limi
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Removes 8-sprites-per-scanline hardware limi
                 choices:
                     "Off":                  disabled
                     "On":                   enabled
             nestopia_palette:
-                prompt: COLOR PALETTE
-                label:  Choose which color palette is going to be used
+                prompt:      COLOR PALETTE
+                description: Choose which color palette is going to be used
                 choices:
                     "consumer":             consumer
                     "cxa2025as":            cxa2025as
@@ -1051,22 +1077,22 @@ libretro:
                     "nes-classic-fbx-fs":   nes-classic-fbx-fs
                     "custom":               custom
             nestopia_blargg_ntsc_filter:
-                prompt: NTSC FILTER
-                label:  Enable blargg NTSC video filters
+                prompt:      NTSC FILTER
+                description: Enable blargg NTSC video filters
                 choices:
                     "Off":                                    disabled
                     "Composite (color bleeding + artifacts)": composite
                     "SVideo (color bleeding only)":           svideo
                     "RGB (crisp image)":                      rgb
             nestopia_overclock:
-                prompt: CPU OVERCLOCK
-                label:  Minimize ingame slowdowns of some games (Contra Force)
+                prompt:      CPU OVERCLOCK
+                description: Minimize ingame slowdowns of some games (Contra Force)
                 choices:
                     "Off":                  1x
                     "2x":                   2x
             nestopia_select_adapter:
-                prompt: 4 PLAYER ADAPTER
-                label:  Manually select a 4 Player Adapter for some games
+                prompt:      4 PLAYER ADAPTER
+                description: Manually select a 4 Player Adapter for some games
                 choices:
                     "Autodetect":           auto
                     "ntsc":                 ntsc
@@ -1075,15 +1101,15 @@ libretro:
       features: [netplay, rewind, autosave, padtokeyboard]
       cfeatures:
             np2kai_model:
-                prompt: PC MODEL
-                label:  Selects the correct PC model being emulated
+                prompt:      PC MODEL
+                description: Selects the correct PC model being emulated
                 choices:
                     "PC-286":    PC-286
                     "PC-9801VM": PC-9801VM
                     "PC-9801VX": PC-9801VX
             np2kai_cpu_feature:
-                prompt: CPU FEATURE
-                label:  Select the processor model
+                prompt:      CPU FEATURE
+                description: Select the processor model
                 choices:
                     "Intel 80386":         Intel 80386
                     "Intel i486DX":        Intel i486DX
@@ -1093,8 +1119,8 @@ libretro:
                     "Intel Pentium 4":     Intel Pentium 4
                     "Neko Processor II":   Neko Processor II
             np2kai_clk_mult:
-                prompt: CPU CLOCK MULTIPLIER
-                label:  Recommended to use somewhere between a 4x and 8x
+                prompt:      CPU CLOCK MULTIPLIER
+                description: Recommended to use somewhere between a 4x and 8x
                 choices:
                     "2x":        2
                     "4x":        4
@@ -1116,8 +1142,8 @@ libretro:
                     "88x":       88
                     "100x":      100
             np2kai_ExMemory:
-                prompt: RAM SIZE
-                label:  Select memory required by game, 13 Mo recommanded
+                prompt:      RAM SIZE
+                description: Select memory required by game, 13 Mo recommanded
                 choices:
                     "1 Mo":      1
                     "3 Mo":      2
@@ -1132,27 +1158,27 @@ libretro:
                     "512 Mo":    512
                     "1024 Mo":   1024
             np2kai_gdc:
-                prompt: GDC
-                label:  Graphic Display Controller model
+                prompt:      GDC
+                description: Graphic Display Controller model
                 choices:
                     "uPD7220":   uPD7220
                     "uPD72020":  uPD72020
             np2kai_skipline:
-                prompt: REMOVE SCANLINES
-                label:  (Off) will show Black Scanline in older games (Graphically designed to use scanlines)
+                prompt:      REMOVE SCANLINES
+                description: (Off) will show Black Scanline in older games (Graphically designed to use scanlines)
                 choices:
                     "Full 255 lines": Full 255 lines
                     "Off":            OFF
                     "On":             ON
             np2kai_realpal:
-                prompt: REAL PALETTES
-                label:  Some games only working correctly with this (Apros)
+                prompt:      REAL PALETTES
+                description: Some games only working correctly with this (Apros)
                 choices:
                     "Off":       OFF
                     "On":        ON
             np2kai_SNDboard:
-                prompt: SOUND BOARD
-                label:  Choose 26K for old games and 86K for newer games
+                prompt:      SOUND BOARD
+                description: Choose 26K for old games and 86K for newer games
                 choices:
                     "None":                                             None
                     "PC9801-14":                                        PC9801-14
@@ -1183,14 +1209,14 @@ libretro:
                     "Otomi-chanx2 + 86":                                Otomi-chanx2 + 86
                     "WaveStar":                                         WaveStar
             np2kai_jast_snd:
-                prompt: JAST SOUND
-                label:  To have music and not only sound in games (Owl-Zoo)
+                prompt:      JAST SOUND
+                description: To have music and not only sound in games (Owl-Zoo)
                 choices:
                     "Off":                          OFF
                     "On":                           ON
             np2kai_joymode:
-                prompt: Joypad D-pad Mapping
-                label:  Emulate a keyboard/mouse/joypad on your gamepad
+                prompt:      Joypad D-pad Mapping
+                description: Emulate a keyboard/mouse/joypad on your gamepad
                 choices:
                     "Off":                          OFF
                     "Mouse":                        Mouse
@@ -1208,14 +1234,14 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             high_resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "320x240":         disabled
                     "640x480":         enabled
             cpu_overclock:
-                prompt: CPU OVERCLOCK
-                label:  Improve frame rates in many games (like NFS)
+                prompt:      CPU OVERCLOCK
+                description: Improve frame rates in many games (like NFS)
                 choices:
                     "1.0x (12.50Mhz)": 1.0x (12.50Mhz)
                     "1.1x (13.75Mhz)": 1.1x (13.75Mhz)
@@ -1225,8 +1251,8 @@ libretro:
                     "1.8x (22.50Mhz)": 1.8x (22.50Mhz)
                     "2.0x (25.00Mhz)": 2.0x (25.00Mhz)
             active_devices:
-                prompt: ACTIVE INPUT DEVICES FIX
-                label:  Fixing a possible bug with controller detection
+                prompt:      ACTIVE INPUT DEVICES FIX
+                description: Fixing a possible bug with controller detection
                 choices:
                     "1":               1
                     "2":               2
@@ -1237,8 +1263,8 @@ libretro:
                     "7":               7
                     "8":               8
             game_fixes_opera:
-                prompt: ADDITIONAL GAME FIXES
-                label:  Enable these options to fix them games
+                prompt:      ADDITIONAL GAME FIXES
+                description: Enable these options to fix them games
                 choices:
                     "Off":               disabled
                     "Alone in the Dark": timing_hack6
@@ -1249,8 +1275,8 @@ libretro:
       features: [                 autosave]
       cfeatures:
             screensize:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "320x240":   320x240
                     "640x480":   640x480
@@ -1263,8 +1289,8 @@ libretro:
                     "2880x2160": 2880x2160
                     "5760x4320": 5760x4320
             filtering:
-                prompt: TEXTURE FILTERING
-                label:  Smooths out textures on 3D objetcs
+                prompt:      TEXTURE FILTERING
+                description: Smooths out textures on 3D objetcs
                 choices:
                     "Automatic":   automatic
                     "N64 3-point": N64 3-point
@@ -1274,8 +1300,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             pce_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Remove 16-sprites-per-scanline hardware limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Remove 16-sprites-per-scanline hardware limit
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -1283,8 +1309,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             sgx_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Remove 16-sprites-per-scanline hardware limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Remove 16-sprites-per-scanline hardware limit
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -1292,8 +1318,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             pcfx_nospritelimit:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Remove 16-sprites-per-scanline hardware limit
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Remove 16-sprites-per-scanline hardware limit
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -1301,37 +1327,37 @@ libretro:
       features: [                 autosave, latency_reduction]
       cfeatures:
             show_bios_bootlogo:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show animation when starting (Breaks some games)
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show animation when starting (Breaks some games)
                 choices:
                     "Off":              disabled
                     "On":               enabled
             frameskip_pcsx:
-                prompt: FRAMESKIP
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      FRAMESKIP
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "Off":              0
                     "1":                1
                     "2":                2
                     "3":                3
             neon_enhancement:
-                prompt: ENHANCED RESOLUTION (SLOWER)
-                label:  Double the resolution (Speed hack causes glitches)
+                prompt:      ENHANCED RESOLUTION (SLOWER)
+                description: Double the resolution (Speed hack causes glitches)
                 choices:
                     "Off":              disabled
                     "On":               enabled
                     "On (Speed hack)":  enabled_with_speedhack
             multitap_pcsx:
-                prompt: ENABLE MULTITAP
-                label:  Allowing 5-8 player support in games
+                prompt:      ENABLE MULTITAP
+                description: Allowing 5-8 player support in games
                 choices:
                     "Off":              disabled
                     "Port1":            port1
                     "Port2":            port2
                     "Port1+2":          port12
             game_fixes_pcsx:
-                prompt: ADDITIONAL GAME FIXES
-                label:  Enable these options to fix them games
+                prompt:      ADDITIONAL GAME FIXES
+                description: Enable these options to fix them games
                 choices:
                     "Off":                                  disabled
                     "Capcom VS games Expand Screen Width":  Capcom_fighting
@@ -1342,12 +1368,34 @@ libretro:
                     "InuYasha Sengoku Battle Fix":          InuYasha_Sengoku
                     "Pandemonium 2 Lazy Screen Update Fix": Pandemonium
                     "Parasite Eve 2/Vandal Hearts 1&2 Fix": Parasite_Eve
+            controller1_pcsx:
+                prompt:      CONTROLLER 1 TYPE
+                description: Use DualShock type for games with Rumble mode
+                choices:
+                    "None":                          0
+                    "Digital Controller":            1
+                    "Analog Controller":             261
+                    "Analog Controller (DualShock)": 517
+                    "Namco GunCon":                  260
+                    "PlayStation Mouse":             258
+                    "NeGcon":                        773
+            controller2_pcsx:
+                prompt:      CONTROLLER 2 TYPE
+                description: Use DualShock type for games with Rumble mode
+                choices:
+                    "None":                          0
+                    "Digital Controller":            1
+                    "Analog Controller":             261
+                    "Analog Controller (DualShock)": 517
+                    "Namco GunCon":                  260
+                    "PlayStation Mouse":             258
+                    "NeGcon":                        773
     picodrive:
       features: [netplay,         autosave]
       cfeatures:
             picodrive_sprlim:
-                prompt: REDUCE SPRITE FLICKERING
-                label:  Reduce sprite flickering when enabled
+                prompt:      REDUCE SPRITE FLICKERING
+                description: Reduce sprite flickering when enabled
                 choices:
                     "Off":          disabled
                     "On":           enabled
@@ -1357,14 +1405,14 @@ libretro:
       features: [         rewind, autosave, latency_reduction]
       cfeatures:
             pokemini_lcdfilter:
-                prompt: LCD FILTER
-                label:  Produces a clean LCD effect
+                prompt:      LCD FILTER
+                description: Produces a clean LCD effect
                 choices:
                     "Off":  none
                     "On":   dotmatrix
             pokemini_lcdmode:
-                prompt: LCD GHOSTING EFFECTS
-                label:  Emulate liquid crystal display
+                prompt:      LCD GHOSTING EFFECTS
+                description: Emulate liquid crystal display
                 choices:
                     "Off":  3shades
                     "On":   analog
@@ -1374,8 +1422,8 @@ libretro:
       features: [         rewind, autosave, latency_reduction]
       cfeatures:
             prboom-resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Smooth out jagged edges on 3D objetcs polygons
+                prompt:      VIDEO RESOLUTION
+                description: Smooth out jagged edges on 3D objetcs polygons
                 choices:
                     "320x200":    320x200
                     "640x400":    640x400
@@ -1391,35 +1439,35 @@ libretro:
       features: [         rewind, autosave, padtokeyboard]
       cfeatures:
             video_resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Increase video to Hi Resolution
+                prompt:      VIDEO RESOLUTION
+                description: Increase video to Hi Resolution
                 choices:
                     "360p":       lores
                     "720p":       hires
                     "1440p":      superhires
             video_standard:
-                prompt: VIDEO STANDARD
-                label:  Switch frequency and resolution by region
+                prompt:      VIDEO STANDARD
+                description: Switch frequency and resolution by region
                 choices:
                     "PAL 50Hz - 288/576px":        PAL
                     "NTSC 60Hz - 240/480px":       NTSC
             zoom_mode:
-                prompt: ZOOM MODE
-                label:  Crops the borders to fit various host screens
+                prompt:      ZOOM MODE
+                description: Crops the borders to fit various host screens
                 choices:
                     "Off":        none
                     "medium":     medium
                     "large":      large
                     "larger":     larger
             keyrah_mapping:
-                prompt: 2P GAMEPAD MAPPING (KEYRAH)
-                label:  Keypad to joyport mappings for 2 players
+                prompt:      2P GAMEPAD MAPPING (KEYRAH)
+                description: Keypad to joyport mappings for 2 players
                 choices:
                     "Off":        disabled
                     "On":         enabled
             mouse_speed:
-                prompt: MOUSE SPEED
-                label:  Affects mouse speed globally.
+                prompt:      MOUSE SPEED
+                description: Affects mouse speed globally.
                 choices:
                     "original":   100
                     "50%":        50
@@ -1429,26 +1477,26 @@ libretro:
                     "170%":       170
                     "200%":       200
             whdload:
-                prompt: WHDLOAD LAUNCHER
-                label:  Enable launching pre-installed WHDLoad installs
+                prompt:      WHDLOAD LAUNCHER
+                description: Enable launching pre-installed WHDLoad installs
                 choices:
                     "Off":        disabled
                     "On":         config
             pad_options:
-                prompt: JUMP ON B
-                label:  Makes second fire button press up
+                prompt:      JUMP ON B
+                description: Makes second fire button press up
                 choices:
                     "Off":        disabled
                     "On":         jump
             disable_joystick:
-                prompt: DISABLE EMULATOR JOYSTICK
-                label:  Passes all physical keyboard events for Pad2Key
+                prompt:      DISABLE EMULATOR JOYSTICK
+                description: Passes all physical keyboard events for Pad2Key
                 choices:
                     "Off":        disabled
                     "On":         enabled
             gfx_framerate:
-                prompt: FRAMESKIP
-                label:  Skip frames to improve performance (Smoothless)
+                prompt:      FRAMESKIP
+                description: Skip frames to improve performance (Smoothless)
                 choices:
                     "Off":        disabled
                     "1":          1
@@ -1457,8 +1505,8 @@ libretro:
       features: [                           latency_reduction, padtokeyboard]
       cfeatures:
             px68k_cpuspeed:
-                prompt: CPU SPEED (OVERCLOCK)
-                label:  Can be used to slow down games that run too fast
+                prompt:      CPU SPEED (OVERCLOCK)
+                description: Can be used to slow down games that run too fast
                 choices:
                     "10Mhz":              10Mhz
                     "16Mhz":              16Mhz
@@ -1469,8 +1517,8 @@ libretro:
                     "150Mhz (Overclock)": 150Mhz (OC)
                     "200Mhz (Overclock)": 200Mhz (OC)
             px68k_ramsize:
-                prompt: RAM SIZE
-                label:  Amount of RAM used
+                prompt:      RAM SIZE
+                description: Amount of RAM used
                 choices:
                     "1MB":                1MB
                     "2MB":                2MB
@@ -1485,8 +1533,8 @@ libretro:
                     "11MB":               11MB
                     "12MB":               12MB
             px68k_frameskip:
-                prompt: FRAME SKIP
-                label:  Improve performance at the expense of smoothness
+                prompt:      FRAME SKIP
+                description: Improve performance at the expense of smoothness
                 choices:
                     "Full Frame":         Full Frame
                     "1/2 Frame":          1/2 Frame
@@ -1500,8 +1548,8 @@ libretro:
                     "1/60 Frame":         1/60 Frame
                     "Auto Frame Skip":    Auto Frame Skip
             px68k_joytype:
-                prompt: TWO PLAYERS JOYPAD TYPE
-                label:  Choose your Joypad type with 2 or 8 buttons
+                prompt:      TWO PLAYERS JOYPAD TYPE
+                description: Choose your Joypad type with 2 or 8 buttons
                 choices:
                     "Default (2 Buttons)":       Default (2 Buttons)
                     "Megadrive (8 Buttons)":     CPSF-MD (8 Buttons)
@@ -1510,16 +1558,16 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             q88_basic_mode:
-                prompt: PC MODEL
-                label:  Selects the correct PC model being emulated
+                prompt:      PC MODEL
+                description: Selects the correct PC model being emulated
                 choices:
                     "N88 BASIC V2":         N88 V2
                     "N88 BASIC V1H":        N88 V1H
                     "N88 BASIC V1S":        N88 V1S
                     "N BASIC":              N
             q88_cpu_clock:
-                prompt: CPU CLOCK (OVERCLOCK)
-                label:  Many games run so fast, reduce slowdown on Ys series
+                prompt:      CPU CLOCK (OVERCLOCK)
+                description: Many games run so fast, reduce slowdown on Ys series
                 choices:
                     "1 MHz (Underclock)":   1
                     "2 MHz (Underclock)":   2
@@ -1529,8 +1577,8 @@ libretro:
                     "32 MHz (Overclock)":   32
                     "64 MHz (Overclock)":   64
             q88_pcg-8100:
-                prompt: USE PCG-8100
-                label:  Emulate the PCG-8100 required for some games
+                prompt:      USE PCG-8100
+                description: Emulate the PCG-8100 required for some games
                 choices:
                     "Off":                  disabled
                     "On":                   enabled
@@ -1542,22 +1590,22 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             reduce_sprite_flicker:
-                prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
-                label:  Increase number of sprites that can be drawn
+                prompt:      REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
+                description: Increase number of sprites that can be drawn
                 choices:
                     "Off":        disabled
                     "On":         enabled
             reduce_slowdown:
-                prompt: REDUCE SLOWDOWN (HACK, UNSTABLE)
-                label:  Overclock SNES CPU for Gradius 3, Super R-Type
+                prompt:      REDUCE SLOWDOWN (HACK, UNSTABLE)
+                description: Overclock SNES CPU for Gradius 3, Super R-Type
                 choices:
                     "Off":        disabled
                     "light":      light
                     "compatible": compatible
                     "max":        max
             overclock_superfx:
-                prompt: SUPER-FX OVERCLOCKING
-                label:  Improve performance on slow devices or cause errors
+                prompt:      SUPER-FX OVERCLOCKING
+                description: Improve performance on slow devices or cause errors
                 choices:
                     "50%":        50%
                     "60%":        60%
@@ -1574,8 +1622,8 @@ libretro:
                     "450%":       450%
                     "500%":       500%
             hires_blend:
-                prompt: HI-RES BLENDING
-                label:  Required for some games effectc (Kirby's Dream Land)
+                prompt:      HI-RES BLENDING
+                description: Required for some games effectc (Kirby's Dream Land)
                 choices:
                     "Off":        disabled
                     "Merge":      merge
@@ -1584,22 +1632,22 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             2010_reduce_sprite_flicker:
-                prompt: REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
-                label:  Increase number of sprites that can be drawn
+                prompt:      REDUCE SPRITE FLICKERING (HACK, UNSTABLE)
+                description: Increase number of sprites that can be drawn
                 choices:
                     "Off":        disabled
                     "On":         enabled
             2010_reduce_slowdown:
-                prompt: REDUCE SLOWDOWN (HACK, UNSTABLE)
-                label:  Overclock SNES CPU for Gradius 3, Super R-Type
+                prompt:      REDUCE SLOWDOWN (HACK, UNSTABLE)
+                description: Overclock SNES CPU for Gradius 3, Super R-Type
                 choices:
                     "Off":        disabled
                     "light":      light
                     "compatible": compatible
                     "max":        max
             2010_overclock_superfx:
-                prompt: SUPER-FX OVERCLOCKING
-                label:  Improve performance on slow devices or cause errors
+                prompt:      SUPER-FX OVERCLOCKING
+                description: Improve performance on slow devices or cause errors
                 choices:
                     "5 MHz (Underclock)":   5 MHz (Underclock)
                     "8 MHz (Underclock)":   8 MHz (Underclock)
@@ -1626,8 +1674,8 @@ libretro:
       features: [         rewind, autosave]
       cfeatures:
             tyrquake_resolution:
-                prompt: VIDEO RESOLUTION
-                label:  Smooth out jagged edges on 3D objetcs polygons
+                prompt:      VIDEO RESOLUTION
+                description: Smooth out jagged edges on 3D objetcs polygons
                 choices:
                     "320x240":    320x240
                     "640x480":    640x480
@@ -1636,8 +1684,8 @@ libretro:
                     "1280x720":   1280x720
                     "1920x1080":  1920x1080
             tyrquake_framerate:
-                prompt: FRAMERATE
-                label:  Modify framerate
+                prompt:      FRAMERATE
+                description: Modify framerate
                 choices:
                     "Automatic":  Automatic
                     "10fps":      10fps
@@ -1656,8 +1704,8 @@ libretro:
                     "155fps":     155fps
                     "160fps":     160fps
             tyrquake_rumble:
-                prompt: RUMBLE
-                label:  Enables joypad rumble
+                prompt:      RUMBLE
+                description: Enables joypad rumble
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -1665,8 +1713,8 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction]
       cfeatures:
             2d_color_mode:
-                prompt: COLOR PALETTE (2D)
-                label:  Choose which color palette to use
+                prompt:      COLOR PALETTE (2D)
+                description: Choose which color palette to use
                 choices:
                     "original":            black & red
                     "black/white":         black & white
@@ -1677,8 +1725,8 @@ libretro:
                     "black/magenta":       black & magenta
                     "black/yellow":        black & yellow
             3d_color_mode:
-                prompt: ANAGLYPH PRESET (3D)
-                label:  Choose the color of your 3D glasses
+                prompt:      ANAGLYPH PRESET (3D)
+                description: Choose the color of your 3D glasses
                 choices:
                     "Off":                 disabled
                     "red/blue":            red & blue
@@ -1692,8 +1740,8 @@ libretro:
             gb:
                 cfeatures:
                     palettes:
-                        prompt: COLORISATION
-                        label:  Set Game Boy palettes to use
+                        prompt:      COLORISATION
+                        description: Set Game Boy palettes to use
                         choices:
                             "original gameboy": original gameboy
                             "black and white":  black and white
@@ -1705,36 +1753,36 @@ libretro:
                             "pink dreams":      pink dreams
                             "weird colors":     weird colors
                     gbcoloroption_gb:
-                        prompt: COLOR CORRECTION
-                        label:  Adjusts output colors to feel real hardware
+                        prompt:      COLOR CORRECTION
+                        description: Adjusts output colors to feel real hardware
                         choices:
                             "Off":       disabled
                             "On":        enabled
                     showborders_gb:
-                        prompt: SUPER GB BORDERS
-                        label:  Only for Super Game Boy enhanced games
+                        prompt:      SUPER GB BORDERS
+                        description: Only for Super Game Boy enhanced games
                         choices:
                             "Off":       disabled
                             "On":        enabled
             gbc:
                 cfeatures:
                     gbcoloroption_gbc:
-                        prompt: COLOR CORRECTION
-                        label:  Adjusts output colors to feel real hardware
+                        prompt:      COLOR CORRECTION
+                        description: Adjusts output colors to feel real hardware
                         choices:
                             "Off":       disabled
                             "On":        enabled
                     showborders_gbc:
-                        prompt: SUPER GB BORDERS
-                        label:  Only for Super Game Boy enhanced games
+                        prompt:      SUPER GB BORDERS
+                        description: Only for Super Game Boy enhanced games
                         choices:
                             "Off":       disabled
                             "On":        enabled
             gba:
                 cfeatures:
                     solarsensor:
-                        prompt: SOLAR SENSOR LEVEL
-                        label: Only for games that employed it (for Boktai)
+                        prompt:      SOLAR SENSOR LEVEL
+                        description: Only for games that employed it (for Boktai)
                         choices:
                             "0":  0
                             "1":  1
@@ -1748,8 +1796,8 @@ libretro:
                             "9":  9
                             "10": 10
                     gyro_sensitivity:
-                        prompt: SENSOR SENSITIVITY (GYROSCOPE)
-                        label: For Gyro-enabled games (bind on left analog)
+                        prompt:      SENSOR SENSITIVITY (GYROSCOPE)
+                        description: For Gyro-enabled games (bind on left analog)
                         choices:
                             "10":  10
                             "15":  15
@@ -1775,8 +1823,8 @@ libretro:
                             "115": 115
                             "120": 120
                     tilt_sensitivity:
-                        prompt: SENSOR SENSITIVITY (TILT)
-                        label: For Gyro-enabled games (bind on right analog)
+                        prompt:      SENSOR SENSITIVITY (TILT)
+                        description: For Gyro-enabled games (bind on right analog)
                         choices:
                             "10":  10
                             "15":  15
@@ -1805,8 +1853,8 @@ libretro:
       features: [         rewind, autosave, latency_reduction]
       cfeatures:
             res_multi:
-                prompt: RESOLUTION MULTIPLIER
-                label:  Resolution multipliers to smooth vectors
+                prompt:      RESOLUTION MULTIPLIER
+                description: Resolution multipliers to smooth vectors
                 choices:
                     "Off":  1
                     "2":    2
@@ -1816,8 +1864,8 @@ libretro:
       features: [         rewind, autosave, latency_reduction, padtokeyboard]
       cfeatures:
             external_palette:
-                prompt: EXTERNAL PALETTE
-                label:  Choose the most accurate colors
+                prompt:      EXTERNAL PALETTE
+                description: Choose the most accurate colors
                 choices:
                     "default":          default
                     "colodore":         colodore
@@ -1837,28 +1885,28 @@ libretro:
                     "rgb":              rgb
                     "vice":             vice
             aspect_ratio:
-                prompt: ASPECT RATIO
-                label:  Switch frequency and resolution by region
+                prompt:      ASPECT RATIO
+                description: Switch frequency and resolution by region
                 choices:
                     "PAL 50Hz - 312/576px":     pal
                     "NTSC 60Hz - 262/492px":    ntsc
             zoom_mode_c64:
-                prompt: ZOOM MODE
-                label:  Crops the borders to fit various host screens
+                prompt:      ZOOM MODE
+                description: Crops the borders to fit various host screens
                 choices:
                     "Off":              none
                     "small":            small
                     "medium":           medium
                     "maximum":          maximum
             JoyPort:
-                prompt: JOYSTICK PORT
-                label:  Choose to use Joystick on port 1 or 2
+                prompt:      JOYSTICK PORT
+                description: Choose to use Joystick on port 1 or 2
                 choices:
                     "Port 1":           Port 1
                     "Port 2":           Port 2
             keyboard_pass_through:
-                prompt: KEYBOARD PASS-THROUGH
-                label:  Passes all physical keyboard events for Pad2Key
+                prompt:      KEYBOARD PASS-THROUGH
+                description: Passes all physical keyboard events for Pad2Key
                 choices:
                     "Off":              disabled
                     "On":               enabled
@@ -1876,20 +1924,20 @@ libretro:
       features: [                 autosave, latency_reduction, padtokeyboard]
       cfeatures:
             usefastblitter:
-                prompt: FAST BLITTER (LESS COMPATIBLE)
-                label:  Use the older and less compatible faster blitter
+                prompt:      FAST BLITTER (LESS COMPATIBLE)
+                description: Use the older and less compatible faster blitter
                 choices:
                     "Off":      disabled
                     "On":       enabled
             bios_vj:
-                prompt: SHOW BIOS BOOTLOGO
-                label:  Show animation when starting (Breaks some games)
+                prompt:      SHOW BIOS BOOTLOGO
+                description: Show animation when starting (Breaks some games)
                 choices:
                     "Off":      disabled
                     "On":       enabled
             doom_res_hack:
-                prompt: DOOM RES HACK
-                label:  Enable for Doom to run at its correct resolution
+                prompt:      DOOM RES HACK
+                description: Enable for Doom to run at its correct resolution
                 choices:
                     "Off":      disabled
                     "On":       enabled
@@ -1897,8 +1945,8 @@ libretro:
       features: [                 autosave]
       cfeatures:
             resolution_mode:
-                prompt: VIDEO RESOLUTION
-                label:  Improve the fidelity of 3D models (unaffect 2D)
+                prompt:      VIDEO RESOLUTION
+                description: Improve the fidelity of 3D models (unaffect 2D)
                 choices:
                     "original": original
                     "2x":       2x
@@ -1907,8 +1955,8 @@ libretro:
                     "1080p":    1080p
                     "4k":       4k
             multitap_yabasanshiro:
-                prompt: ENABLE MULTITAP
-                label:  Allowing 7-12 player support in games
+                prompt:      ENABLE MULTITAP
+                description: Allowing 7-12 player support in games
                 choices:
                     "Off":              disabled
                     "Port1":            port1
@@ -1924,8 +1972,8 @@ cannonball:
   features: [ratio]
   cfeatures:
         highResolution:
-            prompt: HIGH RESOLUTION
-            label:  Increase video to Hi Resolution
+            prompt:      HIGH RESOLUTION
+            description: Increase video to Hi Resolution
             choices:
                 "Off": 0
                 "On":  1
@@ -1933,8 +1981,8 @@ cemu:
   features: [emulated_wiimotes]
   cfeatures:
         gfxbackend:
-            prompt: GRAPHICS BACKEND
-            label:  Choose your graphics rendering
+            prompt:      GRAPHICS BACKEND
+            description: Choose your graphics rendering
             choices:
                 "OpenGL": OpenGL
                 "Vulkan": Vulkan
@@ -1949,14 +1997,14 @@ dolphin:
   features: [ratio, internal_resolution]
   cfeatures:
         perf_hacks:
-            prompt: PERFORMANCE HACKS
-            label:  Increase emulator performance
+            prompt:      PERFORMANCE HACKS
+            description: Increase emulator performance
             choices:
                 "Off": 0
                 "On":  1
         anisotropic_filtering:
-            prompt: ANISOTROPIC FILTERING
-            label:  Enhance the quality with on perspective textures
+            prompt:      ANISOTROPIC FILTERING
+            description: Enhance the quality with on perspective textures
             choices:
                 "Off": 0
                 "2x":  1
@@ -1964,65 +2012,65 @@ dolphin:
                 "8x":  3
                 "16x": 4
         dual_core:
-            prompt: DUAL CORE
-            label:  Usually not much faster than single core mode
+            prompt:      DUAL CORE
+            description: Usually not much faster than single core mode
             choices:
                 "Off": 0
                 "On":  1
         gpu_sync:
-            prompt: GPU SYNC
-            label:  Speed Hack for dual core mode to fix some glitches
+            prompt:      GPU SYNC
+            description: Speed Hack for dual core mode to fix some glitches
             choices:
                 "Off": 0
                 "On":  1
         antialiasing:
-            prompt: ANTI-ALIASING
-            label:  Smooth out jagged edges on 3D objetcs polygons
+            prompt:      ANTI-ALIASING
+            description: Smooth out jagged edges on 3D objetcs polygons
             choices:
                 "Off": 0
                 "2x":  2
                 "4x":  4
                 "8x":  8
         hires_textures:
-            prompt: HIRES TEXTURES
-            label:  Permit to use HD Texture Pack
+            prompt:      HIRES TEXTURES
+            description: Permit to use HD Texture Pack
             choices:
                 "Off": 0
                 "On":  1
         widescreen_hack:
-            prompt: WIDESCREEN HACK
-            label:  You must use a 16/9 RATIO to work
+            prompt:      WIDESCREEN HACK
+            description: You must use a 16/9 RATIO to work
             choices:
                 "Off": 0
                 "On":  1
         enable_cheats:
-            prompt: ENABLE CHEATS
-            label:  To use game cheats or 16/9 Aspect Ratio Fix codes
+            prompt:      ENABLE CHEATS
+            description: To use game cheats or 16/9 Aspect Ratio Fix codes
             choices:
                 "Off": 0
                 "On":  1
         enable_mmu:
-            prompt: MEMORY MANAGEMENT UNIT
-            label:  Allow many games to boot and work properly
+            prompt:      MEMORY MANAGEMENT UNIT
+            description: Allow many games to boot and work properly
             choices:
                 "Off": 0
                 "On":  1
         enable_fastdisc:
-            prompt: FAST DISK SPEED
-            label:  Speed up disc speed to remoe any loading
+            prompt:      FAST DISK SPEED
+            description: Speed up disc speed to remoe any loading
             choices:
                 "Off": 0
                 "On":  1
         vsync:
-            prompt: VSYNC
-            label:  Fix the heavy screen tearing in games (heavy CPU)
+            prompt:      VSYNC
+            description: Fix the heavy screen tearing in games (heavy CPU)
             choices:
                 "Off": 0
                 "On":  1
         gfxbackend:
             archs_include: [x86, x86_64, rpi4]
-            prompt: GRAPHICS BACKEND
-            label:  Choose your graphics rendering
+            prompt:      GRAPHICS BACKEND
+            description: Choose your graphics rendering
             choices:
                 "OpenGL": OGL
                 "Vulkan": Vulkan
@@ -2075,14 +2123,14 @@ mupen64plus:
 openbor:
   cfeatures:
     ratio:
-      prompt: SCREEN RATIO
-      label:  Stretch games to Full Screen but distorted
+      prompt:      SCREEN RATIO
+      description: Stretch games to Full Screen but distorted
       choices:
         "Normal":         0
         "Stretch":        1
     filter:
-      prompt: VIDEO FILTER
-      label:  Apply to achieve some kind of visual effect
+      prompt:      VIDEO FILTER
+      description: Apply to achieve some kind of visual effect
       choices:
         "Simple 2x":      0
         "Bilinear":       1
@@ -2100,8 +2148,8 @@ pcsx2:
   features: [ratio, fullboot, internal_resolution]
   cfeatures:
         anisotropic_filtering:
-            prompt: ANISOTROPIC FILTERING
-            label:  Enhance the quality with on perspective textures
+            prompt:      ANISOTROPIC FILTERING
+            description: Enhance the quality with on perspective textures
             choices:
                 "Off": 0
                 "2x":  2
@@ -2109,8 +2157,8 @@ pcsx2:
                 "8x":  8
                 "16x": 16
         skipdraw:
-            prompt: SKIPDRAW HACK
-            label:  Skip frames to improve performance (Smoothless)
+            prompt:      SKIPDRAW HACK
+            description: Skip frames to improve performance (Smoothless)
             choices:
                 "Off": 0
                 "1":   1
@@ -2119,15 +2167,15 @@ pcsx2:
                 "4":   4
                 "5":   5
         align_sprite:
-            prompt: ALIGN SPRITE (HACK)
-            label:  Remove lines in Internal Resolution (Soul Calibur)
-            label:  
+            prompt:      ALIGN SPRITE (HACK)
+            description: Remove lines in Internal Resolution (Soul Calibur)
+            description: 
             choices:
                 "Off": 0
                 "On":  1
         vsync:
-            prompt: VSYNC
-            label:  Fix the heavy screen tearing in games (heavy CPU)
+            prompt:      VSYNC
+            description: Fix the heavy screen tearing in games (heavy CPU)
             choices:
                 "Off": 0
                 "On":  1
@@ -2136,8 +2184,8 @@ ppsspp:
   features: [ratio, internal_resolution]
   cfeatures:
         frameskip:
-            prompt: FRAME SKIP
-            label:  Skip frames to improve performance (Smoothless)
+            prompt:      FRAME SKIP
+            description: Skip frames to improve performance (Smoothless)
             choices:
                 "Off": 0
                 "On":  1
@@ -2148,14 +2196,14 @@ rpcs3:
   features: []
   cfeatures:
         gui:
-            prompt: GRAPHICAL USER INTERFACE
-            label:  Display the user interface
+            prompt:      GRAPHICAL USER INTERFACE
+            description: Display the user interface
             choices:
                 "Off":      0
                 "On":       1
         gfxbackend:
-            prompt: GRAPHICS BACKEND
-            label:  Choose your graphics rendering
+            prompt:      GRAPHICS BACKEND
+            description: Choose your graphics rendering
             choices:
                 "OpenGL":   OpenGL
                 "Vulkan":   Vulkan
@@ -2170,31 +2218,31 @@ mame:
   features: []
   cfeatures:
         video:
-            prompt: GRAPHICS BACKEND
-            label:  Choose your graphics rendering
+            prompt:      GRAPHICS BACKEND
+            description: Choose your graphics rendering
             choices:
                 "BGFX":          bgfx
                 "Accel":         accel
                 "OpenGL":        opengl
         bgfxbackend:
             archs_include: [x86, x86_64, rpi4]
-            prompt: BGFX BACKEND
-            label:  Choose your graphics API
+            prompt:      BGFX BACKEND
+            description: Choose your graphics API
             choices:
                 "Automatic":     auto
                 "OpenGL":        opengl
                 "OpenGLES":      gles
                 "Vulkan":        vulkan
         rotation:
-            prompt: TATE MODE
-            label:  Rotating display to vertical mode rendering
+            prompt:      TATE MODE
+            description: Rotating display to vertical mode rendering
             choices:
                 "Disabled":      null
                 "Rotate 90":     autoror
                 "Rotate 270":    autorol
         bgfxshaders:
-            prompt: VIDEO FILTER
-            label:  Apply to achieve some kind of visual effect
+            prompt:      VIDEO FILTER
+            description: Apply to achieve some kind of visual effect
             choices:
                 "None":          null
                 "CrtGeom":       crt-geom
@@ -2209,38 +2257,38 @@ wine:
   features: [padtokeyboard]
   cfeatures:
         dxvk:
-            prompt: DXVK
-            label:  Converts the DirectX calls from 9 to 12 in Vulkan
+            prompt:      DXVK
+            description: Converts the DirectX calls from 9 to 12 in Vulkan
             choices:
                 "Off": 0
                 "On":  1
         dxvk_hud:
-            prompt: DXVK HUD
-            label:  See your FPS and version of Vulkan API and Driver
+            prompt:      DXVK HUD
+            description: See your FPS and version of Vulkan API and Driver
             choices:
                 "Off": 0
                 "On":  1
         esync:
-            prompt: ESYNC
-            label:  Can increase performance for games that stress CPU
+            prompt:      ESYNC
+            description: Can increase performance for games that stress CPU
             choices:
                 "Off": 0
                 "On":  1
         fsync:
-            prompt: FSYNC
-            label:  Can improving frame rates and responsiveness
+            prompt:      FSYNC
+            description: Can improving frame rates and responsiveness
             choices:
                 "Off": 0
                 "On":  1
         pba:
-            prompt: PBA
-            label:  Vastly improving the speed of buffer maps
+            prompt:      PBA
+            description: Vastly improving the speed of buffer maps
             choices:
                 "Off": 0
                 "On":  1
         virtual_desktop:
-            prompt: VIRTUAL DESKTOP
-            label:  Define the resolution and a new dedicated window
+            prompt:      VIRTUAL DESKTOP
+            description: Define the resolution and a new dedicated window
             choices:
                 "Off": 0
                 "On":  1


### PR DESCRIPTION
> /libretroConfig.py

- Send ROM options to libretroOptions for Neogeo with help from @lbrpdx
- Fix some core controllers settings with help from @lbrpdx
- Remove "systemNoRewind" limitation because working fine onN2 and PC. These settings must be applied by boards.

> /libretroOptions.py
> /es_features.yml

- Add all the usefull options to ES for the libretro emulators
- All already tested on N2

**Miss:**

- Some "only PC core" options to add
- The new "Commodore family core" options to add too for v30


@susan

- Add LABEL to YML parser
- Understand sub systems with sub options in YML parser (ex: genesisplusgx)
- Don't change the YML options order

@f.caruso

- Add LABEL to ES