### PR TITLE
rtl8192eu: Fix build with gcc-10 (-Wrestrict)

### DIFF
--- a/package/batocera/network/rtl8192eu/0001-Fix-build-with-gcc-10.patch
+++ b/package/batocera/network/rtl8192eu/0001-Fix-build-with-gcc-10.patch
@@ -1,0 +1,116 @@
+From 40e7f8f69581feb02711363adac1c7e37d9f9ed6 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sat, 6 Feb 2021 10:06:22 +0000
+Subject: [PATCH] Fix build with gcc-10
+
+Fixes errors such as this:
+
+```
+os_dep/linux/ioctl_mp.c:611:4: warning: 'sprintf' argument 3 overlaps destination object 'extra' [-Wrestrict]
+error, forbidden warning:ioctl_mp.c:611
+  611 |    sprintf(extra, "%s,pathb=%d", extra, txpower_inx);
+```
+
+Fixes #221
+---
+ core/rtw_mp.c           |  3 ++-
+ os_dep/linux/ioctl_mp.c | 22 +++++++++++++---------
+ 2 files changed, 15 insertions(+), 10 deletions(-)
+
+diff --git a/core/rtw_mp.c b/core/rtw_mp.c
+index 5cf9f25..cb0c057 100644
+--- a/core/rtw_mp.c
++++ b/core/rtw_mp.c
+@@ -2418,6 +2418,7 @@ u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
+ 	u32 psd_data = 0;
+ 	struct psd_init_regs regs = {};
+ 	int psd_analysis = 0;
++	u8 *pdata = data;
+ 
+ #ifdef PLATFORM_LINUX
+ 	if (!netif_running(pAdapter->pnetdev)) {
+@@ -2449,7 +2450,7 @@ u32 mp_query_psd(PADAPTER pAdapter, u8 *data)
+ 			psd_data = rtw_GetPSDData(pAdapter, i - psd_pts);
+ 		else
+ 			psd_data = rtw_GetPSDData(pAdapter, i);
+-		sprintf(data, "%s%x ", data, psd_data);
++		pdata += sprintf(pdata, "%x ", psd_data);
+ 		i++;
+ 	}
+ 
+diff --git a/os_dep/linux/ioctl_mp.c b/os_dep/linux/ioctl_mp.c
+index f9f9b24..c4ef5a6 100644
+--- a/os_dep/linux/ioctl_mp.c
++++ b/os_dep/linux/ioctl_mp.c
+@@ -604,19 +604,20 @@ int rtw_mp_txpower_index(struct net_device *dev,
+ 		txpower_inx = mpt_ProQueryCalTxPower(padapter, rfpath);
+ 		sprintf(extra, " %d", txpower_inx);
+ 	} else {
++		char *pextra = extra;
+ 		txpower_inx = mpt_ProQueryCalTxPower(padapter, 0);
+-		sprintf(extra, "patha=%d", txpower_inx);
++		pextra += sprintf(extra, "patha=%d", txpower_inx);
+ 		if (phal_data->rf_type > RF_1T2R) {
+ 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 1);
+-			sprintf(extra, "%s,pathb=%d", extra, txpower_inx);
++			pextra += sprintf(pextra, ",pathb=%d", txpower_inx);
+ 		}
+ 		if (phal_data->rf_type > RF_2T4R) {
+ 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 2);
+-			sprintf(extra, "%s,pathc=%d", extra, txpower_inx);
++			pextra += sprintf(pextra, ",pathc=%d", txpower_inx);
+ 		}
+ 		if (phal_data->rf_type > RF_3T4R) {
+ 			txpower_inx = mpt_ProQueryCalTxPower(padapter, 3);
+-			sprintf(extra, "%s,pathd=%d", extra, txpower_inx);
++			pextra += sprintf(pextra, ",pathd=%d", txpower_inx);
+ 		}
+ 	}
+ 	wrqu->length = strlen(extra);
+@@ -2254,6 +2255,7 @@ int rtw_efuse_mask_file(struct net_device *dev,
+ 		return 0;
+ 	}
+ 	if (strncmp(extra, "data,", 5) == 0) {
++		char	*pextra = extra;
+ 		u8	*pch;
+ 		char	*ptmp, tmp;
+ 		u8	count = 0;
+@@ -2284,11 +2286,11 @@ int rtw_efuse_mask_file(struct net_device *dev,
+ 		 } while (count < 64);
+ 
+ 		for (i = 0; i < count; i++)
+-			sprintf(extra, "%s:%02x", extra, maskfileBuffer[i]);
++			pextra += sprintf(pextra, ":%02x", maskfileBuffer[i]);
+ 
+ 		padapter->registrypriv.bFileMaskEfuse = _TRUE;
+ 
+-		sprintf(extra, "%s\nLoad Efuse Mask data %d hex ok\n", extra, count);
++		pextra += sprintf(pextra, "\nLoad Efuse Mask data %d hex ok\n", count);
+ 		wrqu->data.length = strlen(extra);
+ 		return 0;
+ 	}
+@@ -2711,16 +2713,18 @@ todo:
+ 	mptbt_BtControlProcess(padapter, &BtReq);
+ 
+ 	if (readtherm == 0) {
+-		sprintf(extra, "BT thermal=");
++		char *pextra = extra;
++		pextra += sprintf(pextra, "BT thermal=");
+ 		for (i = 4; i < pMptCtx->mptOutLen; i++) {
+ 			if ((pMptCtx->mptOutBuf[i] == 0x00) && (pMptCtx->mptOutBuf[i + 1] == 0x00))
+ 				goto exit;
+ 
+-			sprintf(extra, "%s %d ", extra, (pMptCtx->mptOutBuf[i] & 0x1f));
++			pextra += sprintf(pextra, " %d ", (pMptCtx->mptOutBuf[i] & 0x1f));
+ 		}
+ 	} else {
++		char *pextra = extra + strlen(extra);
+ 		for (i = 4; i < pMptCtx->mptOutLen; i++)
+-			sprintf(extra, "%s 0x%x ", extra, pMptCtx->mptOutBuf[i]);
++			pextra += sprintf(pextra, " 0x%x ", pMptCtx->mptOutBuf[i]);
+ 	}
+ 
+ exit:
+-- 
+2.27.0
+


### PR DESCRIPTION
Fix also sent upstream: https://github.com/Mange/rtl8192eu-linux-driver/pull/222