### PR TITLE
Add an option to batocera.conf to force enable Retroachievements

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -350,7 +350,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['cheevos_auto_screenshot'] = 'false'
 
     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
-        if(system.name in systemToRetroachievements):
+        if(system.name in systemToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
             retroarchConfig['cheevos_enable'] = 'true'
             retroarchConfig['cheevos_username'] = systemConfig.get('retroachievements.username', "")
             retroarchConfig['cheevos_password'] = systemConfig.get('retroachievements.password', "")


### PR DESCRIPTION
When a "custom" system is added to EmaulationStation and it supports Retroachievements there is no simple way to enable them.
This adds` *.cheevos_force` option to `batocera.conf`.
For an example, setting this to `msu1.cheevos_force=true` enables that custom system to have Retroachievements without having to set all the options manually:
```
msu1.retroarch.cheevos_enable=true
msu1.retroarch.cheevos_hardcore_mode_enable=false
msu1.retroarch.cheevos_leaderboards_enable=false
msu1.retroarch.cheevos_verbose_enable=false
msu1.retroarch.cheevos_auto_screenshot=true
msu1.retroarch.cheevos_username=_USERNAME_
msu1.retroarch.cheevos_password=*************
msu1.retroarch.cheevos_start_active=false
```
Since I never used Python or modified Batocera before, hopefully all this makes sense.
This should fix https://github.com/batocera-linux/batocera.linux/issues/4236