### PR TITLE
Fix resize (making the 2nd partition unusable on other OSs)

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S02resize
+++ b/board/batocera/fsoverlay/etc/init.d/S02resize
@@ -47,6 +47,7 @@ then
 	"Syncing disk data..........." "Pending"
 	"Checking disk table........." "Pending"
 	"Resizing partition.........." "Pending"
+	"Aligning /userdata.........." "Pending"
 	"Checking /userdata.........." "Pending"
 	"Resizing /userdata.........." "Pending"
     )
@@ -66,14 +67,16 @@ then
     mount -o remount,rw /boot && sed -i -e s+'^[ ]*autoresize'+'#autoresize'+ "${BOOTCONF}" && mount -o remount,ro /boot
 
     # textoutput "Message" "percentage" "command call" 
-    for i in 1 3 5 7 9 11; do
+    for i in 1 3 5 7 9 11 13; do
 	case $i in
 	    1) textoutput $i 01 "sleep 0.1";;
 	    3) textoutput $i 10 "sync";;
 	    5) textoutput $i 30 "sgdisk -e ${DISK}";;
-	    7) textoutput $i 40 "parted -s -m ${DISK} resizepart 2 100%";;
-	    9) textoutput $i 55 "e2fsck -f -p ${PART}";;
-	    11) textoutput $i 75 "resize2fs ${PART}";;
+	    # resizepart can't use 100% otherwise problem with GPT copied at the end of the disk/sdcard
+	    7) textoutput $i 40 "parted -s -m ${DISK} resizepart 2 99%";;
+	    9) textoutput $i 45 "parted -s -m ${DISK} align-check opt 2";;
+	    11) textoutput $i 55 "e2fsck -f -p ${PART}";;
+	    13) textoutput $i 75 "resize2fs ${PART}";;
 	esac
     done
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-install
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-install
@@ -196,7 +196,7 @@ do_install() {
 
     # install
     echo "zcat \"${INSIMG}\" | dd of=\"/dev/${INSDISK}\" bs=40M"
-    echo "writting the disk ${INSDISK}, please wait..."
+    echo "writing to disk ${INSDISK}, please wait..."
     if ! zcat "${INSIMG}" | dd of="/dev/${INSDISK}" bs=40M
     then
 	return 1


### PR DESCRIPTION
I tested on 2 different SDCards (64 and 128GB) and got an issue with resizing on v30, making the second partition unusable on other Linux machines (even other Batoceras!). Not sure if that is the case for **all** SD cards, but to reproduce:

1. Install a fresh Batocera
2. Boot, let the "Resizing partition" process happen
3. Everything seems to be fine, but if you mount this new resized partition into another Batocera box (for example, to copy ROMS), you have the following behavior:
   3.1 By default, only the system partition is mounted (`/dev/sda1` on `/media/BATOCERA` with type `vfat`, but no `/dev/sda2` in my case)
   3.2 Try to force it with: `# mount -t ext4 /dev/sda2 /tmp/oga/`
         ```
         mount: mounting /dev/sda2 on /tmp/oga/ failed: Invalid argument
         ```
   3.3 `# sgdisk /dev/sda`
 ``` Found invalid GPT and valid MBR; converting MBR to GPT format in memory. 
  Warning! Secondary partition table overlaps the last partition by 206625 blocks!
  You will need to delete this partition or resize it in another utility.
  ```
   
   3.4 `fsck.ext4 /dev/sda2` complains about errors as well.

Reason: MBR stores the partition data only at the beginning of the disk. GPT stores it also at the last sectors of the disk, which are overwritten by the `parted resizepart 2 100%` command during S02resize. This PR fixes it.
