### PR TITLE
Cosmetic fix (error message in S31emulationstation for OGA...)

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.basic
@@ -20,6 +20,8 @@ case "${ACTION}" in
     ;;
     "setMode")
     ;;
+    "minTomaxResolution" | "minTomaxResolution-secure")
+    ;;
     "currentMode"|"currentResolution")
         # mode can be different from resolution (ie on rpi)
         test -e "${FILEMODES}" && head -1 "${FILEMODES}" | sed -e s+'^[^:]:\([0-9]*\)x\([0-9]*\)[a-z]*.*$'+'\1x\2'+


### PR DESCRIPTION
Avoid an ugly:
```
/usr/bin/batocera-resolution currentMode
/usr/bin/batocera-resolution currentResolution
error: invalid command minTomaxResolution-secure
```
when invoking /etc/init.d/S31emulationstation on OGA and other archs that use the "basic" version of this script.