### PR TITLE
Duckstation - Fix Extra Memcards Chr Path

### DIFF
--- a/package/batocera/emulators/duckstation/004-savestate-pathandnames.patch
+++ b/package/batocera/emulators/duckstation/004-savestate-pathandnames.patch
@@ -23,7 +23,7 @@ index 50f949e..911a660 100644
 +  if (strncmp(formatted_path.c_str(), "savestates", 10) == 0)
 +    return formatted_path.length() > 10 ? StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.substr(11).c_str()) : "/userdata/saves/psx/duckstation";
 +  if (strncmp(formatted_path.c_str(), "memcards", 8) == 0)
-+    return formatted_path.length() > 8 ? StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.substr(8).c_str()) : "/userdata/saves/psx/duckstation";
++    return formatted_path.length() > 8 ? StringUtil::StdStringFromFormat("%s" FS_OSPATH_SEPARATOR_STR "%s", "/userdata/saves/psx/duckstation", formatted_path.substr(9).c_str()) : "/userdata/saves/psx/duckstation";
 +  
    if (m_user_directory.empty())
    {


### PR DESCRIPTION
I noticed an extra character in the save memcards folder.
It actually works but it's not the right way to be written as a path

![image](https://user-images.githubusercontent.com/54243866/119121915-41cabe00-ba2e-11eb-8dea-fb95555f6cf7.png)
