### PR TITLE
Fix asounrc causing Wine to crash with Sega Model 2

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/asoundrc-dmix+softvol
+++ b/package/batocera/core/batocera-audio/alsa/asoundrc-dmix+softvol
@@ -1,26 +1,34 @@
 # batocera-audio alsa config
-# dmix
+# dmix + softvol
 
 pcm.!default {
-	type plug
-	slave.pcm "dmixer"
+	type            plug
+	slave.pcm       "softvol"
 }
 
-pcm.dmixer {
-	type dmix
-	ipc_key 1024
+ctl.!default {
+	type            hw 
+	card            %CARDNO%
+}
+
+pcm.ddmix {
+	ipc_key         1024
+	type            dmix
 	slave {
-		channels 2
-		pcm "hw:%CARDNO%,%DEVICENO%"
+		pcm         "hw:%CARDNO%,%DEVICENO%"
 		period_time 0
 		period_size 2048
 		buffer_size 8192
-		rate 44100
-	}
-	bindings {
-		0 0
-		1 1
 	}
 }
 
-ctl.!default { type hw card %CARDNO% }
+pcm.softvol {
+	type            softvol
+	slave {
+		pcm         "ddmix"
+	}
+	control {
+		name        "Master"
+		card        %CARDNO%
+	}
+}


### PR DESCRIPTION
Required for Sega Model 2 emulator to work under Wine
- Tested aroundrc fix with multiple x86 systems & RPI4
- Requires further discussion or testing