### PR TITLE
thd: F4 starts terminal/mc session

### DIFF
--- a/board/batocera/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
+++ b/board/batocera/fsoverlay/etc/triggerhappy/triggers.d/multimedia_keys.conf
@@ -6,3 +6,5 @@ KEY_MUTE        1               /usr/bin/amixer sset Master toggle
 KEY_POWER       1               /sbin/shutdown -h now
 # display some information on X displays
 KEY_F2          1               /usr/bin/batocera-info --short | HOME=/userdata/system XAUTHORITY=/var/lib/.Xauthority DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4
+# use midnight commander
+KEY_F4		1		/etc/init.d/S50triggerhappy stop; /etc/init.d/S31emulationstation stop; /usr/bin/openvt -c1 -f -s -w -- /usr/bin/mc -x; /etc/init.d/S31emulationstation start; /etc/init.d/S50triggerhappy start


### PR DESCRIPTION
Give back SBC users to access terminal/midnight commander by pressing F4
Std: mc is started with x extension, press ctrl+o to display terminal
Usefull for Pi400

My very last PR for this year!