### PR TITLE
Bump WinBTRFS

### DIFF
--- a/package/batocera/utils/winbtrfs/winbtrfs.hash
+++ b/package/batocera/utils/winbtrfs/winbtrfs.hash
@@ -1,2 +1,2 @@
 # Locally calculated after checking pgp signature
-sha256 7f4041c6296d157fb35fc873ca1c4bc0cf9cfb128d846055c57510dbd60330f3  btrfs-1.7.6.zip
+sha256 505dd6d2159e9a63e077029c6a8f953fe3d46f2593c2ec0fc74c5245f9d75096  btrfs-1.7.7.zip

--- a/package/batocera/utils/winbtrfs/winbtrfs.mk
+++ b/package/batocera/utils/winbtrfs/winbtrfs.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINBTRFS_VERSION = 1.7.6
+WINBTRFS_VERSION = 1.7.7
 WINBTRFS_SOURCE = btrfs-$(WINBTRFS_VERSION).zip
 WINBTRFS_SITE = https://github.com/maharmstone/btrfs/releases/download/v$(WINBTRFS_VERSION)
 


### PR DESCRIPTION
Only fixes : 

```
Fixed deadlock on high load
Fixed free space issue when installing Genshin Impact
Fixed issue when copying files with wildcards in command prompt
Increased speed of directory lookups
```