### PR TITLE
batocera.conf display.rotate=0,1,2,3 option to rotate the screen

### DIFF
--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -59,5 +59,10 @@ ulimit -S -c unlimited emulationstation
 # dbus launch is required for the gio/gvfs/trash:///...
 eval `dbus-launch --sh-syntax --exit-with-session`
 
+# rotation
+display_rotate="$(/usr/bin/batocera-settings-get display.rotate)"
+EXTRA_OPTS=
+test -n "${display_rotate}" && EXTRA_OPTS="--screenrotate ${display_rotate}"
+
 cd /userdata # es needs a PWD
-openbox --config-file /etc/openbox/rc.xml --startup "emulationstation --windowed"
+openbox --config-file /etc/openbox/rc.xml --startup "emulationstation --windowed ${EXTRA_OPTS}"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -25,6 +25,11 @@ class Emulator():
         systemSettings = recalSettings.loadAll(self.name)
         gameSettings = recalSettings.loadAll(self.name + "[\"" + os.path.basename(rom) + "\"]")
 
+        # add some other options
+        displaySettings = recalSettings.loadAll('display')
+        for opt in displaySettings:
+            self.config["display." + opt] = displaySettings[opt]
+
         # update config
         Emulator.updateConfiguration(self.config, globalSettings)
         Emulator.updateConfiguration(self.config, systemSettings)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -99,6 +99,19 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['menu_show_restart_retroarch'] = 'false'    # this option messes everything up on Batocera if ever clicked
     retroarchConfig['video_driver'] = '"gl"'                    # needed for the ozone menu
 
+    if system.isOptSet("display.rotate"):
+        # 0 => 90 ; 1 => 0 ; 2 => 270 ; 3 => 180
+        if system.config["display.rotate"] == "0":
+            retroarchConfig['video_rotation'] = "1"
+        elif system.config["display.rotate"] == "1":
+            retroarchConfig['video_rotation'] = "0"
+        elif system.config["display.rotate"] == "2":
+            retroarchConfig['video_rotation'] = "3"
+        elif system.config["display.rotate"] == "3":
+            retroarchConfig['video_rotation'] = "2"
+    else:
+        retroarchConfig['video_rotation'] = '1'
+
     if system.isOptSet("gfxbackend") and system.config["gfxbackend"] == "vulkan":
         retroarchConfig['video_driver'] = '"vulkan"'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -86,7 +86,7 @@ class LibretroGenerator(Generator):
         if configToAppend:
             commandArray.extend(["--appendconfig", "|".join(configToAppend)])
 
-         # Netplay mode
+        # Netplay mode
         if 'netplay.mode' in system.config:
             if system.config['netplay.mode'] == 'host':
                 commandArray.append("--host")

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -13,6 +13,11 @@ case "$1" in
 		if [ "$enabled" != "0" ];then
 			batocera-resolution minTomaxResolution-secure
 			settings_lang="$(/usr/bin/batocera-settings-get system.language)"
+			display_rotate="$(/usr/bin/batocera-settings-get display.rotate)"
+
+			EXTRA_OPTS=
+			test -n "${display_rotate}" && EXTRA_OPTS="--screenrotate ${display_rotate}"
+
 			cd /userdata # es need a PWD
 			HOME=/userdata/system LANG="${settings_lang}.UTF-8" %BATOCERA_EMULATIONSTATION_PREFIX% %BATOCERA_EMULATIONSTATION_CMD% %BATOCERA_EMULATIONSTATION_ARGS% %BATOCERA_EMULATIONSTATION_POSTFIX%
 		fi

--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -81,7 +81,7 @@ endef
 # default for most of architectures
 BATOCERA_EMULATIONSTATION_PREFIX = SDL_NOMOUSE=1
 BATOCERA_EMULATIONSTATION_CMD = /usr/bin/emulationstation
-BATOCERA_EMULATIONSTATION_ARGS = --no-splash
+BATOCERA_EMULATIONSTATION_ARGS = --no-splash $${EXTRA_OPTS}
 BATOCERA_EMULATIONSTATION_POSTFIX = \&
 
 # on rpi1: dont load ES in background
@@ -91,12 +91,12 @@ endif
 
 # on rpi 1 2 3, the splash with video + es splash is ok
 ifeq ($(BR2_PACKAGE_RPI_USERLAND),y)
-	BATOCERA_EMULATIONSTATION_ARGS =
+	BATOCERA_EMULATIONSTATION_ARGS = $${EXTRA_OPTS}
 endif
 
 # es splash is ok when there is no video
 ifeq ($(BR2_PACKAGE_BATOCERA_SPLASH_IMAGE)$(BR2_PACKAGE_BATOCERA_SPLASH_ROTATE_IMAGE),y)
-	BATOCERA_EMULATIONSTATION_ARGS =
+	BATOCERA_EMULATIONSTATION_ARGS = $${EXTRA_OPTS}
 endif
 
 # # on x86/x86_64: startx runs ES


### PR DESCRIPTION
xrandr is not used to work on all boards (and for when xorg will be removed)
works only for retroarch (could be done for other emulators if wanted)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>