### PR TITLE
s905 fixes and some cleanup

### DIFF
--- a/board/batocera/amlogic/s905/boot/README.txt
+++ b/board/batocera/amlogic/s905/boot/README.txt
@@ -1,11 +1,10 @@
-In order to boot this disk, you must rename (or copy) one of the file ending with dtb in the boot directory depending on your hardware.
+In order to boot this disk, you must set the correct dtb file in the FDT section of uEnv.txt.
 
-boot/all_merged.dtb   => boot/dtb.img
-boot/gxbb_p200_2G.dtb => boot/dtb.img
-boot/gxbb_p200.dtb    => boot/dtb.img
-boot/gxl_p212_1g.dtb  => boot/dtb.img
-boot/gxl_p212_2g.dtb  => boot/dtb.img
+For example, a tx3 mini you can  use: 
+FDT=/boot/meson-gxl-s905x-p212.dtb
 
-For example, for my hardware, i install batocera on a usb disk,
-then, i rename boot/gxl_p212_1g.dtb to boot/dtb.img.
-On the first boot, i've to press a button too on my hardware to switch on the usb boot.
+On the first boot, you have to press the reset button to force the board to boot from usb/mmc.
+
+
+
+

--- a/board/batocera/amlogic/s905/boot/s905_autoscript.txt
+++ b/board/batocera/amlogic/s905/boot/s905_autoscript.txt
@@ -1,12 +1,7 @@
-setenv kernel_loadaddr "0x11000000"
-setenv initrd_loadaddr "0x13000000"
-setenv hdmimode "1080p60hz"
-setenv init_hdmi "logo=osd1,loaded,${fb_addr},hdmimode=${hdmimode} vout=${hdmimode},enable"
-setenv condev "console=ttyS0,115200n8 console=tty2 loglevel=0 no_console_suspend consoleblank=0"
-setenv bootargs "label=BATOCERA rootflags=data=writeback rw ${init_hdmi} ${condev} fsck.repair=yes net.ifnames=0 mac=${mac}"
-setenv boot_start booti ${kernel_loadaddr} ${initrd_loadaddr} ${dtb_mem_addr}
-if fatload usb 0 ${initrd_loadaddr} /boot/uInitrd; then if fatload usb 0 ${kernel_loadaddr} /boot/linux; then if fatload usb 0 ${dtb_mem_addr} /boot/dtb.img; then run boot_start; else store dtb read ${dtb_mem_addr}; run boot_start;fi;fi;fi;
-if fatload usb 1 ${initrd_loadaddr} /boot/uInitrd; then if fatload usb 1 ${kernel_loadaddr} /boot/linux; then if fatload usb 1 ${dtb_mem_addr} /boot/dtb.img; then run boot_start; else store dtb read ${dtb_mem_addr}; run boot_start;fi;fi;fi;
-if fatload usb 2 ${initrd_loadaddr} /boot/uInitrd; then if fatload usb 2 ${kernel_loadaddr} /boot/linux; then if fatload usb 2 ${dtb_mem_addr} /boot/dtb.img; then run boot_start; else store dtb read ${dtb_mem_addr}; run boot_start;fi;fi;fi;
-if fatload usb 3 ${initrd_loadaddr} /boot/uInitrd; then if fatload usb 3 ${kernel_loadaddr} /boot/linux; then if fatload usb 3 ${dtb_mem_addr} /boot/dtb.img; then run boot_start; else store dtb read ${dtb_mem_addr}; run boot_start;fi;fi;fi;
-if fatload mmc 0 ${initrd_loadaddr} /boot/uInitrd; then if fatload mmc 0 ${kernel_loadaddr} /boot/linux; then if fatload mmc 0 ${dtb_mem_addr} /boot/dtb.img; then run boot_start; else store dtb read ${dtb_mem_addr}; run boot_start;fi;fi;fi;
+setenv kernel_addr "0x11000000"
+setenv initrd_addr "0x13000000"
+setenv env_addr "0x1040000"
+setenv boot_start bootm ${kernel_addr} ${initrd_addr} ${dtb_mem_addr}
+if fatload usb 0 ${env_addr} uEnv.txt; then env import -t ${env_addr} ${filesize}; setenv bootargs ${APPEND}; if fatload usb 0 ${kernel_addr} ${LINUX}; then if fatload usb 0 ${initrd_addr} ${INITRD}; then if fatload usb 0 ${dtb_mem_addr} ${FDT}; then run boot_start; fi; fi; fi; fi;
+if fatload usb 1 ${env_addr} uEnv.txt; then env import -t ${env_addr} ${filesize}; setenv bootargs ${APPEND}; if fatload usb 1 ${kernel_addr} ${LINUX}; then if fatload usb 1 ${initrd_addr} ${INITRD}; then if fatload usb 1 ${dtb_mem_addr} ${FDT}; then run boot_start; fi; fi; fi; fi;
+if fatload mmc 0 ${env_addr} uEnv.txt; then env import -t ${env_addr} ${filesize}; setenv bootargs ${APPEND}; if fatload mmc 0 ${kernel_addr} ${LINUX}; then if fatload mmc 0 ${initrd_addr} ${INITRD}; then if fatload mmc 0 ${dtb_mem_addr} ${FDT}; then run boot_start; fi; fi; fi; fi;

