### PR TITLE
Removing .zip files from the supported extensions for EasyRPG.

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1767,12 +1767,14 @@ easyrpg:
   manufacturer: EasyRPG Team
   release: 2000
   hardware: port
-  extensions: [zip, easyrpg]
+  extensions: [easyrpg]
   emulators:
     easyrpg:
       easyrpg: { requireAnyOf: [BR2_PACKAGE_EASYRPG_PLAYER] }
     libretro:
       easyrpg: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_EASYRPG] }
+  comment_en: |
+          The EasyRPG engine supports RPG Maker 2000 and 2003 games, you have to put the game's entire folder inside, and add .easyrpg to it's name the game folder is the one containing the RPG_RT.ldb file.
 
 cgenius:
   name:       Commander Genius


### PR DESCRIPTION
EasyRPG (be it standalone, or libretro) doesn't support zip files as a valid path, I asked on the discord how to make it so ES wouldn't show zip files anymore, and the es_systems.yml file seems to be the way.

I also added a comment about how to use a game inside easyrpg in Batocera.

Be aware that while I asked, I don't know anything about compiling batocera, or generating the es_systems.cfg itself. So while the need to remove the zip files is there, and a description for the games is also needed (nobody distributes a .easyrpg folder, as it's a batocera thing), consider I didn't test this myself, and I only ended up doing this pull request myself because I want to practice making PRs as getting familiar with it could help writing docs down the road. (And I know not testing is frowned upon, hence why I prefer to say it beforehand).