### PR TITLE
Fix issue #4328: Argon One V2/M.2 cases don't work

### DIFF
--- a/package/batocera/utils/rpigpioswitch/rpi-argonone.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-argonone.py
@@ -120,7 +120,7 @@ def temp_check():
             time.sleep(check_interval)
         prevblock = block
         try:
-            bus.write_byte_data(address,0,block)
+            bus.write_byte(address, block)
         except IOError:
             temp = ""
         time.sleep(check_interval)
@@ -137,7 +137,7 @@ def shutdown_check():
             if FORCE_REBOOT == 1:
                 try:
                     # force fan stop (but not board power off)
-                    bus.write_byte_data(address,0,0x00)
+                    bus.write_byte(address, 0x00)
                 except:
                     print ("Could not stop fan")
                 os.system("/usr/bin/batocera-es-swissknife --reboot" )
@@ -146,7 +146,7 @@ def shutdown_check():
         elif pulsetime >=4 and pulsetime <=5:
             try:
                 # full power off
-                bus.write_byte_data(address,0,0xFF)
+                bus.write_byte(address, 0xFF)
             except:
                 print ("Could not power off")
             os.system("/usr/bin/batocera-es-swissknife --shutdown" )
@@ -166,13 +166,13 @@ if len(sys.argv)>1:
     elif str(sys.argv[1]) == "stop":
         try:
             # force fan stop (but not board power off)
-            bus.write_byte_data(address,0,0x00)
+            bus.write_byte(address, 0x00)
         except:
             print ("Could not stop fan")
     elif str(sys.argv[1]) == "halt":
         try:
             # full power off
-            bus.write_byte_data(address,0,0xFF)
+            bus.write_byte(address, 0xFF)
         except:
             print ("Could not power off")
 else:


### PR DESCRIPTION
I did some looking into issue #4328 since I recently bought another argon one v2 case but decided to install batocera instead of retropie. This fix seems to address the fan issue and the power light lingering issue. Previously I was experiencing the same issues everyone else was having: fans turn on very briefly at start but then never turn on again, and power lights would not go out completely on shutdown.

I looked at the original argon shell script found [here](https://download.argon40.com/argon1.sh) to compare with rpi-argonone.py in batocera. I noticed that write calls to bus were slightly different; the official script uses `bus.write_byte` and the batocera script uses `bus.write_byte_data`.

 I stopped the rpi-gpioswtich script, opened a python3 term, and tried making calls over the bus. A call like `bus.write_byte(address, 25)` turned on the fan. Interestingly a call like `bus.write_byte_data(address, 25, 0)` also seemed to work but I didn't explore that too much. A call like `bus.write_byte(address, 0xFF)` shutdown the device. I edited all these calls in rpi-argonone.py, saved it, restarted rpi-gpioswitch, and saved fs overlay. With an overclock, I verified the fan turns on when cpu gets hot enough. I also shutdown the device and the lights go out properly. I did not test much else like the config file.

I'm not sure what the official script looked like for V1. I did a little looking but the wayback machine only goes back to January 2020 and has had changes but only ever used the `bus.write_byte` function as far as I can tell. There are a lot of github repos with argon one shell scripts but I cannot verify their origins.

I do _not_ have a v1 argon case and so it would be great if someone could test that and ensure no regressions. More v2 testing would be great. This is my first public PR so yay.

Thanks everyone!