### PR TITLE
xash3d: More robust launcher

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
@@ -139,7 +139,8 @@ class Xash3dFwgsGenerator(Generator):
                 os.makedirs(config_dir)
             with open(config_dir + '/custom.cfg', 'w') as f:
                 f.write('\n')
-            os.symlink(config_dir + '/custom.cfg', rom_dir + '/custom.cfg')
+            if not os.path.exists(rom_dir + '/custom.cfg'):
+                os.symlink(config_dir + '/custom.cfg', rom_dir + '/custom.cfg')
 
     def _maybeInitSaveDir(self, game):
         rom_dir = _rom_dir(game)
@@ -147,4 +148,5 @@ class Xash3dFwgsGenerator(Generator):
             save_dir = _save_dir(game)
             if not os.path.exists(save_dir):
                 os.makedirs(save_dir)
-            os.symlink(save_dir, rom_dir + '/save')
+            if not os.path.exists(rom_dir + '/save'):
+                os.symlink(save_dir, rom_dir + '/save')


### PR DESCRIPTION
Do not try to create symlinks if they already exist.

This can happen if the config file or the save directory does not exist
but a symlink already exists in the rom directory.

Signed-off-by: Gleb Mazovetskiy <glex.spb@gmail.com>