### PR TITLE
Fix libGL

### DIFF
--- a/board/batocera/scripts/doWineWow64-32package.sh
+++ b/board/batocera/scripts/doWineWow64-32package.sh
@@ -115,6 +115,7 @@ cp -pr "${G_TARGETDIR}/usr/share/gstreamer-1.0/"* "${TMPOUT}/usr/share/gstreamer
 #ln -s /lib32/pulseaudio "${TMPOUT}/usr/lib/pulseaudio" || exit 1
 cp -p "${G_TARGETDIR}/usr/lib/libEGL_mesa"* "${TMPOUT}/lib32" || exit 1
 cp -p "${G_TARGETDIR}/usr/lib/libGLX_mesa"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libGL.so"* "${TMPOUT}/lib32" || exit 1
 #"${G_TARGETDIR}/usr/lib/pulseaudio/"*.so
 
 # add .so for lutris


### PR DESCRIPTION
@nadenislamarre review

Issue missing 32bit libs
```
find / -name "libGL.so*"
/overlay/base/usr/lib/libGL.so
/overlay/base/usr/lib/libGL.so.1
/overlay/base/usr/lib/libGL.so.1.7.0
/usr/lib/libGL.so
/usr/lib/libGL.so.1
/usr/lib/libGL.so.1.7.0
```