### PR TITLE
Increase the /userdata partition to 512MB

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -68,6 +68,7 @@
 	* fix: USB boot on RPi3 and RPi4
 	* fix: set mac eth addr for vim3
 	* fix: trash on file manager
+	* fix: resizing issue with 2TB or larger drives (now 4k block size)
 
 2020/12/11 - batocera.linux 29
 	* new version is 29. before this, the codification was 5.xx, so the 28th version was 5.27.2. the 1st version (with the same technical arch) was 5.0.

--- a/board/batocera/amlogic/odroidc2/genimage.cfg
+++ b/board/batocera/amlogic/odroidc2/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/odroidc4/genimage.cfg
+++ b/board/batocera/amlogic/odroidc4/genimage.cfg
@@ -12,7 +12,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/odroidn2/genimage.cfg
+++ b/board/batocera/amlogic/odroidn2/genimage.cfg
@@ -12,7 +12,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/s905/genimage.cfg
+++ b/board/batocera/amlogic/s905/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/s905gen3/genimage.cfg
+++ b/board/batocera/amlogic/s905gen3/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/s912/genimage.cfg
+++ b/board/batocera/amlogic/s912/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/amlogic/vim3/genimage.cfg
+++ b/board/batocera/amlogic/vim3/genimage.cfg
@@ -12,7 +12,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/libretech-h5/genimage.cfg
+++ b/board/batocera/libretech-h5/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/odroidxu4/genimage.cfg
+++ b/board/batocera/odroidxu4/genimage.cfg
@@ -32,7 +32,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/orangepi-pc/genimage.cfg
+++ b/board/batocera/orangepi-pc/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/orangepi-zero2/genimage.cfg
+++ b/board/batocera/orangepi-zero2/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/raspberrypi/rpi/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/raspberrypi/rpi3/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi3/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/raspberrypi/rpi4/genimage.cfg
+++ b/board/batocera/raspberrypi/rpi4/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/rockchip/odroidgoa/genimage.cfg
+++ b/board/batocera/rockchip/odroidgoa/genimage.cfg
@@ -32,7 +32,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/rockchip/rk3288/miqi/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/miqi/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
+++ b/board/batocera/rockchip/rk3288/tinkerboard/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/rockchip/rk3399/rock960/genimage.cfg
+++ b/board/batocera/rockchip/rk3399/rock960/genimage.cfg
@@ -12,7 +12,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/rockchip/rk3399/rockpro64/genimage.cfg
+++ b/board/batocera/rockchip/rk3399/rockpro64/genimage.cfg
@@ -12,7 +12,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/s812/genimage.cfg
+++ b/board/batocera/s812/genimage.cfg
@@ -30,7 +30,7 @@ image userdata.ext4 {
 		use-mke2fs = "true"
 		extraargs = "-m 0"
 	}
-	size = "256M"
+	size = "512M"
 	# include files from TARGET_DIR/userdata
 	mountpoint = "/userdata"
 }

--- a/board/batocera/x86/genimage.cfg
+++ b/board/batocera/x86/genimage.cfg
@@ -4,7 +4,7 @@ image userdata.ext4 {
             use-mke2fs = "true"
             extraargs = "-m 0"
         }
-        size = "256M"
+        size = "512M"
         # include files from TARGET_DIR/userdata
         mountpoint = "/userdata"
 }


### PR DESCRIPTION
This is a cleaner way to get the 4k block size
mke2fs will now use the default profile as a result
This avoids large drive not resizing properly.

Tested on multiple drive sizes.

Please add to v30 also.