### PR TITLE
Duckstation - Region/60Hz/Quickmenu

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -76,8 +76,14 @@ class DuckstationGenerator(Generator):
         if not settings.has_section("Console"):
             settings.add_section("Console")
         # Region
-        settings.set("Console", "Region", "Auto")
-
+        if system.isOptSet("duckstation_region") and system.config["duckstation_region"] == 'PAL':
+            settings.set("Console", "Region", "PAL")
+        elif system.isOptSet("duckstation_region") and system.config["duckstation_region"] == 'NTSC-J':
+            settings.set("Console", "Region", "NTSC-J")
+        elif system.isOptSet("duckstation_region") and system.config["duckstation_region"] == 'NTSC-U':
+            settings.set("Console", "Region", "NTSC-U")
+        else:
+            settings.set("Console", "Region", "Auto")
 
         ## [BIOS]
         if not settings.has_section("BIOS"):
@@ -122,6 +128,11 @@ class DuckstationGenerator(Generator):
             settings.set("GPU", "WidescreenHack", "true")
         else:
             settings.set("GPU", "WidescreenHack", "false")
+        # Force 60hz
+        if system.isOptSet("duckstation_60hz") and system.config["duckstation_60hz"] == '1':
+           settings.set("GPU", "ForceNTSCTimings", "true")
+        else:
+           settings.set("GPU", "ForceNTSCTimings", "false")
         # TextureFiltering
         if system.isOptSet("duckstation_texture_filtering") and system.config["duckstation_texture_filtering"] != 'Nearest':
            settings.set("GPU", "TextureFilter", system.config["duckstation_texture_filtering"])
@@ -202,7 +213,7 @@ class DuckstationGenerator(Generator):
 
         # Force defaults to be aligned with evmapy
         settings.set("Hotkeys", "FastForward",                 "Keyboard/Tab")
-        settings.set("Hotkeys", "TogglePause",                 "Keyboard/Pause")
+        settings.set("Hotkeys", "Reset",                       "Keyboard/F6")
         settings.set("Hotkeys", "PowerOff",                    "Keyboard/Escape")
         settings.set("Hotkeys", "LoadSelectedSaveState",       "Keyboard/F1")
         settings.set("Hotkeys", "SaveSelectedSaveState",       "Keyboard/F2")

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3050,118 +3050,131 @@ duckstation:
             prompt:      GRAPHICS BACKEND
             description: Choose your graphics rendering
             choices:
-                "OpenGL":                       OpenGL
-                "Vulkan":                       Vulkan
+                "OpenGL":                        OpenGL
+                "Vulkan":                        Vulkan
         duckstation_threadedpresentation:
             prompt:      VULKAN THREADED
             description: Can mesurably improve performance if Vsync disabled
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
         duckstation_vsync:
             prompt:      VSYNC
             description: Fix the heavy screen tearing in games (heavy CPU)
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
         duckstation_frameskip:
             prompt:      FRAME SKIP
             description: Skip frames to improve performance (Smoothless)
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
         duckstation_PatchFastBoot:
             prompt:      SHOW BIOS BOOTLOGO
             description: Show BIOS animation when starting content
             choices:
-                "Off":                          1
-                "On":                           0
+                "Off":                           1
+                "On":                            0
         duckstation_resolution_scale:
             prompt:      VIDEO RESOLUTION
             description: Improve the fidelity of 3D models (unaffect 2D)
             choices:
-                "1x(native)":                   1
-                "2x":                           2
-                "3x/720p":                      3
-                "4x":                           4
-                "5x/1080p":                     5
-                "6x/1440p":                     6
-                "7x":                           7
-                "8x":                           8
-                "9x/4K":                        9
-                "10x":                          10
-                "11x":                          11
-                "12x":                          12
-                "13x":                          13
-                "14x":                          14
-                "15x":                          15
-                "16x":                          16
+                "1x(native)":                    1
+                "2x":                            2
+                "3x/720p":                       3
+                "4x":                            4
+                "5x/1080p":                      5
+                "6x/1440p":                      6
+                "7x":                            7
+                "8x":                            8
+                "9x/4K":                         9
+                "10x":                           10
+                "11x":                           11
+                "12x":                           12
+                "13x":                           13
+                "14x":                           14
+                "15x":                           15
+                "16x":                           16
         duckstation_antialiasing:
             prompt:      ANTI-ALIASING (MSAA/SSAA)
             description: Smooth out jagged edges on 3D objetcs polygons
             choices:
-                "Off":                          1
-                "2x msaa":                      2
-                "4x msaa":                      4
-                "8x msaa":                      8
-                "16x msaa":                     16
-                "32x msaa":                     32
-                "2x ssaa":                      2-ssaa
-                "4x ssaa":                      4-ssaa
-                "8x ssaa":                      8-ssaa
-                "16x ssaa":                     16-ssaa
-                "32x ssaa":                     32-ssaa
+                "Off":                           1
+                "2x msaa":                       2
+                "4x msaa":                       4
+                "8x msaa":                       8
+                "16x msaa":                      16
+                "32x msaa":                      32
+                "2x ssaa":                       2-ssaa
+                "4x ssaa":                       4-ssaa
+                "8x ssaa":                       8-ssaa
+                "16x ssaa":                      16-ssaa
+                "32x ssaa":                      32-ssaa
         duckstation_texture_filtering:
             prompt:      TEXTURE FILTERING
             description: Smooths out textures on 3D objetcs
             choices:
