### PR TITLE
Add <arch> in pacman XML to filter out arch-specific ports.

### DIFF
--- a/package/batocera/utils/pacman/004-xmloutput.patch
+++ b/package/batocera/utils/pacman/004-xmloutput.patch
@@ -110,8 +110,8 @@ index 35cfcd9..235f53b 100644
 +		  argz_replace(&protected_string, &n, "<", "&lt;", NULL);
 +		  argz_replace(&protected_string, &n, ">", "&gt;", NULL);
 +		  printf("    <packager>%s</packager>\n",  protected_string);
-+		  printf("    <download_size>%lld</download_size>\n",   alpm_pkg_get_size(pkg)/1024);
-+		  printf("    <installed_size>%lld</installed_size>\n", alpm_pkg_get_isize(pkg)/1024);
++		  printf("    <download_size>%ld</download_size>\n",   alpm_pkg_get_size(pkg)/1024);
++		  printf("    <installed_size>%ld</installed_size>\n", alpm_pkg_get_isize(pkg)/1024);
 +
 +		  if(installed_pkg == NULL) {
 +		    printf("    <status>none</status>\n");

--- a/package/batocera/utils/pacman/005-architecture.patch
+++ b/package/batocera/utils/pacman/005-architecture.patch
@@ -1,0 +1,18 @@
+--- pacman-5.2.1_ORIGINAL/src/pacman/package.c	2021-04-21 15:49:43.178909492 -0700
++++ pacman-5.2.1/src/pacman/package.c	2021-04-27 17:07:32.292734413 -0700
+@@ -603,6 +603,7 @@
+ 		  printf("    <packager>%s</packager>\n",  protected_string);
+ 		  printf("    <download_size>%ld</download_size>\n",   alpm_pkg_get_size(pkg)/1024);
+ 		  printf("    <installed_size>%ld</installed_size>\n", alpm_pkg_get_isize(pkg)/1024);
++		  printf("    <arch>%s</arch>\n",                       alpm_pkg_get_arch(pkg));
+ 
+ 		  if(installed_pkg == NULL) {
+ 		    printf("    <status>none</status>\n");
+@@ -637,6 +638,7 @@
+ 					colstr->version, alpm_pkg_get_version(pkg), colstr->nocolor);
+ 
+ 			print_groups(pkg);
++			printf(" <%s>", alpm_pkg_get_arch(pkg)); // Batocera architecture
+ 			if(show_status) {
+ 				print_installed(db_local, pkg);
+ 			}


### PR DESCRIPTION
This is for Linux-native games in Ports. We can't filter them out based on sys-ports, because you'll have the same system on x86_64 and ARM boards. So, we need to differentiate them with this new tag `<arch>` that matches that pacman package architecture.

Example: the quake shareware files are independent from the arch, while the Linux-native 86_64 game super-tux-kart should be listed only for x86_64:
```
  <package>
    <name>ports-quake-shareware</name>
    <repository>batocera</repository>
    <available_version>1.0.0-4</available_version>
    <description>Quake game files (shareware version)</description>
    <url>https://www.dosgamesarchive.com/download/quake/</url>
    <packager>lbrpdx</packager>
    <download_size>15431</download_size>
    <installed_size>28164</installed_size>
    <arch>any</arch>
    <status>none</status>
    <group>sys-ports</group>
  </package>
  <package>
    <name>ports-supertuxkart</name>
    <repository>batocera</repository>
    <available_version>1.2-1</available_version>
    <description>SuperTuxKart is a 3D open-source arcade racer with a variety characters, tracks, and modes to play.</description>
    <url>https://supertuxkart.net/Main_Page</url>
    <packager>kuri</packager>
    <download_size>810493</download_size>
    <installed_size>936788</installed_size>
    <arch>x86_64</arch>
    <status>none</status>
    <group>sys-ports</group>
  </package>
  ```
  
  Also fixed a warning in a previous patch (%lld vs %ls in a string).
  