### PR TITLE
Bump WinBTRFS (v31)

### DIFF
--- a/package/batocera/utils/winbtrfs/winbtrfs.hash
+++ b/package/batocera/utils/winbtrfs/winbtrfs.hash
@@ -1,2 +1,2 @@
 # Locally calculated after checking pgp signature
-sha256 505dd6d2159e9a63e077029c6a8f953fe3d46f2593c2ec0fc74c5245f9d75096  btrfs-1.7.7.zip
+sha256 59e2c69c5b5b07356684912ed8ae7e3f01666299319ac34fb918e032e8eb8aa4  btrfs-1.7.8.zip

--- a/package/batocera/utils/winbtrfs/winbtrfs.mk
+++ b/package/batocera/utils/winbtrfs/winbtrfs.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WINBTRFS_VERSION = 1.7.7
+WINBTRFS_VERSION = 1.7.8
 WINBTRFS_SOURCE = btrfs-$(WINBTRFS_VERSION).zip
 WINBTRFS_SITE = https://github.com/maharmstone/btrfs/releases/download/v$(WINBTRFS_VERSION)
 


### PR DESCRIPTION
Fix some regression and corruption

- Upgraded zstd to version 1.5.0
- Fixed regression stopping driver from working under XP
- Fixed compilation on clang
- Fixed corruption issue when Linux mount option inode_cache had been used
- Fixed recursion issue involving virtual directory \$Root