### PR TITLE
disable sdl2 gamepad mapping

### DIFF
--- a/board/batocera/patches/sdl2/sdl2_disable_gamepadmapping.patch
+++ b/board/batocera/patches/sdl2/sdl2_disable_gamepadmapping.patch
@@ -1,0 +1,14 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+index 1b4c4f2..02d8a69 100644
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -1406,6 +1406,9 @@ LINUX_JoystickGetGamepadMapping(int device_index, SDL_GamepadMapping *out)
+ {
+     SDL_Joystick *joystick;
+ 
++    /* disable this new SDL2 feature ; open/close temporarly the joystick is buggy. it frees up the hwdata informations */
++    return SDL_FALSE;
++
+     joystick = (SDL_Joystick *) SDL_calloc(sizeof(*joystick), 1);
+     if (joystick == NULL) {
+         SDL_OutOfMemory();


### PR DESCRIPTION
this is new in sdl2, but obviously, the temporary
open/close functions to get the BTN_GAMEPAD value erase the hwdata values.

https://www.kernel.org/doc/html/v4.15/input/gamepad.html

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>