### PR TITLE
Fix: RPi4 favored interlaced over progressive video modes

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
@@ -74,7 +74,8 @@ case "${ACTION}" in
 	# select a new one
 	# select the first one valid
 	# is it the best ? or should we loop to search the first with the same ratio ?
-	f_listModes | sed -e s+"^\([0-9]*\):\([0-9]*x[0-9]*\) \([0-9]*\)\(.*\)$"+"\2_\3:\1:\2"+ | sort -rn | # highest resolution first
+	# Highest resolution first, but list [p]rogressive before [i]nterlaced (p is omitted by default)
+	f_listModes | sed -e "/i)$/!"s+")$"+"p)"+ -e s+"^\([0-9]*\):\([0-9]*x[0-9]*\) \([0-9]*\)Hz (\(.*\))$"+"\2_\3_\4:\1:\2"+ | sort -nr | sed -e "s/_[0-9]*x[0-9]*[pi]//" |
             while IFS=':\n' read SORTSTR SUGGMODE SUGGRESOLUTION
             do
 		SUGGWIDTH=$(echo "${SUGGRESOLUTION}" | cut -d x -f 1)


### PR DESCRIPTION
Issue explained in https://github.com/batocera-linux/batocera.linux/issues/3357 
The new voodoo sed command puts the progressive resolutions (1920x1080) above interlaced (1920x1080i) in the ordered list.