--- a/board/batocera/amlogic/s905/boot/uEnv.txt
+++ b/board/batocera/amlogic/s905/boot/uEnv.txt
@@ -1,0 +1,4 @@
+LINUX=/boot/uImage
+INITRD=/boot/uInitrd
+FDT=/boot/meson-gxl-s905x-p212.dtb
+APPEND=label=BATOCERA rootwait quiet loglevel=0 console=ttyAML0,115200n8 console=tty3 vt.global_cursor_default=0 video=Composite-1:d video=HDMI-A-1:1920x1080@60

--- a/board/batocera/amlogic/s905/create-boot-script.sh
+++ b/board/batocera/amlogic/s905/create-boot-script.sh
@@ -15,14 +15,20 @@ BINARIES_DIR=$4
 TARGET_DIR=$5
 BATOCERA_BINARIES_DIR=$6
 
-mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot" 	  || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux" || exit 1
 
-cp "${BINARIES_DIR}/Image"           "${BATOCERA_BINARIES_DIR}/boot/boot/linux"           || exit 1
+
+"${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BATOCERA_BINARIES_DIR}/boot/boot/uImage" || exit 1
+#cp "${BINARIES_DIR}/Image"           "${BATOCERA_BINARIES_DIR}/boot/boot/uImage"         || exit 1
 cp "${BINARIES_DIR}/uInitrd"         "${BATOCERA_BINARIES_DIR}/boot/boot/uInitrd"         || exit 1
 cp "${BINARIES_DIR}/rootfs.squashfs" "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" || exit 1
 
-cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" "${BATOCERA_BINARIES_DIR}/boot/" || exit 1
-cp "${BOARD_DIR}/boot/README.txt"       "${BATOCERA_BINARIES_DIR}/boot/" || exit 1
+cp "${BOARD_DIR}/boot/boot-logo.bmp.gz" 	"${BATOCERA_BINARIES_DIR}/boot/"	  || exit 1
+cp "${BOARD_DIR}/boot/README.txt"       	"${BATOCERA_BINARIES_DIR}/boot/"	  || exit 1
+cp "${BOARD_DIR}/boot/uEnv.txt"       		"${BATOCERA_BINARIES_DIR}/boot/" 	  || exit 1
+
+
 for DTB in meson-gxl-s905d-p230.dtb meson-gxl-s905d-p231.dtb meson-gxl-s905w-p281.dtb meson-gxl-s905w-tx3-mini.dtb meson-gxl-s905x-p212.dtb
 do
 	cp "${BINARIES_DIR}/${DTB}" "${BATOCERA_BINARIES_DIR}/boot/boot/" || exit 1

--- a/board/batocera/amlogic/s905/fsoverlay/etc/init.d/S03mali
+++ b/board/batocera/amlogic/s905/fsoverlay/etc/init.d/S03mali
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-if test "$1" = "start"
-then
-	insmod /lib/modules/3.14.29/kernel/gpu/mali.ko
-fi

--- a/board/batocera/amlogic/s905/fsoverlay/etc/modprobe.d/mali.conf
+++ b/board/batocera/amlogic/s905/fsoverlay/etc/modprobe.d/mali.conf
@@ -1,1 +1,0 @@
-options mali mali_shared_mem_size=0x40000000

--- a/board/batocera/amlogic/s905/fsoverlay/etc/modules.conf
+++ b/board/batocera/amlogic/s905/fsoverlay/etc/modules.conf
@@ -1,3 +1,2 @@
 uinput
 usbhid
-mali


### PR DESCRIPTION
-remove old 3.x vendor modules from fsoverlay 
-switch to use uEnv.txt and on the kernel side to mkimage/uImage
-disable composite output (thanks Demetris!)