### PR TITLE
Fix other Missing Libs

### DIFF
--- a/board/batocera/scripts/doWineWow64-32package.sh
+++ b/board/batocera/scripts/doWineWow64-32package.sh
@@ -118,6 +118,11 @@ cp -p "${G_TARGETDIR}/usr/lib/libGLX_mesa"* "${TMPOUT}/lib32" || exit 1
 cp -p "${G_TARGETDIR}/usr/lib/libGL.so"* "${TMPOUT}/lib32" || exit 1
 cp -p "${G_TARGETDIR}/usr/lib/libGLX.so"* "${TMPOUT}/lib32" || exit 1
 cp -p "${G_TARGETDIR}/usr/lib/libGLdispatch.so"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libxatracker.so"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libXrandr.so"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libXft.so"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libXi.so"* "${TMPOUT}/lib32" || exit 1
+cp -p "${G_TARGETDIR}/usr/lib/libXinerama.so"* "${TMPOUT}/lib32" || exit 1
 #"${G_TARGETDIR}/usr/lib/pulseaudio/"*.so
 
 # add .so for lutris
@@ -136,6 +141,11 @@ for BIN in \
 "${G_TARGETDIR}/usr/lib/libGL"* \
 "${G_TARGETDIR}/usr/lib/libGLX"* \
 "${G_TARGETDIR}/usr/lib/libGLdispatch"* \
+"${G_TARGETDIR}/usr/lib/libxatracker"* \
+"${G_TARGETDIR}/usr/lib/libXrandr"* \
+"${G_TARGETDIR}/usr/lib/libXft"* \
+"${G_TARGETDIR}/usr/lib/libXi"* \
+"${G_TARGETDIR}/usr/lib/libXinerama"* \
 "${G_TARGETDIR}/usr/lib/libncurses.so"* \
 "${G_TARGETDIR}/usr/lib/libmspack.so"* \
 "${G_TARGETDIR}/usr/lib/libdbus"*"so"* \


### PR DESCRIPTION
```
/lib32/libgbm.so KO
ln -s /lib32/libgbm.so.1 /lib32/libgbm.so

/lib32/libglapi.so KO
ln -s /lib32/libglapi.so.0 /lib32/libglapi.so

/lib32/libfreetype.so KO
ln -s /lib32/libfreetype.so.6.17.4 /lib32/libfreetype.so

/lib32/libFAudio.so KO
ln -s /lib32/libFAudio.so.0 /lib32/libFAudio.so
```


```
/lib32/libxatracker.so KO
Missing

/lib32/libXrandr.so KO
Missing

/lib32/libXft.so KO
Missing

/lib32/libXinerama.so KO
Missing

/lib32/libXi.so KO
Missing
```