### PR TITLE
Fix the libretro command to launch the libretro-easyRPG core

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -115,6 +115,10 @@ class LibretroGenerator(Generator):
         if system.name == 'daphne':
             romName = os.path.splitext(os.path.basename(rom))[0]
             rom = batoceraFiles.daphneDatadir + '/roms/' + romName +'.zip'
+
+        # The libretro core for EasyRPG requires to launch the RPG_RT.ldb file inside the .easyrpg folder
+        if system.name == 'easyrpg' and system.config['core'] == "easyrpg":
+            rom = rom + '/RPG_RT.ldb'
         
         if system.name == 'dos' and system.config['core'] == "dosbox":
             rom = 'set ROOT=' + rom


### PR DESCRIPTION
The commands needs to point to the RPG_RT.ldb inside the .easyrpg folder itself, currently it only pointed to the ".easyrpg" folder. Change tested on my end and working (I described it on discord, but let me say it there for reference) :

The core currently fails to launch the game (because the libretro core doesn't expect a folder, but a specific RPG_RT.ldb file inside a game folder), but due to how it works, it won't say "failed to load content", it'll just go to the main menu and display the "default folder" instead, and let you select a game (because the main menu, just like the standalone, expects a folder, I know, it's weird to explain), however that's not really optimal, doesn't support subfolders, and well, just isn't really in the spirit of Batocera, this change will make it load the games correctly, and so it'll boot directly into the game itself.

Please note that this should only edit the libretroGenerator.py File, by adding 4 lines, and not removing any (I say that because I still don't really get all of this github stuff, so don't blindly trust my edits).

And before someone asks about .zip files, as far as I tested, they didn't work in the libretro or standalone at all, so the change doesn't break those (as they don't work).