### PR TITLE
Fix Mugen v30 + Master

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
@@ -31,13 +31,13 @@ class MugenGenerator(Generator):
         if not settings.has_section("Video"):
             settings.add_section("Video")
         settings.set("Video", "FullScreen", "1")
-        #settings.set("Video", "Width",  gameResolution["width"])
-        #settings.set("Video", "Height", gameResolution["height"])
+        settings.set("Video", "Width",  gameResolution["width"])
+        settings.set("Video", "Height", gameResolution["height"])
 
         if not settings.has_section("Config"):
             settings.add_section("Config")
-        #settings.set("Config", "GameWidth",  gameResolution["width"])
-        #settings.set("Config", "GameHeight", gameResolution["height"])
+        settings.set("Config", "GameWidth",  gameResolution["width"])
+        settings.set("Config", "GameHeight", gameResolution["height"])
         settings.set("Config", "Language", "en")
 
         # Save config


### PR DESCRIPTION
For safety we can leave both video options because if a game does not have the option present then it will take the other. 