### PR TITLE
Fix the mouse missing in PPSSPP config menu

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppGenerator.py
@@ -50,3 +50,7 @@ class PPSSPPGenerator(Generator):
     @staticmethod
     def isLowResolution(gameResolution):
         return gameResolution["width"] < 400 or gameResolution["height"] < 400
+
+    # Show mouse on screen for the Config Screen
+    def getMouseMode(self, config):
+        return True


### PR DESCRIPTION
Like asked here :

https://github.com/batocera-linux/batocera.linux/issues/3866

I have try it and working fine, the mouse is auto hidden in game.