### PR TITLE
Per-game libretro-DOSBox-pure settings by default

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -53,10 +53,7 @@ class LibretroGenerator(Generator):
             romDOSName = os.path.splitext(romName)[0]
             romDOSName, romExtension = os.path.splitext(romName)
             if romExtension == '.dos' or romExtension == '.pc':
-                if os.path.isfile(os.path.join(rom, romDOSName + ".bat")):
-                    commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], os.path.join(rom, romDOSName + ".bat")]
-                else:
-                    commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], rom + "/dosbox.bat"]
+                commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], os.path.join(rom, romDOSName + ".bat")]
             else:
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
         else:


### PR DESCRIPTION
DOSBox Pure does not need .bat file.
It displays startup menu if more than 1 executable is in game folder.
DOSBox Pure uses name of .bat file for per-game settings.

With this commit "dosbox.bat" will be specified in command line only if it exists and "Game name.bat" does not exist.
This allows to have per-game settings when no .bat file exists in game folder.