### PR TITLE
post-build-script: Relax /etc/passwd rewrite

### DIFF
--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -12,7 +12,7 @@ BATOCERA_TARGET=$(grep -E "^BR2_PACKAGE_BATOCERA_TARGET_[A-Z_0-9]*=y$" "${BR2_CO
 # For the root user:
 # 1. Use Bash instead of Dash for interactive use.
 # 2. Set home directory to /userdata/system instead of /root.
-sed -i "s|root:x:0:0:root:/root:/bin/dash|root:x:0:0:root:/userdata/system:/bin/bash|g" "${TARGET_DIR}/etc/passwd" || exit 1
+sed -i "s|^root:x:.*$|root:x:0:0:root:/userdata/system:/bin/bash|g" "${TARGET_DIR}/etc/passwd" || exit 1
 
 rm -rf "${TARGET_DIR}/etc/dropbear" || exit 1
 ln -sf "/userdata/system/ssh" "${TARGET_DIR}/etc/dropbear" || exit 1


### PR DESCRIPTION
This way we no longer require a clean build to set home directory and shell correctly.