### PR TITLE
Duckstation ES options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -19,29 +19,166 @@ class DuckstationGenerator(Generator):
         if os.path.exists(settings_path):
             settings.read(settings_path)
 
-        # main
+        ## [MAIN]
         if not settings.has_section("Main"):
             settings.add_section("Main")
-        settings.set("Main", "SettingsVersion", "3") # probably to be updated in the future
+        
+        # Settings, Language and ConfirmPowerOff
+        settings.set("Main", "SettingsVersion", "3") # Probably to be updated in the future
         settings.set("Main", "Language", getLangFromEnvironment())
         settings.set("Main", "ConfirmPowerOff", "false")
-
-        # controller backend
+        # Force Fullscreen
+        settings.set("Main", "EnableFullscreenUI", "true")
+        # Controller backend
         settings.set("Main","ControllerBackend", "SDL")
+        # Force applying game Settings fixes
+        settings.set("Main","ApplyGameSettings", "true")
 
-        # bios
+        # Rewind
+        #if system.isOptSet('rewind') and system.getOptBoolean('rewind') == True:
+        settings.set("Main","RewindEnable",    "true")
+        settings.set("Main","RewindFrequency", "1")        # Frame skipped each seconds
+        if system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"]   == '120':
+            settings.set("Main","RewindSaveSlots", "120")  # Total duration available in sec
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '90':
+            settings.set("Main","RewindSaveSlots", "90")
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '60':
+            settings.set("Main","RewindSaveSlots", "60")
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '30':
+            settings.set("Main","RewindSaveSlots", "30")
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '15':
+            settings.set("Main","RewindSaveSlots", "15")
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '10':
+            settings.set("Main","RewindSaveSlots", "100")
+            settings.set("Main","RewindFrequency", "0,100000")
+        elif system.isOptSet("duckstation_rewind") and system.config["duckstation_rewind"] == '5':
+            settings.set("Main","RewindSaveSlots", "50")
+            settings.set("Main","RewindFrequency", "0,100000")
+        else:
+            settings.set("Main","RewindEnable", "false")
+
+
+        ## [UI]
+        if not settings.has_section("UI"):
+            settings.add_section("UI")
+        # Show Messages
+        settings.set("UI", "ShowOSDMessages", "true")
+
+
+        ## [CONSOLE]
+        if not settings.has_section("Console"):
+            settings.add_section("Console")
+        # Region
+        settings.set("Console", "Region", "Auto")
+
+
+        ## [BIOS]
         if not settings.has_section("BIOS"):
             settings.add_section("BIOS")
-        settings.set("BIOS", "SearchDirectory", "/userdata/bios")
-        if system.isOptSet('fullboot') and system.getOptBoolean('fullboot') == False:
+        settings.set("BIOS", "SearchDirectory", "/userdata/bios") # Path
+        # Boot Logo
+        if system.isOptSet("duckstation_PatchFastBoot") and system.config["duckstation_PatchFastBoot"] != '0':
             settings.set("BIOS", "PatchFastBoot", "true")
         else:
             settings.set("BIOS", "PatchFastBoot", "false")
 
