### PR TITLE
Fix Citra not building

### DIFF
--- a/package/batocera/emulators/citra/citra.mk
+++ b/package/batocera/emulators/citra/citra.mk
@@ -56,7 +56,7 @@ endif
 define CITRA_EVMAP
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	
-	cp -prn $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/citra/3ds.citra.keys
+	cp -prn $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/citra/3ds.citra.keys \
 		$(TARGET_DIR)/usr/share/evmapy
 endef
 


### PR DESCRIPTION
copy command will now work for the bespoke key file used in Citra make