### PR TITLE
Fix force Mouse in Windows Game (v31+v32)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -21,4 +21,7 @@ class WineGenerator(Generator):
         raise Exception("invalid system " + system.name)
 
     def getMouseMode(self, config):
-        return True
+        if "force_mouse" in config and config["force_mouse"] == "0":
+            return False
+        else:
+            return True

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3818,6 +3818,12 @@ wine:
             choices:
                 "Off": 0
                 "On":  1
+        force_mouse:
+            prompt:      ENABLE MOUSE
+            description: Force mouse in games
+            choices:
+                "Off": 0
+                "On":  1
 
 solarus:
   features: []


### PR DESCRIPTION
Add option in ES for Select Mouse Yes or No for windows games.
For fix issue from forum.
By default is mouse is enable in (auto)

Tested work on by Games & Systems