### PR TITLE
Fixes wifi after latest BR bump

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -106,6 +106,10 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_WPA_SUPPLICANT			# wifi
 	select BR2_PACKAGE_WPA_SUPPLICANT_CLI			# wifi
 	select BR2_PACKAGE_WPA_SUPPLICANT_DBUS_INTROSPECTION	# wifi
+	select BR2_PACKAGE_WPA_SUPPLICANT_WIRED		#wpa_supplicant driver
+	select BR2_PACKAGE_WPA_SUPPLICANT_WPA3	#wifi
+	select BR2_PACKAGE_WPA_SUPPLICANT_NL80211	#wpa_supplicant driver
+	select BR2_PACKAGE_WPA_SUPPLICANT_WEXT	#wpa_supplicant driver
 	select BR2_PACKAGE_DROPBEAR				# ssh server
 	select BR2_PACKAGE_PM_UTILS				# suspend
 	select BR2_PACKAGE_QTSIXA_SHANWAN			# ps3 pad


### PR DESCRIPTION
wpa_supplicant now requires drivers to be explicitly enabled.
this change will allow connman to scan & discover wifi properly again.