### PR TITLE
Configuen Default Emu Update

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
@@ -2,30 +2,21 @@ default:
   options:
     video_threaded: true
 
-snes:
-  emulator: libretro
-  core:     snes9x_next
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+dos:
+  emulator: dosbox
+  core:     dosbox
 mastersystem:
   emulator: libretro
   core:     picodrive
 megadrive:
   emulator: libretro
   core:     picodrive
-dos:
-  emulator: dosbox
-  core: dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
+psp:
+  options:
+    frameskip: true
+snes:
+  emulator: libretro
+  core:     snes9x_next

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
@@ -2,14 +2,6 @@ default:
   options:
     video_threaded: true
 
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-    frameskiptype: 2
-    internalresolution: 2
 amiga500:
   emulator: amiberry
   core:     A500
@@ -21,4 +13,12 @@ amigacd32:
   core:     CD32
 dos:
   emulator: dosbox
-  core: dosbox
+  core:     dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
+psp:
+  options:
+    frameskip: true
+    frameskiptype: 2
+    internalresolution: 2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
@@ -5,22 +5,11 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
+  core:     glide64mk2
 neogeocd:
   emulator: libretro
   core:     fbneo
-amiga500:
-  emulator: libretro
-  core:     puae
-amiga1200:
-  emulator: libretro
-  core:     puae
-amigacd32:
-  emulator: libretro
-  core:     puae
-amigacdtv:
-  emulator: libretro
-  core:     puae
+psp:
+  options:
+    frameskip: true
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
@@ -1,22 +1,13 @@
 default:
   options:
     video_threaded: true
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+
 dos:
   emulator: dosbox
-  core: dosbox
+  core:     dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
@@ -11,7 +11,7 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
   options:
     mupen64plus.Video-Glide64mk2.aspect: 2
     mupen64plus.Video-General.Rotate: 0 # for people upgrading
@@ -19,12 +19,4 @@ psp:
   options:
     frameskip: true
     ppsspp.General.InternalScreenRotation: 0 # for people upgrading
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidn2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidn2.yml
@@ -1,29 +1,20 @@
 default:
   options:
     video_threaded: true
-n64:
-  emulator: libretro
-  core: mupen64plus-next
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+
 gamecube:
   emulator: dolphin
-  core: dolphin
+  core:     dolphin
   options:
     platform: drm
-wii:
-  emulator: dolphin
-  core: dolphin
-  options:
-    platform: drm
+n64:
+  emulator: libretro
+  core:     mupen64plus-next
 nds:
   emulator: libretro
   core:     melonds
-
+wii:
+  emulator: dolphin
+  core:     dolphin
+  options:
+    platform: drm

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -5,28 +5,19 @@ default:
     retroarch.audio_latency:   64
     retroarch.video_hard_sync: 0
     
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
-psx:
+dreamcast:
   options:
     # menu retroarch
     # settings to fix sound issue only on Odroid XU4
     retroarch.audio_latency:   128
     retroarch.video_hard_sync: 1
-dreamcast:
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
+psp:
+  options:
+    frameskip: true
+psx:
   options:
     # menu retroarch
     # settings to fix sound issue only on Odroid XU4

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
@@ -2,30 +2,21 @@ default:
   options:
     video_threaded: true
 
-snes:
-  emulator: libretro
-  core:     snes9x_next
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+dos:
+  emulator: dosbox
+  core:     dosbox
 mastersystem:
   emulator: libretro
   core:     picodrive
 megadrive:
   emulator: libretro
   core:     picodrive
-dos:
-  emulator: dosbox
-  core: dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
+psp:
+  options:
+    frameskip: true
+snes:
+  emulator: libretro
+  core:     snes9x_next

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
@@ -1,18 +1,10 @@
 default:
   options:
     video_threaded: true
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+
 dos:
   emulator: dosbox
-  core: dosbox
+  core:     dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
@@ -4,19 +4,10 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
 psp:
   options:
     frameskip: true
     frameskiptype: 2
     internalresolution: 2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
 

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rockpro64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rockpro64.yml
@@ -5,18 +5,10 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
 psp:
   options:
     frameskip: true
     frameskiptype: 2
     internalresolution: 2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi1.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi1.yml
@@ -4,15 +4,6 @@ default:
     video_threaded: true
     smooth:         false
     
-snes:
-  emulator: libretro
-  core:     pocketsnes
-gba:
-  emulator: libretro
-  core:     gpsp
-mame:
-  emulator: libretro
-  core:     imame4all
 amiga500:
   emulator: amiberry
   core:     A500
@@ -22,12 +13,21 @@ amiga1200:
 amigacd32:
   emulator: amiberry
   core:     CD32
