### PR TITLE
Switch to OpenAL (Fix Sound Message in v31)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -92,7 +92,7 @@ class Rpcs3Generator(Generator):
         else:
             rpcs3ymlconfig["Video"]['Renderer'] = 'OpenGL' # Vulkan
 
-        rpcs3ymlconfig["Audio"]['Renderer'] = 'FAudio' # ALSA does not support buffering so we have sound cuts ex: Rayman Origin
+        rpcs3ymlconfig["Audio"]['Renderer'] = 'OpenAL' # ALSA does not support buffering so we have sound cuts ex: Rayman Origin
         rpcs3ymlconfig["Audio"]['Audio Channels'] = 'Downmix to Stereo'
         
         rpcs3ymlconfig["Miscellaneous"]['Exit RPCS3 when process finishes'] = True


### PR DESCRIPTION
FAudio is not available now in v31.
Also OpenAL support buffering too and sound is OK
And OpenAL is recommend by RPCS3.
Tested on v31 sound is OK with rayman too.