### PR TITLE
Fix: batocera-bluetooth script - remove of devices

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth
+++ b/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth
@@ -109,9 +109,9 @@ case "${ACTION}" in
 	do_stoptrust
 	;;
     "remove")
-	if test $# = 1
+	if test $# = 2
 	then
-	    do_remove "${1}" || exit 1
+	    do_remove "${2}" || exit 1
 	else
 	    do_help "${0}"
 	    exit 1


### PR DESCRIPTION
Due the removal of shift operator, remove operation now needs two arguments setted.
Just a minor fix

Caused by https://github.com/batocera-linux/batocera.linux/pull/3461