### PR TITLE
Bump es-theme-carbon

### DIFF
--- a/package/batocera/emulationstation/es-theme-carbon/es-theme-carbon.mk
+++ b/package/batocera/emulationstation/es-theme-carbon/es-theme-carbon.mk
@@ -3,8 +3,8 @@
 # EmulationStation theme "Carbon"
 #
 ################################################################################
-# Version.: Commits on Dec 23, 2020
-ES_THEME_CARBON_VERSION = 22608d8e4834549c21ff4081b880f32fdcad6ba2
+# Version.: Commits on Jan 8, 2021
+ES_THEME_CARBON_VERSION = 6a87321cadd096c3eff154060e1207fcc7c06480
 ES_THEME_CARBON_SITE = $(call github,fabricecaruso,es-theme-carbon,$(ES_THEME_CARBON_VERSION))
 
 define ES_THEME_CARBON_INSTALL_TARGET_CMDS


### PR DESCRIPTION
For new systems (X1, Channel F, DivolutionX...) + all .png have been quantized, saving 6MB on the overall theme.