### PR TITLE
ES Options Cleanup 2 + Updates

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuControllers.py
@@ -11,29 +11,26 @@ import configparser
 import json
 
 # Create the controller configuration file
-#first controller will ALWAYS BE A Gamepad
-#additional controllers will either be a Pro Controller or Wiimote
+# First controller will ALWAYS BE A Gamepad
+# Additional controllers will either be a Pro Controller or Wiimote
 def generateControllerConfig(system, playersControllers, rom):
-    #make controller directory if it doesn't exist
+    # Make controller directory if it doesn't exist
     if not path.isdir(batoceraFiles.CONF + "/cemu/controllerProfiles"):
         os.mkdir(batoceraFiles.CONF + "/cemu/controllerProfiles")
 
     if not path.isdir(batoceraFiles.CONF + "/evmapy"):
         os.mkdir(batoceraFiles.CONF + "/evmapy")
 
-    #purge old controller files
+    # Purge old controller files
     for counter in range(0,8):
         configFileName = "{}/{}".format(batoceraFiles.CONF + "/cemu/controllerProfiles/", "controller" + str(counter) +".txt")
         if os.path.isfile(configFileName):
             os.remove(configFileName)
 
-    #Create the evmapy configFile
-
+    # Create the evmapy configFile
     configFileName = "{}/{}".format(batoceraFiles.CONF + "/evmapy/","wiiu.keys")
     if os.path.isfile(configFileName):
         os.remove(configFileName)
-
-
 
     data =  {}
     data['actions_player1'] = []
@@ -46,15 +43,14 @@ def generateControllerConfig(system, playersControllers, rom):
     with open(batoceraFiles.CONF + "/evmapy/wiiu.keys", 'w') as outfile:
         json.dump(data, outfile)
 
-
-    #We are exporting SDL_GAMECONTROLLERCONFIG in cemuGenerator, so we can assume all controllers are now working with xInput
+    # We are exporting SDL_GAMECONTROLLERCONFIG in cemuGenerator, so we can assume all controllers are now working with xInput
     nplayer = 0
 
     for playercontroller, pad in sorted(playersControllers.items()):
         cemuSettings = configparser.ConfigParser(interpolation=None)
         cemuSettings.optionxform = str
 
-        #Add Default Sections
+        # Add Default Sections
         if not cemuSettings.has_section("General"):
             cemuSettings.add_section("General")
         if not cemuSettings.has_section("Controller"):
@@ -72,7 +68,6 @@ def generateControllerConfig(system, playersControllers, rom):
             cemuSettings.set("General", "emulate", "Wii U Pro Controller")
             addIndex = 1
 
-
         cemuSettings.set("Controller", "rumble", "0")
         cemuSettings.set("Controller", "leftRange", "1")
         cemuSettings.set("Controller", "rightRange", "1")
@@ -81,57 +76,55 @@ def generateControllerConfig(system, playersControllers, rom):
         cemuSettings.set("Controller", "buttonThreshold", ".5")
 
         if (system.isOptSet('emulatedwiimotes') and system.getOptBoolean('emulatedwiimotes') == True):
-            #Assumes a sideways wiimote configuration
-            cemuSettings.set("Controller", "1", "button_4")    # A
-            cemuSettings.set("Controller", "2", "button_8")    # B
-            cemuSettings.set("Controller", "3", "button_1")    # 1
-            cemuSettings.set("Controller", "4", "button_2")    # 2
-            cemuSettings.set("Controller", "5", "button_800000000")    # C
-            cemuSettings.set("Controller", "6", "button_100000000")    # Z
-            cemuSettings.set("Controller", "7", "button_40")    # +
-            cemuSettings.set("Controller", "8", "button_80")    # -
-            cemuSettings.set("Controller", "9", "button_10000000")    # Up (Binds to Left on Controller)
-            cemuSettings.set("Controller", "10", "button_20000000")   # Down (Binds to Right on Controller)
-            cemuSettings.set("Controller", "11", "button_8000000")   # Left (Binds to Down on Controller)
-            cemuSettings.set("Controller", "12", "button_4000000")   # Right (Binds to Up on Controller
-            cemuSettings.set("Controller", "13", "button_400000000")   # Nunchuk Up (RStick)
-            cemuSettings.set("Controller", "14", "button_10000000000")   # Nunchuk Down (RStick)
+            # Assumes a sideways wiimote configuration
+            cemuSettings.set("Controller", "1", "button_4")             # A
+            cemuSettings.set("Controller", "2", "button_8")             # B
+            cemuSettings.set("Controller", "3", "button_1")             # 1
+            cemuSettings.set("Controller", "4", "button_2")             # 2
+            cemuSettings.set("Controller", "5", "button_800000000")     # C
+            cemuSettings.set("Controller", "6", "button_100000000")     # Z
+            cemuSettings.set("Controller", "7", "button_40")            # +
+            cemuSettings.set("Controller", "8", "button_80")            # -
+            cemuSettings.set("Controller", "9", "button_10000000")      # Up (Binds to Left on Controller)
+            cemuSettings.set("Controller", "10", "button_20000000")     # Down (Binds to Right on Controller)
+            cemuSettings.set("Controller", "11", "button_8000000")      # Left (Binds to Down on Controller)
+            cemuSettings.set("Controller", "12", "button_4000000")      # Right (Binds to Up on Controller
+            cemuSettings.set("Controller", "13", "button_400000000")    # Nunchuk Up (RStick)
+            cemuSettings.set("Controller", "14", "button_10000000000")  # Nunchuk Down (RStick)
             cemuSettings.set("Controller", "15", "button_8000000000")   # Nunchuk Left (RStick)
-            cemuSettings.set("Controller", "16", "button_200000000")   # Nunchuk Right (RStick)
-            cemuSettings.set("Controller", "17", "0")   # Home
+            cemuSettings.set("Controller", "16", "button_200000000")    # Nunchuk Right (RStick)
+            cemuSettings.set("Controller", "17", "0")                   # Home
             cemuSettings.set("Controller", "nunchuck", "1")
             cemuSettings.set("Controller", "motionPlus", "0")
         else:
