### PR TITLE
Libretro PUAE options Update

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -181,6 +181,11 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('puae_video_resolution', system.config['video_resolution'])
         else:
             coreSettings.save('puae_video_resolution', '"hires"')
+        # Zoom Mode    
+        if system.isOptSet('zoom_mode') and system.config['zoom_mode'] != 'automatic':
+            coreSettings.save('puae_zoom_mode', system.config['zoom_mode'])
+        else:
+            coreSettings.save('puae_zoom_mode', '"auto"')
         # Frameskip
         if system.isOptSet('gfx_framerate'):
             coreSettings.save('puae_gfx_framerate', system.config['gfx_framerate'])
@@ -198,11 +203,6 @@ def generateCoreSettings(coreSettings, system, rom):
                 coreSettings.save('puae_floppy_speed', system.config['puae_floppy_speed'])
             else:
                 coreSettings.save('puae_floppy_speed', '"100"')
-            # Zoom Mode    
-            if system.isOptSet('zoom_mode'):
-                coreSettings.save('puae_zoom_mode', system.config['zoom_mode'])
-            else:
-                coreSettings.save('puae_zoom_mode', '"none"')
             # 2P Gamepad Mapping (Keyrah)
             if system.isOptSet('keyrah_mapping'):
                 coreSettings.save('puae_keyrah_keypad_mappings', system.config['keyrah_mapping'])

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1841,6 +1841,7 @@ libretro:
                     "A1200 (2MB Chip + 8MB Fast)":     A1200
                     "A4000/040 (2MB Chip + 8MB Fast)": A4040
                     "CDTV (1MB Chip)":                 CDTV
+                    "CD32 Default (2MB Chip)":         CD32
                     "CD32 (2MB Chip + 8MB Fast)":      CD32FR
             cpu_compatibility:
                 prompt:      CPU COMPATIBILITY
@@ -1895,9 +1896,22 @@ libretro:
                 prompt:      VIDEO RESOLUTION
                 description: Increase video to Hi Resolution
                 choices:
-                    "360p":       lores
-                    "720p":       hires
-                    "1440p":      superhires
+                    "Low 360p":         lores
+                    "High 720p":        hires
+                    "Super-high 1440p": superhires
+            zoom_mode:
+                prompt:      ZOOM MODE
+                description: Crops the borders to fit various host screens
+                choices:
+                    "Off":            none
+                    "Autofit screen": automatic
+                    "minimum":        minimum
+                    "smaller":        smaller
+                    "small":          small
+                    "medium":         medium
+                    "large":          large
+                    "larger":         larger
+                    "maximum":        maximum
             gfx_framerate:
                 prompt:      FRAMESKIP
                 description: Skip frames to improve performance (Smoothless)
@@ -1919,14 +1933,12 @@ libretro:
       systems:
             amiga500:
                 cfeatures:
-                    zoom_mode:
-                        prompt:      ZOOM MODE
-                        description: Crops the borders to fit various host screens
+                    puae_floppy_speed:
+                        prompt:      FLOPPY TURBO SPEED
+                        description: Remove loading but can add possible glitches/crash
                         choices:
-                            "Off":    none
-                            "medium": medium
-                            "large":  large
-                            "larger": larger
+                            "Off":    100
+                            "On":     0
                     keyrah_mapping:
                         prompt:      2P GAMEPAD MAPPING (KEYRAH)
                         description: Keypad to joyport mappings for 2 players
@@ -1959,14 +1971,6 @@ libretro:
                         choices:
                             "Off":    100
                             "On":     0
-                    zoom_mode:
-                        prompt:      ZOOM MODE
-                        description: Crops the borders to fit various host screens
-                        choices:
-                            "Off":    none
-                            "medium": medium
-                            "large":  large
-                            "larger": larger
                     keyrah_mapping:
                         prompt:      2P GAMEPAD MAPPING (KEYRAH)
                         description: Keypad to joyport mappings for 2 players


### PR DESCRIPTION
- Move Zoom mode for all Amiga machines
- Add all the new Zoom mode and the AUTO one
- Put the Auto zoom by default, it fit the screen perfectly
- Add one CD32 missed Model
- Add the "Floppy Turbo" option to Amiga 500