### PR TITLE
batocera-settings: bump to 0.0.5

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings.hash
+++ b/package/batocera/core/batocera-settings/batocera-settings.hash
@@ -1,3 +1,3 @@
 # Locally calculated
-sha256  61fda3083c7109a3146a69e1eb1399b36137c8d517a688bb0e4786ab34940e1f  batocera-settings-0.0.4.tar.gz
+sha256  280f9b6a05c3d0d32e2d4a733f03b287365139ffcf9d336510a663a5b92095e0  batocera-settings-0.0.5.tar.gz
 sha256  c64a84bc21adbd6cf8d2a552ed5c4e33d90d13dae3cadb8babf259af01b81e0f  LICENSE

--- a/package/batocera/core/batocera-settings/batocera-settings.mk
+++ b/package/batocera/core/batocera-settings/batocera-settings.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SETTINGS_VERSION = 0.0.4
+BATOCERA_SETTINGS_VERSION = 0.0.5
 BATOCERA_SETTINGS_LICENSE = MIT
 BATOCERA_SETTINGS_SITE = $(call github,batocera-linux,mini_settings,$(BATOCERA_SETTINGS_VERSION))
 BATOCERA_SETTINGS_CONF_OPTS = \


### PR DESCRIPTION
Disables file validation by default for the `batocera-settings-get` command. This allows (limited) usage with /boot/config.txt. Refs #3349

https://github.com/batocera-linux/mini_settings/commit/b9822f8f8aaafbc46cf9123f3b3e10d9b0d523ac