### PR TITLE
Bumped many libretro cores

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-atari800/libretro-atari800.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-atari800/libretro-atari800.mk
@@ -3,8 +3,8 @@
 # ATARI800
 #
 ################################################################################
-# Version.: Commits on May 29, 2021
-LIBRETRO_ATARI800_VERSION = b59fb7e92577b734cfdd7b73bfc9821bfab247c2
+# Version.: Commits on Aug 2, 2021
+LIBRETRO_ATARI800_VERSION = bcbbf63c049f5381271da4221009b461abe7a596
 LIBRETRO_ATARI800_SITE = $(call github,libretro,libretro-atari800,$(LIBRETRO_ATARI800_VERSION))
 LIBRETRO_ATARI800_LICENSE = GPL
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-beetle-pcfx/libretro-beetle-pcfx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-beetle-pcfx/libretro-beetle-pcfx.mk
@@ -3,8 +3,8 @@
 # BEETLE_PCFX
 #
 ################################################################################
-# Version.: Commits on Apr 12, 2021
-LIBRETRO_BEETLE_PCFX_VERSION = ceff11eab32febfcf8507f0bfe618bcdf80e75ef
+# Version.: Commits on July 9, 2021
+LIBRETRO_BEETLE_PCFX_VERSION = 3896104f3308b05d217d7212ed08a0fdea839230
 LIBRETRO_BEETLE_PCFX_SITE = $(call github,libretro,beetle-pcfx-libretro,$(LIBRETRO_BEETLE_PCFX_VERSION))
 LIBRETRO_BEETLE_PCFX_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-beetle-psx/libretro-beetle-psx.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-beetle-psx/libretro-beetle-psx.mk
@@ -3,8 +3,8 @@
 # LIBRETRO_BEETLE_PSX
 #
 ################################################################################
-# Version.: Commits on May 29, 2021
-LIBRETRO_BEETLE_PSX_VERSION = 78f4e82eca4540c99089a307d1ab1ae9711f35d2
+# Version.: Commits on Aug 2, 2021
+LIBRETRO_BEETLE_PSX_VERSION = f71ab8b8104c1cf2d4706eb0b90c5ad0420a26ea
 LIBRETRO_BEETLE_PSX_SITE = $(call github,libretro,beetle-psx-libretro,$(LIBRETRO_BEETLE_PSX_VERSION))
 LIBRETRO_BEETLE_PSX_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/libretro-bsnes-hd.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/libretro-bsnes-hd.mk
@@ -3,8 +3,8 @@
 # BSNES-HD
 #
 ################################################################################
-# Version.: Commits on Mar 30, 2021
-LIBRETRO_BSNES_HD_VERSION = d2d7815c25ec3f0e3df0afd3b8a0df81ecd0e25f
+# Version.: Commits on Jun 18, 2021
+LIBRETRO_BSNES_HD_VERSION = 0fd18e0f5767284fd373aebd75b00b5bab0d44a9
 LIBRETRO_BSNES_HD_SITE = $(call github,DerKoun,bsnes-hd,$(LIBRETRO_BSNES_HD_VERSION))
 LIBRETRO_BSNES_HD_LICENSE = GPLv3
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on May 03, 2021
-LIBRETRO_DOSBOX_PURE_VERSION = 0.13
+# Version.: Commits on July 25, 2021
+LIBRETRO_DOSBOX_PURE_VERSION = 0.14
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
@@ -3,7 +3,8 @@
 # FBNEO
 #
 ################################################################################
-LIBRETRO_FBNEO_VERSION = e255f544fbbda18cbef3b384982de06f99bd1159
+# Last revision: Aug 2, 2021
+LIBRETRO_FBNEO_VERSION = 575020220899ca449a054217f5232926acc0bb35
 LIBRETRO_FBNEO_SITE = $(call github,libretro,FBNeo,$(LIBRETRO_FBNEO_VERSION))
 LIBRETRO_FBNEO_LICENSE = Non-commercial
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
@@ -3,7 +3,8 @@
 # FCEUMM
 #
 ################################################################################
-LIBRETRO_FCEUMM_VERSION = a42bd198a0c28f367a7ef255ba63cf2827eaa3b0
+# Last commit: July 30, 2021
+LIBRETRO_FCEUMM_VERSION = afe2b4d9650d9e468b20636a3eab6bac2b8f9844
 LIBRETRO_FCEUMM_SITE = $(call github,libretro,libretro-fceumm,$(LIBRETRO_FCEUMM_VERSION))
 LIBRETRO_FCEUMM_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-freeintv/libretro-freeintv.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-freeintv/libretro-freeintv.mk
@@ -3,8 +3,8 @@
 # LIBRETRO_FREEINTV
 #
 ################################################################################
