### PR TITLE
es.resolution as mode in batocera-boot.conf

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -14,9 +14,10 @@
 	* add: splash for x86_64 and rpi4
 	* add: virtual resolutions for games to limit the maximum resolution
 	* add: video mode for drm now includes some information to not be applied over different tvs
+	* add: es.maxresolution is now renamed es.resolution in batocera-boot.conf and can take any value from listModes (aka max-1920x1080)
 	* bump: python to 3
 	* bump: kodi to 19
-    * bump: GCC compiler to 10.2
+	* bump: GCC compiler to 10.2
 	* bump: Flycast
 	* bump: Daphne (Hypseus+Singe) to 2.3.0
 	* bump: SwitchRes tool

--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -47,10 +47,13 @@ settings_output="$(/usr/bin/batocera-settings-get global.dpi)"
 
 # set user desired resolution
 # nice workaround for displays which tell X11 to use strange resolutions
-settings_output="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf es.maxresolution)"
-[ ! -z "${settings_output}" ] && batocera-resolution minTomaxResolution "${settings_output}"
-
-batocera-resolution minTomaxResolution
+settings_output="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf es.resolution)"
+if [ -z "${settings_output}" ]
+then
+    batocera-resolution minTomaxResolution-secure
+else
+    batocera-resolution setMode "${settings_output}"
+fi
 
 # allow coredumps for ES
 ulimit -H -c unlimited

--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -11,15 +11,13 @@ fi
 case "$1" in
 	start)
 		enabled="$(/usr/bin/batocera-settings-get system.es.atstartup)"
-		secured="$(/usr/bin/batocera-settings-get system.es.maxresolution)"
-		bootresolution="$(/usr/bin/batocera-settings-get -f "$BOOTCONF" es.maxresolution)"
-		test ! -z "${bootresolution}" && secured="${bootresolution}"
+		bootresolution="$(/usr/bin/batocera-settings-get -f "$BOOTCONF" es.resolution)"
 		if [ "$enabled" != "0" ];then
-			if test "${secured}" = 0 -o -z "${secured}"
+			if test -z "${bootresolution}"
 			then
-			  batocera-resolution minTomaxResolution-secure
+			    batocera-resolution minTomaxResolution-secure
 			else
-			  batocera-resolution minTomaxResolution "${secured}"
+			    batocera-resolution setMode "${bootresolution}"
 			fi
 			settings_lang="$(/usr/bin/batocera-settings-get system.language)"
 			display_rotate="$(/usr/bin/batocera-settings-get display.rotate)"


### PR DESCRIPTION
- rename es.maxresolution to es.resolution
- now instead of taking a maximum wxh value, takes a value
  from batocera-resolution listModes
  this can be a fixed resolution (thus more precised than the previous way)
  or a max-640x480 or any value

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>