### PR TITLE
Enable boot on USB for RPi3/RPi4

### DIFF
--- a/board/batocera/raspberrypi/rpi3/boot/cmdline.txt
+++ b/board/batocera/raspberrypi/rpi3/boot/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.fiq_fix_enable=1 sdhci-bcm2708.sync_after_dma=0 dwc_otg.lpm_enable=0 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=/dev/mmcblk0p1 rootwait fastboot noswap
+dwc_otg.fiq_fix_enable=1 sdhci-bcm2708.sync_after_dma=0 dwc_otg.lpm_enable=0 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap

--- a/board/batocera/raspberrypi/rpi4/boot/cmdline.txt
+++ b/board/batocera/raspberrypi/rpi4/boot/cmdline.txt
@@ -1,1 +1,1 @@
-dwc_otg.fiq_fix_enable=1 sdhci-bcm2708.sync_after_dma=0 dwc_otg.lpm_enable=0 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=/dev/mmcblk0p1 rootwait fastboot noswap
+dwc_otg.fiq_fix_enable=1 sdhci-bcm2708.sync_after_dma=0 dwc_otg.lpm_enable=0 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap


### PR DESCRIPTION
Thanks to @emclinux - the same cmdline.txt can boot off SDcard or USB for RPi3 and RPi4