### PR TITLE
Missing dependency on pygame with Python3

### DIFF
--- a/package/batocera/emulators/python-pygame2/Config.in
+++ b/package/batocera/emulators/python-pygame2/Config.in
@@ -7,6 +7,7 @@ config BR2_PACKAGE_PYTHON_PYGAME2
 	select BR2_PACKAGE_SDL2_MIXER
 	select BR2_PACKAGE_LIBPNG
 	select BR2_PACKAGE_JPEG
+	select BR2_PACKAGE_PYTHON_PSUTIL
 
 	help
 	  Pygame is a cross-platfrom library designed to make it easy


### PR DESCRIPTION
Fixes one of the issues on https://github.com/batocera-linux/batocera.linux/issues/3469 (Pygame not launching anything)