### PR TITLE
fix: ALSA audio fix for Pi family

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -1,5 +1,39 @@
 #!/bin/sh
 
+#List of exceptions not to use alsoundrc-dcmix+sofvol, for example Pi family
+#Adressed to issue 3901, 3902
+EXCEPTIONS="bcm2835 BCM2835"
+
+do_usage() {
+	echo "$1 list"
+	echo "$1 get"
+	echo "$1 set {auto|custom|<device>}"
+	echo "$1 test"
+}	
+
+do_select_audiodevice() {
+	if echo "${MODE}" | grep -qE '^[0-9]*,[0-9]* '; then
+		cardnb="$(echo "${MODE}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)"
+		devicenb="$(echo "${MODE}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)"
+		sed -e "s;%CARDNO%;${cardnb};g" -e "s;%DEVICENO%;${devicenb};g" /usr/share/batocera/alsa/asoundrc-dmix+softvol > /userdata/system/.asoundrc
+	else
+		# No valid device selected
+		return 1
+	fi
+
+	#This uses exceptions list, currently only for Pi platform and set a more easy .asoundrc
+	for i in $EXCEPTIONS; do
+		if echo "${MODE}" | grep -qE "$i"; then
+			sleep 1
+			cat > /userdata/system/.asoundrc <<-_EOF_
+				pcm.!default { type plug slave { pcm "hw:${cardnb},${devicenb}" } }
+				ctl.!default { type hw card ${cardnb} }
+			_EOF_
+		fi
+	done	
+}
+
+
 ACTION="$1"
 
 case "${ACTION}" in
@@ -25,18 +59,14 @@ case "${ACTION}" in
 			custom)
 				# do nothing!
 			;;
-
 			*)
-				if echo "${MODE}" | grep -qE '^[0-9]*,[0-9]* '; then
-					cardnb="$(echo "${MODE}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)"
-					devicenb="$(echo "${MODE}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)"
-					sed -e "s;%CARDNO%;${cardnb};g" -e "s;%DEVICENO%;${devicenb};g" /usr/share/batocera/alsa/asoundrc-dmix+softvol > /userdata/system/.asoundrc
-				fi
-			;;
+				do_select_audiodevice
 		esac
 	;;
 
 	test)
 		aplay "/usr/share/sounds/Mallet.wav"
 	;;
+	*)
+		do_usage $(basename $0)
 esac


### PR DESCRIPTION
Tested on Pi3/Pi4 should only affect these family afaik (bcm2835)

Tested HDMI (internal)
Tested Audiojack (internal)
Tested external USB device

Interal devices use a simple .asoundrc
external device use the one with softmixer....

@nadenislamarre @jdorigao not the best piece of coding but works
This adresses issue https://github.com/batocera-linux/batocera.linux/issues/3901 and https://github.com/batocera-linux/batocera.linux/issues/3902