+dos:
+  emulator: dosbox
+  core:     dosbox
+gba:
+  emulator: libretro
+  core:     gpsp
+mame:
+  emulator: libretro
+  core:     imame4all
 mastersystem:
   emulator: libretro
   core:     picodrive
 megadrive:
   emulator: libretro
   core:     picodrive
-dos:
-  emulator: dosbox
-  core: dosbox
+snes:
+  emulator: libretro
+  core:     pocketsnes

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi2.yml
@@ -3,12 +3,6 @@ default:
     video_threaded: true
     videomode:      CEA 4 HDMI
 
-snes:
-  emulator: libretro
-  core:     snes9x_next
-n64:
-  options:
-    videomode: DMT 4 HDMI
 amiga500:
   emulator: amiberry
   core:     A500
@@ -24,3 +18,9 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
+n64:
+  options:
+    videomode: DMT 4 HDMI
+snes:
+  emulator: libretro
+  core:     snes9x_next

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -9,12 +9,3 @@ psp:
   options:
     frameskip: true
     videomode: DMT 4 HDMI
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -4,19 +4,10 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds
+psp:
+  options:
+    frameskip: true

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
@@ -3,30 +3,21 @@ default:
     video_threaded: true
     retroarch.audio_out_rate: 44100
 
-snes:
-  emulator: libretro
-  core:     snes9x_next
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-psp:
-  options:
-    frameskip: true
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+dos:
+  emulator: dosbox
+  core:     dosbox
 mastersystem:
   emulator: libretro
   core:     picodrive
 megadrive:
   emulator: libretro
   core:     picodrive
-dos:
-  emulator: dosbox
-  core: dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
+psp:
+  options:
+    frameskip: true
+snes:
+  emulator: libretro
+  core:     snes9x_next

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
@@ -5,19 +5,8 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
 psp:
   options:
     frameskip: true
-amiga500:
-  emulator: libretro
-  core:     puae
-amiga1200:
-  emulator: libretro
-  core:     puae
-amigacd32:
-  emulator: libretro
-  core:     puae
-amigacdtv:
-  emulator: libretro
-  core:     puae
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
@@ -1,22 +1,13 @@
 default:
   options:
     video_threaded: true
-n64:
-  emulator: mupen64plus
-  core: glide64mk2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+
 dos:
   emulator: dosbox
-  core: dosbox
+  core:     dosbox
+n64:
+  emulator: mupen64plus
+  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds
-

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
@@ -4,19 +4,8 @@ default:
 
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
 psp:
   options:
     frameskip: true
-amiga500:
-  emulator: libretro
-  core:     puae
-amiga1200:
-  emulator: libretro
-  core:     puae
-amigacd32:
-  emulator: libretro
-  core:     puae
-amigacdtv:
-  emulator: libretro
-  core:     puae
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
@@ -2,23 +2,14 @@ default:
   options:
     video_threaded: true
 
+dos:
+  emulator: dosbox
+  core:     dosbox
 n64:
   emulator: mupen64plus
-  core: glide64mk2
+  core:     glide64mk2
 psp:
   options:
     frameskip: true
     frameskiptype: 2
     internalresolution: 2
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
-dos:
-  emulator: dosbox
-  core: dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-vim3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-vim3.yml
@@ -1,29 +1,20 @@
 default:
   options:
     video_threaded: true
-n64:
-  emulator: libretro
-  core: mupen64plus-next
-amiga500:
-  emulator: amiberry
-  core:     A500
-amiga1200:
-  emulator: amiberry
-  core:     A1200
-amigacd32:
-  emulator: amiberry
-  core:     CD32
+
 gamecube:
   emulator: dolphin
-  core: dolphin
+  core:     dolphin
   options:
     platform: drm
-wii:
-  emulator: dolphin
-  core: dolphin
-  options:
-    platform: drm
+n64:
+  emulator: libretro
+  core:     mupen64plus-next
 nds:
   emulator: libretro
   core:     melonds
-
+wii:
+  emulator: dolphin
+  core:     dolphin
+  options:
+    platform: drm

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86.yml
@@ -1,21 +1,19 @@
 default:
   options:
     duckstationControllerBackend: auto
+
+model3:
+  emulator: supermodel
+  core:     supermodel
 n64:
   emulator: mupen64plus
-  core: glide64mk2
-saturn:
-  emulator: libretro
-  core:     beetle-saturn
-amigacdtv:
-  emulator: fsuae
-  core:     CDTV
+  core:     glide64mk2
 pcengine:
   emulator: libretro
   core:     pce
 pcenginecd:
   emulator: libretro
   core:     pce