-# Version.: Commits on May 12, 2021
-LIBRETRO_FREEINTV_VERSION = 5fc8d85ee9699baaaf0c63399c364f456097fc1e
+# Version.: Commits on July 30, 2021
+LIBRETRO_FREEINTV_VERSION = 1e9078406ddc9b00dd4def8d54d6c9bc78b49e1c
 LIBRETRO_FREEINTV_SITE = $(call github,libretro,freeintv,$(LIBRETRO_FREEINTV_VERSION))
 LIBRETRO_FREEINTV_LICENSE = GPLv3
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-fuse/libretro-fuse.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fuse/libretro-fuse.mk
@@ -3,7 +3,8 @@
 # FUSE
 #
 ################################################################################
-LIBRETRO_FUSE_VERSION = 5b1c05330e907556d99a8caca769ce273fdc9198
+# Last check: Aug 3, 2021
+LIBRETRO_FUSE_VERSION = 5f331e9772d305ba5209db0910b1963b9d0974c0
 LIBRETRO_FUSE_SITE = $(call github,libretro,fuse-libretro,$(LIBRETRO_FUSE_VERSION))
 LIBRETRO_FUSE_LICENSE = GPLv3
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-gambatte/libretro-gambatte.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-gambatte/libretro-gambatte.mk
@@ -3,8 +3,8 @@
 # GAMBATTE
 #
 ################################################################################
-# Version.: Commits on May 18, 2021
-LIBRETRO_GAMBATTE_VERSION = 94221ec7037ff880e7977313bccdc8c0ee7ae679
+# Version.: Commits on Aug 2, 2021
+LIBRETRO_GAMBATTE_VERSION = 4e5c14cbc373a165353e0f7d9c14c0ae6ed31985
 LIBRETRO_GAMBATTE_SITE = $(call github,libretro,gambatte-libretro,$(LIBRETRO_GAMBATTE_VERSION))
 LIBRETRO_GAMBATTE_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-handy/libretro-handy.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-handy/libretro-handy.mk
@@ -3,7 +3,8 @@
 # LIBRETRO HANDY
 #
 ################################################################################
-LIBRETRO_HANDY_VERSION = 85d55f1c5738d8ea51dc2088bff97c934ec0d53c
+# Last commit: July 30, 2021
+LIBRETRO_HANDY_VERSION = 39a84f93e839f22a8c1f5ea35b80e910183476ce
 LIBRETRO_HANDY_SITE = $(call github,libretro,libretro-handy,$(LIBRETRO_HANDY_VERSION))
 LIBRETRO_HANDY_LICENSE = Zlib
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-kronos/libretro-kronos.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-kronos/libretro-kronos.mk
@@ -3,8 +3,8 @@
 # LIBRETRO-KRONOS
 #
 ################################################################################
-# Version.: Commits on Jan 14, 2020
-LIBRETRO_KRONOS_VERSION = a39f95a5a2f66cedb51a00d0f49ea1ee222384d8
+# Version.: Commits on July 27, 2021
+LIBRETRO_KRONOS_VERSION = 0903968e2ffa9cef2ab513ad87de1faf8db8f6a5
 LIBRETRO_KRONOS_SITE = $(call github,FCare,kronos,$(LIBRETRO_KRONOS_VERSION))
 LIBRETRO_KRONOS_LICENSE = BSD-3-Clause
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-lutro/libretro-lutro.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-lutro/libretro-lutro.mk
@@ -3,7 +3,8 @@
 # LUTRO
 #
 ################################################################################
-LIBRETRO_LUTRO_VERSION = 33950cbbf1e6b4a740c09b7b8611fa4b157138c4
+# Last commit: July 22, 2021
+LIBRETRO_LUTRO_VERSION = 1de21d04160d8aa6e1dba76e38f669772ef98c3e
 LIBRETRO_LUTRO_SITE = $(call github,libretro,libretro-lutro,$(LIBRETRO_LUTRO_VERSION))
 LIBRETRO_LUTRO_LICENSE = MIT
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
@@ -3,7 +3,8 @@
 # MAME2003 PLUS
 #
 ################################################################################
-LIBRETRO_MAME2003_PLUS_VERSION = 91b506848bfa239c581e060a409e79c4f4d4d88e
+# Last check: Aug 2, 2021
+LIBRETRO_MAME2003_PLUS_VERSION = 952000b4e9cdb720d4c3bfe22c1e13fdde9c4dff
 LIBRETRO_MAME2003_PLUS_SITE = $(call github,libretro,mame2003-plus-libretro,$(LIBRETRO_MAME2003_PLUS_VERSION))
 LIBRETRO_MAME2003_PLUS_LICENSE = MAME
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mgba/libretro-mgba.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mgba/libretro-mgba.mk
@@ -3,8 +3,8 @@
 # MGBA
 #
 ################################################################################
-# Version.: Release on Apr 18, 2021
-LIBRETRO_MGBA_VERSION = 0.9.1
+# Version.: Release on July 12, 2021
+LIBRETRO_MGBA_VERSION = 0.9.2
 LIBRETRO_MGBA_SITE = $(call github,mgba-emu,mgba,$(LIBRETRO_MGBA_VERSION))
 LIBRETRO_MGBA_LICENSE = MPLv2.0
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mupen64plus-next/libretro-mupen64plus-next.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mupen64plus-next/libretro-mupen64plus-next.mk
@@ -3,8 +3,8 @@
 # MUPEN64PLUS-NEXT
 #
 ################################################################################
