### PR TITLE
Supermodel Additional Options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
@@ -37,6 +37,16 @@ class SupermodelGenerator(Generator):
         if system.isOptSet("forceFeedback") and system.getOptBoolean("forceFeedback"):
             commandArray.append("-force-feedback")
 
+        # powerpc frequesncy
+        if system.isOptSet("ppcFreq"):
+            commandArray.append("-ppc-frequency={}".format(system.config["ppcFreq"]))
+
+        #driving controls
+        if system.isOptSet("pedalSwap") and system.getOptBoolean("pedalSwap"):
+            drivingGame = 1
+        else:
+            drivingGame = 0
+
         # resolution
         commandArray.append("-res={},{}".format(gameResolution["width"], gameResolution["height"]))
 
@@ -47,7 +57,7 @@ class SupermodelGenerator(Generator):
         copy_nvram_files()
 
         # config
-        configPadsIni(playersControllers)
+        configPadsIni(playersControllers, drivingGame)
 
         return Command.Command(array=commandArray)
 
@@ -64,28 +74,48 @@ def copy_nvram_files():
             if not os.path.exists(targetDir + "/" + file):
                 copyfile(sourceDir + "/" + file, targetDir + "/" + file)
 
-def configPadsIni(playersControllers):
-    templateFile = "/usr/share/supermodel/Supermodel.ini.template"
+def configPadsIni(playersControllers, altControl):
+    if bool(altControl):
+        templateFile = "/usr/share/supermodel/Supermodel-Driving.ini.template"
+        mapping = {
+            "button1": "y",
+            "button2": "b",
+            "button3": "a",
+            "button4": "x",
+            "button5": "pageup",
+            "button6": "pagedown",
+            "button7": None,
+            "button8": None,
+            "button9": "start", # start
+            "button10": "select", # coins
+            "axisX": "joystick1left",
+            "axisY": "joystick1up",
+            "axisZ": "l2",
+            "axisRX": "joystick2left",
+            "axisRY": "joystick2up",
+            "axisRZ": "r2"
+        }
+    else:
+        templateFile = "/usr/share/supermodel/Supermodel.ini.template"
+        mapping = {
+            "button1": "y",
+            "button2": "b",
+            "button3": "a",
+            "button4": "x",
+            "button5": "pageup",
+            "button6": "pagedown",
+            "button7": "l2",
+            "button8": "r2",
+            "button9": "start", # start
+            "button10": "select", # coins
+            "axisX": "joystick1left",
+            "axisY": "joystick1up",
+            "axisZ": None,
+            "axisRX": "joystick2left",
+            "axisRY": "joystick2up",
+            "axisRZ": None
+        }
     targetFile = "/userdata/system/configs/supermodel/Supermodel.ini"
-
-    mapping = {
-        "button1": "y",
-        "button2": "b",
-        "button3": "a",
-        "button4": "x",
-        "button5": "pageup",
-        "button6": "pagedown",
-        "button7": "l2",
-        "button8": "r2",
-        "button9": "start", # start
-        "button10": "select", # coins
-        "axisX": "joystick1left",
-        "axisY": "joystick1up",
-        "axisZ": None,
-        "axisRX": "joystick2left",
-        "axisRY": "joystick2up",
-        "axisRZ": None
-    }
 
     mapping_fallback = {
         "axisX": "left",
@@ -218,5 +248,9 @@ def input2input(playersControllers, player, joynum, button, axisside = None):
                     return "JOY{}_RXAXIS{}".format(joynum+1, sidestr)
                 elif button == "joystick2up":
                     return "JOY{}_RYAXIS{}".format(joynum+1, sidestr)
+                elif button == "l2":
+                    return "JOY{}_ZAXIS{}".format(joynum+1, sidestr)
+                elif button == "r2":
+                    return "JOY{}_RZAXIS{}".format(joynum+1, sidestr)
 
     return None

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3733,6 +3733,22 @@ supermodel:
             choices:
                 "Off":      0
                 "On":       1
+        pedalSwap:
+            prompt:      MODERN PEDAL CONTROLS
+            description: Moves Accel/Brake to triggers and gear shift to shoulder buttons or right stick
+            choices:
+                "Off":      0
+                "On":       1
+        ppcFreq:
+            prompt:      ADJUST POWERPC FREQUENCY
+            description: Change the speed of the emulated PowerPC chip (fixes some issues)
+            choices:
+                "25":           25
+                "50 (Default)": 50
+                "75":           75
+                "100":          100
+                "125":          125
+                "150":          150
 
 cgenius:
   features: []

--- a/package/batocera/emulators/supermodel/supermodel.mk
+++ b/package/batocera/emulators/supermodel/supermodel.mk
@@ -24,6 +24,15 @@ define SUPERMODEL_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/bin/supermodel $(TARGET_DIR)/usr/bin/supermodel
 	$(INSTALL) -D -m 0644 $(@D)/Config/Games.xml $(TARGET_DIR)/usr/share/supermodel/Games.xml
 	$(INSTALL) -D -m 0644 $(@D)/Config/Supermodel.ini $(TARGET_DIR)/usr/share/supermodel/Supermodel.ini.template
+	$(INSTALL) -D -m 0644 $(@D)/Config/Supermodel.ini $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputAccelerator = "KEY_UP,JOY1_UP"|InputAccelerator = "KEY_UP,JOY1_RZAXIS_POS"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputBrake = "KEY_DOWN,JOY1_DOWN"|InputBrake = "KEY_DOWN,JOY1_ZAXIS_POS"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShift1 = "KEY_Q,JOY1_BUTTON5"|InputGearShift1 = "KEY_Q"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShift2 = "KEY_W,JOY1_BUTTON6"|InputGearShift2 = "KEY_W"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShift3 = "KEY_E,JOY1_BUTTON7"|InputGearShift3 = "KEY_E"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShift4 = "KEY_R,JOY1_BUTTON8"|InputGearShift4 = "KEY_R"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShiftUp = "KEY_Y"|InputGearShiftUp = "KEY_Y,JOY1_BUTTON6,JOY1_RYAXIS_NEG"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
+	$(SED) 's|InputGearShiftDown = "KEY_H"|InputGearShiftDown = "KEY_H,JOY1_BUTTON5,JOY1_RYAXIS_POS"|g' $(TARGET_DIR)/usr/share/supermodel/Supermodel-Driving.ini.template
 endef
 
 define SUPERMODEL_LINE_ENDINGS_FIXUP


### PR DESCRIPTION
Adds additional per-game/system settings to Supermodel:

Modern Pedal Controls
By default, accelerate and brake are mapped to left stick up/down. Activating this option will move those controls to L2/R2 with analog trigger support. The gearshift functions normally mapped to those are disabled, and the up/down shift (works on games with 2 & 4 position shifters) is mapped to both L/R and right stick up/down.
This creates an alternate template file at compilation that's called by the generator if the option is on.
Tested with 8BitDo Pro+ in XInput mode.

Adjust PowerPC Frequency
The default PowerPC frequency of 50MHz can cause issues with some games - ie. screen tearing in Sega Rally 2. Setting it to 100 fixes that. It can be lowered for some other games to improve performance on lower-end systems. Values for 25-150 (in increments of 25) are added, others can be added later if needed.
Tested with Sega Rally 2 - screen tearing was visible on countdown numbers & the helicopter in the first race at the defaults, gone after setting to 100.