### PR TITLE
Bump batocera-settings to 0.0.4

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings.hash
+++ b/package/batocera/core/batocera-settings/batocera-settings.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  82fde321fb1aa5425071a7bad58fa09b8434dcae06983fe029f6fa926bb03c9a  batocera-settings-0.0.3.tar.gz
+sha256  61fda3083c7109a3146a69e1eb1399b36137c8d517a688bb0e4786ab34940e1f  batocera-settings-0.0.4.tar.gz
 sha256  c64a84bc21adbd6cf8d2a552ed5c4e33d90d13dae3cadb8babf259af01b81e0f  LICENSE

--- a/package/batocera/core/batocera-settings/batocera-settings.mk
+++ b/package/batocera/core/batocera-settings/batocera-settings.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SETTINGS_VERSION = 0.0.3
+BATOCERA_SETTINGS_VERSION = 0.0.4
 BATOCERA_SETTINGS_LICENSE = MIT
 BATOCERA_SETTINGS_SITE = $(call github,batocera-linux,mini_settings,$(BATOCERA_SETTINGS_VERSION))
 BATOCERA_SETTINGS_CONF_OPTS = \


### PR DESCRIPTION
Allows `batocera-settings-set` to be used with `/boot/config.txt`.

Fixes #3349

https://github.com/batocera-linux/mini_settings/commit/32d05a4bfaa6110fc80b49c0e9dbf7dfeb08fcf6