### PR TITLE
Libretro-Flycast synchronous rendering option in ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1002,6 +1002,11 @@ def generateCoreSettings(coreSettings, system, rom):
 
     # Sega Dreamcast / Atomiswave / Naomi
     if (system.config['core'] == 'flycast'):
+        # Synchronous rendering
+        if system.isOptSet('reicast_synchronous_rendering'):
+            coreSettings.save('reicast_synchronous_rendering', system.config['reicast_synchronous_rendering'])
+        else:
+            coreSettings.save('reicast_synchronous_rendering', '"enabled"')
         # Threaded Rendering
         coreSettings.save('reicast_threaded_rendering',  '"enabled"')
         # Enable controller force feedback

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -9,6 +9,8 @@ dreamcast:
     # settings to fix sound issue only on Odroid XU4
     retroarch.audio_latency:   128
     retroarch.video_hard_sync: 1
+    # setting to fix Flycast performances on xu4
+    reicast_synchronous_rendering: disabled
 n64:
   emulator: mupen64plus
   core:     glide64mk2

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -617,6 +617,12 @@ libretro:
     flycast:
       features: [autosave]
       cfeatures:
+            reicast_synchronous_rendering:
+                prompt:      SYNCHRONOUS RENDERING
+                description: Wait for the GPU to render frames instead of skipping
+                choices:
+                    "Off": disabled 
+                    "On": enabled
             reicast_internal_resolution:
                 prompt:      VIDEO RESOLUTION
                 description: Improve the fidelity of 3D models (unaffect 2D)


### PR DESCRIPTION
I tried adding a new option to ES after some discord reports mentioned the Synchronous Rendering in libretro-flycast had a performance impact for the xu4 (Actually, I asked @nadenislamarre on discord if I could try it, and he gave me instructions), testing on my own batocera PC worked, however I have a doubt regarding the change made specifically for xu4 (which is a device I don't have myself), as I'm not sure I made it correctly (the configgen-defaults files aren't making completely sense for me), if anyone can look and tell me if the changes I made are correct or not, I'd appreciate it.

As usual, consider I am not familiar with the way scripts work, and that something "obviously wrong" might not be seen by me, especially since I cannot compile batocera, so the .yml files are edited by hand "after the fact" and I don't actually know how to generate the .xml from them locally.