### PR TITLE
Fix hardware type ordering for amiga and msx

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1680,6 +1680,7 @@ amiga:
   release:
   hardware: computer
   group: amiga
+  force:      True
 
 msx:
   name:       Msx
@@ -1687,6 +1688,7 @@ msx:
   release:
   hardware: computer
   group: msx
+  force:      True
 
 windows:
   name:       Windows

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1679,7 +1679,7 @@ amiga:
   manufacturer: Commodore
   release:
   hardware: computer
-  group: amiga
+  extensions: [adf, uae, ipf, dms, dmz, adz, lha, hdf, exe, m3u, zip]
   force:      True
 
 msx:
@@ -1687,7 +1687,7 @@ msx:
   manufacturer: Microsoft
   release:
   hardware: computer
-  group: msx
+  extensions: [dsk, mx2, rom, zip, 7z]
   force:      True
 
 windows:

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1674,6 +1674,20 @@ ports:
   comment_fr: |
           Jeux et applications Linux additionnels qui peuvent etre lancés depuis un script .sh.
 
+amiga:
+  name:       Amiga
+  manufacturer: Commodore
+  release:
+  hardware: computer
+  group: amiga
+
+msx:
+  name:       Msx
+  manufacturer: Microsoft
+  release:
+  hardware: computer
+  group: msx
+
 windows:
   name:       Windows
   manufacturer: Microsoft

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1679,7 +1679,6 @@ amiga:
   manufacturer: Commodore
   release:
   hardware: computer
-  extensions: [adf, uae, ipf, dms, dmz, adz, lha, hdf, exe, m3u, zip]
   force:      True
 
 msx:
@@ -1687,7 +1686,6 @@ msx:
   manufacturer: Microsoft
   release:
   hardware: computer
-  extensions: [dsk, mx2, rom, zip, 7z]
   force:      True
 
 windows:


### PR DESCRIPTION
Fix amiga and msx 'groups' wrongly added to 'System' hardware type instead of 'Computers' when using Hardware Ordering in Emulation Station

Before fix :
![IMG_20210318_181155922](https://user-images.githubusercontent.com/1405681/111867974-b4a8b180-8977-11eb-812b-6a89d5aeb908.jpg)
After fix:
![IMG_20210320_122811910](https://user-images.githubusercontent.com/1405681/111868060-149f5800-8978-11eb-96eb-1f8fe6c23a41.jpg)
