### PR TITLE
Fixes Edimax EW-7611ULB wifi not being detected

### DIFF
--- a/board/batocera/rockchip/odroidgoa/linux_patches/linux-rtl8723bu.patch
+++ b/board/batocera/rockchip/odroidgoa/linux_patches/linux-rtl8723bu.patch
@@ -1,0 +1,20 @@
+diff --git a/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c b/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
+index f16e69e8f05b..ea10f500c1c0 100755
+--- a/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
++++ b/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
+@@ -126,6 +126,7 @@ static void rtw_dev_shutdown(struct device *dev)
+ #endif
+ 
+ 
++#define USB_VENDER_ID_EDIMAX		0x7392
+ #define USB_VENDER_ID_REALTEK		0x0BDA
+ 
+ 
+@@ -194,6 +195,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
+ 	//*=== Realtek demoboard ===*/
+ 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB720,0xff,0xff,0xff),.driver_info = RTL8723B}, /* 8723BU 1*1 */
+ 	//{USB_DEVICE(USB_VENDER_ID_REALTEK, 0xB720),.driver_info = RTL8723B}, /* 8723BU */
++	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xA611, 0xff, 0xff, 0xff), .driver_info = RTL8723B}, / 8723BU 1*1 */
+ #endif
+ 
+ #ifdef CONFIG_RTL8703B


### PR DESCRIPTION
Patches the Odroid kernel for the RTL driver to detect the Edimax ID