### PR TITLE
Disable MUPEN64PLUS_GLES2 on aarch64

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -792,8 +792,9 @@ config BR2_PACKAGE_BATOCERA_MUPEN64
                                                            BR2_PACKAGE_BATOCERA_TARGET_ROCKCHIP_ANY
                                                            # GLIDEN64
 
-        select BR2_PACKAGE_MUPEN64PLUS_GLES2            if BR2_PACKAGE_BATOCERA_RPI_VCORE           || \
-                                                           BR2_PACKAGE_BATOCERA_TARGET_ROCKCHIP_ANY
+        select BR2_PACKAGE_MUPEN64PLUS_GLES2            if !BR2_aarch64 && ( \
+                                                           BR2_PACKAGE_BATOCERA_RPI_VCORE           || \
+                                                           BR2_PACKAGE_BATOCERA_TARGET_ROCKCHIP_ANY)
                                                            # GLES2
 
         select BR2_PACKAGE_MUPEN64PLUS_V20_GLIDEN64     if BR2_PACKAGE_BATOCERA_RPI_VCORE


### PR DESCRIPTION
aarch64 is not yet supported:
https://github.com/ricrpi/mupen64plus-video-gles2n64/issues/29