### PR TITLE
Update default N64 core

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-libretech-h5.yml
@@ -7,9 +7,6 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-miqi.yml
@@ -10,9 +10,6 @@ amigacd32:
 dos:
   emulator: dosbox
   core:     dosbox
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
@@ -2,9 +2,6 @@ default:
   options:
     retroarch.audio_out_rate: 44100
 
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 neogeocd:
   emulator: libretro
   core:     fbneo

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc4.yml
@@ -1,9 +1,6 @@
 dos:
   emulator: dosbox
   core:     dosbox
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
@@ -10,8 +10,6 @@ default:
     resolutionIsReversed: true
 
 n64:
-  emulator: mupen64plus
-  core:     glide64mk2
   options:
     ratio: "16/9"
     mupen64plus.Video-General.Rotate: 0 # for people upgrading

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -11,9 +11,6 @@ dreamcast:
     retroarch.video_hard_sync: 1
     # setting to fix Flycast performances on xu4
     reicast_synchronous_rendering: disabled
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-zero2.yml
@@ -1,6 +1,4 @@
 dos:
   emulator: dosbox
   core:     dosbox
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
@@ -2,9 +2,6 @@ default:
   options:
     audio_driver: pulse
 
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rock960.yml
@@ -1,6 +1,3 @@
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi1.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi1.yml
@@ -28,6 +28,12 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
+n64:
+  emulator: mupen64plus
+  core:     gliden64
+n64dd:
+  emulator: mupen64plus
+  core:     gliden64
 snes:
   emulator: libretro
   core:     pocketsnes

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,7 +1,11 @@
 n64:
+  emulator: mupen64plus
+  core:     gliden64
   options:
     videomode: DMT 4 HDMI
 n64dd:
+  emulator: mupen64plus
+  core:     gliden64
   options:
     videomode: DMT 4 HDMI
 psp:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -1,9 +1,3 @@
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
-n64dd:
-  emulator: mupen64plus
-  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
@@ -11,9 +11,6 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
@@ -2,9 +2,6 @@ default:
   options:
     retroarch.audio_out_rate: 44100
 
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905gen3.yml
@@ -1,9 +1,6 @@
 dos:
   emulator: dosbox
   core:     dosbox
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 nds:
   emulator: libretro
   core:     melonds

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
@@ -1,6 +1,3 @@
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-tinkerboard.yml
@@ -1,9 +1,6 @@
 dos:
   emulator: dosbox
   core:     dosbox
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 psp:
   options:
     frameskip: 1

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86.yml
@@ -1,9 +1,3 @@
-model3:
-  emulator: supermodel
-  core:     supermodel
-n64:
-  emulator: mupen64plus
-  core:     glide64mk2
 pcengine:
   emulator: libretro
   core:     pce

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -176,6 +176,9 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     genesisplusgx
+model3:
+  emulator: supermodel
+  core:     supermodel
 moonlight:
   emulator: moonlight
   core: moonlight
@@ -202,10 +205,10 @@ fpinball:
   core:     fpinball
 n64:
   emulator: mupen64plus
-  core:     gliden64
+  core:     glide64mk2
 n64dd:
   emulator: mupen64plus
-  core:     gliden64
+  core:     glide64mk2
 naomi:
   emulator: libretro
   core:     flycast


### PR DESCRIPTION
Mupen64Plaus MK2 is the best video plugin used by all these boards :

libretech-H5, Miqi, OdroicC2, OdroidC4, OdroidGOA, Odroidxu4, OrangePi-Zero2, Rk3399, Rock960, Rpi4, S812, S905, S905-gen3, S912, Tinkeboard, PC86 & 64

Now we also have video options for this plugin in ES, the best choice is to put it by default.
To make sense with Discord discussion and this comit

https://github.com/batocera-linux/batocera.linux/pull/3703