### PR TITLE
Ported back (and enhanced) system.es.maxresolution from v29

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
@@ -5,10 +5,14 @@ shift
 
 FILEMODES="/sys/class/graphics/fb0/modes"
 
-if test -z "${ACTION}"
-then
+f_usage() {
     echo "${0} currentMode" >&2
     echo "${0} currentResolution" >&2
+}
+
+if test -z "${ACTION}"
+then
+    f_usage
     exit 1
 fi
 
@@ -20,7 +24,10 @@ case "${ACTION}" in
     ;;
     "currentMode"|"currentResolution")
         # mode can be different from resolution (ie on rpi)
-	test -e "${FILEMODES}" && head -1 "${FILEMODES}" | sed -e s+'^[^:]:\([0-9]*\)x\([0-9]*\)[a-z]*.*$'+'\1x\2'+
-	;;
+        test -e "${FILEMODES}" && head -1 "${FILEMODES}" | sed -e s+'^[^:]:\([0-9]*\)x\([0-9]*\)[a-z]*.*$'+'\1x\2'+
+        ;;
+    *)
+        f_usage
+        ;;
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
@@ -3,14 +3,18 @@
 ACTION=$1
 shift
 
-if test -z "${ACTION}"
-then
+f_usage() {
     echo "${0} listModes" >&2
     echo "${0} setMode <MODE>" >&2
     echo "${0} currentMode" >&2
     echo "${0} currentResolution" >&2
     echo "${0} minTomaxResolution" >&2
     echo "${0} minTomaxResolution-secure" >&2
+}
+
+if test -z "${ACTION}"
+then
+    f_usage
     exit 1
 fi
 
@@ -51,9 +55,15 @@ case "${ACTION}" in
 	;;
     "minTomaxResolution")
 	# minimize resolution because of 4K tv
-	MAXWIDTH=1920
-	MAXHEIGHT=1080
-
+	MWIDTH=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f1) # the final added x is for compatibility with v29
+	MHEIGHT=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f2)
+	if test -n "$MWIDTH" -a -n "$MHEIGHT" -a "$MWIDTH" != 0 -a "$MHEIGHT" != 0; then
+		MAXWIDTH="$MWIDTH"
+		MAXHEIGHT="$MHEIGHT"
+	else
+		MAXWIDTH=1920
+		MAXHEIGHT=1080
+	fi
 	# if current resolution is ok, keep it
 	read CURRENTWIDTH CURRENTHEIGHT <<< $(f_listModes "current" | sed -e s+"^\([0-9]*\):\([0-9]*\)x\([0-9]*\) \([0-9]*\)\(.*\)$"+"\2 \3"+)
 	if test "${CURRENTWIDTH}" -le "${MAXWIDTH}" -a "${CURRENTHEIGHT}" -le "${MAXHEIGHT}"
@@ -77,6 +87,8 @@ case "${ACTION}" in
 		fi
             done
         ;;
-
+    *)
+        f_usage
+        ;;
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
@@ -3,14 +3,18 @@
 ACTION=$1
 shift
 
-if test -z "${ACTION}"
-then
+f_usage() {
     echo "${0} listModes" >&2
     echo "${0} setMode <MODE>" >&2
     echo "${0} currentMode" >&2
     echo "${0} currentResolution" >&2
     echo "${0} minTomaxResolution" >&2
     echo "${0} minTomaxResolution-secure" >&2
+}
+
+if test -z "${ACTION}"
+then
+    f_usage
     exit 1
 fi
 
@@ -35,8 +39,15 @@ case "${ACTION}" in
 	;;
     "minTomaxResolution" | "minTomaxResolution-secure")
 	# minimize resolution because of 4K tv
-	MAXWIDTH=1920
-	MAXHEIGHT=1080
+	MWIDTH=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f1) # the final added x is for compatibility with v29
+	MHEIGHT=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f2)
+	if test -n "$MWIDTH" -a -n "$MHEIGHT" -a "$MWIDTH" != 0 -a "$MHEIGHT" != 0; then
+		MAXWIDTH="$MWIDTH"
+		MAXHEIGHT="$MHEIGHT"
+	else
+		MAXWIDTH=1920
+		MAXHEIGHT=1080
+	fi
 	CURRENT_RESOLUTION=$(tvservice --current-resolution)
 	CURRENTWIDTH=$(echo "${CURRENT_RESOLUTION}" | cut -d x -f 1)
 	CURRENTHEIGHT=$(echo "${CURRENT_RESOLUTION}" | cut -d x -f 2)