-model3:
-  emulator: supermodel
-  core:     supermodel
+saturn:
+  emulator: libretro
+  core:     beetle-saturn

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -10,119 +10,24 @@ default:
     bezel:          default
     forceNoBezel:   false
     duckstationControllerBackend: evdev
-nes:
+
+# 0-C
+
+3do:
   emulator: libretro
-  core:     fceumm
-snes:
-  emulator: libretro
-  core:     snes9x
-n64:
-  emulator: mupen64plus
-  core:     gliden64
-gba:
-  emulator: libretro
-  core:     mgba
-gb:
-  emulator: libretro
-  core:     gambatte
-gbc:
-  emulator: libretro
-  core:     gambatte
-gb2players:
-  emulator: libretro
-  core:     tgbdual
-gbc2players:
-  emulator: libretro
-  core:     tgbdual
-fds:
-  emulator: libretro
-  core:     fceumm
-virtualboy:
-  emulator: libretro
-  core:     vb
-gamecube:
-  emulator: dolphin
-  core: dolphin
-wii:
-  emulator: dolphin
-  core: dolphin
-ps2:
-  emulator: pcsx2
-  core: pcsx2
-  options:
-    fullboot: true
-nds:
-  emulator: libretro
-  core:     desmume
+  core:     opera
 3ds:
   emulator: citra
   core:     citra
-sg1000:
-  emulator: libretro
-  core:     genesisplusgx
-mastersystem:
-  emulator: libretro
-  core:     genesisplusgx
-megadrive:
-  emulator: libretro
-  core:     genesisplusgx
-gamegear:
-  emulator: libretro
-  core:     genesisplusgx
-sega32x:
-  emulator: libretro
-  core:     picodrive
-segacd:
-  emulator: libretro
-  core:     genesisplusgx
-saturn:
-  emulator: libretro
-  core:     yabasanshiro
-dreamcast:
-  emulator: libretro
-  core: flycast
-atomiswave:
-  emulator: libretro
-  core:     flycast
-naomi:
-  emulator: libretro
-  core:     flycast
-neogeo:
-  emulator: libretro
-  core:     fbneo
-neogeocd:
-  emulator: libretro
-  core:     neocd
-mame:
-  emulator: libretro
-  core:     mame078plus
-hbmame:
-  emulator: libretro
-  core:     hbmame
-fbneo:
-  emulator: libretro
-  core:     fbneo
-msx1:
-  emulator: libretro
-  core:     bluemsx
-msx2:
-  emulator: libretro
-  core:     bluemsx
-msx2+:
-  emulator: libretro
-  core:     bluemsx
-msxturbor:
-  emulator: libretro
-  core:     bluemsx
 amiga500:
-  emulator: fsuae
-  core:     A500
+  emulator: libretro
+  core:     puae
 amiga1200:
-  emulator: fsuae
-  core:     A1200
+  emulator: libretro
+  core:     puae
 amigacd32:
-  emulator: fsuae
-  core:     CD32
+  emulator: libretro
+  core:     puae
 amigacdtv:
   emulator: libretro
   core:     puae
@@ -131,87 +36,9 @@ amstradcpc:
   core:     cap32
 apple2:
   emulator: linapple
-  core: linapple
+  core:     linapple
   options:
     videomode: default
-atarist:
-  emulator: libretro
-  core:     hatari
-zxspectrum:
-  emulator: libretro
-  core:     fuse
-odyssey2:
-  emulator: libretro
-  core:     o2em
-zx81:
-  emulator: libretro
-  core:     '81'
-dos:
-  emulator: libretro
-  core: dosbox_pure
-  options:
-    videomode: default
-    video_threaded: false
-c64:
-  emulator: vice
-  core:     x64
-c128:
-  emulator: vice
-  core:     x128
-c20:
-  emulator: vice
-  core:     xvic
-pet:
-  emulator: vice
-  core:     xpet
-x68000:
-  emulator: libretro
-  core:     px68k
-ngp:
-  emulator: libretro
-  core:     mednafen_ngp
-ngpc:
-  emulator: libretro
-  core:     mednafen_ngp
-gameandwatch:
-  emulator: libretro
-  core:     gw
-  options:
-    forceNoBezel: true
-vectrex:
-  emulator: libretro
-  core:     vecx
-lynx:
-  emulator: libretro
-  core:     mednafen_lynx
-lutro:
-  emulator: libretro
-  core:     lutro
-wswan:
-  emulator: libretro
-  core:     mednafen_wswan
-  options:
-    ratio: 16/10
-wswanc:
-  emulator: libretro
-  core: mednafen_wswan
-  options:
-    ratio: 16/10
-pcengine:
-  emulator: libretro
-  core:     pce_fast
-pcenginecd:
-  emulator: libretro
-  core:     pce_fast
-supergrafx:
-  emulator: libretro
-  core:     mednafen_supergrafx
-pcfx:
-  emulator: libretro
-  core:     pcfx
-intellivision:
-  emulator: libretro
-  core:     freeintv
 atari2600:
   emulator: libretro
   core:     stella
