### PR TITLE
Duckstation - Fixing bad path for savestates

### DIFF
--- a/package/batocera/emulators/duckstation/004-savestate-pathandnames.patch
+++ b/package/batocera/emulators/duckstation/004-savestate-pathandnames.patch
@@ -20,8 +20,11 @@ index da4198ab..63db3c4a 100644
 +  if (strncmp(formatted_path.c_str(), "screenshots", 11) == 0)
 +    return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata", formatted_path.c_str());
 +
-+  if (strncmp(formatted_path.c_str(), "savestates", 10) == 0 || strncmp(formatted_path.c_str(), "memcards", 7) == 0)
-+    return StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.c_str());
++  if (strncmp(formatted_path.c_str(), "savestates", 10) == 0)
++    return formatted_path.length() > 10 ? StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.substr(11).c_str()) : "/userdata/saves/psx/duckstation";
++
++  if (strncmp(formatted_path.c_str(), "memcards", 7) == 0)
++    return formatted_path.length() > 7 ? StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.substr(8).c_str()) : "/userdata/saves/psx/duckstation";
 +  
    if (m_user_directory.empty())
    {


### PR DESCRIPTION
Fixing Bad path for save states
Starting to homogeinize savefolders like with savestates AND saves on the samefolder
````saves/<system>/<emulator>/<cores> (if exists)/*.sav*.srm etc...````

exemples : 
saves/psx/duckstation/Metal Gear Solid (France) (Disc 1) [SLES_015.06]_1.mcd
saves/psx/duckstation/Metal Gear Solid (France) (Disc 1) [SLES_015.06]_1.sav

saves/psx/libretro/pcsx_rearmed/Metal Gear Solid (France) [SLES_015.06].srm
saves/psx/libretro/pcsx_rearmed/Metal Gear Solid (France) [SLES_015.06].state

Made by F.Caruso
![image](https://user-images.githubusercontent.com/54243866/115754778-db09a480-a39c-11eb-99ae-465c5ff54c6f.png)
