### PR TITLE
Bump batocera-settings to 0.0.3

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings.hash
+++ b/package/batocera/core/batocera-settings/batocera-settings.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  f547318502d83fc0eab544d0f2a2f405ea895dd250b37c8e5fe45196664bd084  batocera-settings-0.0.2.tar.gz
+sha256  82fde321fb1aa5425071a7bad58fa09b8434dcae06983fe029f6fa926bb03c9a  batocera-settings-0.0.3.tar.gz
 sha256  c64a84bc21adbd6cf8d2a552ed5c4e33d90d13dae3cadb8babf259af01b81e0f  LICENSE

--- a/package/batocera/core/batocera-settings/batocera-settings.mk
+++ b/package/batocera/core/batocera-settings/batocera-settings.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SETTINGS_VERSION = 0.0.2
+BATOCERA_SETTINGS_VERSION = 0.0.3
 BATOCERA_SETTINGS_LICENSE = MIT
 BATOCERA_SETTINGS_SITE = $(call github,batocera-linux,mini_settings,$(BATOCERA_SETTINGS_VERSION))
 BATOCERA_SETTINGS_CONF_OPTS = \


### PR DESCRIPTION
Adds support for UTF-8 byte order mark. https://github.com/batocera-linux/mini_settings/commit/4ca2be9c688b2f6a9e0c7d48c7b77ba18f1f004e

The config file should not contain them in the first place but it can happen with certain editors and is unintuitive for users to diagnose.

Reported in https://forum.batocera.org/d/5391-bluethoot-stopped/4