### PR TITLE
genimage.cfg: Bump system partition sizes to 7 GiB

### DIFF
--- a/board/batocera/amlogic/odroidc2/genimage.cfg
+++ b/board/batocera/amlogic/odroidc2/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/odroidc4/genimage.cfg
+++ b/board/batocera/amlogic/odroidc4/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 			extraargs = "-F 32 -n BATOCERA"
 			@files
 		}
-		size = 3G
+		size = 7074M
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/odroidn2/genimage.cfg
+++ b/board/batocera/amlogic/odroidn2/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 			extraargs = "-F 32 -n BATOCERA"
 			@files
 		}
-		size = 3G
+		size = 7074M
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/s905/genimage.cfg
+++ b/board/batocera/amlogic/s905/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/s912/genimage.cfg
+++ b/board/batocera/amlogic/s912/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/amlogic/vim3/genimage.cfg
+++ b/board/batocera/amlogic/vim3/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 		extraargs = "-F 32 -n BATOCERA"
 		@files
 	}
-	size = 3G
+	size = 7074M
 }
 
 image userdata.ext4 {

--- a/board/batocera/libretech-h5/genimage.cfg
+++ b/board/batocera/libretech-h5/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 81765 * 512 * 63 = 2637411840
-		# 2637411840 / 1024 / 1024 = 2515 MiB
-		size = 2637411840
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/odroidxu4/genimage.cfg
+++ b/board/batocera/odroidxu4/genimage.cfg
@@ -21,9 +21,9 @@ image boot.vfat {
         #
 		# must be a multiple of 32 for the odroid xu4 ; i don't know why
 		#
-		# 81765 * 512 * 63 = 2637411840
-		# 2637411840 / 1024 / 1024 = 2515 MiB
-		size = 2637411840
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/orangepi-pc/genimage.cfg
+++ b/board/batocera/orangepi-pc/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 81765 * 512 * 63 = 2637411840
-		# 2637411840 / 1024 / 1024 = 2515 MiB
-		size = 2637411840
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/orangepi-zero2/genimage.cfg
+++ b/board/batocera/orangepi-zero2/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 81765 * 512 * 63 = 2637411840
-		# 2637411840 / 1024 / 1024 = 2515 MiB
-		size = 2637411840
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi3/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi3/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/raspberrypi/rpi4/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi4/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/odroidgoa/genimage.cfg
+++ b/board/batocera/rockchip/odroidgoa/genimage.cfg
@@ -21,9 +21,9 @@ image boot.vfat {
         #
         # must be a multiple of 32 for the odroid xu4 ; i don't know why
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3288/miqi/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/miqi/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
         # 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
         # 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
         #
-        # 81765 * 512 * 63 = 2637411840
-        # 2637411840 / 1024 / 1024 = 2515 MiB
-        size = 2637411840
+        # 229993 * 512 * 63 = 7418654208
+        # 7418654208 / 1024 / 1024 = 7074 MiB
+        size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3399/rock960/genimage.cfg
+++ b/board/batocera/rockchip/rk3399/rock960/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 		extraargs = "-F 32 -n BATOCERA"
 		@files
 	}
-	size = 3G
+	size = 7074M
 }
 
 image userdata.ext4 {

--- a/board/batocera/rockchip/rk3399/rockpro64/genimage.cfg
+++ b/board/batocera/rockchip/rk3399/rockpro64/genimage.cfg
@@ -3,7 +3,7 @@ image boot.vfat {
 		extraargs = "-F 32 -n BATOCERA"
 		@files
 	}
-	size = 3G
+	size = 7074M
 }
 
 image userdata.ext4 {

--- a/board/batocera/s812/genimage.cfg
+++ b/board/batocera/s812/genimage.cfg
@@ -19,9 +19,9 @@ image boot.vfat {
 		# 39009 tracks * 63 sector / track = 2457567 * 512 bytes / sector = 1258274304 bytes (16896 bytes under 1200M)
 		# 39010 tracks * 63 sector / track = 2457630 * 512 bytes / sector = 1258306560 bytes (15360 bytes over 1200M)
 		#
-		# 81765 * 512 * 63 = 2637411840
-		# 2637411840 / 1024 / 1024 = 2515 MiB
-		size = 2637411840
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }
 
 image userdata.ext4 {

--- a/board/batocera/x86/genimage-boot.cfg
+++ b/board/batocera/x86/genimage-boot.cfg
@@ -7,7 +7,7 @@ image boot.vfat {
         # Must be a multiple of  63 (err: Total number of sectors (2457600) not a multiple of sectors per track (63)!)
         # Must be a multiple of 512
         #
-        # 3225600000 / 1024 / 1024 / 1024 = 3   GB
-        # 3773952000 / 1024 / 1024 / 1024 = 3.5 GB
-        size = 3773952000
+		# 229993 * 512 * 63 = 7418654208
+		# 7418654208 / 1024 / 1024 = 7074 MiB
+		size = 7418654208
 }


### PR DESCRIPTION
Following discussion in batocera.linux.
This future proofs the upgrade process.

1. Using 7074 MiB, because exactly 7 GiB is not divisible by 63.
2. Assuming that SD cards and USB sticks smaller than 16 GiB are non-existent by now.
   Even 16 GiB cards are already disappearing.
3. 7 GiB chosen to still fit on an 8 GiB SD card.