-                "Nearest-Neighbor":             Nearest
-                "Bilinear":                     Bilinear
-                "Bilinear (no Edge Blending)":  BilinearBinAlpha
-                "JINC2":                        Jinc2
-                "JINC2 (no Edge Blending)":     Jinc2BinAlpha
-                "xBR":                          xBR
-                "xBR (no Edge Blending)":       xBRBinAlpha
+                "Nearest-Neighbor":              Nearest
+                "Bilinear":                      Bilinear
+                "Bilinear (no Edge Blending)":   BilinearBinAlpha
+                "JINC2":                         Jinc2
+                "JINC2 (no Edge Blending)":      Jinc2BinAlpha
+                "xBR":                           xBR
+                "xBR (no Edge Blending)":        xBRBinAlpha
         duckstation_CropMode:
             prompt:      CROP MODE
             description: Changes how much of the image is cropped
             choices:
-                "Off":                          "None"
-                "Only Overscan Area":           "Overscan"
-                "All Borders":                  "Borders"
+                "Off":                           "None"
+                "Only Overscan Area":            "Overscan"
+                "All Borders":                   "Borders"
         duckstation_widescreen_hack:
             prompt:      WIDESCREEN HACK
             description: You must use a 16/9 RATIO and disable BEZEL
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
+        duckstation_region:
+            prompt:      CONSOLE REGION
+            description: Change Region of Emulator
+            choices:
+                "Europe-Australia":              PAL
+                "USA-Canada":                    NTSC-U
+                "Japan":                         NTSC-J
+        duckstation_60hz:
+            prompt:      FORCE 60Hz
+            description: Force 60Hz NTSC Timing
+            choices:
+                "Off":                           0
+                "On":                            1
         duckstation_custom_textures:
             prompt:      CUSTOM TEXTURES
             description: Permit to use HD Texture Pack, preload use more RAM 
             choices:
-                "Off":                   0
-                "Normal":                normal
-                "Preload":               preload
+                "Off":                           0
+                "Normal":                        normal
+                "Preload":                       preload
         duckstation_rumble:
             prompt:      RUMBLE
             description: Activate vibration on supported controllers
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
         duckstation_digitalmode:
             prompt:      DPAD TO JOYSTICK
             description: Use your Joystick as a Dpad with Analog controllers
             choices:
-                "Off":                          0
-                "On":                           1
+                "Off":                           0
+                "On":                            1
         duckstation_multitap:
             prompt:      MULTITAP
             description: Allows 5 or 8 max players support in games
             choices:
-                "Off":                          Disabled
-                "Port 1":                       Port1Only
-                "Port 2":                       Port2Only
-                "Port 1+2":                     BothPorts
+                "Off":                           Disabled
+                "Port 1":                        Port1Only
+                "Port 2":                        Port2Only
+                "Port 1+2":                      BothPorts
         duckstation_Controller1:
             prompt:      CONTROLLER 1 TYPE
             description: Use DualShock type for games with Rumble mode

--- a/package/batocera/emulators/duckstation/psx.duckstation.keys
+++ b/package/batocera/emulators/duckstation/psx.duckstation.keys
@@ -19,16 +19,22 @@
 	    "description": "Load State"
 	},
 	{
+            "trigger": ["hotkey", "a"],
+            "type": "key",
+            "target": [ "KEY_F7" ],
+	    "description": "Reset Iso"
+	},
+	{
             "trigger": ["hotkey", "b"],
             "type": "key",
-            "target": [ "KEY_PAUSE" ],
-	    "description": "X-Pause Emulator"
+            "target": [ "KEY_F6" ],
+	    "description": "QuickMenu"
 	},
 	{
             "trigger": ["hotkey", "pageup"],
             "type": "key",
             "target": [ "KEY_F10" ],
-	    "description": "L1-ScreenShot"
+	    "description": "ScreenShot"
 	},
 	{
             "trigger": ["hotkey", "up"],
@@ -52,7 +58,7 @@
             "trigger": ["hotkey", "pagedown"],
             "type": "key",
             "target": [ "KEY_F8" ],
-	    "description": "R1-Next Disc (m3u)"
+	    "description": "Next Disc (m3u)"
 	},
 	{
             "trigger": ["hotkey", "right"],


### PR DESCRIPTION
Duckstation : 
* Adding Region selection
* add possibility to Force 60hz Timing
* And future Quickmenu Assigned to Hotkey + X (Playstation) like libretro Quickmenu
![image](https://user-images.githubusercontent.com/54243866/115993133-b64a4280-a5d1-11eb-8d59-941300c39add.png)
