### PR TITLE
batocera-scripts: Fix incorrect usage of `shift`

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-install
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-install
@@ -7,16 +7,21 @@ settingsupdateurl="$(/usr/bin/batocera-settings-get updates.url)"
 test -n "${settingsupdateurl}" && updateurl="${settingsupdateurl}"
 
 IMGFOLDER="/userdata/system/installs"
-ACTION=$1
-shift
 
 do_help() {
-    PROG=$1
-    echo "${PROG} listDisks" >&2
-    echo "${PROG} listArchs" >&2
-    echo "${PROG} listFiles" >&2
-    echo "${PROG} install <disk> <arch|file>" >&2
+	echo "$0 listDisks" >&2
+	echo "$0 listArchs" >&2
+	echo "$0 listFiles" >&2
+	echo "$0 install <disk> <arch|file>" >&2
 }
+
+if [ $# -eq 0 ]; then
+	do_help
+	exit 1
+fi
+
+ACTION=$1
+shift
 
 determine_part_prefix() {
     # /dev/mmcblk0p3 => /dev/mmcblk0
@@ -228,7 +233,9 @@ case "${ACTION}" in
 	    exit 1
 	fi
 	;;
-    *)
-	do_help "${0}"
+	*)
+		do_help
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-overclock
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-overclock
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-ARCH=$(cat /usr/share/batocera/batocera.arch)
+f_usage() {
+	echo "$0 list" >&2
+	echo "$0 set <VALUE>" >&2
+}
+
+ARCH="$(cat /usr/share/batocera/batocera.arch)"
 GRPICONFFILE="/boot/config.txt"
 GODROIDCONFFILE="/boot/config.ini"
 
@@ -252,6 +257,11 @@ setValue() {
     esac
 }
 
+if [ $# -eq 0 ]; then
+	f_usage
+	exit 1
+fi
+
 ACTION=$1
 shift
 
@@ -268,6 +278,10 @@ case "${ACTION}" in
 	then
 	    exit 1
 	fi
+	*)
+		f_usage
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
@@ -1,21 +1,19 @@
 #!/bin/sh
 
-ACTION=$1
-shift
-
 FILEMODES="/sys/class/graphics/fb0/modes"
 
 f_usage() {
-    echo "${0} currentMode" >&2
-    echo "${0} currentResolution" >&2
+	echo "$0 currentMode" >&2
+	echo "$0 currentResolution" >&2
 }
 
-if test -z "${ACTION}"
-then
-    f_usage
-    exit 1
+if [ $# -eq 0 ]; then
+	f_usage
+	exit 1
 fi
 
+ACTION=$1
+shift
 
 case "${ACTION}" in
     "listModes")
@@ -26,8 +24,9 @@ case "${ACTION}" in
         # mode can be different from resolution (ie on rpi)
         test -e "${FILEMODES}" && head -1 "${FILEMODES}" | sed -e s+'^[^:]:\([0-9]*\)x\([0-9]*\)[a-z]*.*$'+'\1x\2'+
         ;;
-    *)
-        f_usage
-        ;;
+	*)
+		f_usage
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.tvservice
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-ACTION=$1
-shift
-
 f_usage() {
     echo "${0} listModes" >&2
     echo "${0} setMode <MODE>" >&2
@@ -12,11 +9,13 @@ f_usage() {
     echo "${0} minTomaxResolution-secure" >&2
 }
 
-if test -z "${ACTION}"
-then
-    f_usage
-    exit 1
+if [ $# -eq 0 ]; then
+	f_usage
+	exit 1
 fi
+
+ACTION=$1
+shift
 
 case "${ACTION}" in
     "listModes")
@@ -73,8 +72,9 @@ case "${ACTION}" in
 		fi
 	    done
 	;;
-    *)
-        f_usage
-        ;;
+	*)
+		f_usage
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-ACTION=$1
-shift
-
 f_usage() {
     echo "${0} listModes" >&2
     echo "${0} setMode <MODE>" >&2
@@ -14,11 +11,13 @@ f_usage() {
     echo "${0} minTomaxResolution-secure" >&2
 }
 
-if test -z "${ACTION}"
-then
-    f_usage
-    exit 1
+if [ $# -eq 0 ]; then
+	f_usage
+	exit 1
 fi
+
+ACTION=$1
+shift
 
 case "${ACTION}" in
     "listModes")
@@ -99,8 +98,9 @@ case "${ACTION}" in
     "setDPI")
         xrandr --dpi $1
         ;;
-    *)
-        f_usage
-	;;
+	*)
+		f_usage
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-store
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-store
@@ -7,6 +7,17 @@
 DEST_PKG=/userdata/system/pacman/pkg
 DB_FILE=/userdata/system/pacman/db/db.lck
 
+do_help() {
+	echo "$0 install <package>" >&2
+	echo "$0 remove  <package>" >&2
+	echo "$0 list" >&2
+	echo "$0 list-repositories" >&2
+	echo "$0 clean" >&2
+	echo "$0 clean-all" >&2
+	echo "$0 refresh" >&2
+	echo "$0 update" >&2
+}
+
 # Just a work meter - better than some static output
 do_bepatient() {
 	local COUNT=0
@@ -44,6 +55,11 @@ do_clean () {
 		rm -f ${DB_FILE}
 	fi
 }
+
+if [ $# -eq 0 ]; then
+	do_help
+	exit 1
+fi
 
 ACTION=$1
 shift
@@ -171,13 +187,7 @@ case "${ACTION}" in
 	) | python
 	     exit $?
 	;;
-    *)
-	echo "${0} install <package>" >&2
-	echo "${0} remove  <package>" >&2
-	echo "${0} list" >&2
-	echo "${0} list-repositories" >&2
-	echo "${0} clean" >&2
-	echo "${0} clean-all" >&2
-	echo "${0} refresh" >&2
-	echo "${0} update" >&2
+	*)
+		do_help
+		exit 1
 esac

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -1,11 +1,8 @@
 #!/bin/sh
 
-ACTION=$1
-shift
-
 do_help() {
-    echo "${1} scanlist" >&2
-    echo "${1} list" >&2
+    echo "$0 scanlist" >&2
+    echo "$0 list" >&2
 }
 
 do_list() {
@@ -53,6 +50,15 @@ do_start() {
     connmanctl scan   wifi || return 1
 }
 
+
+if [ $# -eq 0 ]; then
+	do_help
+	exit 1
+fi
+
+ACTION=$1
+shift
+
 case "${ACTION}" in
     "list")
 	do_list
@@ -71,7 +77,9 @@ case "${ACTION}" in
     "disable")
 	do_disable || exit 1
 	;;
-    *)
-	do_help "${0}"
+	*)
+		do_help
+		>&2 echo "error: invalid command ${ACTION}"
+		exit 1
 esac
 exit 0


### PR DESCRIPTION
In POSIX shell, `shift` errors if there are no arguments to shift.
This is unlike Bash, where `shift` is a no-op in this case.

@crcerror