### PR TITLE
Add safeguard in mupen64plus mk to avoid defining 32-bit-only neon GC…

### DIFF
--- a/package/batocera/emulators/mupen64plus/mupen64plus-core/mupen64plus-core.mk
+++ b/package/batocera/emulators/mupen64plus/mupen64plus-core/mupen64plus-core.mk
@@ -40,7 +40,7 @@ ifeq ($(BR2_aarch64),y)
 	MUPEN64PLUS_PARAMS += VFP_HARD=1
 endif
 
-ifeq ($(BR2_ARM_CPU_HAS_NEON),y)
+ifeq ($(BR2_arm)$(BR2_ARM_CPU_HAS_NEON),yy)
 	MUPEN64PLUS_CORE_CPUFLAGS += -marm -DNO_ASM -DARM -D__arm__ -DARM_ASM -D__NEON_OPT -DNOSSE
 	MUPEN64PLUS_GL_CFLAGS += -D__ARM_NEON__ -D__NEON_OPT -ftree-vectorize -mvectorize-with-neon-quad -ftree-vectorizer-verbose=2 -funsafe-math-optimizations -fno-finite-math-only
 


### PR DESCRIPTION
…C params on aarch64 builds