### PR TITLE
fix for the standalone EasyRPG-player launch command

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/easyrpg/easyrpgGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/easyrpg/easyrpgGenerator.py
@@ -8,7 +8,7 @@ import controllersConfig
 class EasyRPGGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, gameResolution):
-        commandArray = ["easyrpg-player", rom]
+        commandArray = ["easyrpg-player", "--project-path", rom]
         return Command.Command(
             array=commandArray,
             env={


### PR DESCRIPTION
The current command used to launch the standalone EasyRPG-player from ES wasn't working, as the path to the rom needs to be included with the "--project-path" option.