-        # hotkeys
+        ## [GPU]
+        if not settings.has_section("GPU"):
+            settings.add_section("GPU")
+
+        # Backend - Default OpenGL
+        if system.isOptSet("gfxbackend") and system.config["gfxbackend"] == 'Vulkan':
+            settings.set("GPU", "Renderer", "Vulkan")
+        else:
+            settings.set("GPU", "Renderer", "OpenGL")
+        # Multisampling force (MSAA or SSAA)
+        settings.set("GPU", "PerSampleShading", "false")
+        if system.isOptSet("duckstation_antialiasing") and system.config["duckstation_antialiasing"] != '1':
+            tab = system.config["duckstation_antialiasing"].split('-')
+            settings.set("GPU", "Multisamples", tab[0])
+            if len(tab) > 1:
+                settings.set("GPU", "PerSampleShading", "true")
+        else:
+            settings.set("GPU", "Multisamples", "1")
+        # Threaded Presentation (Vulkan Improve)
+        if system.isOptSet("duckstation_threadedpresentation") and system.config["duckstation_threadedpresentation"] != '0':
+            settings.set("GPU", "ThreadedPresentation", "true")
+        else:
+            settings.set("GPU", "ThreadedPresentation", "false")
+        # Internal resolution
+        if system.isOptSet("duckstation_resolution_scale") and system.config["duckstation_resolution_scale"] != '1':
+            settings.set("GPU", "ResolutionScale", system.config["duckstation_resolution_scale"])
+        else:
+            settings.set("GPU", "ResolutionScale", "1")
+        # WideScreen Hack
+        if system.isOptSet('duckstation_widescreen_hack') and system.config["duckstation_widescreen_hack"] != '0' and system.config["ratio"] == "16/9": # and system.config["bezel"] == "none"::
+            settings.set("GPU", "WidescreenHack", "true")
+        else:
+            settings.set("GPU", "WidescreenHack", "false")
+        # TextureFiltering
+        if system.isOptSet("duckstation_texture_filtering") and system.config["duckstation_texture_filtering"] != 'Nearest':
+           settings.set("GPU", "TextureFilter", system.config["duckstation_texture_filtering"])
+        else:
+           settings.set("GPU", "TextureFilter", "Nearest")
+        
+
+        ## [DISPLAY]
+        if not settings.has_section("Display"):
+            settings.add_section("Display")
+
+        # Aspect Ratio
+        settings.set("Display", "AspectRatio", getGfxRatioFromConfig(system.config, gameResolution))
+        # Vsync
+        if system.isOptSet("duckstation_vsync") and system.config["duckstation_vsync"] != '1':
+            settings.set("Display", "Vsync", "false")
+        else:
+            settings.set("Display", "Vsync", "true")
+        # CropMode
+        if system.isOptSet("duckstation_CropMode") and system.config["duckstation_CropMode"] != 'None':
+           settings.set("Display", "CropMode", system.config["duckstation_CropMode"])
+        else:
+            settings.set("Display", "CropMode", "Overscan")
+        # Enable Frameskipping
+        if system.isOptSet('duckstation_frameskip') and system.config["duckstation_frameskip"] != '0':
+            settings.set("Display", "DisplayAllFrames", "true")
+        else:
+            settings.set("Display", "DisplayAllFrames", "false")
+
+
+        ## [CHEEVOS]
+        if not settings.has_section("Cheevos"):
+            settings.add_section("Cheevos")
+        
+        # Retroachievements : TODO
+        #settings.set("Cheevos", "Enabled",  "true")
+        #settings.set("Cheevos", "Username", "")
+        #settings.set("Cheevos", "Token",    "")                      # http://retroachievements.org/dorequest.php?r=login&u=%s&p=%s
+        #settings.set("Cheevos", "UseFirstDiscFromPlaylist", "false") # When enabled, the first disc in a playlist will be used for achievements, regardless of which disc is active
+        #settings.set("Cheevos", "RichPresence",  "true")             # Enable rich presence information will be collected and sent to the server where supported
+        #settings.set("Cheevos", "ChallengeMode", "false")            # Disables save states, cheats, slowdown functions but you receive 2x achievements points.
+        #settings.set("Cheevos", "TestMode",      "false")            # DuckStation will assume all achievements are locked and not send any unlock notifications to the server.
+
+
+        ## [CONTROLLERPORTS]
+        if not settings.has_section("ControllerPorts"):
+            settings.add_section("ControllerPorts")
+        
+        # Multitap
+        if system.isOptSet("duckstation_multitap") and system.config["duckstation_multitap"] != 'Disabled':
+            settings.set("ControllerPorts", "MultitapMode", system.config["duckstation_multitap"])
+        else:
+            settings.set("ControllerPorts", "MultitapMode", "Disabled")
+
+
+        ## [CONTROLLERS]
+        configurePads(settings, playersControllers, system)
+
+
+        ## [HOTKEYS]
         if not settings.has_section("Hotkeys"):
             settings.add_section("Hotkeys")
-        # force defaults to be aligned with evmapy
+
+        # Force defaults to be aligned with evmapy
         settings.set("Hotkeys", "FastForward",                 "Keyboard/Tab")
         settings.set("Hotkeys", "TogglePause",                 "Keyboard/Pause")
         settings.set("Hotkeys", "PowerOff",                    "Keyboard/Escape")
@@ -50,35 +187,10 @@ class DuckstationGenerator(Generator):
         settings.set("Hotkeys", "SelectPreviousSaveStateSlot", "Keyboard/F3")
         settings.set("Hotkeys", "SelectNextSaveStateSlot",     "Keyboard/F4")
         settings.set("Hotkeys", "Screenshot",                  "Keyboard/F10")
+        settings.set("Hotkeys", "Rewind",                      "Keyboard/F5")
 
-        # controllers
-        configurePads(settings, playersControllers)
 
