### PR TITLE
updated boot vc4 checks and more verbose info in the config.txt file

### DIFF
--- a/board/batocera/raspberrypi/rpi4/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi4/boot/config.txt
@@ -135,4 +135,17 @@ dtparam=audio=on
 
 [rpi4]
 # Enable DRM VC4 V3D driver on top of the dispmanx display stack
+# Preferred 'Full' Kernel Mode Setting (KMS)
 dtoverlay=vc4-kms-v3d-pi4,noaudio
+
+# Optional 'Fake' KMS for displays that won't work with 'Full' KMS
+#dtoverlay=vc4-fkms-v3d
+
+# Ensure only one display output can be used on the Pi4 with batocera
+max_framebuffers=1
+
+[DPI]
+# Put any DPI required display code here
+# i.e. Official 7" DSI Raspberry Pi Touch Display for 'Full' KMS
+#ignore_lcd=1
+#dtoverlay=vc4-kms-dsi-7inch

--- a/board/batocera/raspberrypi/rpi4/fsoverlay/etc/init.d/S03checkbootconfig
+++ b/board/batocera/raspberrypi/rpi4/fsoverlay/etc/init.d/S03checkbootconfig
@@ -3,10 +3,11 @@
 # only at boot
 test "$1" != "start" && exit 0
 
-# check for this line
+# check for an appropriate vc4 overlay line
 grep -qE '^dtoverlay=vc4-kms-v3d-pi4,noaudio$' /boot/config.txt && exit 0
+grep -qE '^dtoverlay=vc4-fkms-v3d' /boot/config.txt && exit 0
 
-# update the file
+# update the file with preferred 'full' kms if not present
 mount -o remount,rw /boot || exit 1
 sed -i '/^[ ]*dtoverlay[ ]*=[ ]*vc4.*$/d'          /boot/config.txt || exit 0
 (echo;echo 'dtoverlay=vc4-kms-v3d-pi4,noaudio') >> /boot/config.txt || exit 0


### PR DESCRIPTION
This will help users that have panels not fully supported by the 'full' KMS driver yet
As per - https://github.com/batocera-linux/batocera.linux/issues/3717

Also sets the max_framebuffers to 1 so people with dual displays don't run into issues (not supported with ES etc)
Created [DPI] section for users with these various panel configurations.

Note: Raspberry Pi OS still uses fake KMS by default even with March 2021 release.