### PR TITLE
Users report problems with this option : Threaded video

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 amiga500:
   emulator: amiberry
   core:     A500

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
@@ -1,6 +1,5 @@
 default:
   options:
-    video_threaded: true
     retroarch.audio_out_rate: 44100
 
 n64:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidn2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidn2.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 gamecube:
   emulator: dolphin
   core:     dolphin

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -1,6 +1,5 @@
 default:
   options:
-    video_threaded: true
     # menu retroarch
     retroarch.audio_latency:   64
     retroarch.video_hard_sync: 0

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 n64:
   emulator: mupen64plus
   core:     glide64mk2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rockpro64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rockpro64.yml
@@ -1,6 +1,5 @@
 default:
   options:
-    video_threaded: true
     audio_driver: pulse
 
 n64:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 n64:
   options:
     videomode: DMT 4 HDMI

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 n64:
   emulator: mupen64plus
   core:     glide64mk2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
@@ -1,6 +1,5 @@
 default:
   options:
-    video_threaded: true
     retroarch.audio_out_rate: 44100
 
 dos:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
@@ -1,6 +1,5 @@
 default:
   options:
-    video_threaded: true
     retroarch.audio_out_rate: 44100
 
 n64:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 n64:
   emulator: mupen64plus
   core:     glide64mk2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 dos:
   emulator: dosbox
   core:     dosbox

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-vim3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-vim3.yml
@@ -1,7 +1,3 @@
-default:
-  options:
-    video_threaded: true
-
 gamecube:
   emulator: dolphin
   core:     dolphin


### PR DESCRIPTION
Tested on PI3 PI4 PC, better with option at false
Like write in LIBRETRO doc here:

https://docs.libretro.com/guides/troubleshooting-retroarch/#threaded-video

If your video driver has very bad performance, it is possible to run it on a thread to avoid almost all video driver overhead. Set video_threaded = true in config. Butter smooth VSync behavior in this case is impossible however, and latency might increase slighly. Use only if you cannot obtain full speed otherwise.