@@ -224,129 +51,318 @@ atari7800:
 atari800:
   emulator: libretro
   core:     atari800
-prboom:
+atarist:
   emulator: libretro
-  core:     prboom
-mrboom:
+  core:     hatari
+atomiswave:
   emulator: libretro
-  core:     mrboom
+  core:     flycast
+c64:
+  emulator: vice
+  core:     x64
+c128:
+  emulator: vice
+  core:     x128
+c20:
+  emulator: vice
+  core:     xvic
 cannonball:
   emulator: cannonball
   core:     cannonball
-sdlpop:
-  emulator: sdlpop
-  core:     sdlpop
-psx:
-  emulator: libretro
-  core:     pcsx_rearmed
 cavestory:
   emulator: libretro
   core:     nxengine
-scummvm:
+channelf:
   emulator: libretro
-  core:     scummvm
+  core:     freechaf
 colecovision:
   emulator: libretro
   core:     bluemsx
+
+# D-L
+
+daphne:
+  emulator: daphne
+  core:     hypseus
+devilutionx:
+  emulator: devilutionx
+  core:     devilutionx
+dos:
+  emulator: libretro
+  core:     dosbox_pure
+  options:
+    videomode: default
+    video_threaded: false
+dreamcast:
+  emulator: libretro
+  core:     flycast
+easyrpg:
+  emulator: easyrpg
+  core:     easyrpg
+fbneo:
+  emulator: libretro
+  core:     fbneo
+fds:
+  emulator: libretro
+  core:     fceumm
+flash:
+  emulator: ruffle
+  core:     ruffle
+fmtowns:
+  emulator: tsugaru
+  core:     tsugaru
+gameandwatch:
+  emulator: libretro
+  core:     gw
+  options:
+    forceNoBezel: true
+gamecube:
+  emulator: dolphin
+  core:     dolphin
+gamegear:
+  emulator: libretro
+  core:     genesisplusgx
+gb:
+  emulator: libretro
+  core:     gambatte
+gb2players:
+  emulator: libretro
+  core:     tgbdual
+gba:
+  emulator: libretro
+  core:     mgba
+gbc:
+  emulator: libretro
+  core:     gambatte
+gbc2players:
+  emulator: libretro
+  core:     tgbdual
+gx4000:
+  emulator: libretro
+  core:     cap32
+hbmame:
+  emulator: libretro
+  core:     hbmame
+intellivision:
+  emulator: libretro
+  core:     freeintv
 jaguar:
   emulator: libretro
   core:     virtualjaguar
-3do:
-  emulator: libretro
-  core:     opera
 kodi:
   emulator: kodi
   options:
     videomode: default
+lightgun:
+  emulator: libretro
+  core:     mame078plus
+lutro:
+  emulator: libretro
+  core:     lutro
+lynx:
+  emulator: libretro
+  core:     mednafen_lynx
+
+# M-O
+
+mame:
+  emulator: libretro
+  core:     mame078plus
+mastersystem:
+  emulator: libretro
+  core:     genesisplusgx
+megadrive:
+  emulator: libretro
+  core:     genesisplusgx
 moonlight:
   emulator: moonlight
   core: moonlight
-psp:
-  emulator: ppsspp
-  core: ppsspp
-satellaview:
+mrboom:
   emulator: libretro
-  core:     snes9x
-sufami:
+  core:     mrboom
+msx1:
   emulator: libretro
-  core:     snes9x
-pokemini:
+  core:     bluemsx
+msx2:
   emulator: libretro
-  core:     pokemini
-gx4000:
+  core:     bluemsx
+msx2+:
   emulator: libretro
-  core:     cap32
-thomson:
+  core:     bluemsx
+msxturbor:
   emulator: libretro