-        # Backend - Default OpenGL
-        if not settings.has_section("GPU"):
-            settings.add_section("GPU")
-        if system.isOptSet("gfxbackend") and system.config["gfxbackend"] == 'Vulkan':
-            settings.set("GPU", "Renderer", "Vulkan")
-        else:
-            settings.set("GPU", "Renderer", "OpenGL")
-
-        # console
-        if not settings.has_section("Console"):
-            settings.add_section("Console")
-        settings.set("Console", "Region", "Auto")
-            
-        # internal resolution
-        if system.isOptSet('internalresolution'):
-            settings.set("GPU", "ResolutionScale", system.config["internalresolution"])
-        else:
-            settings.set("GPU", "ResolutionScale", "0") # 0 for auto
-
-        # Show fps
-        if not settings.has_section("UI"):
-            settings.add_section("UI")
-        settings.set("UI", "ShowOSDMessages", "true")
-        if not settings.has_section("Display"):
-            settings.add_section("Display")
+        # Show FPS (Debug)
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
             settings.set("Display", "ShowFPS",        "true")
             settings.set("Display", "ShowSpeed",      "true")
@@ -90,8 +202,6 @@ class DuckstationGenerator(Generator):
             settings.set("Display", "ShowVPS",        "false")
             settings.set("Display", "ShowResolution", "false")
 
-        settings.set("Display", "AspectRatio", getGfxRatioFromConfig(system.config, gameResolution))
-
         # Save config
         if not os.path.exists(os.path.dirname(settings_path)):
             os.makedirs(os.path.dirname(settings_path))
@@ -102,20 +212,22 @@ class DuckstationGenerator(Generator):
         env = {"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"}
         return Command.Command(array=commandArray, env=env)
 
+
 def getGfxRatioFromConfig(config, gameResolution):
+    #ratioIndexes = ["Auto (Game Native)", "4:3", "16:9", "1:1", "1:1 PAR", "2:1 (VRAM 1:1)", "3:2", "5:4", "8:7", "16:10", "19:9", "20:9", "32:9"]
     # 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:
-        if config["ratio"] == "4/3":
-            return "4:3"
-        elif config["ratio"] == "16/9":
-            return "16:9"
+        if config["ratio"] == "2/1":
+            return "2:1 (VRAM 1:1)"
+        else:
+            return config["ratio"].replace("/",":")
 
     if ("ratio" not in config or ("ratio" in config and config["ratio"] == "auto")) and gameResolution["width"] / float(gameResolution["height"]) >= (16.0 / 9.0) - 0.1: # let a marge
-            return "16:9"
+        return "16:9"
+        
+    return "4:3"
 
-    return "Auto (Game Native)"
-
-def configurePads(settings, playersControllers):
+def configurePads(settings, playersControllers, system):
     mappings = {
         "ButtonUp":       "up",
         "ButtonDown":     "down",
@@ -139,22 +251,41 @@ def configurePads(settings, playersControllers):
         "AxisRightY":     "joystick2up"
         }
     
-    # clear existing config
-    for i in range(1, 5):
+    # Clear existing config
+    for i in range(1, 8):
         if settings.has_section("Controller" + str(i)):
             settings.remove_section("Controller" + str(i))
     
     nplayer = 1
     for playercontroller, pad in sorted(playersControllers.items()):
-        section = "Controller" + str(nplayer)
-        settings.add_section(section)
+        controller = "Controller" + str(nplayer)
+        
+        ## [SECTION]
+        if not settings.has_section(controller):
+            settings.add_section(controller)
 
-        settings.set(section, "Type", "AnalogController")
-        settings.set(section, "AnalogDPadInDigitalMode", "true")
+        # Controller Type
+        settings.set(controller, "Type", "DigitalController")
+        if system.isOptSet("duckstation_" + controller) and system.config['duckstation_' + controller] != 'DigitalController':
+            settings.set(controller, "Type", system.config["duckstation_" + controller])
+
+        # Rumble
+        controllerRumbleList = {'AnalogController', 'NamcoGunCon', 'NeGcon'};
+        if system.isOptSet("duckstation_rumble") and system.config["duckstation_rumble"] != '0':
+            if system.isOptSet("duckstation_" + controller) and (system.config["duckstation_" + controller] in controllerRumbleList):
+                settings.set(controller, "Rumble", "Controller" + str(pad.index))
+        else:
+            settings.set(controller, "Rumble", "false")
+
+        # Dpad to Joystick
+        if system.isOptSet("duckstation_digitalmode") and system.config["duckstation_digitalmode"] != '0':
+            settings.set(controller, "AnalogDPadInDigitalMode", "true")
+        else:
+            settings.set(controller, "AnalogDPadInDigitalMode", "false")
 
         for mapping in mappings:
             if mappings[mapping] in pad.inputs:
