### PR TITLE
batocera-audio: Clean up scripts

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -1,42 +1,43 @@
-#!/bin/bash	
+#!/bin/sh
 
-ACTION=$1	
+ACTION="$1"
 
-case "${ACTION}" in	
-	"unlock-volume")
-		echo "obsolete"
-	;;	
-
-	"list")	
-		echo "auto"	
-		echo "custom"	
-		LANG=C aplay -l | grep -E '^card [0-9]*:' | sed -e s+'^card \([0-9]*\): \(.*\), device \([0-9]*\): [^\[]* \[\([^]]*\)].*$'+'\1,\3 \4 \2'+	
-	;;	
-
-	"get")	
-		/usr/bin/batocera-settings-get audio.device	
-	;;	
-
-	"set")	
-		MODE=$2	
-		# auto: no .asoundrc
-		# custom: don't touch .asoundrc	
-		# any other, create .asoundrc
-		if [ "${MODE}" == "auto" ];then	
-			rm -f /userdata/system/.asoundrc
-		elif [ "${MODE}" != "custom" ];then	
-			if echo "${MODE}" | grep -qE '^[0-9]*,[0-9]* ';then	
-				cardnb=$(echo "${MODE}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)	
-				devicenb=$(echo "${MODE}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)	
-				cat > /userdata/system/.asoundrc <<EOF
-pcm.!default { type plug slave { pcm "hw:${cardnb},${devicenb}" } }	
-ctl.!default { type hw card ${cardnb} }	
-EOF
-			fi	
-		fi
+case "${ACTION}" in
+	list)
+		printf '%s\n' auto custom
+		LANG=C aplay -l | grep -E '^card [0-9]*:' | sed -e s+'^card \([0-9]*\): \(.*\), device \([0-9]*\): [^\[]* \[\([^]]*\)].*$'+'\1,\3 \4 \2'+
 	;;
 
-	"test")
+	get)
+		/usr/bin/batocera-settings-get audio.device
+	;;
+
+	set)
+		MODE="$2"
+			# auto: no .asoundrc
+			# custom: don't touch .asoundrc
+			# any other, create .asoundrc
+			auto)
+				rm -f /userdata/system/.asoundrc
+			;;
+
+			custom)
+				# do nothing!
+			;;
+
+			*)
+				if echo "${MODE}" | grep -qE '^[0-9]*,[0-9]* '; then
+					cardnb="$(echo "${MODE}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)"
+					devicenb="$(echo "${MODE}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)"
+					cat > /userdata/system/.asoundrc <<-EOF
+						pcm.!default { type plug slave { pcm "hw:${cardnb},${devicenb}" } }
+						ctl.!default { type hw card ${cardnb} }
+					EOF
+				fi
+			;;
+	;;
+
+	test)
 		aplay "/usr/share/sounds/Mallet.wav"
 	;;
 esac

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-odroidga
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-odroidga
@@ -1,33 +1,27 @@
-#!/bin/bash	
+#!/bin/sh
 
-ACTION=$1	
+ACTION="$1"
 
-case "${ACTION}" in	
-	"unlock-volume")
-		echo "obsolete"
-	;;	
+case "${ACTION}" in
+	list)
+		printf '%s\n' auto speakers headphone
+	;;
 
-	"list")	
-		echo "auto"	
-		echo "speakers"
-		echo "headphone"	
-	;;	
+	get)
+		/usr/bin/batocera-settings-get audio.device
+	;;
 
-	"get")	
-		/usr/bin/batocera-settings-get audio.device	
-	;;	
-
-	"set")	
-		MODE=$2	
-		case "${MODE}" in	
-			"auto"|"speakers")	
-				amixer cset name='Playback Path' SPK	
+	set)
+		MODE="$2"
+		case "${MODE}" in
+			auto | speakers)
+				amixer cset name='Playback Path' SPK
 			;;
 
-			"headphone")	
-				amixer cset name='Playback Path' HP	
-			;;	
-		esac	
+			headphone)
+				amixer cset name='Playback Path' HP
+			;;
+		esac
 	;;
 
 	test)

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-rockpro64
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-rockpro64
@@ -1,40 +1,33 @@
-#!/bin/bash	
+#!/bin/sh
 
-ACTION=$1	
+ACTION="$1"
 
-case "${ACTION}" in	
-	"unlock-volume")
-		echo "obsolete"
-	;;	
+case "${ACTION}" in
+	list)
+		printf '%s\n' auto hdmi headphones custom
+	;;
 
-	"list")	
-		echo "auto"	
-		echo "hdmi"
-		echo "headphones"
-		echo "custom"
-	;;	
+	get)
+		/usr/bin/batocera-settings-get audio.device
+	;;
 
-	"get")	
-		/usr/bin/batocera-settings-get audio.device	
-	;;	
-
-	"set")	
-		MODE=$2	
-		case "${MODE}" in	
-			"auto" | "hdmi")
+	set)
+		MODE="$2"
+		case "${MODE}" in
+			auto | hdmi)
 				# card 2: HDMI [HDMI], device 0: ff8a0000.i2s-i2s-hifi i2s-hifi-0 [ff8a0000.i2s-i2s-hifi i2s-hifi-0]
 				sed -e "s;%CARDNO%;2;g" -e "s;%DEVICENO%;0;g" /usr/share/batocera/alsa/asoundrc-dmix+softvol > /userdata/system/.asoundrc
 			;;
 
-			"headphones")
+			headphones)
 				# card 0: ES8316 [ES8316], device 0: ff890000.i2s-ES8316 HiFi ES8316 HiFi-0 [ff890000.i2s-ES8316 HiFi ES8316 HiFi-0]
 				sed -e "s;%CARDNO%;0;g" -e "s;%DEVICENO%;0;g" /usr/share/batocera/alsa/asoundrc-dmix+softvol > /userdata/system/.asoundrc
 			;;
 
-			"custom")
+			custom)
 				# do nothing!
 			;;
-		esac	
+		esac
 	;;
 
 	test)

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-vim3
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-vim3
@@ -1,34 +1,28 @@
-#!/bin/bash	
+#!/bin/sh
 
-ACTION=$1	
+ACTION="$1"
 
-case "${ACTION}" in	
-	"unlock-volume")
-		echo "obsolete"
-	;;	
+case "${ACTION}" in
+	list)
+		printf '%s\n' auto hdmi custom
+	;;
 
-	"list")	
-		echo "auto"	
-		echo "hdmi"
-		echo "custom"	
-	;;	
+	get)
+		/usr/bin/batocera-settings-get audio.device
+	;;
 
-	"get")	
-		/usr/bin/batocera-settings-get audio.device	
-	;;	
-
-	"set")	
-		MODE=$2	
-		case "${MODE}" in	
-			"auto" | "hdmi")
+	set)
+		MODE="$2"
+		case "${MODE}" in
+			auto | hdmi)
 				# card 0: G12BKHADASVIM3 [G12B-KHADAS-VIM3], device 0: fe.dai-link-0 (*) []
 				sed -e "s;%CARDNO%;0;g" -e "s;%DEVICENO%;0;g" /usr/share/batocera/alsa/asoundrc-dmix+softvol > /userdata/system/.asoundrc
 			;;
 
-			"custom")
+			custom)
 				# do nothing!
 			;;
-		esac	
+		esac
 	;;
 
 	test)


### PR DESCRIPTION
1. Migrate to POSIX Shell.
2. Remove obsolete unlock-audio.
3. Clean up formatting / minor style fixes.

Signed-off-by: Gleb Mazovetskiy <glex.spb@gmail.com>