### PR TITLE
add: batocera-audio PCM device for RetroArch

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -13,7 +13,7 @@ do_usage() {
 
 do_select_audiodevice() {
 	if echo "${MODE}" | grep -qE '^[0-9]*,[0-9]* '; then
-		cardnb="$(echo "${MODE}" | sed -e s+'^\([0-9]*\),.*$'+'\1'+)"
+		cardnb="$(echo "${MODE}"   | sed -e s+'^\([0-9]*\),.*$'+'\1'+)"
 		devicenb="$(echo "${MODE}" | sed -e s+'^[0-9]*,\([0-9]*\) .*$'+'\1'+)"
 	else
 		# No valid device selected
@@ -42,6 +42,11 @@ do_select_audiodevice() {
 }
 
 
+do_select_PCM() {
+    audio_dev="plughw:${cardnb},${devicenb}"
+    (sleep 1 && batocera-settings-set global.retroarch.audio_device "$audio_dev") &
+}
+
 ACTION="$1"
 
 case "${ACTION}" in
@@ -62,13 +67,14 @@ case "${ACTION}" in
 			# any other, create .asoundrc
 			auto)
 				rm -f /userdata/system/.asoundrc
+                (sleep 1 && batocera-settings-set global.retroarch.audio_device " ") &
 			;;
 
 			custom)
 				# do nothing!
 			;;
 			*)
-				do_select_audiodevice
+				do_select_audiodevice && do_select_PCM
 		esac
 	;;
 


### PR DESCRIPTION
This translates audio-device selected from batocera-audio list
to `global.retroarch.audio_device`
It's very bare and only for tests

It a look-ahead tool to set the same device driver for RA and ES
The sub-shell is needed, somehow ES hinders batocera-settings from writing values to batocera.conf

1. It needs to be verfied @rion -> your turn
2. PCM translation should be done more in a way `aplay -L` shows devices
3. Yes it works