-            cemuSettings.set("Controller", "1", "button_2")    # A
-            cemuSettings.set("Controller", "2", "button_1")    # B
-            cemuSettings.set("Controller", "3", "button_8")    # X
-            cemuSettings.set("Controller", "4", "button_4")    # Y
-            cemuSettings.set("Controller", "5", "button_10")    # L
-            cemuSettings.set("Controller", "6", "button_20")    # R
-            cemuSettings.set("Controller", "7", "button_100000000")    # L2
-            cemuSettings.set("Controller", "8", "button_800000000")    # R2
-            cemuSettings.set("Controller", "9", "button_40")    # Start
-            cemuSettings.set("Controller", "10", "button_80")   # Select
-            cemuSettings.set("Controller", str(11 + addIndex), "button_4000000")   # Up
-            cemuSettings.set("Controller", str(12 + addIndex), "button_8000000")   # Down
+            cemuSettings.set("Controller", "1", "button_2")                         # A
+            cemuSettings.set("Controller", "2", "button_1")                         # B
+            cemuSettings.set("Controller", "3", "button_8")                         # X
+            cemuSettings.set("Controller", "4", "button_4")                         # Y
+            cemuSettings.set("Controller", "5", "button_10")                        # L
+            cemuSettings.set("Controller", "6", "button_20")                        # R
+            cemuSettings.set("Controller", "7", "button_100000000")                 # L2
+            cemuSettings.set("Controller", "8", "button_800000000")                 # R2
+            cemuSettings.set("Controller", "9", "button_40")                        # Start
+            cemuSettings.set("Controller", "10", "button_80")                       # Select
+            cemuSettings.set("Controller", str(11 + addIndex), "button_4000000")    # Up
+            cemuSettings.set("Controller", str(12 + addIndex), "button_8000000")    # Down
             cemuSettings.set("Controller", str(13 + addIndex), "button_10000000")   # Left
             cemuSettings.set("Controller", str(14 + addIndex), "button_20000000")   # Right
-            cemuSettings.set("Controller", str(15 + addIndex), "button_100")   # LStick Click
-            cemuSettings.set("Controller", str(16 + addIndex), "button_200")   # RStick Click
+            cemuSettings.set("Controller", str(15 + addIndex), "button_100")        # LStick Click
+            cemuSettings.set("Controller", str(16 + addIndex), "button_200")        # RStick Click
             cemuSettings.set("Controller", str(17 + addIndex), "button_80000000")   # LStick Up
-            cemuSettings.set("Controller", str(18 + addIndex), "button_2000000000")   # LStick Down
-            cemuSettings.set("Controller", str(19 + addIndex), "button_1000000000")   # LStick Left
+            cemuSettings.set("Controller", str(18 + addIndex), "button_2000000000") # LStick Down
+            cemuSettings.set("Controller", str(19 + addIndex), "button_1000000000") # LStick Left
             cemuSettings.set("Controller", str(20 + addIndex), "button_40000000")   # LStick Right
-            cemuSettings.set("Controller", str(21 + addIndex), "button_400000000")   # RStick Up
-            cemuSettings.set("Controller", str(22 + addIndex), "button_10000000000")   # RStick Down
-            cemuSettings.set("Controller", str(23 + addIndex), "button_8000000000")   # RStick Left
-            cemuSettings.set("Controller", str(24 + addIndex), "button_200000000")   # RStick Right
-            cemuSettings.set("Controller", str(25 + addIndex), "button_100")   # Blow Mic
-
+            cemuSettings.set("Controller", str(21 + addIndex), "button_400000000")  # RStick Up
+            cemuSettings.set("Controller", str(22 + addIndex), "button_10000000000")# RStick Down
+            cemuSettings.set("Controller", str(23 + addIndex), "button_8000000000") # RStick Left
+            cemuSettings.set("Controller", str(24 + addIndex), "button_200000000")  # RStick Right
+            cemuSettings.set("Controller", str(25 + addIndex), "button_100")        # Blow Mic
 
         configFileName = "{}/{}".format(batoceraFiles.CONF + "/cemu/controllerProfiles/", "controller" + str(nplayer) + ".txt")
-                # save dolphin.ini
+                # Save dolphin.ini
         with open(configFileName, 'w') as configfile:
             cemuSettings.write(configfile)
         nplayer+=1
-

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -4,6 +4,7 @@ from generators.Generator import Generator
 import Command
 import os
 from os import path
+from os import environ
 import batoceraFiles
 from xml.dom import minidom
 import codecs
@@ -38,11 +39,11 @@ class CemuGenerator(Generator):
             os.mkdir(batoceraFiles.SAVES + "/cemu")
 
         CemuGenerator.CemuConfig(batoceraFiles.CONF + "/cemu/settings.xml", system)
-        # copy the file from where cemu reads it
+        # Copy the file from where cemu reads it
         shutil.copyfile("/userdata/bios/cemu/keys.txt", "/userdata/system/configs/cemu/keys.txt")
         if not os.path.exists(cemu_exe) or not filecmp.cmp("/usr/cemu/Cemu.exe", cemu_exe):
             shutil.copyfile("/usr/cemu/Cemu.exe", cemu_exe)
-        # copy cemuhook for secure upgrade
+        # Copy cemuhook for secure upgrade
         if not os.path.exists(cemu_hook) or not filecmp.cmp("/usr/cemu/cemuhook.ini", cemu_hook):
             shutil.copyfile("/usr/cemu/cemuhook.ini", cemu_hook)
         if not os.path.exists(keystone_dll) or not filecmp.cmp("/usr/cemu/keystone.dll", keystone_dll):
@@ -66,7 +67,7 @@ class CemuGenerator(Generator):
 
     @staticmethod
     def CemuConfig(configFile, system):
-        # config file
+        # Config file
         config = minidom.Document()
         if os.path.exists(configFile):
             try:
@@ -74,14 +75,14 @@ class CemuGenerator(Generator):
             except:
                 pass # reinit the file
 
-        # root
+        ## [ROOT]
         xml_root = CemuGenerator.getRoot(config, "content")
 
-        ###
+        # Remove auto updates
         CemuGenerator.setSectionConfig(config, xml_root, "check_update", "false")
-        # avoid the welcome window
+        # Avoid the welcome window
         CemuGenerator.setSectionConfig(config, xml_root, "gp_download", "true")
-        ###
+        # Other options
         CemuGenerator.setSectionConfig(config, xml_root, "logflag", "0")
         CemuGenerator.setSectionConfig(config, xml_root, "advanced_ppc_logging", "false")
         CemuGenerator.setSectionConfig(config, xml_root, "use_discord_presence", "false")
@@ -89,28 +90,63 @@ class CemuGenerator(Generator):
         CemuGenerator.setSectionConfig(config, xml_root, "cpu_mode", "1")
         CemuGenerator.setSectionConfig(config, xml_root, "vk_warning", "false")
         CemuGenerator.setSectionConfig(config, xml_root, "fullscreen", "true")
