### PR TITLE
Fix shutdown hang on network mounts

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -4,8 +4,8 @@ if [ "$1" = "stop" ]
 then
     # umount all network configs
     # don't just remount the one of the config in case the config changed
-    umount -a -t nfs
-    umount -a -t cifs
+    umount -l -a -t nfs
+    umount -l -a -t cifs
     exit 0
 fi
 


### PR DESCRIPTION
Problem: shutdown hangs if mount /userdata with Samba/NFS mounts due to device or resource busy.
Fix: add a lazy umount flag -l in existing stop function and everything works.