### PR TITLE
Add Pipewire

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -312,6 +312,8 @@ menu "Utils"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/utils/flatpak/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/utils/pm-utils/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/utils/mangohud/Config.in"
+  source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/utils/pulseaudio-utils/Config.in"
+  source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/utils/pulsemixer/Config.in"
 endmenu
 
 menu "Libraries"

--- a/package/batocera/core/batocera-audio/Config.in
+++ b/package/batocera/core/batocera-audio/Config.in
@@ -1,9 +1,14 @@
 config BR2_PACKAGE_BATOCERA_AUDIO
 	bool "batocera-audio"
-	select BR2_PACKAGE_BLUEZ_ALSA
+	select BR2_PACKAGE_BLUEZ_ALSA #	Not longer needed
 	select BR2_PACKAGE_ALSA_UTILS
-	select BR2_PACKAGE_ALSA_UTILS_AMIXER
-	select BR2_PACKAGE_ALSA_UTILS_APLAY
+	select BR2_PACKAGE_ALSA_UTILS_AMIXER #	Not longer needed
+	select BR2_PACKAGE_ALSA_UTILS_APLAY #	Not longer needed
 	select BR2_PACKAGE_ALSA_PLUGINS
+	select BR2_PACKAGE_SBC
+	select BR2_PACKAGE_PIPEWIRE
+	select BR2_PACKAGE_PULSEMIXER
+	select BR2_PACKAGE_PULSEAUDIO_UTILS
+	select BR2_PACKAGE_RTKIT
 	help
 	  Audio support and scripts for batocera.linux

--- a/package/batocera/core/batocera-audio/Config.in.old
+++ b/package/batocera/core/batocera-audio/Config.in.old
@@ -1,0 +1,9 @@
+config BR2_PACKAGE_BATOCERA_AUDIO
+	bool "batocera-audio"
+	select BR2_PACKAGE_BLUEZ_ALSA
+	select BR2_PACKAGE_ALSA_UTILS
+	select BR2_PACKAGE_ALSA_UTILS_AMIXER
+	select BR2_PACKAGE_ALSA_UTILS_APLAY
+	select BR2_PACKAGE_ALSA_PLUGINS
+	help
+	  Audio support and scripts for batocera.linux

--- a/package/batocera/core/batocera-audio/batocera-audio.mk.old
+++ b/package/batocera/core/batocera-audio/batocera-audio.mk.old
@@ -4,10 +4,21 @@
 #
 ################################################################################
 
-BATOCERA_AUDIO_VERSION = 6
+BATOCERA_AUDIO_VERSION = 5
 BATOCERA_AUDIO_LICENSE = GPL
+BATOCERA_AUDIO_DEPENDENCIES = alsa-lib
 BATOCERA_AUDIO_SOURCE=
-BATOCERA_AUDIO_DEPENDENCIES = pipewire
+BATOCERA_AUDIO_DEPENDENCIES += alsa-plugins
+
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3326_ANY),y)
+ALSA_SUFFIX = "-rk3326"
+else ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3399),y)
+ALSA_SUFFIX = "-rk3399"
+else ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_S922X),y)
+ALSA_SUFFIX = "-s922x"
+else
+ALSA_SUFFIX =
+endif
 
 define BATOCERA_AUDIO_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/lib/python3.9 \
@@ -15,11 +26,7 @@ define BATOCERA_AUDIO_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/share/sounds \
 		$(TARGET_DIR)/usr/share/batocera/alsa \
 		$(TARGET_DIR)/etc/init.d \
-		$(TARGET_DIR)/etc/udev/rules.d \
-		$(TARGET_DIR)/etc/dbus-1/system.d \
-		$(TARGET_DIR)/etc/alsa/conf.d \
-		$(TARGET_DIR)/etc/pipewire/media-session.d
-
+		$(TARGET_DIR)/etc/udev/rules.d
 	# default alsa configurations
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-audio/alsa/asoundrc-* \
 		$(TARGET_DIR)/usr/share/batocera/alsa/
@@ -35,22 +42,6 @@ define BATOCERA_AUDIO_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/bin/soundconfig
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-audio/alsa/batocera-audio$(ALSA_SUFFIX) \
 		$(TARGET_DIR)/usr/bin/batocera-audio
