### PR TITLE
fix configparser store list

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-store
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-store
@@ -151,7 +151,7 @@ case "${ACTION}" in
 
 	import sys
 	import subprocess
-	import ConfigParser
+	import configparser
 	import io
 
 	def getConfig():
@@ -164,8 +164,8 @@ case "${ACTION}" in
 	        raise Exception("unable to read config")
 
 	    buf = io.StringIO(out.decode('utf-8'))
-	    config = ConfigParser.ConfigParser(allow_no_value=True)
-	    config.readfp(buf)
+	    config = configparser.ConfigParser(allow_no_value=True, interpolation=None, strict=False) # strict because there are some duplicated values
+	    config.read_file(buf)
 	    return config
 
 	def config2xml(config):


### PR DESCRIPTION
there is still an issue i won't handle in the py:
SigLevel is present several times by pacman-conf (fresh install)

# pacman-conf
[options]
RootDir = /
DBPath = /userdata/system/pacman/db/
CacheDir = /userdata/system/pacman/pkg/
HookDir = /etc/pacman/hooks/
GPGDir = /etc/pacman.d/gnupg/
LogFile = /userdata/system/pacman/pacman.log
Architecture = gameforce
CheckSpace
DisableDownloadTimeout
ILoveCandy
CleanMethod = KeepInstalled
SigLevel = PackageOptional
SigLevel = PackageTrustedOnly
SigLevel = DatabaseOptional
SigLevel = DatabaseTrustedOnly
[batocera]
Usage = All
Server = https://store.batocera.org/


Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>