### PR TITLE
rpi3: vc4-fkms-v3d

### DIFF
--- a/board/batocera/raspberrypi/rpi3/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi3/boot/config.txt
@@ -82,4 +82,4 @@ initramfs boot/initrd.gz
 dtparam=audio=on
 
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-kms-v3d,noaudio
+dtoverlay=vc4-fkms-v3d

--- a/board/batocera/raspberrypi/rpi3/fsoverlay/etc/init.d/S03checkbootconfig
+++ b/board/batocera/raspberrypi/rpi3/fsoverlay/etc/init.d/S03checkbootconfig
@@ -4,12 +4,12 @@
 test "$1" != "start" && exit 0
 
 # check for this line
-grep -qE '^dtoverlay=vc4-kms-v3d,noaudio$' /boot/config.txt && exit 0
+grep -qE '^dtoverlay=vc4-fkms-v3d$' /boot/config.txt && exit 0
 
 # update the file
 mount -o remount,rw /boot || exit 1
 sed -i '/^[ ]*dtoverlay[ ]*=[ ]*vc4.*$/d'          /boot/config.txt || exit 0
-(echo;echo 'dtoverlay=vc4-kms-v3d,noaudio') >> /boot/config.txt || exit 0
+(echo;echo 'dtoverlay=vc4-fkms-v3d') >> /boot/config.txt || exit 0
 mount -o remount,ro /boot || exit 1
 shutdown -r now
 


### PR DESCRIPTION
With the use of vc4-fkms-v3d for rpi3 we have no problem with the audio.