-        
-        ## Audio Settings - Turn audio on for TV
+
+        # Language
+        CemuGenerator.setSectionConfig(config, xml_root, "console_language", str(getGameCubeLangFromEnvironment()))
+
+        ## [GAME PATH]
+        CemuGenerator.setSectionConfig(config, xml_root, "GamePaths", "")
+        game_root = CemuGenerator.getRoot(config, "GamePaths")
+
+        # Default games path
+        CemuGenerator.setSectionConfig(config, game_root, "Entry", "/userdata/roms/wiiu")
+
+
+        ## [AUDIO]
         CemuGenerator.setSectionConfig(config, xml_root, "Audio", "")
         audio_root = CemuGenerator.getRoot(config, "Audio")
+
+        # Turn audio ONLY on TV
         CemuGenerator.setSectionConfig(config, audio_root, "TVDevice", "default")
         CemuGenerator.setSectionConfig(config, audio_root, "TVVolume", "90")
-        ##TVVolume
-        #Graphic Settings
-        
+
+
+        ## [GRAPHIC]
         CemuGenerator.setSectionConfig(config, xml_root, "Graphic", "")
         graphic_root = CemuGenerator.getRoot(config, "Graphic")
 
+        # Graphical backend
         if system.isOptSet("gfxbackend"):
             if system.config["gfxbackend"] == "Vulkan":
-                CemuGenerator.setSectionConfig(config, graphic_root, "api", "1") #Vulkan
+                CemuGenerator.setSectionConfig(config, graphic_root, "api", "1") # Vulkan
             else:
-                CemuGenerator.setSectionConfig(config, graphic_root, "api", "0") #OpenGL
+                CemuGenerator.setSectionConfig(config, graphic_root, "api", "0") # OpenGL
         else:
-            CemuGenerator.setSectionConfig(config, graphic_root, "api", "1") #Vulkan
+            CemuGenerator.setSectionConfig(config, graphic_root, "api", "1")     # Vulkan
 
-        # save the config file
+        # Async VULKAN Shader compilation
+        if system.isOptSet("async") and system.config["async"] == "0":
+            CemuGenerator.setSectionConfig(config, graphic_root, "AsyncCompile", "false") 
+        else:
+            CemuGenerator.setSectionConfig(config, graphic_root, "AsyncCompile", "true")
+
+        ## [GRAPHIC]
+        CemuGenerator.setSectionConfig(config, graphic_root, "Overlay", "")
+        overlay_root = CemuGenerator.getRoot(config, "Overlay")
+
+        # Display FPS / CPU / GPU / RAM
+        CemuGenerator.setSectionConfig(config, overlay_root, "FPS",       "true")
+        CemuGenerator.setSectionConfig(config, overlay_root, "CPUUsage",  "true")
+        CemuGenerator.setSectionConfig(config, overlay_root, "RAMUsage",  "true")
+        CemuGenerator.setSectionConfig(config, overlay_root, "VRAMUsage", "true")
+        if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
+            CemuGenerator.setSectionConfig(config, overlay_root, "Position", "1")
+        else:
+            CemuGenerator.setSectionConfig(config, overlay_root, "Position", "0")
+
+        # Save the config file
         xml = open(configFile, "w")
+
         # TODO: python 3 - workawround to encode files in utf-8
         xml = codecs.open(configFile, "w", "utf-8")
         dom_string = os.linesep.join([s for s in config.toprettyxml().splitlines() if s.strip()]) # remove ugly empty lines while minicom adds them...
@@ -141,3 +177,13 @@ class CemuGenerator(Generator):
             xml_elt.firstChild.data = value
         else:
             xml_elt.appendChild(config.createTextNode(value))
+
+
+# Lauguage auto setting
+def getGameCubeLangFromEnvironment():
+    lang = environ['LANG'][:5]
+    availableLanguages = { "ja_JP": 0, "en_US": 1, "fr_FR": 2, "de_DE": 3, "it_IT": 4, "es_ES": 5, "zh_CN": 6, "ko_KR": 7, "hu_HU": 8, "pt_PT": 9, "ru_RU": 10, "zh_TW": 11 }
+    if lang in availableLanguages:
+        return availableLanguages[lang]
+    else:
+        return availableLanguages["en_US"]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -92,7 +92,7 @@ class CemuGenerator(Generator):
         CemuGenerator.setSectionConfig(config, xml_root, "fullscreen", "true")
 
         # Language
-        CemuGenerator.setSectionConfig(config, xml_root, "console_language", str(getGameCubeLangFromEnvironment()))
+        CemuGenerator.setSectionConfig(config, xml_root, "console_language", str(getCemuLangFromEnvironment()))
 
         ## [GAME PATH]
         CemuGenerator.setSectionConfig(config, xml_root, "GamePaths", "")
@@ -135,14 +135,18 @@ class CemuGenerator(Generator):
         overlay_root = CemuGenerator.getRoot(config, "Overlay")
 
         # Display FPS / CPU / GPU / RAM
-        CemuGenerator.setSectionConfig(config, overlay_root, "FPS",       "true")
-        CemuGenerator.setSectionConfig(config, overlay_root, "CPUUsage",  "true")
-        CemuGenerator.setSectionConfig(config, overlay_root, "RAMUsage",  "true")
-        CemuGenerator.setSectionConfig(config, overlay_root, "VRAMUsage", "true")
         if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
             CemuGenerator.setSectionConfig(config, overlay_root, "Position", "1")
+            CemuGenerator.setSectionConfig(config, overlay_root, "FPS",       "true")
+            CemuGenerator.setSectionConfig(config, overlay_root, "CPUUsage",  "true")
+            CemuGenerator.setSectionConfig(config, overlay_root, "RAMUsage",  "true")
+            CemuGenerator.setSectionConfig(config, overlay_root, "VRAMUsage", "true")
         else:
             CemuGenerator.setSectionConfig(config, overlay_root, "Position", "0")
+            CemuGenerator.setSectionConfig(config, overlay_root, "FPS",       "false")
+            CemuGenerator.setSectionConfig(config, overlay_root, "CPUUsage",  "false")
+            CemuGenerator.setSectionConfig(config, overlay_root, "RAMUsage",  "false")
+            CemuGenerator.setSectionConfig(config, overlay_root, "VRAMUsage", "false")
 
         # Save the config file
         xml = open(configFile, "w")
@@ -180,7 +184,7 @@ class CemuGenerator(Generator):
 
 
 # Lauguage auto setting
-def getGameCubeLangFromEnvironment():
+def getCemuLangFromEnvironment():
     lang = environ['LANG'][:5]
     availableLanguages = { "ja_JP": 0, "en_US": 1, "fr_FR": 2, "de_DE": 3, "it_IT": 4, "es_ES": 5, "zh_CN": 6, "ko_KR": 7, "hu_HU": 8, "pt_PT": 9, "ru_RU": 10, "zh_TW": 11 }
     if lang in availableLanguages:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
