### PR TITLE
Bump VKD3D-Proton

### DIFF
--- a/package/batocera/emulators/wine/vkd3d-proton/vkd3d-proton.hash
+++ b/package/batocera/emulators/wine/vkd3d-proton/vkd3d-proton.hash
@@ -1,2 +1,2 @@
 # Locally calculated after checking pgp signature
-sha256 8c6f6ca7a019ab0c6221d08c321d2a6e12bcd68ffa3626317a3fa91bd64b10ca  vkd3d-proton-2.3.tar.zst
+sha256 cc16085c2f9a579eb5a6f5caf99837d2f78606fd078dfab487f121bd1d14cc93  vkd3d-proton-2.3.1.tar.zst

--- a/package/batocera/emulators/wine/vkd3d-proton/vkd3d-proton.mk
+++ b/package/batocera/emulators/wine/vkd3d-proton/vkd3d-proton.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-VKD3D_PROTON_VERSION = 2.3
+VKD3D_PROTON_VERSION = 2.3.1
 VKD3D_PROTON_SOURCE = vkd3d-proton-$(VKD3D_PROTON_VERSION).tar.zst
 VKD3D_PROTON_SITE = https://github.com/HansKristian-Work/vkd3d-proton/releases/download/v$(VKD3D_PROTON_VERSION)
 VKD3D_PROTON_LICENSE = lgpl


### PR DESCRIPTION
That only fixes :

```
Improved support for older Wine and Vulkan Loader versions.
Fix blocky shadows in Horizon Zero Dawn.
Fix the install script failing on Wine installs not built with upstream vkd3d.
Fix minor dxil translation issues.
```

Most important fix is : 
`Improved support for older Wine and Vulkan Loader versions.`