-
-	# pipewire-pulse policy
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-audio/pulseaudio-system.conf \
-		$(TARGET_DIR)/etc/dbus-1/system.d
-
-	# pipewire-alsa
-	ln -sft $(TARGET_DIR)/etc/alsa/conf.d \
-		/usr/share/alsa/alsa.conf.d/{50-pipewire,99-pipewire-default}.conf 
-	install -Dm644 /dev/null $(TARGET_DIR)/etc/pipewire/media-session.d/with-alsa
-
-	# pipewire-media-session config: disable dbus device reservation
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-audio/media-session.conf \
-		$(TARGET_DIR)/etc/pipewire/media-session.d
-
-	# # get rid of pulseaudio files
-	# rm -rf $(TARGET_DIR)/etc/pulse
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/core/batocera-audio/media-session.conf
+++ b/package/batocera/core/batocera-audio/media-session.conf
@@ -1,0 +1,109 @@
+# Media session config file for PipeWire version "0.3.27" #
+
+context.properties = {
+    # Properties to configure the session and some
+    # modules.
+    #mem.mlock-all = false
+    support.dbus  = false
+    #log.level     = 2
+    #alsa.seq.name  = Midi-Bridge
+}
+
+context.spa-libs = {
+    # Mapping from factory name to library.
+    api.bluez5.*    = bluez5/libspa-bluez5
+    api.alsa.*      = alsa/libspa-alsa
+    api.v4l2.*      = v4l2/libspa-v4l2
+    api.libcamera.* = libcamera/libspa-libcamera
+}
+
+context.modules = [
+    #{   name = <module-name>
+    #    [ args = { <key> = <value> ... } ]
+    #    [ flags = [ [ ifexists ] [ nofail ] ]
+    #}
+    #
+    # Loads a module with the given parameters.
+    # If ifexists is given, the module is ignored when it is not found.
+    # If nofail is given, module initialization failures are ignored.
+    #
+    # Uses RTKit to boost the data thread priority.
+    {   name = libpipewire-module-rtkit
+        args = {
+            #nice.level   = -11
+            #rt.prio      = 88
+            #rt.time.soft = 200000
+            #rt.time.hard = 200000
+        }
+        flags = [ ifexists nofail ]
+    }
+
+    # The native communication protocol.
+    {   name = libpipewire-module-protocol-native }
+
+    # Allows creating nodes that run in the context of the
+    # client. Is used by all clients that want to provide
+    # data to PipeWire.
+    {   name = libpipewire-module-client-node }
+
+    # Allows creating devices that run in the context of the
+    # client. Is used by the session manager.
+    {   name = libpipewire-module-client-device }
+
+    # Makes a factory for wrapping nodes in an adapter with a
+    # converter and resampler.
+    {   name = libpipewire-module-adapter }
+
+    # Allows applications to create metadata objects. It creates
+    # a factory for Metadata objects.
+    {   name = libpipewire-module-metadata }
+
+    # Provides factories to make session manager objects.
+    {   name = libpipewire-module-session-manager }
+]
+
+session.modules = {
+    # These are the modules that are enabled when a file with
+    # the key name is found in the media-session.d config directory.
+    # the default bundle is always enabled.
+
+    default = [
+        flatpak                 # manages flatpak access
+        portal                  # manage portal permissions
+        v4l2                    # video for linux udev detection
+        #libcamera              # libcamera udev detection
+        suspend-node            # suspend inactive nodes
+        policy-node             # configure and link nodes
+        #metadata               # export metadata API
+        #default-nodes          # restore default nodes
+        #default-profile        # restore default profiles
+        #default-routes         # restore default route
+        #streams-follow-default # move streams when default changes
+        #alsa-seq               # alsa seq midi support
+        #alsa-monitor           # alsa udev detection
+        #bluez5                 # bluetooth support
+        #restore-stream         # restore stream settings
+        #logind                 # systemd-logind seat support
+    ]
+    with-audio = [
+        metadata
+        default-nodes
+        default-profile
+        default-routes
+        alsa-seq
+        alsa-monitor
+    ]
+    with-alsa = [
+        with-audio
+    ]
+    with-jack = [
+        with-audio
+    ]
+    with-pulseaudio = [
+        with-audio
+        bluez5
+        logind
+        restore-stream
+        streams-follow-default
+    ]
+}