-# Version.: Commits on May 31, 2021
-LIBRETRO_MUPEN64PLUS_NEXT_VERSION = b4024d75597da162bbc7cb693b8cef0d6da75105
+# Version.: Commits on July 19, 2021
+LIBRETRO_MUPEN64PLUS_NEXT_VERSION = ecfc77e9a49617d25b683aec7a8217bd044cfc6a
 LIBRETRO_MUPEN64PLUS_NEXT_SITE = $(call github,libretro,mupen64plus-libretro-nx,$(LIBRETRO_MUPEN64PLUS_NEXT_VERSION))
 LIBRETRO_MUPEN64PLUS_NEXT_LICENSE = GPLv2
 LIBRETRO_MUPEN64PLUS_NEXT_DEPENDENCIES = host-nasm retroarch

--- a/package/batocera/emulators/retroarch/libretro/libretro-prosystem/libretro-prosystem.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-prosystem/libretro-prosystem.mk
@@ -3,8 +3,8 @@
 # PROSYSTEM
 #
 ################################################################################
-# Version.: Commits on May 12, 2021
-LIBRETRO_PROSYSTEM_VERSION = fa44adacf8af44a86c94462f90829bb9f8cd8a11
+# Version.: Commits on Aug 3, 2021
+LIBRETRO_PROSYSTEM_VERSION = d365645a460d5ac8c052278e24e8c112956d76c9
 LIBRETRO_PROSYSTEM_SITE = $(call github,libretro,prosystem-libretro,$(LIBRETRO_PROSYSTEM_VERSION))
 LIBRETRO_PROSYSTEM_LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-puae/libretro-puae.mk
@@ -3,7 +3,8 @@
 # PUAE
 #
 ################################################################################
-LIBRETRO_PUAE_VERSION = b5d11f4ec552a0eeb8dbdc0b6668e958ff25081a
+# Last commit: July 31, 2021
+LIBRETRO_PUAE_VERSION = 1ba1fa92df8075010d334bdd9df7a3ae00e3c750
 LIBRETRO_PUAE_SITE = $(call github,libretro,libretro-uae,$(LIBRETRO_PUAE_VERSION))
 LIBRETRO_PUAE__LICENSE = GPLv2
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-px68k/libretro-px68k.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-px68k/libretro-px68k.mk
@@ -3,7 +3,8 @@
 # PX68K
 #
 ################################################################################
-LIBRETRO_PX68K_VERSION = 16d59eb96e239b4fe31796df197506a7b73511c4
+# Last commit: July 12, 2021
+LIBRETRO_PX68K_VERSION = 979a4a9fa33a309f12432b69fe5dc2bccd0aab8a
 LIBRETRO_PX68K_SITE = $(call github,libretro,px68k-libretro,$(LIBRETRO_PX68K_VERSION))
 LIBRETRO_PX68K_LICENSE = Unknown
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-vba-m/libretro-vba-m.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vba-m/libretro-vba-m.mk
@@ -3,7 +3,8 @@
 # VBA-M
 #
 ################################################################################
-LIBRETRO_VBA_M_VERSION = c08bb6bdb0c8576ea60aa41a22f96eaaeac6adea
+# Last commit: July 22, 2021
+LIBRETRO_VBA_M_VERSION = 96ce316bcd159253e9f724a807fb23af5f51706c
 LIBRETRO_VBA_M_SITE = $(call github,visualboyadvance-m,visualboyadvance-m,$(LIBRETRO_VBA_M_VERSION))
 
 define LIBRETRO_VBA_M_BUILD_CMDS

--- a/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
@@ -3,7 +3,8 @@
 # LIBRETRO-VICE
 #
 ################################################################################
-LIBRETRO_VICE_VERSION = 3e60783ac88101584122947d85157b74ff9a30a0
+# Last commit: July 28, 2021 
+LIBRETRO_VICE_VERSION = 297779365febf8082d7638a8d1d5e5fe08221ecf
 LIBRETRO_VICE_SITE = $(call github,libretro,vice-libretro,$(LIBRETRO_VICE_VERSION))
 LIBRETRO_VICE_LICENSE = GPLv2
 


### PR DESCRIPTION
Tested on x86_64 - bumped to their latest version:

- libretro-atari800
- libretro-beetle-pcfx
- libretro-beetle-psx
- libretro-bsnes-hd
- libretro-dosbox-pure
- libretro-fbneo
- libretro-fceumm
- libretro-freeintv
- libretro-fuse
- libretro-gambatte
- libretro-handy
- libretro-kronos
- libretro-lutro
- libretro-mame2003-plus
- libretro-mgba
- libretro-mupen64plus-next
- libretro-prosystem
- libretro-puae
- libretro-px68k
- libretro-vba-m
- libretro-vice

