### PR TITLE
Per-game libretro DOSBox settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -48,7 +48,11 @@ class LibretroGenerator(Generator):
         if system.name == 'neogeocd' and system.config['core'] == "fbneo":
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--subsystem", "neocd", "--config", system.config['configfile']]
         elif system.name == 'dos':
-            commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], rom + "/dosbox.bat"]
+            romDOSName = os.path.splitext(romName)[0]
+            if os.path.isfile(os.path.join(rom, romDOSName + ".bat")):
+                commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], os.path.join(rom, romDOSName + ".bat")]
+            else:
+                commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], rom + "/dosbox.bat"]
         else:
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
 


### PR DESCRIPTION
Allow to use "Game name.bat" instead of "dosbox.bat".
"Game name.bat" is preferred over "dosbox.bat".

Currently it is impossible to specify any per game settings for libretro-DOSBox games because name of game options file is derived from "dosbox.bat" and is "dosbox" for all games.
This commit resolves this issue by allowing to use "Game name.bat" instead of "dosbox.bat". If "Game name.bat" is used libretro recognizes game name and using game options files becomes possible.
The "Game name.bat" must not contain ".pc" folder extension.