### PR TITLE
fixed EDIMAX USB driver for Odroid GO Advance

### DIFF
--- a/board/batocera/rockchip/odroidgoa/linux_patches/linux-rtl8723bu.patch
+++ b/board/batocera/rockchip/odroidgoa/linux_patches/linux-rtl8723bu.patch
@@ -1,0 +1,20 @@
+diff --git a/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c b/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
+index f16e69e8f05b..ea10f500c1c0 100755
+--- a/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
++++ b/drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c
+@@ -126,6 +126,7 @@ static void rtw_dev_shutdown(struct device *dev)
+ #endif
+ 
+ 
++#define USB_VENDER_ID_EDIMAX		0x7392
+ #define USB_VENDER_ID_REALTEK		0x0BDA
+ 
+ 
+@@ -194,6 +195,7 @@ static struct usb_device_id rtw_usb_id_tbl[] ={
+ 	//*=== Realtek demoboard ===*/
+ 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xB720,0xff,0xff,0xff),.driver_info = RTL8723B}, /* 8723BU 1*1 */
+ 	//{USB_DEVICE(USB_VENDER_ID_REALTEK, 0xB720),.driver_info = RTL8723B}, /* 8723BU */
++	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xA611,0xff,0xff,0xff),.driver_info = RTL8723B}, /* 8723BU 1*1 */
+ #endif
+ 
+ #ifdef CONFIG_RTL8703B


### PR DESCRIPTION
Tested compile - definitely works
I used - make odroidgoa-pkg PKG=linux

Applying linux-rtl8723bu.patch using patch: 
patching file drivers/net/wireless/rockchip_wlan/rtl8723bu/os_dep/linux/usb_intf.c

INSTALL drivers/net/wireless/rockchip_wlan/rtl8723bu/8723bu.ko

>>> linux 30aa1268194d24461299d45f35bf4f4a48c461a7 Installing to images directory
/usr/bin/install -m 0644 -D /odroidgoa/build/linux-30aa1268194d24461299d45f35bf4f4a48c461a7/arch/arm64/boot/Image /odroidgoa/images/Image
# dtbs moved from arch/<ARCH>/boot to arch/<ARCH>/boot/dts since 3.8-rc1
install -D /odroidgoa/build/linux-30aa1268194d24461299d45f35bf4f4a48c461a7/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux.dtb /odroidgoa/images/rk3326-odroidgo2-linux.dtb
install -D /odroidgoa/build/linux-30aa1268194d24461299d45f35bf4f4a48c461a7/arch/arm64/boot/dts/rockchip/rk3326-odroidgo2-linux-v11.dtb /odroidgoa/images/rk3326-odroidgo2-linux-v11.dtb
install -D /odroidgoa/build/linux-30aa1268194d24461299d45f35bf4f4a48c461a7/arch/arm64/boot/dts/rockchip/rk3326-odroidgo3-linux.dtb /odroidgoa/images/rk3326-odroidgo3-linux.dtb
install -D /odroidgoa/build/linux-30aa1268194d24461299d45f35bf4f4a48c461a7/arch/arm64/boot/dts/rk3326-rg351p-linux.dtb /odroidgoa/images/rk3326-rg351p-linux.dtb
make: Leaving directory '/build/buildroot'
make[1]: Leaving directory '/home/dman/batocera.linux'