--- a/package/batocera/core/batocera-audio/pulseaudio-system.conf
+++ b/package/batocera/core/batocera-audio/pulseaudio-system.conf
@@ -1,0 +1,5 @@
+<busconfig>
+  <policy user="root">
+    <allow own="org.pulseaudio.Server"/>
+  </policy>
+</busconfig>

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -124,13 +124,15 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_QTSIXA_SHANWAN                       # ps3 pad
 	select BR2_PACKAGE_XARCADE2JSTICK                       # keyboard events of the Xarcade Tankstick
 	select BR2_PACKAGE_UTIL_LINUX_LIBMOUNT                  # for util-linux compilation to work (so, may be removed in the future)
-    select BR2_PACKAGE_FBDUMP                               # tool to capture snapshots from the Linux kernel framebuffer device and write them out as a PPM file
-    select BR2_PACKAGE_FBGRAB                               # framebuffer screenshot program, capturing the linux frambuffer and converting it to a png-picture
-    select BR2_PACKAGE_FBV                                  # very simple graphic file viewer for the framebuffer console, capable of displaying GIF, JPEG, PNG and BMP files using libungif, libjpeg and libpng
-    select BR2_PACKAGE_EUDEV_RULES_GEN                      # fork of systemd-udev with the goal of obtaining better compatibility with existing software such as OpenRC and Upstart
-    select BR2_PACKAGE_BOOST_ATOMIC                         # library that provides atomic data types and operations on these data types
-    select BR2_PACKAGE_UTIL_LINUX_LIBSMARTCOLS              # library is used for smart adaptive formatting of tabular data
-    select BR2_PACKAGE_UTIL_LINUX_SETTERM                   # Set terminal attributes
+	select BR2_PACKAGE_FBDUMP                               # tool to capture snapshots from the Linux kernel framebuffer device and write them out as a PPM file
+	select BR2_PACKAGE_FBGRAB                               # framebuffer screenshot program, capturing the linux frambuffer and converting it to a png-picture
+	select BR2_PACKAGE_FBV                                  # very simple graphic file viewer for the framebuffer console, capable of displaying GIF, JPEG, PNG and BMP files using libungif, libjpeg and libpng
+	select BR2_PACKAGE_EUDEV_RULES_GEN                      # fork of systemd-udev with the goal of obtaining better compatibility with existing software such as OpenRC and Upstart
+	select BR2_PACKAGE_BOOST_ATOMIC                         # library that provides atomic data types and operations on these data types
+	select BR2_PACKAGE_UTIL_LINUX_LIBSMARTCOLS              # library is used for smart adaptive formatting of tabular data
+	select BR2_PACKAGE_UTIL_LINUX_SETTERM                   # Set terminal attributes
+	select BR2_PACKAGE_PULSEAUDIO_UTILS                     # Add pactl for configure Pipewire
+	select BR2_PACKAGE_PULSEMIXER                           # Add audiomixer for configure Pipewire
 
 	# Deprecated, which what library should we replace ?
 	select BR2_PACKAGE_PARTED                               # partition management (for the first boot)

--- a/package/batocera/utils/pulseaudio-utils/Config.in
+++ b/package/batocera/utils/pulseaudio-utils/Config.in
@@ -1,0 +1,26 @@
+config BR2_PACKAGE_PULSEAUDIO_UTILS
+	bool "pulseaudio-utils"
+	depends on BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC
+	depends on BR2_USE_WCHAR
+	depends on BR2_TOOLCHAIN_HAS_THREADS
+	depends on !BR2_STATIC_LIBS
+	depends on BR2_USE_MMU # fork()
+	select BR2_PACKAGE_LIBTOOL
+	select BR2_PACKAGE_LIBSNDFILE
+	select BR2_PACKAGE_PULSEAUDIO_ENABLE_ATOMIC
+	select BR2_PACKAGE_SPEEX
+	help
+	  PulseAudio is a sound system for POSIX OSes, meaning that it
+	  is a proxy for your sound applications. It allows you to do
+	  advanced operations on your sound data as it passes between
+	  your application and your hardware. Things like transferring
+	  the audio to a different machine, changing the sample format
+	  or channel count and mixing several sounds into one are
+	  easily achieved using a sound server.
+
+	  http://pulseaudio.org
+
+comment "pulseaudio needs a toolchain w/ wchar, threads, dynamic library"
+	depends on BR2_USE_MMU
+	depends on BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC
+	depends on !BR2_USE_WCHAR || !BR2_TOOLCHAIN_HAS_THREADS || BR2_STATIC_LIBS