@@ -18,7 +18,7 @@ class CitraGenerator(Generator):
 
     @staticmethod
     def writeCITRAConfig(citraConfigFile, system, playersControllers):
-        # pads
+        # Pads
         citraButtons = {
             "button_a":      "a",
             "button_b":      "b",
@@ -47,24 +47,30 @@ class CitraGenerator(Generator):
         if os.path.exists(citraConfigFile):
             citraConfig.read(citraConfigFile)
 
-        # layout section
+        ## [LAYOUT]
         if not citraConfig.has_section("Layout"):
             citraConfig.add_section("Layout")
 
-        if system.isOptSet('layout_option'):
-            citraConfig.set("Layout", "custom_layout", "0")
-            citraConfig.set("Layout", "layout_option", system.config['layout_option'])
+        # Screen Layout
+        citraConfig.set("Layout", "custom_layout", "0")
+        if system.isOptSet('citra_screen_layout'):
+            tab = system.config["citra_screen_layout"].split('-')
+            citraConfig.set("Layout", "swap_screen",   tab[1])
+            citraConfig.set("Layout", "layout_option", tab[0])
         else:
-            citraConfig.set("Layout", "custom_layout", "0")
+            citraConfig.set("Layout", "swap_screen",   "false")
             citraConfig.set("Layout", "layout_option", "4")
-        
-        # UI section
+
+
+        ## [UI]
         if not citraConfig.has_section("UI"):
             citraConfig.add_section("UI")
         
+        # Start Fullscreen
         citraConfig.set("UI", "fullscreen", "true")
-        
-        # controls section
+
+
+        ## [CONTROLS]
         if not citraConfig.has_section("Controls"):
             citraConfig.add_section("Controls")
 
@@ -78,7 +84,7 @@ class CitraGenerator(Generator):
 
         for index in playersControllers :
             controller = playersControllers[index]
-            # we only care about player 1
+            # We only care about player 1
             if controller.player != "1":
                 continue
             for x in citraButtons:
@@ -87,7 +93,7 @@ class CitraGenerator(Generator):
                 citraConfig.set("Controls", "profiles\\1\\" + x, '"{}"'.format(CitraGenerator.setAxis(citraAxis[x], controller.guid, controller.inputs)))
             break
 
-        ### update the configuration file
+        ## Update the configuration file
         if not os.path.exists(os.path.dirname(citraConfigFile)):
             os.makedirs(os.path.dirname(citraConfigFile))
         with open(citraConfigFile, 'w') as configfile:
@@ -95,7 +101,7 @@ class CitraGenerator(Generator):
 
     @staticmethod
     def setButton(key, padGuid, padInputs):
-        # it would be better to pass the joystick num instead of the guid because 2 joysticks may have the same guid
+        # It would be better to pass the joystick num instead of the guid because 2 joysticks may have the same guid
         if key in padInputs:
             input = padInputs[key]
 
@@ -104,7 +110,7 @@ class CitraGenerator(Generator):
             elif input.type == "hat":
                 return ("engine:sdl,guid:{},hat:{},direction:{}").format(padGuid, input.id, CitraGenerator.hatdirectionvalue(input.value))
             elif input.type == "axis":
-                # untested, need to configure an axis as button / triggers buttons to be tested too
+                # Untested, need to configure an axis as button / triggers buttons to be tested too
                 return ("engine:sdl,guid:{},axis:{},direction:{},threshold:{}").format(padGuid, input.id, "+", 0.5)
 
     @staticmethod

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -39,6 +39,10 @@ class DolphinGenerator(Generator):
         if not dolphinSettings.has_section("Analytics"):
             dolphinSettings.add_section("Analytics")
 
+        # Define default games path
+        dolphinSettings.set("General", "ISOPath0", '"/userdata/roms/wii"')
+        dolphinSettings.set("General", "ISOPath1", '"/userdata/roms/gamecube"')
+
         # Draw or not FPS
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
             dolphinSettings.set("General", "ShowLag",        '"True"')
@@ -81,9 +85,9 @@ class DolphinGenerator(Generator):
         else:
             dolphinSettings.set("Core", "SyncGPU", '"False"')
 
-        # Language (for gamecube at least)
-        dolphinSettings.set("Core", "SelectedLanguage", str(getGameCubeLangFromEnvironment()))
-        dolphinSettings.set("Core", "GameCubeLanguage", str(getGameCubeLangFromEnvironment()))
+        # Language
+        dolphinSettings.set("Core", "SelectedLanguage", str(getGameCubeLangFromEnvironment())) # Wii
+        dolphinSettings.set("Core", "GameCubeLanguage", str(getGameCubeLangFromEnvironment())) # GC
 
         # Enable MMU
         if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu"):
@@ -199,13 +203,13 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Enhancements", "MaxAnisotropy", '"0"')
 
-		# Anti aliasing
+        # Anti aliasing
         if system.isOptSet('antialiasing'):
             dolphinGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:
             dolphinGFXSettings.set("Settings", "MSAA", '"0"')
 
-		# Save gfx.ini
+        # Save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:
             dolphinGFXSettings.write(configfile)
 
@@ -221,7 +225,7 @@ class DolphinGenerator(Generator):
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
 
-
+# Ratio
 def getGfxRatioFromConfig(config, gameResolution):
     # 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -16,7 +16,7 @@ class Pcsx2Generator(Generator):
         isAVX2 = checkAvx2()
         sseLib = checkSseLib(isAVX2)
 
-        # config files
+        # Config files
         configureReg(batoceraFiles.pcsx2ConfigDir)
         configureUI(batoceraFiles.pcsx2ConfigDir, batoceraFiles.BIOS, system.config, gameResolution)
         configureVM(batoceraFiles.pcsx2ConfigDir, system)
@@ -28,23 +28,25 @@ class Pcsx2Generator(Generator):
         else:
             commandArray = [batoceraFiles.batoceraBins['pcsx2'], rom]
 
-        # fullscreen
+        # Fullscreen
         commandArray.append("--fullscreen")
 
-        # no gui
+        # No GUI
         commandArray.append("--nogui")
 
-        # fullboot
-        if system.isOptSet('fullboot') and system.getOptBoolean('fullboot') == True:
+        # Fullboot
+        if system.isOptSet('fullboot') and system.config['fullboot'] == '0':
+            print("Fast Boot and skip BIOS")
+        else:
             commandArray.append("--fullboot")
 
-        # plugins
+        # Plugins
         real_pluginsDir = batoceraFiles.pcsx2PluginsDir
         if isAVX2:
             real_pluginsDir = batoceraFiles.pcsx2Avx2PluginsDir
         commandArray.append("--gs="   + real_pluginsDir + "/" + sseLib)
         
-        # arch
+        # Arch
         arch = "x86"
         with open('/usr/share/batocera/batocera.arch', 'r') as content_file:
             arch = content_file.read()
@@ -95,7 +97,7 @@ def configureVM(config_directory, system):
         f.write("[EmuCore]\n")
         f.close()
     
-    # this file looks like a .ini
+    # This file looks like a .ini
     pcsx2VMConfig = configparser.ConfigParser(interpolation=None)
     # To prevent ConfigParser from converting to lower case
     pcsx2VMConfig.optionxform = str   
@@ -103,23 +105,33 @@ def configureVM(config_directory, system):
     if os.path.isfile(configFileName):  
         pcsx2VMConfig.read(configFileName)
     
+    ## [EMUCORE/GS]
     if not pcsx2VMConfig.has_section("EmuCore/GS"):
-        #Some defaults needed on first run 
         pcsx2VMConfig.add_section("EmuCore/GS")
-        pcsx2VMConfig.set("EmuCore/GS","VsyncQueueSize", "2")
-        pcsx2VMConfig.set("EmuCore/GS","FrameLimitEnable", "1")
-        pcsx2VMConfig.set("EmuCore/GS","SynchronousMTGS", "disabled")
-        pcsx2VMConfig.set("EmuCore/GS","FrameSkipEnable", "disabled")
-        pcsx2VMConfig.set("EmuCore/GS","LimitScalar", "1.00")
-        pcsx2VMConfig.set("EmuCore/GS","FramerateNTSC", "59.94")
-        pcsx2VMConfig.set("EmuCore/GS","FrameratePAL", "50")
-        pcsx2VMConfig.set("EmuCore/GS","FramesToDraw", "2")
-        pcsx2VMConfig.set("EmuCore/GS","FramesToSkip", "2")
 
+    # Some defaults needed on first run 
+    pcsx2VMConfig.set("EmuCore/GS","VsyncQueueSize", "2")
+    pcsx2VMConfig.set("EmuCore/GS","FrameLimitEnable", "1")
+    pcsx2VMConfig.set("EmuCore/GS","SynchronousMTGS", "disabled")
+    pcsx2VMConfig.set("EmuCore/GS","FrameSkipEnable", "disabled")
+    pcsx2VMConfig.set("EmuCore/GS","LimitScalar", "1.00")
+    pcsx2VMConfig.set("EmuCore/GS","FramerateNTSC", "59.94")
+    pcsx2VMConfig.set("EmuCore/GS","FrameratePAL", "50")
+    pcsx2VMConfig.set("EmuCore/GS","FramesToDraw", "2")
+    pcsx2VMConfig.set("EmuCore/GS","FramesToSkip", "2")
+
+    # Vsync
+    if system.isOptSet('vsync'):
+        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", system.config["vsync"])
+    else:
+        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", "1")    
+
+
+    ## [EMUCORE]
     if not pcsx2VMConfig.has_section("EmuCore"):
         pcsx2VMConfig.add_section("EmuCore")
 
-    # enable multitap
+    # Enable Multitap
     if system.isOptSet('multitap') and system.config['multitap'] != 'disabled':
         if system.config['multitap'] == 'port1':
             pcsx2VMConfig.set("EmuCore","MultitapPort0_Enabled", "enabled")
@@ -134,62 +146,108 @@ def configureVM(config_directory, system):
         pcsx2VMConfig.set("EmuCore","MultitapPort0_Enabled", "disabled")
         pcsx2VMConfig.set("EmuCore","MultitapPort1_Enabled", "disabled")
 
-    if system.isOptSet('vsync'):
-        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", system.config["vsync"])
+    # Enable Cheats
+    if system.isOptSet('EmuCore_EnableCheats'):
+        pcsx2VMConfig.set("EmuCore","EnableCheats", system.config["EmuCore_EnableCheats"])
     else:
-        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", "1")    
+        pcsx2VMConfig.set("EmuCore","EnableCheats", "disabled")
+
+    # Enabme Widescreen Patches
+    if system.isOptSet('EmuCore_EnableWideScreenPatches'):
+        pcsx2VMConfig.set("EmuCore","EnableWideScreenPatches", system.config["EmuCore_EnableWideScreenPatches"])
+    else:
+        pcsx2VMConfig.set("EmuCore","EnableWideScreenPatches", "disabled")
+
+    # Automatic Gamefixes
+    if system.isOptSet('EmuCore_EnablePatches'):
+        pcsx2VMConfig.set("EmuCore","EnablePatches", system.config["EmuCore_EnablePatches"])
+    else:
+        pcsx2VMConfig.set("EmuCore","EnablePatches", "enabled")
+
+
+    ## [EMUCORE/GAMEFIXES]
+    if not pcsx2VMConfig.has_section("EmuCore/Gamefixes"):
+        pcsx2VMConfig.add_section("EmuCore/Gamefixes")
+
+    # Manual Gamefixes
+    if system.isOptSet('EmuCore_ManualPatches') and system.config["EmuCore_ManualPatches"] != 'disabled':
+        pcsx2VMConfig.set("EmuCore/Gamefixes",system.config["EmuCore_ManualPatches"], "enabled")
+    else:
+        pcsx2VMConfig.set("EmuCore/Gamefixes","VuAddSubHack",           "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","FpuCompareHack",         "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","FpuMulHack",             "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","FpuNegDivHack",          "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","XgKickHack",             "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","IPUWaitHack",            "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","EETimingHack",           "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","SkipMPEGHack",           "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","OPHFlagHack",            "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","DMABusyHack",            "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","VIFFIFOHack",            "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","VIF1StallHack",          "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","GIFFIFOHack",            "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","GoemonTlbHack",          "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","ScarfaceIbit",           "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","CrashTagTeamRacingIbit", "disabled")
+        pcsx2VMConfig.set("EmuCore/Gamefixes","VU0KickstartHack",       "disabled")
+
 
     with open(configFileName, 'w') as configfile:
         pcsx2VMConfig.write(configfile)
-        
-        
+
+
 def configureGFX(config_directory, system):
     configFileName = "{}/{}".format(config_directory + "/inis", "GSdx.ini")
     if not os.path.exists(config_directory):
         os.makedirs(config_directory + "/inis")
     
-    #create the config file if it doesn't exist
+    # Create the config file if it doesn't exist
     if not os.path.exists(configFileName):
         f = open(configFileName, "w")
         f.write("osd_fontname = /usr/share/fonts/dejavu/DejaVuSans.ttf\n")
         f.close()
-        
     
     # Update settings
     pcsx2GFXSettings = UnixSettings(configFileName, separator=' ')
     pcsx2GFXSettings.save("osd_fontname", "/usr/share/fonts/dejavu/DejaVuSans.ttf")
     pcsx2GFXSettings.save("osd_indicator_enabled", 1)
     pcsx2GFXSettings.save("UserHacks", 1)
-    #showFPS
+
+    # ShowFPS
     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS'):
         pcsx2GFXSettings.save("osd_monitor_enabled", 1)
     else:
         pcsx2GFXSettings.save("osd_monitor_enabled", 0)
-    #internal resolution
-    if system.isOptSet('internalresolution'):
-        pcsx2GFXSettings.save("upscale_multiplier", system.config["internalresolution"])
+
+    # Internal resolution
+    if system.isOptSet('internal_resolution'):
+        pcsx2GFXSettings.save("upscale_multiplier", system.config["internal_resolution"])
     else:
         pcsx2GFXSettings.save("upscale_multiplier", "1")
-    #skipdraw
+
+    # Skipdraw Hack
     if system.isOptSet('skipdraw'):
         pcsx2GFXSettings.save('UserHacks_SkipDraw', system.config['skipdraw'])
     else:
         pcsx2GFXSettings.save('UserHacks_SkipDraw', '0')
-    #align sprite
+
+    # Align sprite Hack
     if system.isOptSet('align_sprite'):
         pcsx2GFXSettings.save('UserHacks_align_sprite_X', system.config['align_sprite'])
     else:
         pcsx2GFXSettings.save('UserHacks_align_sprite_X', '0')
-        
+
+    # Vsync
     if system.isOptSet('vsync'):
         pcsx2GFXSettings.save("vsync", system.config["vsync"])
     else:
         pcsx2GFXSettings.save("vsync", "1")
 
+    # Anisotropic Filtering
     if system.isOptSet('anisotropic_filtering'):
         pcsx2GFXSettings.save("MaxAnisotropy", system.config["anisotropic_filtering"])
     else:
-        pcsx2GFXSettings.save("MaxAnisotropy", "0")    
+        pcsx2GFXSettings.save("MaxAnisotropy", "0")
 
     pcsx2GFXSettings.write()
 
@@ -198,7 +256,7 @@ def configureUI(config_directory, bios_directory, system_config, gameResolution)
     if not os.path.exists(config_directory + "/inis"):
         os.makedirs(config_directory + "/inis")
 
-    # find the first bios
+    # Find the first BIOS
     bios = [ "PS2 Bios 30004R V6 Pal.bin", "scph10000.bin", "scph39001.bin", "SCPH-70004_BIOS_V12_PAL_200.BIN" ]
     biosFound = False
     for bio in bios:
@@ -209,16 +267,17 @@ def configureUI(config_directory, bios_directory, system_config, gameResolution)
     if not biosFound:
         raise Exception("No bios found")
 
+    # Ratio
     resolution = getGfxRatioFromConfig(system_config, gameResolution)
 
-    # this file looks like a .ini, but no, it miss the first section name...
+    # This file looks like a .ini, but no, it miss the first section name...
     iniConfig = configparser.ConfigParser(interpolation=None)
     # To prevent ConfigParser from converting to lower case
     iniConfig.optionxform = str
     if os.path.exists(configFileName):
         try:
             file = io.StringIO()
-            # fake an initial section, because pcsx2 doesn't put one
+            # Fake an initial section, because pcsx2 doesn't put one
             file.write('[NO_SECTION]\n')
             file.write(io.open(configFileName, encoding='utf_8_sig').read())
             file.seek(0, os.SEEK_SET)
@@ -235,13 +294,13 @@ def configureUI(config_directory, bios_directory, system_config, gameResolution)
     iniConfig.set("Filenames",  "BIOS",        biosFile)
     iniConfig.set("GSWindow",   "AspectRatio", resolution)
 
-    # save the ini file
+    # Save the ini file
     if not os.path.exists(os.path.dirname(configFileName)):
         os.makedirs(os.path.dirname(configFileName))
     with open(configFileName, 'w') as configfile:
         iniConfig.write(configfile)
 
-    # remove the first line (the [NO_SECTION])
+    # Remove the first line (the [NO_SECTION])
     with open(configFileName, 'r') as fin:
         data = fin.read().splitlines(True)
     with open(configFileName, 'w') as fout:
@@ -252,7 +311,7 @@ def configureAudio(config_directory):
     if not os.path.exists(config_directory + "/inis"):
         os.makedirs(config_directory + "/inis")
 
-    # keep the custom files
+    # Keep the custom files
     if os.path.exists(configFileName):
         return
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -20,17 +20,24 @@ def writePPSSPPConfig(system):
             pass
 
     createPPSSPPConfig(iniConfig, system)
-    # save the ini file
+    # Save the ini file
     if not os.path.exists(os.path.dirname(batoceraFiles.ppssppConfig)):
         os.makedirs(os.path.dirname(batoceraFiles.ppssppConfig))
     with open(batoceraFiles.ppssppConfig, 'w') as configfile:
         iniConfig.write(configfile)
 
 def createPPSSPPConfig(iniConfig, system):
+
+    ## [GRAPHICS]
     if not iniConfig.has_section("Graphics"):
         iniConfig.add_section("Graphics")
-    if not iniConfig.has_section("General"):
-        iniConfig.add_section("General")
+
+    # Graphics Backend : TODO (Not used for now)
+    iniConfig.set("Graphics", "FailedGraphicsBackends", "0 (OPENGL)")
+    if system.isOptSet('gfxbackend'):
+        iniConfig.set("Graphics", "GraphicsBackend", system.config["gfxbackend"])
+    else:
+        iniConfig.set("Graphics", "GraphicsBackend", "0 (OPENGL)")
 
     # Display FPS
     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
@@ -41,7 +48,7 @@ def createPPSSPPConfig(iniConfig, system):
     # Frameskip
     iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not pourcent
     iniConfig.set("Graphics", "AutoFrameSkip", "False")
-    if system.isOptSet("frameskip") and system.config["frameskip"] != 0:
+    if system.isOptSet("frameskip"):
         if system.config["frameskip"] == "automatic":
             iniConfig.set("Graphics", "AutoFrameSkip", "True")
             iniConfig.set("Graphics", "FrameSkip",     "1")
@@ -51,10 +58,36 @@ def createPPSSPPConfig(iniConfig, system):
         iniConfig.set("Graphics", "FrameSkip",     "0")
 
     # Internal Resolution
-    if system.isOptSet('internalresolution'):
-        iniConfig.set("Graphics", "InternalResolution", str(system.config["internalresolution"]))
+    if system.isOptSet('internal_resolution'):
+        iniConfig.set("Graphics", "InternalResolution", str(system.config["internal_resolution"]))
     else:
         iniConfig.set("Graphics", "InternalResolution", "1")
+
+    # Texture Scaling Level
+    if system.isOptSet('texture_scaling_level'):
+        iniConfig.set("Graphics", "TexScalingLevel", system.config["texture_scaling_level"])
+    else:
+        iniConfig.set("Graphics", "TexScalingLevel", "1")
+    # Texture Scaling Type
+    if system.isOptSet('texture_scaling_type'):
+        iniConfig.set("Graphics", "TexScalingType", system.config["texture_scaling_type"])
+    else:
+        iniConfig.set("Graphics", "TexScalingType", "0")
+    # Texture Deposterize
+    if system.isOptSet('texture_deposterize'):
+        iniConfig.set("Graphics", "TexDeposterize", system.config["texture_deposterize"])
+    else:
+        iniConfig.set("Graphics", "TexDeposterize", "True")
+
+    # Anisotropic Filtering
+    if system.isOptSet('anisotropic_filtering'):
+        iniConfig.set("Graphics", "AnisotropyLevel", system.config["anisotropic_filtering"])
+    else:
+        iniConfig.set("Graphics", "AnisotropyLevel", "3")
+
+    ## [GENERAL]
+    if not iniConfig.has_section("General"):
+        iniConfig.add_section("General")
 
     # Rewinding
     if system.isOptSet('rewind') and system.getOptBoolean('rewind') == True:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1262,7 +1262,7 @@ libretro:
                     "DMA Only (Slightly Faster)":   dma
             multitap_mednafen:
                 prompt:      MULTITAP
-                description: Allowing 5-8 player support in games
+                description: Allows 5 or 8 max players support in games
                 choices:
                     "Off":              disabled
                     "Port 1":           port1
@@ -1871,7 +1871,7 @@ libretro:
                     "On (Speed hack)":  enabled_with_speedhack
             multitap_pcsx:
                 prompt:      MULTITAP
-                description: Allowing 5-8 player support in games
+                description: Allows 5 or 8 max players support in games
                 choices:
                     "Off":              disabled
                     "Port1":            port1
@@ -2767,8 +2767,8 @@ cannonball:
             choices:
                 "Off": 0
                 "On":  1
+
 cemu:
-  features: [emulated_wiimotes]
   cfeatures:
         gfxbackend:
             prompt:      GRAPHICS BACKEND
@@ -2776,15 +2776,40 @@ cemu:
             choices:
                 "OpenGL": OpenGL
                 "Vulkan": Vulkan
+        async:
+            prompt:      ASYNC SHADER
+            description: Speedup shader compilation (Vulkan only)
+            choices:
+                "Off":    0
+                "On":     1
+        emulatedwiimotes:
+            prompt:      EMULATE WIIMOTE
+            description: Use gamepad like Sideway Wiimote, Nunchuk on RStick
+            choices:
+                "Off":    0
+                "On":     1
 
 citra:
-  features: [ratio, rewind, screen_layout]
+  features: [ratio, rewind, ]
+  cfeatures:
+        citra_screen_layout:
+            prompt:      SCREEN LAYOUT
+            description: Allows you to arrange the DS screens
+            choices:
+                "top/bottom":            4-false
+                "bottom/top":            4-true
+                "left/right":            3-false
+                "right/left":            3-true
+                "top only":              0-false
+                "bottom only":           0-true
+                "hybrid top ratio 4":    2-false
+                "hybrid bottom ratio 4": 2-true
 
 daphne:
   features: [ratio, padtokeyboard]
 
 dolphin:
-  features: [ratio, internal_resolution]
+  features: [ratio]
   cfeatures:
         gfxbackend:
             archs_include: [x86, x86_64, rpi4, odroidgoa]
@@ -2799,6 +2824,18 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
+        internal_resolution:
+            prompt:      VIDEO RESOLUTION
+            description: Improve the fidelity of 3D models (unaffect 2D)
+            choices:
+                "1x native (640x528)":  1
+                "2x 720p (1280x1056)":  2
+                "3x 1080p (1920x1584)": 3
+                "4x 1440p (2560x2112)": 4
+                "5x (3200x2640)":       5
+                "6x 4K (3840x3168)":    6
+                "7x (4480x3696)":       7
+                "8x 5K (5120x4224)":    8
         anisotropic_filtering:
             prompt:      ANISOTROPIC FILTERING
             description: Enhance the quality with on perspective textures
@@ -2885,11 +2922,16 @@ dolphin:
 
   systems:
     wii:
-        features: [emulated_wiimotes]
         cfeatures:
+            emulatedwiimotes:
+                prompt:      EMULATE WIIMOTE
+                description: Use your gamepad like a vertical Wiimote in game
+                choices:
+                    "Off":                       0
+                    "On":                        1
             controller_mode:
-                prompt:      GAMEPAD CONTROLLER MODE
-                description: Use gamepad with L2 for Shake and more on right stick
+                prompt:      CUSTOMIZE WIIMOTE & GAMEPAD
+                description: Wiimote Sideway, L2 for Shake, Nunchuk on RStick
                 choices:
                     "Off":                       disabled
                     "Classic Controller":        cc
@@ -3025,7 +3067,7 @@ duckstation:
                 "On":                           1
         duckstation_multitap:
             prompt:      MULTITAP
-            description: Allowing 5-8 player support in games
+            description: Allows 5 or 8 max players support in games
             choices:
                 "Off":                          Disabled
                 "Port 1":                       Port1Only
@@ -3205,25 +3247,34 @@ openbor:
                 "Dot Matrix":     11
 
 pcsx2:
-  features: [ratio, fullboot, internal_resolution]
+  features: [ratio]
   cfeatures:
-        multitap:
-            prompt:      MULTITAP
-            description: Allowing 5-8 player support in games
+        fullboot:
+            prompt:      SHOW BIOS BOOTLOGO
+            description: Show BIOS animation when starting content
             choices:
-                "Off":      disabled
-                "Port1":    port1
-                "Port2":    port2
-                "Port1+2":  port12
+                "Off":         0
+                "On":          1
+        internal_resolution:
+            prompt:      VIDEO RESOLUTION
+            description: Improve the fidelity of 3D models (unaffect 2D)
+            choices:
+                "1x 640x480":  1
+                "2x 720p":     2
+                "3x 1080p":    3
+                "4x 1440p 2K": 4
+                "5x 1620p 3K": 5
+                "6x 2160p 4K": 6
+                "7x 2880p 5K": 7
         anisotropic_filtering:
             prompt:      ANISOTROPIC FILTERING
             description: Enhance the quality with on perspective textures
             choices:
-                "Off":      0
-                "2x":       2
-                "4x":       4
-                "8x":       8
-                "16x":      16
+                "Off":         0
+                "2x":          2
+                "4x":          4
+                "8x":          8
+                "16x":         16
         skipdraw:
             prompt:      SKIPDRAW HACK
             description: Skip frames to improve performance (Smoothless)
@@ -3246,21 +3297,124 @@ pcsx2:
             choices:
                 "Off":      0
                 "On":       1
+        EmuCore_EnableCheats:
+            prompt:      GAMES CHEATS
+            description: For cheating in games as with Action Replay
+            choices:
+                "Off":      disabled
+                "On":       enabled
+        EmuCore_EnableWideScreenPatches:
+            prompt:      WIDESCREEN PATCHES
+            description: You must use a 16/9 RATIO and disable BEZEL
+            choices:
+                "Off":      disabled
+                "On":       enabled
+        EmuCore_EnablePatches:
+            prompt:      AUTOMATIC GAMEFIXES
+            description: Selectively use specific tested fixes for games
+            choices:
+                "Off":      disabled
+                "On":       enabled
+        EmuCore_ManualPatches:
+            prompt:      MANUAL GAMEFIXES
+            description: They can cause compatibility or performance issues
+            choices:
+                "Off":                                               disabled
+                "VU Add hack - Fixes Tri-Ace games boot crash":      VuAddSubHack
+                "FPU Compare hack - For Digimon Rumble Arena 2":     FpuCompareHack
+                "FPU Multiply hack - For Tales of Destiny":          FpuMulHack
+                "FPU Negative Div hack - For Gundam Games":          FpuNegDivHack
+                "VU XGkick hack - For Eremental Gerad":              XgKickHack
+                "FFX videos fix - Fixes bad graphics overlay":       IPUWaitHack
+                "EE timing hack - Try if all else fails":            EETimingHack
+                "Skip MPEG hack - Skips videos/FMVs that freezes":   SkipMPEGHack
+                "OPH Flag hack - Try if game freeze on same frame":  OPHFlagHack
+                "Handle DMAC writes when it busy":                   DMABusyHack
+                "Simulate VIF1 FIFO read - Fix slow loading":        VIFFIFOHack
+                "Delay VIF1 Stalls - For SOCOM2 n Spy Hunter":       VIF1StallHack
+                "Enable the GIF FIFO - Wallace and Gromit, Dj Hero": GIFFIFOHack
+                "Preload TLB hack to avoid tlb miss on Goemon":      GoemonTlbHack
+                "VU I bit hack - Scarface The World is Yours":       ScarfaceIbit
+                "VU I bit hack - Crash Tag Team Racing":             CrashTagTeamRacingIbit
+                "VUO Kickstart to avoid sync problems with VU1":     VU0KickstartHack
+        multitap:
+            prompt:      MULTITAP
+            description: Allows 5 or 8 max players support in games
+            choices:
+                "Off":      disabled
+                "Port1":    port1
+                "Port2":    port2
+                "Port1+2":  port12
 
 ppsspp:
-  features: [rewind, ratio, internal_resolution]
+  features: [rewind, ratio]
   cfeatures:
+#        gfxbackend:
+#            archs_include: [x86, x86_64, rpi4, odroidgoa]
+#            prompt:      GRAPHICS BACKEND
+#            description: Choose your graphics rendering
+#            choices:
+#                "OpenGL":               0 (OPENGL)
+#                "Vulkan":               3 (VULKAN)
+        internal_resolution:
+            prompt:      VIDEO RESOLUTION
+            description: Improve the fidelity of 3D models (unaffect 2D)
+            choices:
+                #"Automatic (1:1)":      0
+                "1x 480×272":           1
+                "2x 960x544":           2
+                "3x 720p":              3
+                "4x 1080p":             4
+                "5x 2400x1360":         5
+                "6x 1620p 3K":          6
+                "7x 3360x1904":         7
+                "8x 2160p 4K":          8
+                "9x 4320x2448":         9
+                "10x 4800x2720":        10
         frameskip:
             prompt:      FRAME SKIP
             description: Skip frames to improve performance (Smoothless)
             choices:
-                "Off":        0
-                "Autodetect": automatic
-                "1":          1
-                "2":          2
-                "3":          3
-                "4":          4
-                "5":          5
+                "Off":                  0
+                "Autodetect":           automatic
+                "1":                    1
+                "2":                    2
+                "3":                    3
+                "4":                    4
+                "5":                    5
+        texture_scaling_level:
+            prompt:      TEXTURES UPSCALING (XBRZ)
+            description: Upscaling textures resolution on 3D objetcs
+            choices:
+                "Off":                  1
+                "Automatic":            0
+                "2x":                   2
+                "3x":                   3
+                "4x":                   4
+                "5x":                   5
+        texture_scaling_type:
+            prompt:      TEXTURE ENHANCEMENT (XBRZ)
+            description: Scales up a nearest-neighbor version of the texture
+            choices:
+                "xBRZ":                 0
+                "Hybride":              1
+                "Bicubique":            2
+                "Hybride + Bicubique":  3
+        texture_deposterize:
+            prompt:      TEXTURE DEPOSTERIZE
+            description: Fix the bug that causes bands to appear in textures
+            choices:
+                "Off":                  False
+                "On":                   True
+        anisotropic_filtering:
+            prompt:      ANISOTROPIC FILTERING
+            description: Enhance the quality with on perspective textures
+            choices:
+                "Off":                  0
+                "2x":                   1
+                "4x":                   2
+                "8x":                   3
+                "16x":                  4
 
 reicast:
   features: [ratio]


### PR DESCRIPTION
DOLPHIN

- Add Wii and GC rom path
- Remove "internal_resolution" old option and replace by the new es_features system with real values

PCSX2

- Remove old "fullboot" and replace by the new es_features system
- Remove "internal_resolution" old option and replace by the new es_features system with real values
- Add "games cheat" option
- Add "widescreen patches" option
- Add "automatic gamefixes" option
- Add "manual gemefixes" with "VuAddSubHack" hack for @liberodark

PPSSPP

- Remove "internal_resolution" old option and replace by the new es_features system with real values
- Add "Anisotropic filtering" option
- Add "Texture scalling level" and "type" option
- Add "Texture Deposterize" option

I have try to add "Vulkan" backend, but it not works for now

WII

- Remove "emulated_wiimotes" old option and replace by the new es_features system with real values

CEMU

- Remove "emulated_wiimotes" old option and replace by the new es_features system with real values
- Add Async shader compilation option
- Add the default "ROM path" directory
- Update the "Game Language" default to the system one
- Add "fps info" in debug mode

CITRA

- Remove "screen_layout" old option and replace by the new es_features system with real values

Now we can remove old functions from Emulationstation
https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-app/src/guis/GuiMenu.cpp#L3990