@@ -62,5 +73,8 @@ case "${ACTION}" in
 		fi
 	    done
 	;;
+    *)
+        f_usage
+        ;;
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -3,8 +3,7 @@
 ACTION=$1
 shift
 
-if test -z "${ACTION}"
-then
+f_usage() {
     echo "${0} listModes" >&2
     echo "${0} setMode <MODE>" >&2
     echo "${0} currentMode" >&2
@@ -13,6 +12,11 @@ then
     echo "${0} setOutput <output>" >&2
     echo "${0} minTomaxResolution" >&2
     echo "${0} minTomaxResolution-secure" >&2
+}
+
+if test -z "${ACTION}"
+then
+    f_usage
     exit 1
 fi
 
@@ -58,8 +62,15 @@ case "${ACTION}" in
 	;;
     "minTomaxResolution" | "minTomaxResolution-secure")
 	# minimize resolution because of 4K tv
-	MAXWIDTH=1920
-	MAXHEIGHT=1080
+	MWIDTH=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f1) # the final added x is for compatibility with v29
+	MHEIGHT=$(echo "$1"x | tr -d [[:blank:]] | cut -dx -f2)
+	if test -n "$MWIDTH" -a -n "$MHEIGHT" -a "$MWIDTH" != 0 -a "$MHEIGHT" != 0; then
+		MAXWIDTH="$MWIDTH"
+		MAXHEIGHT="$MHEIGHT"
+	else
+		MAXWIDTH=1920
+		MAXHEIGHT=1080
+	fi
 	CURRENT_RESOLUTION=$(xrandr --currentResolution)
 	CURRENTWIDTH=$(echo "${CURRENT_RESOLUTION}" | cut -d x -f 1)
 	CURRENTHEIGHT=$(echo "${CURRENT_RESOLUTION}" | cut -d x -f 2)
@@ -85,7 +96,11 @@ case "${ACTION}" in
 		fi
 	    done
 	;;
-	"setDPI")
-	xrandr --dpi $1
+    "setDPI")
+        xrandr --dpi $1
+        ;;
+    *)
+        f_usage
+	;;
 esac
 exit 0

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -10,8 +10,14 @@ fi
 case "$1" in
 	start)
 		enabled="$(/usr/bin/batocera-settings-get system.es.atstartup)"
+		secured="$(/usr/bin/batocera-settings-get system.es.maxresolution)"
 		if [ "$enabled" != "0" ];then
-			batocera-resolution minTomaxResolution-secure
+			if test "${secured}" = 0 -o -z "${secured}"
+			then
+			  batocera-resolution minTomaxResolution-secure
+			else
+			  batocera-resolution minTomaxResolution "${secured}"
+			fi
 			settings_lang="$(/usr/bin/batocera-settings-get system.language)"
 			cd /userdata # es need a PWD
 			HOME=/userdata/system LANG="${settings_lang}.UTF-8" %BATOCERA_EMULATIONSTATION_PREFIX% %BATOCERA_EMULATIONSTATION_CMD% %BATOCERA_EMULATIONSTATION_ARGS% %BATOCERA_EMULATIONSTATION_POSTFIX%

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -1,8 +1,9 @@
 #!/bin/sh
+BOOTCONF="/boot/batocera-boot.conf"
 
 # intel-iris-driver
-if grep -qE "^[ ]*intel-i965-driver[ ]*=[ ]*true[ ]*$" /boot/batocera-boot.conf
-then
+irisdriver="$(/usr/bin/batocera-settings-get -f "$BOOTCONF" intel-i965-driver)"
+if test ! -z "${irisdriver}" -a "${irisdriver}" = true; then
 	# Force use i965 driver through global environment variable
 	export MESA_LOADER_DRIVER_OVERRIDE=i965
 fi
@@ -11,6 +12,8 @@ case "$1" in
 	start)
 		enabled="$(/usr/bin/batocera-settings-get system.es.atstartup)"
 		secured="$(/usr/bin/batocera-settings-get system.es.maxresolution)"
+		bootresolution="$(/usr/bin/batocera-settings-get -f "$BOOTCONF" es.maxresolution)"
+		test ! -z "${bootresolution}" && secured="${bootresolution}"
 		if [ "$enabled" != "0" ];then
 			if test "${secured}" = 0 -o -z "${secured}"
 			then


### PR DESCRIPTION
Now you can set the maximum resolution for ES in `batocera.conf` with a syntax like:
     
    system.es.maxresolution=1280x720

(not always 1920x1080 any more, like it was in v29)