### PR TITLE
asoundrc workaround - use dmix for ES & hw for emulators

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/asoundrc-dmix+softvol
+++ b/package/batocera/core/batocera-audio/alsa/asoundrc-dmix+softvol
@@ -1,9 +1,12 @@
 # batocera-audio alsa config
 # dmix + softvol
+# DO NOT CHANGE THIS FILE!!!
 
 pcm.!default {
 	type            plug
-	slave.pcm       "softvol"
+	slave {
+		pcm         "dmixer"
+	}
 }
 
 ctl.!default {
@@ -11,7 +14,8 @@ ctl.!default {
 	card            %CARDNO%
 }
 
-pcm.ddmix {
+# type dmix used for ES to workaround HDMI audio cards with multiple audio streams
+pcm.dmixer {
 	ipc_key         1024
 	type            dmix
 	slave {
@@ -22,10 +26,11 @@ pcm.ddmix {
 	}
 }
 
+# type softvol used to workaround Wine issues
 pcm.softvol {
 	type            softvol
 	slave {
-		pcm         "ddmix"
+		pcm         "dmixer"
 	}
 	control {
 		name        "Master"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -211,6 +211,25 @@ def main(args, maxnbplayers):
             mouseChanged = True
             videoMode.changeMouse(True)
 
+        # set the audio output accordingly
+        audioconfigFile = "/userdata/system/.asoundrc"
+        if os.path.isfile(audioconfigFile):
+            eslog.log("Changing asoundrc file to hardware")
+            a_file = open(audioconfigFile, "r")
+            list_of_lines = a_file.readlines()
+            # read the line we want
+            line_we_want = list_of_lines[21]
+            eslog.log("Line we want: {}".format(line_we_want))
+            # replace the line
+            list_of_lines[7] = line_we_want
+            # write the new file
+            a_file = open(audioconfigFile, "w")
+            a_file.writelines(list_of_lines)
+            a_file.close()
+            # restart alsa
+            eslog.log("Restart alsa to set to hw")
+            os.system("/etc/init.d/S01audio restart")
+            
         # run a script before emulator starts
         callExternalScripts("/usr/share/batocera/configgen/scripts", "gameStart", [systemName, system.config['emulator'], effectiveCore, effectiveRom])
         callExternalScripts("/userdata/system/scripts", "gameStart", [systemName, system.config['emulator'], effectiveCore, effectiveRom])
@@ -227,6 +246,24 @@ def main(args, maxnbplayers):
         finally:
             Evmapy.stop()
 
+        # reset the audio
+        if os.path.isfile(audioconfigFile):
+            eslog.log("Changing asoundrc file to dmix")
+            a_file = open(audioconfigFile, "r")
+            list_of_lines = a_file.readlines()
+            # read the line we want
+            line_we_want = list_of_lines[32]
+            eslog.log("Line we want: {}".format(line_we_want))
+            # replace the line
+            list_of_lines[7] = line_we_want
+            # write the new file
+            a_file = open(audioconfigFile, "w")
+            a_file.writelines(list_of_lines)
+            a_file.close()
+            # restart alsa
+            eslog.log("Restart alsa to set to dmix")
+            os.system("/etc/init.d/S01audio restart")
+        
         # run a script after emulator shuts down
         callExternalScripts("/userdata/system/scripts", "gameStop", [systemName, system.config['emulator'], effectiveCore, effectiveRom])
         callExternalScripts("/usr/share/batocera/configgen/scripts", "gameStop", [systemName, system.config['emulator'], effectiveCore, effectiveRom])


### PR DESCRIPTION
Setting up dmix+softvol gets around some wine bugs however it causes audio issues for people with varying audio cards whether hdmi, analogue or usb.
We therefore setup the dmix & softvol options but still use hw as default, this get's around temperamental wine.