--- a/package/batocera/utils/pulseaudio-utils/pulseaudio-utils.mk
+++ b/package/batocera/utils/pulseaudio-utils/pulseaudio-utils.mk
@@ -1,0 +1,156 @@
+################################################################################
+#
+# pulseaudio utils
+#
+################################################################################
+
+PULSEAUDIO_UTILS_VERSION = 14.2
+PULSEAUDIO_UTILS_SOURCE = pulseaudio-$(PULSEAUDIO_UTILS_VERSION).tar.xz
+PULSEAUDIO_UTILS_SITE = https://freedesktop.org/software/pulseaudio/releases
+PULSEAUDIO_UTILS_INSTALL_STAGING = YES
+PULSEAUDIO_UTILS_LICENSE = LGPL-2.1+ (specific license for modules, see LICENSE file)
+PULSEAUDIO_UTILS_LICENSE_FILES = LICENSE GPL LGPL
+PULSEAUDIO_UTILS_CONF_OPTS = \
+	--disable-default-build-tests \
+	--disable-legacy-database-entry-format \
+	--disable-manpages \
+	--disable-running-from-build-tree
+
+PULSEAUDIO_UTILS_DEPENDENCIES = \
+	host-pkgconf libtool libsndfile speex \
+	$(TARGET_NLS_DEPENDENCIES) \
+	$(if $(BR2_PACKAGE_LIBGLIB2),libglib2) \
+	$(if $(BR2_PACKAGE_AVAHI_DAEMON),avahi) \
+	$(if $(BR2_PACKAGE_DBUS),dbus) \
+	$(if $(BR2_PACKAGE_OPENSSL),openssl) \
+	$(if $(BR2_PACKAGE_FFTW_SINGLE),fftw-single) \
+	$(if $(BR2_PACKAGE_SYSTEMD),systemd)
+
+ifeq ($(BR2_PACKAGE_LIBSAMPLERATE),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-samplerate
+PULSEAUDIO_UTILS_DEPENDENCIES += libsamplerate
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-samplerate
+endif
+
+ifeq ($(BR2_PACKAGE_GDBM),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --with-database=gdbm
+PULSEAUDIO_UTILS_DEPENDENCIES += gdbm
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --with-database=simple
+endif
+
+ifeq ($(BR2_PACKAGE_JACK2),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-jack
+PULSEAUDIO_UTILS_DEPENDENCIES += jack2
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-jack
+endif
+
+ifeq ($(BR2_PACKAGE_LIBATOMIC_OPS),y)
+PULSEAUDIO_UTILS_DEPENDENCIES += libatomic_ops
+ifeq ($(BR2_sparc_v8)$(BR2_sparc_leon3),y)
+PULSEAUDIO_UTILS_CONF_ENV += CFLAGS="$(TARGET_CFLAGS) -DAO_NO_SPARC_V9"
+endif
+endif
+
+ifeq ($(BR2_PACKAGE_ORC),y)
+PULSEAUDIO_UTILS_DEPENDENCIES += orc
+PULSEAUDIO_UTILS_CONF_ENV += ORCC=$(HOST_DIR)/bin/orcc
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-orc
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-orc
+endif
+
+ifeq ($(BR2_PACKAGE_LIBCAP),y)
+PULSEAUDIO_UTILS_DEPENDENCIES += libcap
+PULSEAUDIO_UTILS_CONF_OPTS += --with-caps
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --without-caps
+endif
+
+# gtk3 support needs X11 backend
+ifeq ($(BR2_PACKAGE_LIBGTK3_X11),y)
+PULSEAUDIO_UTILS_DEPENDENCIES += libgtk3
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-gtk3
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-gtk3
+endif
+
+ifeq ($(BR2_PACKAGE_LIBSOXR),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --with-soxr
+PULSEAUDIO_UTILS_DEPENDENCIES += libsoxr
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --without-soxr
+endif
+
+ifeq ($(BR2_PACKAGE_BLUEZ5_UTILS)$(BR2_PACKAGE_SBC),yy)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-bluez5
+PULSEAUDIO_UTILS_DEPENDENCIES += bluez5_utils sbc
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-bluez5
+endif
+
+ifeq ($(BR2_PACKAGE_HAS_UDEV),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-udev
+PULSEAUDIO_UTILS_DEPENDENCIES += udev
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-udev
+endif
+
+ifeq ($(BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-webrtc-aec
+PULSEAUDIO_UTILS_DEPENDENCIES += webrtc-audio-processing
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-webrtc-aec
+endif
+
+# neon intrinsics not available with float-abi=soft
+ifeq ($(BR2_ARM_SOFT_FLOAT),)
+ifeq ($(BR2_ARM_CPU_HAS_NEON),y)
+PULSEAUDIO_UTILS_USE_NEON = y
+endif
+endif
+
+ifeq ($(PULSEAUDIO_UTILS_USE_NEON),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-neon-opt=yes
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-neon-opt=no
+endif
+
+# pulseaudio alsa backend needs pcm/mixer apis
+ifeq ($(BR2_PACKAGE_ALSA_LIB_PCM)$(BR2_PACKAGE_ALSA_LIB_MIXER),yy)
+PULSEAUDIO_UTILS_DEPENDENCIES += alsa-lib
+PULSEAUDIO_UTILS_CONF_OPTS += --enable-alsa
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-alsa
+endif
+
+ifeq ($(BR2_PACKAGE_LIBXCB)$(BR2_PACKAGE_XLIB_LIBSM)$(BR2_PACKAGE_XLIB_LIBXTST),yyy)
+PULSEAUDIO_UTILS_DEPENDENCIES += libxcb xlib_libSM xlib_libXtst
+
+# .desktop file generation needs nls support, so fake it for !locale builds
+# https://bugs.freedesktop.org/show_bug.cgi?id=54658
+ifeq ($(BR2_SYSTEM_ENABLE_NLS),)
+define PULSEAUDIO_UTILS_FIXUP_DESKTOP_FILES
+	cp $(@D)/src/daemon/pulseaudio.desktop.in \
+		$(@D)/src/daemon/pulseaudio.desktop
+endef
+PULSEAUDIO_UTILS_POST_PATCH_HOOKS += PULSEAUDIO_UTILS_FIXUP_DESKTOP_FILES
+endif
+
+else
+PULSEAUDIO_UTILS_CONF_OPTS += --disable-x11
+endif
+
+define PULSEAUDIO_UTILS_INSTALL_TARGET_CMDS
+	# pactl
+	cp $(@D)/src/pactl $(TARGET_DIR)/usr/bin/
+	
+	# libpulse
+	cp $(@D)/src/.libs/libpulse.so $(TARGET_DIR)/usr/lib/
+	ln -sf libpulse.so $(TARGET_DIR)/usr/lib/libpulse.so.0
+	cp $(@D)/src/.libs/libpulsecommon-$(PULSEAUDIO_UTILS_VERSION).so $(TARGET_DIR)/usr/lib/
+endef
+
+$(eval $(autotools-package))

--- a/package/batocera/utils/pulsemixer/Config.in
+++ b/package/batocera/utils/pulsemixer/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_PULSEMIXER
+	bool "pulsemixer"
+	depends on BR2_PACKAGE_PYTHON3
+	depends on BR2_PACKAGE_PULSEAUDIO_UTILS
+	help
+	  CLI and curses mixer for PulseAudio

--- a/package/batocera/utils/pulsemixer/pulsemixer.mk
+++ b/package/batocera/utils/pulsemixer/pulsemixer.mk
@@ -1,0 +1,13 @@
+################################################################################
+#
+# pulsemixer
+#
+################################################################################
+PULSEMIXER_VERSION = 1.5.1
+PULSEMIXER_SITE = $(call github,GeorgeFilipkin,pulsemixer,$(PULSEMIXER_VERSION))
+PULSEMIXER_LICENSE = MIT
+PULSEMIXER_LICENSE_FILES = LICENSE
+PULSEMIXER_SETUP_TYPE = distutils
+PULSEMIXER_DEPENDENCIES = python3 pulseaudio-utils
+
+$(eval $(python-package))


### PR DESCRIPTION
Build OK
also is need too : 
RTKIT : #3856
BR2_PACKAGE_PIPEWIRE_GSTREAMER=y
BR2_PACKAGE_ALSA_LIB=y

But is work on batocera : 

```
Welcome to PipeWire version 0.3.26. Type 'help' for usage.
remote 0 is named 'pipewire-0'
```

For start in boot can be add in `~/.xinitrc`
With : `pipewire &` 
PW is installed in `/usr/bin/pipewire`

Probably better to upgrade in 0.3.31

Now i can activate only for x86_64

Other good information here : 

https://gitlab.com/tcamargo/pequilinux/-/tree/master/package/pequilinux/boot/openrc-initscripts/initd

Have rewrite PR now is based on the work of Poke