### PR TITLE
Lima based boards do not implement fences used in SDL 2.0.14 atomic k…

### DIFF
--- a/board/batocera/amlogic/odroidc2/patches/sdl2/001-force-kmsdrm-legacy.patch
+++ b/board/batocera/amlogic/odroidc2/patches/sdl2/001-force-kmsdrm-legacy.patch
@@ -1,0 +1,10 @@
+--- a/src/video/SDL_video.c	2021-03-13 23:56:52.682656805 +0100
++++ b/src/video/SDL_video.c	2021-03-13 23:57:03.129323317 +0100
+@@ -95,7 +95,6 @@
+     &PSP_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_KMSDRM
+-    &KMSDRM_bootstrap,
+     &KMSDRM_LEGACY_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_RPI

--- a/board/batocera/amlogic/s905/patches/sdl2/001-force-kmsdrm-legacy.patch
+++ b/board/batocera/amlogic/s905/patches/sdl2/001-force-kmsdrm-legacy.patch
@@ -1,0 +1,10 @@
+--- a/src/video/SDL_video.c	2021-03-13 23:56:52.682656805 +0100
++++ b/src/video/SDL_video.c	2021-03-13 23:57:03.129323317 +0100
+@@ -95,7 +95,6 @@
+     &PSP_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_KMSDRM
+-    &KMSDRM_bootstrap,
+     &KMSDRM_LEGACY_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_RPI

--- a/board/batocera/libretech-h5/patches/sdl2/001-force-kmsdrm-legacy.patch
+++ b/board/batocera/libretech-h5/patches/sdl2/001-force-kmsdrm-legacy.patch
@@ -1,0 +1,10 @@
+--- a/src/video/SDL_video.c	2021-03-13 23:56:52.682656805 +0100
++++ b/src/video/SDL_video.c	2021-03-13 23:57:03.129323317 +0100
+@@ -95,7 +95,6 @@
+     &PSP_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_KMSDRM
+-    &KMSDRM_bootstrap,
+     &KMSDRM_LEGACY_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_RPI

--- a/board/batocera/orangepi-pc/patches/sdl2/001-force-kmsdrm-legacy.patch
+++ b/board/batocera/orangepi-pc/patches/sdl2/001-force-kmsdrm-legacy.patch
@@ -1,0 +1,10 @@
+--- a/src/video/SDL_video.c	2021-03-13 23:56:52.682656805 +0100
++++ b/src/video/SDL_video.c	2021-03-13 23:57:03.129323317 +0100
+@@ -95,7 +95,6 @@
+     &PSP_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_KMSDRM
+-    &KMSDRM_bootstrap,
+     &KMSDRM_LEGACY_bootstrap,
+ #endif
+ #if SDL_VIDEO_DRIVER_RPI


### PR DESCRIPTION
…msdrm backend, force kmsdrm_legacy