### PR TITLE
Possibility to automatically update bootloader & autoupdate for OGOA

### DIFF
--- a/board/batocera/rockchip/odroidgoa/boot/post-batocera-upgrade.sh
+++ b/board/batocera/rockchip/odroidgoa/boot/post-batocera-upgrade.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# use bs=32768 to improve speed and reduce wear
+# please note! this changes seek and count behavior
+
+# idbloader.img is dynamic size and needs nulling before write
+dd if=/dev/zero of=/dev/mmcblk0 bs=32768 seek=1 count=127 status=none
+dd if=/boot/post-batocera-upgrade/idbloader.img of=/dev/mmcblk0 bs=32768 seek=1 status=none
+
+# uboot.img
+dd if=/boot/post-batocera-upgrade/uboot.img of=/dev/mmcblk0 bs=32768 seek=256 status=none
+
+# trust.img
+dd if=/boot/post-batocera-upgrade/trust.img of=/dev/mmcblk0 bs=32768 seek=384 status=none

--- a/board/batocera/rockchip/odroidgoa/create-boot-script.sh
+++ b/board/batocera/rockchip/odroidgoa/create-boot-script.sh
@@ -28,4 +28,11 @@ cp "${BINARIES_DIR}/rk3326-odroidgo3-linux.dtb"     "${BATOCERA_BINARIES_DIR}/bo
 
 cp "${BOARD_DIR}/boot/boot.ini"                     "${BATOCERA_BINARIES_DIR}/boot/"                                    || exit 1
 
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade" || exit 1
+# please note! the script must be named /boot/post-batocera-upgrade/post-batocera-upgrade.sh
+cp "${BOARD_DIR}/boot/post-batocera-upgrade.sh"     "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade"               || exit 1
+cp "${BINARIES_DIR}/idbloader.img"                  "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade"               || exit 1
+cp "${BINARIES_DIR}/uboot.img"                      "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade"               || exit 1
+cp "${BINARIES_DIR}/trust.img"                      "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade"               || exit 1
+
 exit 0

--- a/board/batocera/scripts/post-image-script.sh
+++ b/board/batocera/scripts/post-image-script.sh
@@ -67,6 +67,12 @@ do
     # rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
     mv "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" "${BATOCERA_BINARIES_DIR}/boot/boot/batocera" || exit 1
 
+    # remove post-batocera-upgrade folder
+    if test -e "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade"
+    then
+        rm -rf "${BATOCERA_BINARIES_DIR}/boot/post-batocera-upgrade" || exit 1
+    fi
+
     # create *.img
     if test "${IMGMODE}" = "multi"
     then

--- a/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
@@ -154,6 +154,15 @@ then
     exit 1
 fi
 
+# remove old /boot/post-batocera-upgrade if exists
+if test -e "/boot/post-batocera-upgrade"
+then
+    if ! rm -rf /boot/post-batocera-upgrade
+    then
+        exit 1
+    fi
+fi
+
 # backup boot files
 # all these files doesn't exist on non rpi platform, so, we have to test them
 # don't put the boot.ini file while it's not really to be customized
@@ -188,6 +197,18 @@ do
         fi
     fi
 done
+
+# run post-batocera-upgrade.sh if folder exists
+if test -e "/boot/post-batocera-upgrade"
+then
+    echo "running post-batocera-upgrade.sh"
+    if ! /boot/post-batocera-upgrade/post-batocera-upgrade.sh
+    then
+        echo "post-batocera-upgrade.sh failed" >&2
+    else
+        rm -rf /boot/post-batocera-upgrade
+    fi
+fi
 
 echo "synchronizing disk"
 


### PR DESCRIPTION
Bootloader autoupdate for ODROID GO-Advance.

This works by running "post-batocera-upgrade/post-batocera-upgrade.sh" from boot.tar.xz during the update.

f077914defa550bfbeee6ed7767cd884c049b284 can be used as reference for adding bootloader autoupdate for other boards.

"post-batocera-upgrade/post-batocera-upgrade.sh" can be useful for miscellaneous other tasks during the update. For example file renaming.

Resolves #3886