### PR TITLE
bump lutris

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -30,6 +30,7 @@
 	* bump: FAudio (Wine) to 21.01
 	* bump: Dosbox-X to 0.83.9
 	* bump: Linux 5.10.x LTS kernel series for x86, x86_64 and mainline supported aarch64 & arm SOC's
+	* bump: Lutris (Wine) to 6.0
 	* bump: DXVK (Wine) to 1.7.3
 	* bump: VKD3D-Proton (Wine) to 2.1
 	* bump: Mesa3D to 20.3.3

--- a/package/batocera/emulators/wine/wine-lutris-wow64_32/wine-lutris-wow64_32.mk
+++ b/package/batocera/emulators/wine/wine-lutris-wow64_32/wine-lutris-wow64_32.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINE_LUTRIS_WOW64_32_VERSION = f0df5a3e9d112998a64b5ddfee48442367cc38d5
+WINE_LUTRIS_WOW64_32_VERSION = lutris-6.0
 WINE_LUTRIS_WOW64_32_SITE = $(call github,lutris,wine,$(WINE_LUTRIS_WOW64_32_VERSION))
 WINE_LUTRIS_WOW64_32_LICENSE = LGPL-2.1+
 WINE_LUTRIS_WOW64_32_DEPENDENCIES = host-bison host-flex host-wine-lutris

--- a/package/batocera/emulators/wine/wine-lutris/wine-lutris.mk
+++ b/package/batocera/emulators/wine/wine-lutris/wine-lutris.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINE_LUTRIS_VERSION = f0df5a3e9d112998a64b5ddfee48442367cc38d5
+WINE_LUTRIS_VERSION = lutris-6.0
 WINE_LUTRIS_SITE = $(call github,lutris,wine,$(WINE_LUTRIS_VERSION))
 WINE_LUTRIS_LICENSE = LGPL-2.1+
 WINE_LUTRIS_DEPENDENCIES = host-bison host-flex host-wine-lutris


### PR DESCRIPTION
Stable build of Lutris wine based off Wine 6.0.

This builds fixes some issues:

    Occasional graphics freeze for a couple seconds
    .NET not installing properly with Winetricks
    missing sounds in Cyberpunk 2077

This Wine build provides support for Media Foundation through GStreamer and should offer a working out of the box experience for many games.
