### PR TITLE
es_input.cfg: Fix hotkey for X-Box 360 pad

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -379,7 +379,7 @@
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
-		<input name="hotkey" type="button" id="6" value="1" code="314" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />


### PR DESCRIPTION
Previous ID 6 was the same as "select" ID
ID 8 matches SDL2 value for the guide button:

https://github.com/gabomdq/SDL_GameControllerDB/blob/d3f1cea1197b1b5aabf554c2d27e767148cbb955/gamecontrollerdb.txt#L834