### PR TITLE
Bump Proton (31)

### DIFF
--- a/package/batocera/emulators/wine/wine-proton-wow64_32/wine-proton-wow64_32.mk
+++ b/package/batocera/emulators/wine/wine-proton-wow64_32/wine-proton-wow64_32.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINE_PROTON_WOW64_32_VERSION = 2117f849363107537dfc954451ed96237b5b3f9d
+WINE_PROTON_WOW64_32_VERSION = proton-wine-5.13-6
 WINE_PROTON_WOW64_32_SITE = $(call github,ValveSoftware,wine,$(WINE_PROTON_WOW64_32_VERSION))
 WINE_PROTON_WOW64_32_LICENSE = LGPL-2.1+
 WINE_PROTON_WOW64_32_DEPENDENCIES = host-bison host-flex host-wine-proton

--- a/package/batocera/emulators/wine/wine-proton/wine-proton.mk
+++ b/package/batocera/emulators/wine/wine-proton/wine-proton.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINE_PROTON_VERSION = 2117f849363107537dfc954451ed96237b5b3f9d
+WINE_PROTON_VERSION = proton-wine-5.13-6
 WINE_PROTON_SITE = $(call github,ValveSoftware,wine,$(WINE_PROTON_VERSION))
 WINE_PROTON_LICENSE = LGPL-2.1+
 WINE_PROTON_DEPENDENCIES = host-bison host-flex host-wine-proton


### PR DESCRIPTION
Change log :
- Previously in Experimental: Fixed Cyberpunk 2077 world sound issues
- Previously in Experimental: Improved controller support and hotplugging in Yakuza Like a - Dragon, Subnautica, DOOM (2016), and Virginia
- Nioh 2 is now playable
- Fixed black screen on focus loss in DOOM Eternal on AMD
- Restored VR support in No Man's Sky
- Voice chat in Deep Rock Galactic is now functional
- Better support for PlayStation 5 controllers
- Sound in Dark Sector is working now
- Fixed Need for Speed (2015) hang on AMD
- More fixes for game input being active while the Steam overlay is up