### PR TITLE
WINE Locale

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -397,7 +397,13 @@ play_wine() {
     dxvk_install "${WINEPOINT}" || return 1
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    WINE_LANG=$(getWine_var "${WINEPOINT}" "LANG" "")
+    if test -n "${WINE_LANG}"
+	then
+        (cd "${WINEPOINT}/${WINE_DIR}" && LC_ALL=${WINE_LANG} WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    else
+        (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    fi
     waitWineServer
 }
 
@@ -416,7 +422,13 @@ play_pc() {
 
     WINE_CMD=$(getWine_var "${GAMENAME}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${GAMENAME}" "DIR" "")
-    (cd "${GAMENAME}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    WINE_LANG=$(getWine_var "${GAMENAME}" "LANG" "")
+    if test -n "${WINE_LANG}"
+	then
+        (cd "${GAMENAME}/${WINE_DIR}" && LC_ALL=${WINE_LANG} WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    else
+        (cd "${GAMENAME}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    fi
     waitWineServer
 }
 
@@ -478,7 +490,13 @@ play_winetgz() {
 
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    WINE_LANG=$(getWine_var "${WINEPOINT}" "LANG" "")
+    if test -n "${WINE_LANG}"
+	then
+        (cd "${WINEPOINT}/${WINE_DIR}" && LC_ALL=${WINE_LANG} WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    else
+        (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    fi
     waitWineServer
 }
 
@@ -518,7 +536,13 @@ play_squashfs() {
 
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
-    (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    WINE_LANG=$(getWine_var "${WINEPOINT}" "LANG" "")
+    if test -n "${WINE_LANG}"
+	then
+        (cd "${WINEPOINT}/${WINE_DIR}" && LC_ALL=${WINE_LANG} WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    else
+        (cd "${WINEPOINT}/${WINE_DIR}" && WINEPREFIX=${WINEPOINT} eval "${WINE} ${VDESKTOP} ${WINE_CMD}")
+    fi
     waitWineServer
 
     # try to clean the cdrom


### PR DESCRIPTION
Allows the language to be changed per game for WINE. Needed for certain older Windows Unicode games (mostly Japanese). If not used, games with Unicode filenames may fail to launch, and other games may display text incorrectly. May require additional fonts to be installed via Winetricks, depending on the game.

Add a line to the game's autorun.cmd formatted as LANG=[language code]. For example, "LANG=ja_JP.UTF-8" will set the game to use Japanese.

Tested under v31 as WINE is currently broken in v32. batocera-wine had no changes between versions.