### PR TITLE
fix dolphin exit 2 times

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -38,6 +38,8 @@ class DolphinGenerator(Generator):
             dolphinSettings.add_section("Interface")
         if not dolphinSettings.has_section("Analytics"):
             dolphinSettings.add_section("Analytics")
+        if not dolphinSettings.has_section("Display"):
+            dolphinSettings.add_section("Display")
 
         # Define default games path
         dolphinSettings.set("General", "ISOPath0", '"/userdata/roms/wii"')
@@ -60,6 +62,10 @@ class DolphinGenerator(Generator):
 
         # Don't confirm at stop
         dolphinSettings.set("Interface", "ConfirmStop", '"False"')
+
+        # only 1 window (fixes exit and gui display)
+        dolphinSettings.set("Display", "RenderToMain", '"True"')
+        dolphinSettings.set("Display", "Fullscreen", '"True"')
 
         # Enable Cheats
         if system.isOptSet("enable_cheats") and system.getOptBoolean("enable_cheats"):

--- a/package/batocera/emulators/dolphin-emu/006-nicerlaunch.patch
+++ b/package/batocera/emulators/dolphin-emu/006-nicerlaunch.patch
@@ -1,0 +1,27 @@
+diff --git a/Source/Core/DolphinQt/GameList/GameList.cpp b/Source/Core/DolphinQt/GameList/GameList.cpp
+index 65c870b..1931230 100644
+--- a/Source/Core/DolphinQt/GameList/GameList.cpp
++++ b/Source/Core/DolphinQt/GameList/GameList.cpp
+@@ -218,8 +218,7 @@ void GameList::UpdateColumnVisibility()
+ void GameList::MakeEmptyView()
+ {
+   const QString refreshing_msg = tr("Refreshing...");
+-  const QString empty_msg = tr("Dolphin could not find any GameCube/Wii ISOs or WADs.\n"
+-                               "Double-click here to set a games directory...");
++  const QString empty_msg = QString::fromStdString("");
+ 
+   m_empty = new QLabel(this);
+   m_empty->setText(refreshing_msg);
+diff --git a/Source/Core/DolphinQt/MainWindow.cpp b/Source/Core/DolphinQt/MainWindow.cpp
+index 20572d8..a34f004 100644
+--- a/Source/Core/DolphinQt/MainWindow.cpp
++++ b/Source/Core/DolphinQt/MainWindow.cpp
+@@ -1768,6 +1768,8 @@ void MainWindow::Show()
+   // If the booting of a game was requested on start up, do that now
+   if (m_pending_boot != nullptr)
+   {
++    m_menu_bar->hide();
++    m_tool_bar->hide();
+     StartGame(std::move(m_pending_boot));
+     m_pending_boot.reset();
+   }


### PR DESCRIPTION
not sure it works while i were not able to reproduce.
but now, there is only one window to close, so it should
be ok.
moreover, hide the menubard and tool bar and empty list message at boot

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>