### PR TITLE
odroidgoa: Disable RTL driver packages

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -163,9 +163,11 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 
     # wireless drivers
     select BR2_PACKAGE_RTL8821AU                         if !BR2_PACKAGE_BATOCERA_RPI_VCORE             && \
-                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC    && \
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA
     select BR2_PACKAGE_RTL8192EU                         if !BR2_PACKAGE_BATOCERA_RPI_VCORE             && \
-                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC    && \
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA
     select BR2_PACKAGE_RTL8821CE                         if !BR2_PACKAGE_BATOCERA_RPI_VCORE             && \
                                                             !BR2_PACKAGE_BATOCERA_TARGET_S812           && \
                                                             !BR2_PACKAGE_BATOCERA_TARGET_RPI3           && \
@@ -174,7 +176,8 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
                                                             !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_ZERO2 && \
                                                             !BR2_PACKAGE_BATOCERA_TARGET_MIQI           && \
                                                             !BR2_PACKAGE_BATOCERA_TARGET_TINKERBOARD    && \
-                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ORANGEPI_PC    && \
+                                                            !BR2_PACKAGE_BATOCERA_TARGET_ODROIDGOA
 
     # gpu drivers
     select BR2_PACKAGE_BATOCERA_GPU_X86			 if BR2_PACKAGE_BATOCERA_TARGET_X86_ANY


### PR DESCRIPTION
These driver packages do not build with gcc-10.

The drivers for these cards are already in the kernel anyway.