### PR TITLE
Support for OneXPlayer + changes tate mode on PC

### DIFF
--- a/board/batocera/fsoverlay/etc/udev/rules.d/99-onexplayer.rules
+++ b/board/batocera/fsoverlay/etc/udev/rules.d/99-onexplayer.rules
@@ -1,0 +1,3 @@
+#OneXPlayer
+SUBSYSTEM=="input", ATTRS{name}=="ShanWan     Cloud Gamepad", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
+ACTION=="add", ATTRS{idVendor}=="2563", ATTRS{idProduct}=="058d", RUN+="/sbin/modprobe xpad", RUN+="/bin/bash -c 'echo 2563 058d > /sys/bus/usb/drivers/xpad/new_id'" 

--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -30,7 +30,8 @@ settings_output="$(/usr/bin/batocera-settings-get global.dpi)"
 #####################
 ## CUSTOMISATIONS ###
 # to customize your display, you can copy this file to ~/.xinitrc and then modify it
-
+# You can also use display.rotate in batocera.conf (see below)
+#
 # rotate the screen
 # xrandr -o left
 # xrandr -o right
@@ -68,7 +69,34 @@ eval `dbus-launch --sh-syntax --exit-with-session`
 # rotation
 display_rotate="$(/usr/bin/batocera-settings-get display.rotate)"
 EXTRA_OPTS=
-test -n "${display_rotate}" && EXTRA_OPTS="--screenrotate ${display_rotate}"
+ARCH="$(cat /usr/share/batocera/batocera.arch)"
+if test -n "${display_rotate}"; then
+	case "${ARCH}" in
+		x86_64|x86)
+			case "${display_rotate}" in
+				"1")
+					xrandr -o right
+					;;
+				"2")
+					xrandr -o inverted
+					;;
+				"3")
+					xrandr -o left
+					;;
+			esac
+			;;
+		*)
+			EXTRA_OPTS="--screenrotate ${display_rotate}"
+			;;
+	esac
+fi
+
+forcedresolution="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf es.forcedresolution)"
+if test -n "${forcedresolution}"
+then
+	export DISPLAY=:0.0
+	batocera-resolution forceMode "${forcedresolution}"
+fi
 
 # nvidia
 # these are 3 variables used only by nvidia to take nvidia gpu over intel cards when such hybrid cards are available

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -86,7 +86,10 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['menu_show_restart_retroarch'] = 'false'    # this option messes everything up on Batocera if ever clicked
     retroarchConfig['video_driver'] = '"gl"'                    # needed for the ozone menu
 
-    if system.isOptSet("display.rotate"):
+    with open("/usr/share/batocera/batocera.arch") as fb:
+        arch = fb.readline().strip()
+
+    if (system.isOptSet("display.rotate") and arch not in [ 'x86_64', 'x86']):
         # 0 => 0 ; 1 => 270; 2 => 180 ; 3 => 90
         if system.config["display.rotate"] == "0":
             retroarchConfig['video_rotation'] = "0"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -9,6 +9,7 @@ f_usage() {
     echo "${0} setOutput <output>" >&2
     echo "${0} minTomaxResolution" >&2
     echo "${0} minTomaxResolution-secure" >&2
+    echo "${0} forceMode <horizontal>x<vertical>:<refresh>" >&2
 }
 
 f_minTomaxResolution() {
@@ -61,7 +62,7 @@ case "${ACTION}" in
 	echo "max-1920x1080:maximum 1920x1080"
 	echo "max-640x480:maximum 640x480"
 	xrandr --listModes | sed -e s+'\*$'++ | sed -e s+'^[^ ]* \(.*\)$'+'\1:\1'+
-    ;;
+	;;
     "setMode")
 	MODE=$1
 
@@ -111,7 +112,28 @@ case "${ACTION}" in
     "setDPI")
         xrandr --dpi $1
         ;;
-	*)
+    "forceMode")
+        REQUESTED=$1
+	H=$(echo "$REQUESTED" | sed "s/\([0-9]*\)x.*/\1/")
+	V=$(echo "$REQUESTED" | sed "s/.*x\([0-9]*\).*/\1/")
+	R=$(echo "$REQUESTED" | grep : | sed "s/.*:\([0-9]*\)/\1/")
+	if [ z"$H" != z  ] && [ z"$V" != z ]; then
+            if [ z"$R" != z ]; then
+                MODELINE=$(cvt "$H" "$V" "$R")
+	    else
+                MODELINE=$(cvt "$H" "$V")
+	    fi
+	else
+            >&2 echo "error: invalid mode ${REQUESTED}"
+	fi
+        MODE=$(echo "$MODELINE" | egrep -v "^#" | tail -n 1 | sed "s/^Modeline //")
+        MNAME=$(echo "$MODE" | cut -d' ' -f1)
+        OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
+        xrandr --newmode ${MODE}
+        xrandr --addmode "${OUTPUT}" "${MNAME}"
+	xrandr --output "${OUTPUT}" --mode "${MNAME}"
+	;;
+    *)
 		f_usage
 		>&2 echo "error: invalid command ${ACTION}"
 		exit 1

--- a/package/batocera/core/batocera-splash/Ssplash-mpv.template
+++ b/package/batocera/core/batocera-splash/Ssplash-mpv.template
@@ -58,6 +58,11 @@ do_videostart ()
         video_rotation=$(do_angels_conversion $video_rotation)
         [[ $? -eq 0 ]] && mpv_video=--video-rotate=${video_rotation}
     fi
+    video_resize=$(batocera-settings-get -f /boot/batocera-boot.conf splash.video.resize)
+    if [[ $? -eq 0 ]]; then
+        resize=$(echo "${video_resize}" | sed "s/x/:/")
+        mpv_video="${mpv_video} --vf=scale=${resize}"
+    fi
 
     # it should be drm everywhere (including for x86_64 while it is on fb) -- only rpi doesn't use drm and it doesn't use this boot splash script
     /usr/bin/mpv --really-quiet --no-config --hwdec=yes %PLAYER_OPTIONS% $mpv_audio $mpv_video "$video" &

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -2594,4 +2594,27 @@
 		<input name="x" type="button" id="2" value="1" code="307" />
 		<input name="y" type="button" id="3" value="1" code="308" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="03000000632500008d05000003000000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="6" value="1" code="314" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="l3" type="button" id="9" value="1" code="317" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
+		<input name="r3" type="button" id="10" value="1" code="318" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="3" value="1" code="308" />
+		<input name="y" type="button" id="2" value="1" code="307" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
The OneXPlayer needs several changes to be supported properly:
- wifi6 needs last firmware (my previous PR already merged)
- controller needs a specific udev rule to be supported through xpad
- screen is rotated, so I changed the way we support screen rotation on PC (through batocera.conf only, no change in xinitrc any more as it's not resilient to Batocera upgrades)
- Also screen is natively 1600x2560 (on 8"4...) with no lower resolution available. I forced a 1920x1080:60Hz through batocera-boot.conf with a new command in batocera-resolution to support this.

I'll write a wiki article to explain how to make it work. Result: https://batocera.org/users/lbrpdx/OneXPlayer_480.mov