-                settings.set(section, mapping, "Controller" + str(pad.index) + "/" + input2definition(pad.inputs[mappings[mapping]]))
+                settings.set(controller, mapping, "Controller" + str(pad.index) + "/" + input2definition(pad.inputs[mappings[mapping]]))
         nplayer = nplayer + 1
 
 def input2definition(input):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1117,7 +1117,7 @@ libretro:
                     "Full":                         full
                     "DMA Only (Slightly Faster)":   dma
             multitap_mednafen:
-                prompt:      ENABLE MULTITAP
+                prompt:      MULTITAP
                 description: Allowing 5-8 player support in games
                 choices:
                     "Off":              disabled
@@ -1726,7 +1726,7 @@ libretro:
                     "On":               enabled
                     "On (Speed hack)":  enabled_with_speedhack
             multitap_pcsx:
-                prompt:      ENABLE MULTITAP
+                prompt:      MULTITAP
                 description: Allowing 5-8 player support in games
                 choices:
                     "Off":              disabled
@@ -2295,7 +2295,7 @@ libretro:
                     "160fps":     160fps
             tyrquake_rumble:
                 prompt:      RUMBLE
-                description: Enables joypad rumble
+                description: Enables joypad rumble (vibration)
                 choices:
                     "Off":        disabled
                     "On":         enabled
@@ -2597,7 +2597,7 @@ libretro:
                     "1080p":    1080p
                     "4k":       4k
             multitap_yabasanshiro:
-                prompt:      ENABLE MULTITAP
+                prompt:      MULTITAP
                 description: Allowing 7-12 player support in games
                 choices:
                     "Off":      disabled
@@ -2729,7 +2729,7 @@ dolphin:
                 "Off": 0
                 "On":  1
         rumble:
-            prompt:      ENABLE RUMBLE
+            prompt:      RUMBLE
             description: To use vibration on games with Rumble mode
             choices:
                 "Off": 0
@@ -2759,15 +2759,152 @@ dosbox-x:
   features: [ratio, padtokeyboard]
 
 duckstation:
-  features: [ratio, fullboot, internal_resolution]
+  features: [videomode, ratio]
   cfeatures:
+        duckstation_rewind:
+            prompt:      REWIND
+            description: Warning, this feature use a lot of RAM & VRAM
+            choices:
+                "Off":                                         "false"
+                "5  sec Accurate / 250 Mo RAM + 1200 Mo VRAM": 5
+                "10 sec Accurate / 500 Mo RAM + 2400 Mo VRAM": 10
+                "15 sec / Total 135 Mo RAM (Small boards)":    15
+                "30 sec / Total 270 Mo RAM (Middle boards)":   30
+                "60 sec / 300 Mo RAM + 240 Mo VRAM":           60
+                "90 sec / 450 Mo RAM + 360 Mo VRAM":           90
+                "120 sec / 600 Mo RAM + 480 Mo VRAM":          120
         gfxbackend:
             archs_include: [x86, x86_64, rpi4, odroidgoa]
             prompt:      GRAPHICS BACKEND
             description: Choose your graphics rendering
             choices:
