### PR TITLE
batocera-store: Clean up action handling

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-store
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-store
@@ -45,6 +45,22 @@ do_clean () {
 	fi
 }
 
+print_help() {
+	echo "${0} install <package>" >&2
+	echo "${0} remove  <package>" >&2
+	echo "${0} list" >&2
+	echo "${0} list-repositories" >&2
+	echo "${0} clean" >&2
+	echo "${0} clean-all" >&2
+	echo "${0} refresh" >&2
+	echo "${0} update" >&2
+}
+
+if [ $# -eq 0 ]; then
+	print_help
+	exit
+fi
+
 ACTION=$1
 shift
 do_clean #Delete db.lck file if it's NOT in usage
@@ -172,12 +188,8 @@ case "${ACTION}" in
 	     exit $?
 	;;
     *)
-	echo "${0} install <package>" >&2
-	echo "${0} remove  <package>" >&2
-	echo "${0} list" >&2
-	echo "${0} list-repositories" >&2
-	echo "${0} clean" >&2
-	echo "${0} clean-all" >&2
-	echo "${0} refresh" >&2
-	echo "${0} update" >&2
+      >&2 echo "error: unknown action ${ACTION}"
+      >&2 echo
+      print_help
+      exit 1
 esac


### PR DESCRIPTION
1. Fixes `shift: can't shift that many` in dash.
2. Prints an error on unknown action.