### PR TITLE
MAME Control Modifications

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -184,10 +184,14 @@ class MameGenerator(Generator):
             "JOYSTICK_DOWN":  "joystick1down",
             "JOYSTICK_LEFT":  "joystick1left",
             "JOYSTICK_RIGHT": "joystick1right",
-            "JOYSTICKLEFT_UP":    "joystick2up",
-            "JOYSTICKLEFT_DOWN":  "joystick2down",
-            "JOYSTICKLEFT_LEFT":  "joystick2left",
-            "JOYSTICKLEFT_RIGHT": "joystick2right",
+            "JOYSTICKLEFT_UP":    "joystick1up",
+            "JOYSTICKLEFT_DOWN":  "joystick1down",
+            "JOYSTICKLEFT_LEFT":  "joystick1left",
+            "JOYSTICKLEFT_RIGHT": "joystick1right",
+            "JOYSTICKRIGHT_UP": "joystick2up",
+            "JOYSTICKRIGHT_DOWN": "joystick2down",
+            "JOYSTICKRIGHT_LEFT": "joystick2left",
+            "JOYSTICKRIGHT_RIGHT": "joystick2right",
             "BUTTON1": "b",
             "BUTTON2": "y",
             "BUTTON3": "a",
@@ -250,40 +254,40 @@ class MameGenerator(Generator):
         xml_newseq = config.createElement("newseq")
         xml_newseq.setAttribute("type", "standard")
         xml_port.appendChild(xml_newseq)
-        value = config.createTextNode("JOYCODE_{}_{}".format(padindex+1, MameGenerator.input2definition(key, input, reversed)))
+        value = config.createTextNode(MameGenerator.input2definition(key, input, padindex + 1, reversed))
         xml_newseq.appendChild(value)
         return xml_port
 
     @staticmethod
-    def input2definition(key, input, reversed):
+    def input2definition(key, input, joycode, reversed):
         if input.type == "button":
-            return "BUTTON{}".format(int(input.id)+1)
+            return "JOYCODE_{}_BUTTON{}".format(joycode, int(input.id)+1)
         elif input.type == "hat":
             if input.value == "1":
-                return "HAT1UP"
+                return "JOYCODE_{}_HAT1UP".format(joycode)
             elif input.value == "2":
-                return "HAT1RIGHT"
+                return "JOYCODE_{}_HAT1RIGHT".format(joycode)
             elif input.value == "4":
-                return "HAT1DOWN"
+                return "JOYCODE_{}_HAT1DOWN".format(joycode)
             elif input.value == "8":
-                return "HAT1LEFT"
+                return "JOYCODE_{}_HAT1LEFT".format(joycode)
         elif input.type == "axis":
             if key == "joystick1up" or key == "up":
-                return "YAXIS_UP_SWITCH"
+                return "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP".format(joycode, joycode)
             if key == "joystick1down" or key == "down":
-                return "YAXIS_DOWN_SWITCH"
+                return "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN".format(joycode, joycode)
             if key == "joystick1left" or key == "left":
-                return "YAXIS_LEFT_SWITCH"
+                return "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT".format(joycode, joycode)
             if key == "joystick1right" or key == "right":
-                return "YAXIS_RIGHT_SWITCH"
+                return "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT".format(joycode, joycode)
             if key == "joystick2up":
-                return "RYAXIS_NEG_SWITCH"
+                return "JOYCODE_{}_RYAXIS_NEG_SWITCH OR JOYCODE_{}_BUTTON4".format(joycode, joycode)
             if key == "joystick2down":
-                return "RYAXIS_POS_SWITCH"
+                return "JOYCODE_{}_RYAXIS_POS_SWITCH OR JOYCODE_{}_BUTTON1".format(joycode, joycode)
             if key == "joystick2left":
-                return "RXAXIS_NEG_SWITCH"
+                return "JOYCODE_{}_RXAXIS_NEG_SWITCH OR JOYCODE_{}_BUTTON3".format(joycode, joycode)
             if key == "joystick2right":
-                return "RXAXIS_POS_SWITCH"
+                return "JOYCODE_{}_RXAXIS_POS_SWITCH OR JOYCODE_{}_BUTTON2".format(joycode, joycode)
         eslog.log("unable to find input2definition for {} / {}".format(input.type, key))
         return "unknown"
 


### PR DESCRIPTION
Several changes to default MAME standalone default controls:

Default for Joystick will be both D-Pad & left analog
For dual stick games, Left Joystick was being set to use the right analog, corrected that to duplicate single joystick
Right Joystick was unmapped, will use right analog & face buttons in proper UDLR directions

Tested on v31 with an 8BitDo Pro controller set to xinput mode. D-pad/left analog controls worked properly in all games, Left/Right sticks & buttons worked properly in Robotron 2084.

Required modifying the input2definition function to pass the joystick code as a variable in order to get the OR functions working properly.

May require additional testing with other controller types (stickless) and multiple controllers. It's likely the detection for stickless controllers can be removed entirely since it's using both as valid inputs.
