### PR TITLE
Increase partition sizes (1899 -> 2515 MiB)

### DIFF
--- a/board/batocera/amlogic/odroidc2/genimage.cfg
+++ b/board/batocera/amlogic/odroidc2/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/s905/genimage.cfg
+++ b/board/batocera/amlogic/s905/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-	# 61765 * 512 * 63 = 1992291840
-	# 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/s912/genimage.cfg
+++ b/board/batocera/amlogic/s912/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992130560
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/libretech-h5/genimage.cfg
+++ b/board/batocera/libretech-h5/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 61765 * 512 * 63 = 1992291840
-		# 1992291840 / 1024 / 1024 = 1899 MB
-		size = 1992291840
+		# 81765 * 512 * 63 = 2637411840
+		# 2637411840 / 1024 / 1024 = 2515 MiB
+		size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/odroidxu4/genimage.cfg
+++ b/board/batocera/odroidxu4/genimage.cfg
@@ -19,11 +19,11 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-	# must be a multiple of 32 for the odroid xu4 ; i don't know why
-	#
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+		# must be a multiple of 32 for the odroid xu4 ; i don't know why
+		#
+		# 81765 * 512 * 63 = 2637411840
+		# 2637411840 / 1024 / 1024 = 2515 MiB
+		size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/orangepi-pc/genimage.cfg
+++ b/board/batocera/orangepi-pc/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 61765 * 512 * 63 = 1992291840
-		# 1992291840 / 1024 / 1024 = 1899 MB
-		size = 1992291840
+		# 81765 * 512 * 63 = 2637411840
+		# 2637411840 / 1024 / 1024 = 2515 MiB
+		size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/orangepi-zero2/genimage.cfg
+++ b/board/batocera/orangepi-zero2/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 61765 * 512 * 63 = 1992291840
-		# 1992291840 / 1024 / 1024 = 1899 MB
-		size = 1992291840
+		# 81765 * 512 * 63 = 2637411840
+		# 2637411840 / 1024 / 1024 = 2515 MiB
+		size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi3/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi3/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi4/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi4/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/odroidgoa/genimage.cfg
+++ b/board/batocera/rockchip/odroidgoa/genimage.cfg
@@ -19,11 +19,11 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-	# must be a multiple of 32 for the odroid xu4 ; i don't know why
-	#
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # must be a multiple of 32 for the odroid xu4 ; i don't know why
+        #
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3288/miqi/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/miqi/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 61765 * 512 * 63 = 1992291840
-        # 1992291840 / 1024 / 1024 = 1899 MB
-        size = 1992291840
+        # 81765 * 512 * 63 = 2637411840
+        # 2637411840 / 1024 / 1024 = 2515 MiB
+        size = 2637411840
 }
 
 image userdata.ext4 {

--- a/board/batocera/s812/genimage.cfg
+++ b/board/batocera/s812/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 61765 * 512 * 63 = 1992291840
-		# 1992291840 / 1024 / 1024 = 1899 MB
-		size = 1992291840
+		# 81765 * 512 * 63 = 2637411840
+		# 2637411840 / 1024 / 1024 = 2515 MiB
+		size = 2637411840
 }
 
 image userdata.ext4 {


### PR DESCRIPTION
The current batocera debug image for odroidgoA is over 1 GiB (1.1 GiB to
be precise), so the upgrade fails.

Increase the partition sizes for all the boards that previously used 1899.

Signed-off-by: Gleb Mazovetskiy <glex.spb@gmail.com>