### PR TITLE
ogoa: use system.cpu.governor for GPU and DMC

### DIFF
--- a/board/batocera/rockchip/odroidgoa/fsoverlay/usr/share/batocera/configgen/scripts/governor.sh
+++ b/board/batocera/rockchip/odroidgoa/fsoverlay/usr/share/batocera/configgen/scripts/governor.sh
@@ -2,17 +2,17 @@
 
 EVENT=$1
 
-case "${EVENT}" in
-    gameStart)
-	echo performance > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
-	echo performance > /sys/devices/platform/dmc/devfreq/dmc/governor
-	echo performance > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
-    ;;
-    gameStop)
-	echo simple_ondemand > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
-	echo dmc_ondemand    > /sys/devices/platform/dmc/devfreq/dmc/governor
-	echo performance     > /sys/devices/system/cpu/cpufreq/policy0/scaling_governor
-    ;;
-esac
+test "$EVENT" = "gameStart" || test "$EVENT" = "gameStop" || exit 0
+
+CPU_GOVERNOR="$(/usr/bin/batocera-settings-get system.cpu.governor)"
+
+if { [ "${EVENT}" = "gameStart" ] && [ "${CPU_GOVERNOR}" = "performance" ]; }
+then
+  echo performance > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+  echo performance > /sys/devices/platform/dmc/devfreq/dmc/governor
+else
+  echo simple_ondemand > /sys/devices/platform/ff400000.gpu/devfreq/ff400000.gpu/governor
+  echo dmc_ondemand    > /sys/devices/platform/dmc/devfreq/dmc/governor
+fi
 
 exit 0


### PR DESCRIPTION
Set GPU and DMC governors based on system.cpu.governor setting value

Depends on ab37cb607d160b08ddf0746d831681ff86378d6d

Partially resolves #4084 