### PR TITLE
batocera-settings: Bump to 0.0.2

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings.hash
+++ b/package/batocera/core/batocera-settings/batocera-settings.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  73532e2aa8ef9385dfb6f3c23b3ed7d60ecd0abeda053e31a4e38c481eaaa2d7  batocera-settings-0.0.1.tar.gz
+sha256  f547318502d83fc0eab544d0f2a2f405ea895dd250b37c8e5fe45196664bd084  batocera-settings-0.0.2.tar.gz
 sha256  c64a84bc21adbd6cf8d2a552ed5c4e33d90d13dae3cadb8babf259af01b81e0f  LICENSE

--- a/package/batocera/core/batocera-settings/batocera-settings.mk
+++ b/package/batocera/core/batocera-settings/batocera-settings.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SETTINGS_VERSION = 0.0.1
+BATOCERA_SETTINGS_VERSION = 0.0.2
 BATOCERA_SETTINGS_LICENSE = MIT
 BATOCERA_SETTINGS_SITE = $(call github,batocera-linux,mini_settings,$(BATOCERA_SETTINGS_VERSION))
 BATOCERA_SETTINGS_CONF_OPTS = \


### PR DESCRIPTION
1. Fixes a bug in `batocera-settings-set`.
2. `batocera-settings-set` now creates a file if it does not exist