### PR TITLE
Fix for battery percentage on rg351p with patch from 351ELEC

### DIFF
--- a/board/batocera/rockchip/odroidgoa/linux_patches/0013-rg315p-battery.patch
+++ b/board/batocera/rockchip/odroidgoa/linux_patches/0013-rg315p-battery.patch
@@ -1,0 +1,48 @@
+--- a/drivers/power/rk817_battery.c	2021-02-05 16:31:59.891190059 -0500
++++ b/drivers/power/rk817_battery.c	2021-02-05 16:33:29.720760751 -0500
+@@ -2019,6 +2019,29 @@ static int rk817_bat_get_charge_state(st
+ 	return (battery->usb_in || battery->ac_in);
+ }
+ 
++//static int rg351p_battery_skip = 30000;
++static int rg351p_battery_pre_voltage = 5000;
++#define RG351_BAT_MAX_VOLTAGE 3900
++#define RG351_BAT_MIN_VOLTAGE 3300
++static int rk817_battery_rg351p_capacity_get(int voltage,int charge_status)
++{
++	if(rg351p_battery_pre_voltage>=5000){
++		rg351p_battery_pre_voltage = RG351_BAT_MAX_VOLTAGE;
++	}
++	//if(rg351p_battery_skip++ >= 30000){
++		if(voltage<3900 && voltage>3300 && (voltage<rg351p_battery_pre_voltage || charge_status)){
++			rg351p_battery_pre_voltage = voltage;
++		}else if(voltage>=3900){
++			rg351p_battery_pre_voltage = RG351_BAT_MAX_VOLTAGE;
++		}else if(voltage<=3300){
++			rg351p_battery_pre_voltage = RG351_BAT_MIN_VOLTAGE;
++		}
++		//rg351p_battery_skip = 0;
++	//}
++	return (rg351p_battery_pre_voltage-RG351_BAT_MIN_VOLTAGE)/((RG351_BAT_MAX_VOLTAGE-RG351_BAT_MIN_VOLTAGE)/100);
++	
++}
++
+ static int rk817_battery_get_property(struct power_supply *psy,
+ 				      enum power_supply_property psp,
+ 				      union power_supply_propval *val)
+@@ -2037,9 +2060,14 @@ static int rk817_battery_get_property(st
+ 			val->intval = VIRTUAL_VOLTAGE * 1000;
+ 		break;
+ 	case POWER_SUPPLY_PROP_CAPACITY:
++		/*
+ 		val->intval = (battery->dsoc  + 500) / 1000;
+ 		if (battery->pdata->bat_mode == MODE_VIRTUAL)
+ 			val->intval = VIRTUAL_SOC;
++		*/
++		//dev_err(dev, "%d\n",battery->voltage_avg);
++		val->intval = rk817_battery_rg351p_capacity_get(battery->voltage_avg,rk817_bat_get_charge_state(battery));
++		
+ 		break;
+ 	case POWER_SUPPLY_PROP_HEALTH:
+ 		val->intval = POWER_SUPPLY_HEALTH_GOOD;
+


### PR DESCRIPTION
Fix the percentage of the rg351p/m battery by applying the patch from 351ELEC.

I hope this does no harm to the other odroidgoa devices.

Patch from: https://github.com/351ELEC/351ELEC/blob/d81407396baca679224c183de0b7da1ab232d9e1/projects/Rockchip/devices/RG351P/packages/linux/patches/02-rg351p-luali.patch#L5907