### PR TITLE
add: Splash video rotation for mpv (mainly x86)

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -8,7 +8,7 @@
 [ "$1" = "stop" ] || exit 0
 
 set --
-for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled splash.screen.sound
+for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled splash.screen.sound splash.video.rotation
 do
     value="$(/usr/bin/batocera-settings-get "$key")" || continue
     if [ "$value" != "$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf "$key")" ]

--- a/package/batocera/core/batocera-splash/S03splash-mpv.template
+++ b/package/batocera/core/batocera-splash/S03splash-mpv.template
@@ -1,9 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 DAEMON="splash"
 
 soundDisabled() {
     grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
+}
+
+do_angels_conversion ()
+{
+    [[ $1 -lt 0 || $1 -gt 3 ]] && echo 0 || echo $(($1*90))
+    return $?
 }
 
 do_start ()
@@ -37,13 +43,21 @@ do_imagestart()
 do_videostart ()
 {
     video="$1"
-    mpv_opt=
+    mpv_audio=
     if soundDisabled
     then
-        mpv_opt=--no-audio
+        mpv_audio=--no-audio
     fi
+
+    mpv_video=
+    video_rotation=$(batocera-settings-get -f /boot/batocera-boot.conf splash.video.rotation)
+    if [[ $? -eq 0 ]]; then
+        video_rotation=$(do_angels_conversion $video_rotation)
+        [[ $? -eq 0 ]] && mpv_video=--video-rotate=${video_rotation}
+    fi
+
     # it should be drm everywhere (including for x86_64 while it is on fb) -- only rpi doesn't use drm and it doesn't use this boot splash script
-    /usr/bin/mpv --really-quiet -fs --no-config %PLAYER_OPTIONS% $mpv_opt "$video" &
+    /usr/bin/mpv --really-quiet -fs --no-config %PLAYER_OPTIONS% $mpv_audio $mpv_video "$video" &
     wait $!
 }
 

--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -46,6 +46,9 @@ kodi.xbutton=1
 ## fastboot:  Stop video as soon as ES is ready to start
 #splash.screen.length=auto
 
+## Enable video rotation (if supported) values 0,1,2,3 rotate to 0,90,180 and 270 clockwise
+#splash.video.rotation=0
+
 # ------------ A1 - Platform Specific Options ----------- #
 ## ODROID-C2
 ## CEC only works on your 1st tv HDMI port (EXYNOS driver limitation)
@@ -266,11 +269,11 @@ updates.type=stable
 # Set fullboot to 0 to disable BIOS when booting an ISO
 #ps2.fullboot=1
 
-# Scraper
+## Scraper
 # Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart
 #scrapper.style=s,b,f,a,l,3b
 
-# Enable DXVK for Wine and FPS HUD.
+## Enable DXVK for Wine and FPS HUD.
 #windows.dxvk=0
 #windows.dxvk_hud=0
 


### PR DESCRIPTION
Tested and valitated by user RION

Option can be set to `batocera.conf`
Only values 0,1,2,3 are valid and build the multiples of 90
Other values will be ignored

Only mpv is supported so far (more to come if there is demand)