-  core:     theodore
+  core:     bluemsx
+mugen:
+  emulator: mugen
+  core:     proton
+n64:
+  emulator: mupen64plus
+  core:     gliden64
+naomi:
+  emulator: libretro
+  core:     flycast
+nds:
+  emulator: libretro
+  core:     desmume
+neogeo:
+  emulator: libretro
+  core:     fbneo
+neogeocd:
+  emulator: libretro
+  core:     neocd
+nes:
+  emulator: libretro
+  core:     fceumm
+ngp:
+  emulator: libretro
+  core:     mednafen_ngp
+ngpc:
+  emulator: libretro
+  core:     mednafen_ngp
+odyssey2:
+  emulator: libretro
+  core:     o2em
+openbor:
+  emulator: openbor
+  core:     openbor6412
+  options:
+    ratio:  0
+    filter: 0
+
+# P-S
+
 pc88:
   emulator: libretro
   core:     quasi88
 pc98:
   emulator: libretro
   core:     np2kai
-lightgun:
+pcengine:
   emulator: libretro
-  core:     mame078plus
-daphne:
-  emulator: daphne
-  core:     hypseus
+  core:     pce_fast
+pcenginecd:
+  emulator: libretro
+  core:     pce_fast
+pcfx:
+  emulator: libretro
+  core:     pcfx
+pet:
+  emulator: vice
+  core:     xpet
+pico8:
+  emulator: libretro
+  core:     retro8
+  options:
+    ratio: 1/1
+pokemini:
+  emulator: libretro
+  core:     pokemini
+prboom:
+  emulator: libretro
+  core:     prboom
+ps2:
+  emulator: pcsx2
+  core:     pcsx2
+  options:
+    fullboot: true
+ps3:
+  emulator: rpcs3
+  core:     rpcs3
+psp:
+  emulator: ppsspp
+  core: ppsspp
+psx:
+  emulator: libretro
+  core:     pcsx_rearmed
+pygame:
+  emulator: pygame
+  core:     pygame
+satellaview:
+  emulator: libretro
+  core:     snes9x
+saturn:
+  emulator: libretro
+  core:     yabasanshiro
+scummvm:
+  emulator: libretro
+  core:     scummvm
+sdlpop:
+  emulator: sdlpop
+  core:     sdlpop
+sega32x:
+  emulator: libretro
+  core:     picodrive
+segacd:
+  emulator: libretro
+  core:     genesisplusgx
+sg1000:
+  emulator: libretro
+  core:     genesisplusgx
+solarus:
+  emulator: solarus
+  core:     solarus
+sufami:
+  emulator: libretro
+  core:     snes9x
+snes:
+  emulator: libretro
+  core:     snes9x
+supergrafx:
+  emulator: libretro
+  core:     mednafen_supergrafx
+
+# T-Z
+
+thomson:
+  emulator: libretro
+  core:     theodore
+tic80:
+  emulator: libretro
+  core:     tic80
 tyrquake:
   emulator: libretro
   core:     tyrquake
-openbor:
-  emulator: openbor
-  core:     openbor6412
-  options:
-    ratio: 0
-    filter: 0
+vectrex:
+  emulator: libretro
+  core:     vecx
+virtualboy:
+  emulator: libretro
+  core:     vb
+wii:
+  emulator: dolphin
+  core:     dolphin
+wiiu:
+  emulator: cemu
+  core:     cemu
 windows:
   emulator: wine
   core:     proton
 windows_installers:
   emulator: wine
   core:     proton
-wiiu:
-  emulator: cemu
-  core:     cemu
-ps3:
-  emulator: rpcs3
-  core:     rpcs3
-pygame:
-  emulator: pygame
-  core:     pygame
-tic80:
+wswan:
   emulator: libretro
-  core:     tic80
-pico8:
-  emulator: libretro
-  core:     retro8
+  core:     mednafen_wswan
   options:
-    ratio: 1/1
-channelf:
+    ratio: 16/10
+wswanc:
   emulator: libretro
-  core:     freechaf
+  core:     mednafen_wswan
+  options:
+    ratio: 16/10
 x1:
   emulator: libretro
   core:     x1
-devilutionx:
-  emulator: devilutionx
-  core:     devilutionx
-solarus:
-  emulator: solarus
-  core:     solarus
-easyrpg:
-  emulator: easyrpg
-  core:     easyrpg
+x68000:
+  emulator: libretro
+  core:     px68k
 xash3d_fwgs:
   emulator: xash3d_fwgs
   core:     xash3d_fwgs
-fmtowns:
-  emulator: tsugaru
-  core:     tsugaru
-mugen:
-  emulator: mugen
-  core:     proton
-flash:
-  emulator: ruffle
-  core:     ruffle
+zx81:
+  emulator: libretro
+  core:     '81'
+zxspectrum:
+  emulator: libretro
+  core:     fuse
+  


### PR DESCRIPTION
- Alphabetically order systems
- Change FSUAE by default by PUAE
- Let Amiberry for boards less powerful than PI3b+