### PR TITLE
Gambatte - Smart Coloring and Disabled

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -778,11 +778,22 @@ def generateCoreSettings(coreSettings, system, rom):
 
         if (system.name == 'gb'):
             # GB: Colorization of GB games
-            if system.isOptSet('gb_colorization') and system.config['gb_colorization'] != 'none':
-                coreSettings.save('gambatte_gb_colorization',     '"internal"')
-                coreSettings.save('gambatte_gb_internal_palette', '"' + system.config['gb_colorization'] + '"')
+            if system.isOptSet('gb_colorization'):
+                if system.config['gb_colorization'] == 'none':                           #No Selection --> Classic Green
+                    coreSettings.save('gambatte_gb_colorization',     '"internal"')
+                    coreSettings.save('gambatte_gb_internal_palette', '"Special 1"')
+                elif system.config['gb_colorization'] == 'GB - Disabled':                #Disabled --> Black and White Color
+                    coreSettings.save('gambatte_gb_colorization',     '"disabled"')
+                    coreSettings.save('gambatte_gb_internal_palette', '"Special 1"')
+                elif system.config['gb_colorization'] == 'GB - SmartColor':              #Smart Coloring --> Gambatte's most colorful/appropriate color
+                    coreSettings.save('gambatte_gb_colorization',     '"auto"')
+                    coreSettings.save('gambatte_gb_internal_palette', '"Special 1"')
+                else:                                                                    #User Selection
+                    coreSettings.save('gambatte_gb_colorization',     '"internal"')           
+                    coreSettings.save('gambatte_gb_internal_palette', '"' + system.config['gb_colorization'] + '"')
             else:
-                coreSettings.save('gambatte_gb_colorization',     '"Special 1"')
+                coreSettings.save('gambatte_gb_colorization',         '"internal"')      #It's an empty file, set to Classic Green
+                coreSettings.save('gambatte_gb_internal_palette',     '"Special 1"')
 
     if (system.config['core'] == 'mgba'):
         # Skip BIOS intro

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -814,9 +814,11 @@ libretro:
                         description: Set Game Boy palettes to use
                         choices:
                             "Off":                              none
+                            "GB - Smart Coloring":              GB - SmartColor
                             "GB - DMG":                         GB - DMG
                             "GB - Light":                       GB - Light
                             "GB - Pocket":                      GB - Pocket
+                            "GB - Black and White":             GB - Disabled
                             "GBC - Blue":                       GBC - Blue
                             "GBC - Brown":                      GBC - Brown
                             "GBC - Dark Blue":                  GBC - Dark Blue


### PR DESCRIPTION
According to RetroArch,
This option can be set to select the best colorful/appropriate value for the game.

I know it's an "auto" value, so **it's forbidden**
**BUT** this is an option that set different values to game  !
It must be possible to select it (I used it as default personnaly because I don't like the original green)

Exemple : 
Picross with this Auto value set a brown palette that is much more enjoyable 
Aladdin with this Auto set a Original green/yellow palette

![image](https://user-images.githubusercontent.com/54243866/119158707-cb8e8180-ba56-11eb-82f0-632e7831ec32.png)

Just to show you the differences : 

**Pokemon Blue**
Disabled:
<a href="https://www.imagebam.com/view/ME2M8T1" target="_blank"><img src="https://thumbs4.imagebam.com/ed/c2/7a/ME2M8T1_t.png" alt="pokdisabled.png"/></a>
Internal - GB Pocket:
<a href="https://www.imagebam.com/view/ME2M8SZ" target="_blank"><img src="https://thumbs4.imagebam.com/a6/38/bd/ME2M8SZ_t.png" alt="pokpocket.png"/></a>
Smart Coloring:
<a href="https://www.imagebam.com/view/ME2M8T2" target="_blank"><img src="https://thumbs4.imagebam.com/a6/20/b7/ME2M8T2_t.png" alt="poksmart.png"/></a>

**Mario and Yoshi**
Disabled:
<a href="https://www.imagebam.com/view/ME2M8T7" target="_blank"><img src="https://thumbs4.imagebam.com/be/2a/96/ME2M8T7_t.png" alt="marioyoshidisabled.png"/></a>
Internal - GB Pocket:
<a href="https://www.imagebam.com/view/ME2M8T5" target="_blank"><img src="https://thumbs4.imagebam.com/1b/fe/cb/ME2M8T5_t.png" alt="marioyoshipok.png"/></a>
Smart Coloring:
<a href="https://www.imagebam.com/view/ME2M8T8" target="_blank"><img src="https://thumbs4.imagebam.com/c7/5c/4e/ME2M8T8_t.png" alt="marioyoshismart.png"/></a>