-                "OpenGL": OpenGL
-                "Vulkan": Vulkan
+                "OpenGL":                       OpenGL
+                "Vulkan":                       Vulkan
+        duckstation_threadedpresentation:
+            prompt:      VULKAN THREADED
+            description: Can mesurably improve performance if Vsync disabled
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_vsync:
+            prompt:      VSYNC
+            description: Fix the heavy screen tearing in games (heavy CPU)
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_frameskip:
+            prompt:      FRAME SKIP
+            description: Skip frames to improve performance (Smoothless)
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_PatchFastBoot:
+            prompt:      SHOW BIOS BOOTLOGO
+            description: Show BIOS animation when starting content
+            choices:
+                "Off":                          1
+                "On":                           0
+        duckstation_resolution_scale:
+            prompt:      VIDEO RESOLUTION
+            description: Improve the fidelity of 3D models (unaffect 2D)
+            choices:
+                "1x(native)":                   1
+                "2x":                           2
+                "3x/720p":                      3
+                "4x":                           4
+                "5x/1080p":                     5
+                "6x/1440p":                     6
+                "7x":                           7
+                "8x":                           8
+                "9x/4K":                        9
+                "10x":                          10
+                "11x":                          11
+                "12x":                          12
+                "13x":                          13
+                "14x":                          14
+                "15x":                          15
+                "16x":                          16
+        duckstation_antialiasing:
+            prompt:      ANTI-ALIASING (MSAA/SSAA)
+            description: Smooth out jagged edges on 3D objetcs polygons
+            choices:
+                "Off":                          1
+                "2x msaa":                      2
+                "4x msaa":                      4
+                "8x msaa":                      8
+                "16x msaa":                     16
+                "32x msaa":                     32
+                "2x ssaa":                      2-ssaa
+                "4x ssaa":                      4-ssaa
+                "8x ssaa":                      8-ssaa
+                "16x ssaa":                     16-ssaa
+                "32x ssaa":                     32-ssaa
+        duckstation_texture_filtering:
+            prompt:      TEXTURE FILTERING
+            description: Smooths out textures on 3D objetcs
+            choices:
+                "Nearest-Neighbor":             Nearest
+                "Bilinear":                     Bilinear
+                "Bilinear (no Edge Blending)":  BilinearBinAlpha
+                "JINC2":                        Jinc2
+                "JINC2 (no Edge Blending)":     Jinc2BinAlpha
+                "xBR":                          xBR
+                "xBR (no Edge Blending)":       xBRBinAlpha
+        duckstation_CropMode:
+            prompt:      CROP MODE
+            description: Changes how much of the image is cropped
+            choices:
+                "Off":                          "None"
+                "Only Overscan Area":           "Overscan"
+                "All Borders":                  "Borders"
+        duckstation_widescreen_hack:
+            prompt:      WIDESCREEN HACK
+            description: You must use a 16/9 RATIO and disable BEZEL
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_rumble:
+            prompt:      RUMBLE
+            description: Activate vibration on supported controllers
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_digitalmode:
+            prompt:      DPAD TO JOYSTICK
+            description: Use your Joystick as a Dpad with Analog controllers
+            choices:
+                "Off":                          0
+                "On":                           1
+        duckstation_multitap:
+            prompt:      MULTITAP
+            description: Allowing 5-8 player support in games
+            choices:
+                "Off":                          Disabled
+                "Port 1":                       Port1Only
+                "Port 2":                       Port2Only
+                "Port 1+2":                     BothPorts
+        duckstation_Controller1:
+            prompt:      CONTROLLER 1 TYPE
+            description: Use DualShock type for games with Rumble mode
+            choices:
+                "None":                          None
+                "Digital Controller":            DigitalController
+                "Analog Controller (DualShock)": AnalogController
+                "Analog Joystick":               AnalogJoystick
+                "Namco GunCon (Rumble)":         NamcoGunCon
+                "PlayStation Mouse":             PlayStationMouse
+                "NeGcon (Rumble)":               NeGcon
+        duckstation_Controller2:
+            prompt:      CONTROLLER 2 TYPE
+            description: Use DualShock type for games with Rumble mode
+            choices:
+                "None":                          None
+                "Digital Controller":            DigitalController
+                "Analog Controller (DualShock)": AnalogController
+                "Analog Joystick":               AnalogJoystick
+                "Namco GunCon (Rumble)":         NamcoGunCon
+                "PlayStation Mouse":             PlayStationMouse
+                "NeGcon (Rumble)":               NeGcon
 
 flycast:
   features: [ratio]
@@ -2923,8 +3060,8 @@ pcsx2:
   features: [ratio, fullboot, internal_resolution]
   cfeatures:
         multitap:
-            prompt:      ENABLE MULTITAP
-            description: Allowing up to 8 players support in games
+            prompt:      MULTITAP
+            description: Allowing 5-8 player support in games
             choices:
                 "Off":      disabled
                 "Port1":    port1

--- a/package/batocera/emulators/duckstation/psx.duckstation.keys
+++ b/package/batocera/emulators/duckstation/psx.duckstation.keys
@@ -36,6 +36,11 @@
             "target": [ "KEY_F4" ]
 	},
 	{
+            "trigger": ["hotkey", "left"],
+            "type": "key",
+            "target": [ "KEY_F5" ]
+	},
+	{
             "trigger": ["hotkey", "right"],
             "type": "key",
             "target": [ "KEY_TAB" ]


### PR DESCRIPTION
- Add the emulator options to ES
- Stop to use "fullboot" global option
- Stop to use "internal_resolution" global option