### PR TITLE
tty: L_ALT+L_CTRL+F10 starts interactive shell session

### DIFF
--- a/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
+++ b/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
@@ -2,9 +2,10 @@ KEY_VOLUMEUP	1		/usr/bin/amixer set Master 5%+
 KEY_VOLUMEUP	2		/usr/bin/amixer set Master 5%+
 KEY_VOLUMEDOWN	1		/usr/bin/amixer set Master 5%-
 KEY_VOLUMEDOWN	2		/usr/bin/amixer set Master 5%-
-KEY_MUTE        1               /usr/bin/amixer sset Master toggle
-KEY_POWER       1               /sbin/shutdown -h now
+KEY_MUTE		1		/usr/bin/amixer sset Master toggle
+KEY_POWER		1		/sbin/shutdown -h now
 # display some information on X displays
-KEY_F2          1               /usr/bin/batocera-info --short | HOME=/userdata/system XAUTHORITY=/var/lib/.Xauthority DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4
-KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
-KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
+KEY_F2			1		/usr/bin/batocera-info --short | HOME=/userdata/system XAUTHORITY=/var/lib/.Xauthority DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4
+# some more terminal functions, F10 opens midnight commander, F11 stops ES only
+KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S50triggerhappy stop; /etc/init.d/S31emulationstation stop; /usr/bin/openvt -c1 -f -s -w -- /usr/bin/mc -x; /etc/init.d/S31emulationstation start; /etc/init.d/S50triggerhappy start
+KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop

--- a/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys_disabled.conf
+++ b/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys_disabled.conf
@@ -1,3 +1,4 @@
-KEY_POWER       1               /sbin/shutdown -h now
-KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
-KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
+KEY_POWER		1		/sbin/shutdown -h now
+# some more terminal functions, F10 opens midnight commander, F11 stops ES only
+KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S50triggerhappy stop; /etc/init.d/S31emulationstation stop; /usr/bin/openvt -c1 -f -s -w -- /usr/bin/mc -x; /etc/init.d/S31emulationstation start; /etc/init.d/S50triggerhappy start
+KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop


### PR DESCRIPTION
L_ALT+L_CTRL+F10
Starts interactive session with mc aka midnight commander

1. Triggerhappy needs to be stopped to make Funtions Keys work in mc-session
2. ES is terminated
3. Midnight Commander session starts in tty1, after quitting mc with exit or F10
4. ES autostart
5. Triggerhappy starts again

L_ALT+L_CTRL+F11
Just terminates current ES session for error reports

--------------

The chvt 1 command seems not to work on Pi3 with B30
With openvt it's possible to create an interactive session which after exit automatically returns to ES

We nned to stop triggerhappy to make use of the additional functions keys to work in mc

Use ctrl+o inside mc to get shell inputs