### PR TITLE
rpi3: config.txt

### DIFF
--- a/board/batocera/raspberrypi/rpi3/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi3/boot/config.txt
@@ -81,7 +81,3 @@ initramfs boot/initrd.gz
 
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
-
-[rpi3]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
-#dtoverlay=vc4-kms-v3d


### PR DESCRIPTION
Keeping this option in the rpi3 config.txt file can confuse the user as the KMS is not enabled for rpi3 yet.
