### PR TITLE
Use emulatorlauncher for ports, adding pad2key support to ports and flatpak

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -51,6 +51,7 @@ from generators.drastic.drasticGenerator import DrasticGenerator
 from generators.xemu.xemuGenerator import XemuGenerator
 from generators.cgenius.cgeniusGenerator import CGeniusGenerator
 from generators.flatpak.flatpakGenerator import FlatpakGenerator
+from generators.sh.shGenerator import ShGenerator
 
 import controllersConfig as controllers
 import signal
@@ -105,6 +106,7 @@ generators = {
     'xemu': XemuGenerator(),
     'cgenius': CGeniusGenerator(),
     'flatpak': FlatpakGenerator(),
+    'sh': ShGenerator(),
 }
 
 def main(args, maxnbplayers):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+from generators.Generator import Generator
+import Command
+
+class ShGenerator(Generator):
+
+    def generate(self, system, rom, playersControllers, gameResolution):
+
+        commandArray = ["/bin/sh", rom]
+        return Command.Command(array=commandArray)
+
+    def getMouseMode(self, config):
+        return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -7,7 +7,8 @@ class ShGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, gameResolution):
 
-        commandArray = ["/bin/sh", rom]
+        launchfile = rom + "/launch.sh"
+        commandArray = ["/bin/sh", launchfile]
         return Command.Command(array=commandArray)
 
     def getMouseMode(self, config):

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -265,6 +265,9 @@ pico8:
 pokemini:
   emulator: libretro
   core:     pokemini
+ports:
+  emulator: sh
+  core:     sh
 prboom:
   emulator: libretro
   core:     prboom

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -265,7 +265,7 @@ pico8:
 pokemini:
   emulator: libretro
   core:     pokemini
-ports:
+linux:
   emulator: sh
   core:     sh
 prboom:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3222,3 +3222,9 @@ xemu:
                 "Center":   center
                 "Scale":    scale
                 "Stretch":  stretch
+
+sh:
+  features: [padtokeyboard]
+
+flatpak:
+  features: [padtokeyboard]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1665,7 +1665,10 @@ ports:
   extensions: [sh]
   group: ports
   path:       /userdata/roms/ports
-  command:    "/bin/sh %ROM% %CONTROLLERSCONFIG%"
+  command:    "python /usr/lib/python3.9/site-packages/configgen/emulatorlauncher.py %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%"
+  emulators:
+    sh:
+      sh:  { requireAnyOf: [] }
   force:      True
   comment_en: |
           Third party Linux games and apps that can be run from a .sh script.

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1665,15 +1665,29 @@ ports:
   extensions: [sh]
   group: ports
   path:       /userdata/roms/ports
-  command:    "python /usr/lib/python3.9/site-packages/configgen/emulatorlauncher.py %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%"
-  emulators:
-    sh:
-      sh:  { requireAnyOf: [] }
+  command:    "/bin/sh %ROM% %CONTROLLERSCONFIG%"
   force:      True
   comment_en: |
           Third party Linux games and apps that can be run from a .sh script.
   comment_fr: |
           Jeux et applications Linux additionnels qui peuvent etre lancés depuis un script .sh.
+
+linux:
+  name:       Linux
+  manufacturer: Ports
+  release:
+  hardware: port
+  extensions: [port]
+  group: ports
+  path:       /userdata/roms/linux
+  command:    "python /usr/lib/python3.9/site-packages/configgen/emulatorlauncher.py %CONTROLLERSCONFIG% -system %SYSTEM% -rom %ROM%"
+  emulators:
+    sh:
+      sh:  { requireAnyOf: [] }
+  comment_en: |
+          Third party Linux games and apps that can be run from a .port folder containing a launch.sh script.
+  comment_fr: |
+          Jeux et applications Linux additionnels qui peuvent etre lancés depuis un dossier .port qui contient un script nommé launch.sh.
 
 amiga:
   name:       Amiga


### PR DESCRIPTION
**This should be a draft pull request!**

The basic idea was to be able to set a pad2key to the ports (the system that launches .sh files) and flatpak systems. I decided I had to make it so even the ports would go through emulatorLauncher, that way the pad2key could be implemented the same way as the others.

I could locally make the video mode also editable from ES using this method, however I couldn't see a single line called "videomode" in the es_features.yml (as opposed to the es_features.cfg in the actual OS in the end).

I would like to know first if the changes I made are dirty and bad, or are meant the way they were supposed to be. Scripts were tested locally but I still can't build Batocera given my hardware, so keep that in mind as well. Like there is a "command: " for the es_systems.yml, but it seems exclusive to the ports system, so now that it uses the emulatorLauncher script, maybe it isn't neede anymore? Also I didn't put anything in the "requireAnyOf" value, as /bin/sh is everywhere, so I don't think it'd need to be listed as a dependency specific to a system?

The next thing I'd like to know would be : where should I put a default .keys file for flatpak and ports, I know where they go in the end OS, but I don't know where I'd have to put them in the source.

And the last point would be to be able to set videomode, I believe it is a default feature so just defining "features: [padtokeyboard]" might actually enable this as well, but I am not sure…

I'm sorry if I sound confusing. I just wanted to be able to make videomode and pad2key a reality for flatpak and ports (especially ports, as I have some linux games that run in that folder, and the lack of hotkey+start to quit was annoying, plus some games would require keyboards input as well).