### PR TITLE
PSX: Add hash for PSXONPSP660.BIN BIOS

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -139,12 +139,13 @@ systems = {
 
     # ---------- Sony Computer Entertainment ---------- #
     # https://docs.libretro.com/library/pcsx_rearmed/#bios
-    "psx": { "name": "PSX", "biosFiles": [  { "md5": "6e3735ff4c7dc899ee98981385f6f3d0", "file": "bios/scph101.bin"    },
-                                            { "md5": "dc2b9bf8da62ec93e868cfd29f0d067d", "file": "bios/scph1001.bin"   },
-                                            { "md5": "8dd7d5296a650fac7319bce665a6a53c", "file": "bios/scph5500.bin"   },
-                                            { "md5": "490f666e1afb15b7362b406ed1cea246", "file": "bios/scph5501.bin"   },
-                                            { "md5": "32736f17079d0b2b7024407c39bd3050", "file": "bios/scph5502.bin"   },
-                                            { "md5": "1e68c231d0896b7eadcad1d7d8e76129", "file": "bios/scph7001.bin"   } ] },
+    "psx": { "name": "PSX", "biosFiles": [  { "md5": "c53ca5908936d412331790f4426c6c33", "file": "bios/psxonpsp660.bin" },
+                                            { "md5": "6e3735ff4c7dc899ee98981385f6f3d0", "file": "bios/scph101.bin"     },
+                                            { "md5": "dc2b9bf8da62ec93e868cfd29f0d067d", "file": "bios/scph1001.bin"    },
+                                            { "md5": "8dd7d5296a650fac7319bce665a6a53c", "file": "bios/scph5500.bin"    },
+                                            { "md5": "490f666e1afb15b7362b406ed1cea246", "file": "bios/scph5501.bin"    },
+                                            { "md5": "32736f17079d0b2b7024407c39bd3050", "file": "bios/scph5502.bin"    },
+                                            { "md5": "1e68c231d0896b7eadcad1d7d8e76129", "file": "bios/scph7001.bin"    } ] },
 
     # https://pcsx2.net/config-guide/official-english-pcsx2-configuration-guide.html#Bios
     "ps2": { "name": "PS2", "biosFiles": [  { "md5": "28922c703cc7d2cf856f177f2985b3a9", "file": "bios/SCPH30004R.bin" },


### PR DESCRIPTION
Support was added to PCSX ReARMed in https://github.com/libretro/pcsx_rearmed/pull/339

This is perhaps the best BIOS for PSX, see https://forums.libretro.com/t/psx-bios-from-psp-6-60-optimised-to-play-games-more-smoothly-but-how/16976

See also: https://www.duckstation.org/wiki/BIOS.
We're still missing some bioses here, notably the one found on PS3: duckstation supports it but not PCSX ReARMed (sent https://github.com/libretro/pcsx_rearmed/pull/498)