### PR TITLE
modern terminal: mc in color

### DIFF
--- a/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
@@ -1,4 +1,4 @@
 # ---- ALIAS VALUES ----
-alias mc='mc -x'
+alias mc='mc -xc'
 alias batocera-check-updates='batocera-es-swissknife --update'
 


### PR DESCRIPTION
Without -c parameter mc is in black and white. At least on PuTTY with UTF-8 character set and VT100 line drawing.