### PR TITLE
bump: retroarch to v1.9.5

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/014-cheevos-sounds.patch
+++ b/package/batocera/emulators/retroarch/retroarch/014-cheevos-sounds.patch
@@ -1,8 +1,8 @@
 diff --git a/configuration.c b/configuration.c
-index f0750fb..d64b2d7 100644
+index 6850178..d5bb787 100644
 --- a/configuration.c
 +++ b/configuration.c
-@@ -1261,6 +1261,7 @@ static struct config_array_setting *populate_settings_array(settings_t *settings
+@@ -1264,6 +1264,7 @@ static struct config_array_setting *populate_settings_array(settings_t *settings
  #ifdef HAVE_CHEEVOS
     SETTING_ARRAY("cheevos_username",         settings->arrays.cheevos_username, false, NULL, true);
     SETTING_ARRAY("cheevos_password",         settings->arrays.cheevos_password, false, NULL, true);
@@ -10,7 +10,7 @@ index f0750fb..d64b2d7 100644
     SETTING_ARRAY("cheevos_token",            settings->arrays.cheevos_token, false, NULL, true);
     SETTING_ARRAY("cheevos_leaderboards_enable", settings->arrays.cheevos_leaderboards_enable, true, "false", true);
  #endif
-@@ -2426,6 +2427,7 @@ void config_set_defaults(void *data)
+@@ -2431,6 +2432,7 @@ void config_set_defaults(void *data)
  #ifdef HAVE_CHEEVOS
     *settings->arrays.cheevos_username                 = '\0';
     *settings->arrays.cheevos_password                 = '\0';
@@ -18,122 +18,11 @@ index f0750fb..d64b2d7 100644
     *settings->arrays.cheevos_token                    = '\0';
  #endif
  
-@@ -3002,7 +3004,7 @@ error:
- }
- 
- #ifdef RARCH_CONSOLE
--static void video_driver_load_settings(global_t *global, 
-+static void video_driver_load_settings(global_t *global,
-       config_file_t *conf)
- {
-    bool               tmp_bool = false;
-@@ -3171,10 +3173,10 @@ static bool config_load_file(global_t *global,
-       size_t tmp = 0;
-       if (config_get_size_t(conf, size_settings[i].ident, &tmp))
-          *size_settings[i].ptr = tmp ;
--      /* Special case for rewind_buffer_size - need to convert 
-+      /* Special case for rewind_buffer_size - need to convert
-        * low values to what they were
-        * intended to be based on the default value in config.def.h
--       * If the value is less than 10000 then multiple by 1MB because if 
-+       * If the value is less than 10000 then multiple by 1MB because if
-        * the retroarch.cfg
-        * file contains rewind_buffer_size = "100",
-        * then that ultimately gets interpreted as
-@@ -3378,7 +3380,7 @@ static bool config_load_file(global_t *global,
-          *settings->paths.directory_screenshot = '\0';
-       }
-    }
--   
-+
- #if defined(__APPLE__) && defined(OSX)
- #if defined(__aarch64__)
-    /* Wrong architecture, set it back to arm64 */
-@@ -3624,7 +3626,7 @@ bool config_load_override(void *data)
-    fill_pathname_application_special(config_directory, sizeof(config_directory),
-          APPLICATION_SPECIAL_DIRECTORY_CONFIG);
- 
--   /* Concatenate strings into full paths for core_path, game_path, 
-+   /* Concatenate strings into full paths for core_path, game_path,
-     * content_path */
-    fill_pathname_join_special_ext(game_path,
-          config_directory, core_name,
-@@ -3672,7 +3674,7 @@ bool config_load_override(void *data)
-       {
-          RARCH_LOG("[Overrides]: Content dir-specific overrides stacking on top of previous overrides.\n");
-          snprintf(temp_path, sizeof(temp_path),
--               "%s|%s", 
-+               "%s|%s",
-                path_get(RARCH_PATH_CONFIG_APPEND),
-                content_path
-                );
-@@ -3704,7 +3706,7 @@ bool config_load_override(void *data)
-       {
-          RARCH_LOG("[Overrides]: Game-specific overrides stacking on top of previous overrides.\n");
-          snprintf(temp_path, sizeof(temp_path),
--               "%s|%s", 
-+               "%s|%s",
-                path_get(RARCH_PATH_CONFIG_APPEND),
-                game_path
-                );
-@@ -3963,7 +3965,7 @@ static void video_driver_save_settings(global_t *global, config_file_t *conf)
-  * @user              : Controller number to save
-  * Writes a controller autoconf file to disk.
-  **/
--bool config_save_autoconf_profile(const 
-+bool config_save_autoconf_profile(const
-       char *device_name, unsigned user)
- {
-    static const char* invalid_filename_chars[] = {
-@@ -4360,7 +4362,7 @@ bool config_save_overrides(enum override_type type, void *data)
- 
-    settings            = (settings_t*)calloc(1, sizeof(settings_t));
- 
--   config_directory[0] = override_directory[0] = core_path[0] = 
-+   config_directory[0] = override_directory[0] = core_path[0] =
-           game_path[0] = '\0';
- 
-    fill_pathname_application_special(config_directory, sizeof(config_directory),
-@@ -4626,14 +4628,14 @@ bool input_remapping_load_file(void *data, const char *path)
-       for (j = 0; j < RARCH_FIRST_CUSTOM_BIND + 8; j++)
-       {
-          const char *key_string = key_strings[j];
--         
-+
-          if (j < RARCH_FIRST_CUSTOM_BIND)
-          {
-             int btn_remap = -1;
-             int key_remap = -1;
-             char btn_ident[128];
-             char key_ident[128];
--                           
-+
-             btn_ident[0] = key_ident[0] = '\0';
- 
-             fill_pathname_join_delim(btn_ident, s1,
-@@ -4660,7 +4662,7 @@ bool input_remapping_load_file(void *data, const char *path)
-          {
-             char stk_ident[128];
-             int stk_remap = -1;
--            
-+
-             stk_ident[0]  = '\0';
- 
-             fill_pathname_join_delim(stk_ident, s3,
-@@ -4718,7 +4720,7 @@ bool input_remapping_save_file(const char *path)
- 
-    remap_file[0]                     = '\0';
- 
--   fill_pathname_join_concat(remap_file, dir_input_remapping, path, 
-+   fill_pathname_join_concat(remap_file, dir_input_remapping, path,
-          FILE_PATH_REMAP_EXTENSION,
-          sizeof(remap_file));
- 
 diff --git a/configuration.h b/configuration.h
-index 0bad72c..c4d1677 100644
+index 81a2f3c..cd2d698 100644
 --- a/configuration.h
 +++ b/configuration.h
-@@ -363,6 +363,7 @@ typedef struct settings
+@@ -365,6 +365,7 @@ typedef struct settings
        char menu_driver[32];
        char cheevos_username[32];
        char cheevos_password[256];
@@ -142,53 +31,10 @@ index 0bad72c..c4d1677 100644
        char cheevos_leaderboards_enable[32];
        char video_context_driver[32];
 diff --git a/retroarch.c b/retroarch.c
-index 9850c21..d622436 100644
+index 4e643c2..d8b0fa8 100644
 --- a/retroarch.c
 +++ b/retroarch.c
-@@ -2,9 +2,9 @@
-  *  Copyright (C) 2010-2014 - Hans-Kristian Arntzen
-  *  Copyright (C) 2011-2017 - Daniel De Matteis
-  *  Copyright (C) 2012-2015 - Michael Lelli
-- *  Copyright (C) 2014-2017 - Jean-André Santoni
-+ *  Copyright (C) 2014-2017 - Jean-Andrï¿½ Santoni
-  *  Copyright (C) 2016-2019 - Brad Parker
-- *  Copyright (C) 2016-2019 - Andrés Suárez (input mapper/Discord code)
-+ *  Copyright (C) 2016-2019 - Andrï¿½s Suï¿½rez (input mapper/Discord code)
-  *  Copyright (C) 2016-2017 - Gregor Richards (network code)
-  *
-  *  RetroArch is free software: you can redistribute it and/or modify it under the terms
-@@ -2676,10 +2676,10 @@ int generic_menu_entry_action(
-       {
-          if (!string_is_equal(current_value, "..."))
-             snprintf(speak_string, sizeof(speak_string),
--                  "%s %s %s", title_name, current_label, current_value); 
-+                  "%s %s %s", title_name, current_label, current_value);
-          else
-             snprintf(speak_string, sizeof(speak_string),
--                  "%s %s", title_name, current_label); 
-+                  "%s %s", title_name, current_label);
-       }
-       else
-       {
-@@ -7700,7 +7700,7 @@ static void netplay_announce(struct rarch_state *p_rarch)
-    frontend_drv =
-       (const frontend_ctx_driver_t*)frontend_driver_get_cpu_architecture_str(
-             frontend_architecture_tmp, sizeof(frontend_architecture_tmp));
--   snprintf(frontend_architecture, 
-+   snprintf(frontend_architecture,
-          sizeof(frontend_architecture),
-          "%s %s",
-          frontend_drv->ident,
-@@ -10806,7 +10806,7 @@ static bool retroarch_apply_shader(
-                      preset_file);
-             else
-                snprintf(msg, sizeof(msg),
--                     "%s: %s", 
-+                     "%s: %s",
-                      msg_hash_to_str(MSG_SHADER),
-                      msg_hash_to_str(MENU_ENUM_LABEL_VALUE_NONE)
-                      );
-@@ -29188,8 +29188,8 @@ static void audio_driver_load_menu_bgm_callback(retro_task_t *task,
+@@ -29226,8 +29226,8 @@ static void audio_driver_load_menu_bgm_callback(retro_task_t *task,
  
  void audio_driver_load_system_sounds(void)
  {
@@ -199,7 +45,7 @@ index 9850c21..d622436 100644
     char basename_noext[PATH_MAX_LENGTH];
     struct rarch_state *p_rarch           = &rarch_st;
     settings_t *settings                  = p_rarch->configuration_settings;
-@@ -29212,20 +29212,6 @@ void audio_driver_load_system_sounds(void)
+@@ -29250,20 +29250,6 @@ void audio_driver_load_system_sounds(void)
     if (!audio_enable_menu && !audio_enable_cheevo_unlock)
        goto end;
  
@@ -220,14 +66,13 @@ index 9850c21..d622436 100644
     list          = dir_list_new(sounds_path, MENU_SOUND_FORMATS, false, false, false, false);
     list_fallback = dir_list_new(sounds_fallback_path, MENU_SOUND_FORMATS, false, false, false, false);
  
-@@ -29268,8 +29254,14 @@ void audio_driver_load_system_sounds(void)
+@@ -29306,8 +29292,13 @@ void audio_driver_load_system_sounds(void)
              path_notice = path;
           else if (string_is_equal_noncase(basename_noext, "bgm"))
              path_bgm = path;
 -         else if (string_is_equal_noncase(basename_noext, "unlock"))
 -            path_cheevo_unlock = path;
-+         else
-+	      if(string_is_empty(settings->arrays.cheevos_unlock_sound)) {
++         else if(string_is_empty(settings->arrays.cheevos_unlock_sound)) {
 +	         if (string_is_equal_noncase(basename_noext, "unlock"))
 +	            path_cheevo_unlock = path;
 +	         } else {
@@ -237,12 +82,3 @@ index 9850c21..d622436 100644
        }
     }
  
-@@ -36116,7 +36108,7 @@ static void runloop_task_msg_queue_push(
-  *   yet exist, provides source path from which initial
-  *   options should be extracted
-  *
-- *   NOTE: caller must ensure 
-+ *   NOTE: caller must ensure
-  *   path and src_path are NULL-terminated
-  *  */
- static void rarch_init_core_options_path(

--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -3,8 +3,8 @@
 # retroarch
 #
 ################################################################################
-# Version.: Release on May 29, 2021
-RETROARCH_VERSION = v1.9.4
+# Version.: Release on Jun 13, 2021
+RETROARCH_VERSION = v1.9.5
 RETROARCH_SITE = $(call github,libretro,RetroArch,$(RETROARCH_VERSION))
 RETROARCH_LICENSE = GPLv3+
 RETROARCH_DEPENDENCIES = host-pkgconf dejavu retroarch-assets flac

--- a/package/batocera/emulators/retroarch/shaders/slang-shaders/slang-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/slang-shaders/slang-shaders.mk
@@ -3,8 +3,8 @@
 # SLANG SHADERS
 #
 ################################################################################
-# Version.: Commits on May 28, 2021
-SLANG_SHADERS_VERSION = 70256e15f6af3ca7770b35d7b75c2e90d41ae206
+# Version.: Commits on Jun 10, 2021
+SLANG_SHADERS_VERSION = 123c67303ccdfc2f67c55f87a0bfedb255d97665
 SLANG_SHADERS_SITE = $(call github,libretro,slang-shaders,$(SLANG_SHADERS_VERSION))
 SLANG_SHADERS_LICENSE = GPL
 


### PR DESCRIPTION
- ALSATHREAD: Make alsathread default for all ALSA devices with threads
- ARCHIVE: Fix loading of archived content with file names containing '#' characters
- CHEEVOS: Upgrade to rcheevos 10.1
- CHEEVOS: Challenge indicators
- CHEEVOS: Group achievements by category in quick menu
- CHEEVOS: Relabel 'Start Active' with 'Encore Mode'
- D3D10: Window title should now update
- D3D11: Window title should now update
- D3D11: Allow fastforward in fullscreen
- D3D12: Window title should now update
- D3D12: Allow fastforward in fullscreen
- CRT/SWITCHRES: New implementation
- FONTS: Improve message wrapping with CJK languages
- FONTS: Fix garbled characters when converting encodings
- INPUT: Allow the 8 analog stick directions to be used as keys for core keyboard mappings
- LIBRETRO: Add API extension for setting 'need_fullpath' based on content file extension and to request persistent frontend content data buffers
- MENU/SEARCH: Add enhanced search functionality to the 'Manage Cores' menu
- OPENDINGUX: Fix black screens when triggering gfx driver initialisation via menu actions
- UNIX: Get better battery stats on sysfs nodes
- VIDEO: Extend Frame Delay range to 19 to accommodate PAL land too
- WIFI/LAKKA: Add nmcli to wifi drivers
- WIFI/LAKKA: Add wifi configuration menu
- X11: fix fullscreen when swapping monitors/resolution

https://github.com/libretro/RetroArch/blob/master/CHANGES.md#195