### PR TITLE
Fix for Supermodel shaders (no geometry) using Legacy3D or New3D without Quad

### DIFF
--- a/package/batocera/emulators/supermodel/003-fix-r3dshadertriangles-mesa.patch
+++ b/package/batocera/emulators/supermodel/003-fix-r3dshadertriangles-mesa.patch
@@ -1,0 +1,20 @@
+--- a/Src/Graphics/New3D/R3DShaderTriangles.h	2021-03-03 14:04:46.971560780 +0100
++++ b/Src/Graphics/New3D/R3DShaderTriangles.h	2021-03-03 14:08:49.444885783 +0100
+@@ -3,7 +3,7 @@
+ 
+ static const char *vertexShaderR3D = R"glsl(
+ 
+-#version 120
++#version 130
+ 
+ // uniforms
+ uniform float	modelScale;
+@@ -61,7 +61,7 @@
+ 
+ static const char *fragmentShaderR3D = R"glsl(
+ 
+-#version 120
++#version 130
+ 
+ uniform sampler2D tex1;			// base tex
+ uniform sampler2D tex2;			// micro tex (optional)

--- a/package/batocera/emulators/supermodel/supermodel.mk
+++ b/package/batocera/emulators/supermodel/supermodel.mk
@@ -30,6 +30,7 @@ define SUPERMODEL_LINE_ENDINGS_FIXUP
 	# DOS2UNIX Supermodel.ini and Main.cpp - patch system does not support different line endings
 	sed -i -E -e "s|\r$$||g" $(@D)/Src/OSD/SDL/Main.cpp
 	sed -i -E -e "s|\r$$||g" $(@D)/Src/Inputs/Inputs.cpp
+	sed -i -E -e "s|\r$$||g" $(@D)/Src/Graphics/New3D/R3DShaderTriangles.h
 endef
 
 define SUPERMODEL_POST_PROCESS


### PR DESCRIPTION
Worth cherry-picking for 30 or if we do a 30.1 release