### PR TITLE
2 player Game Boy enhancements

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -7,6 +7,7 @@
         * add: LR-FBAlpha for weaker SBC (RPI0/1/2)
 		* add: Sega Model 2 emulator - runs under Wine (x86_64)
 		* add: Sonic Retro Engine Decompilation Ports
+		* add: 2-player Game Boy/Color save syncing and support for 2 different linked ROMs
         * fix: RetroAchievements for Watara Supervision
         * fix: battery indicator on Odroid Go Advance
         * rpi3: Switch to driver mesa3d

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -55,7 +55,6 @@ class LibretroGenerator(Generator):
             GBMultiROM = list()
             GBMultiFN = list()
             GBMultiSys = list()
-            romGBName = os.path.splitext(romName)[0]
             romGBName, romExtension = os.path.splitext(romName)
             # If ROM file is a .gb2 text, retrieve the filenames
             if romExtension.lower() == '.gb2':
@@ -80,7 +79,7 @@ class LibretroGenerator(Generator):
             else:
                 # Otherwise fill in the list with the single game
                 GBMultiROM.append(rom)
-                GBMultiFN.append(rom.split(":")[1])
+                GBMultiFN.append(romName)
                 if system.name == "gb2players":
                     GBMultiSys.append("gb")
                 else:
@@ -89,6 +88,8 @@ class LibretroGenerator(Generator):
             if len(GBMultiROM) >= 2:
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, GBMultiROM[0], "--subsystem", "gb_link_2p", GBMultiROM[1], "--config", system.config['configfile']]
                 dontAppendROM = True
+            else:
+                commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
             # Handling for the save copy
             if (system.isOptSet('sync_saves') and system.config["sync_saves"] == '1'):
                 if len(GBMultiROM) >= 2:
@@ -133,7 +134,7 @@ class LibretroGenerator(Generator):
                 for x in range(len(GBMultiSave)):
                     saveFile = "/userdata/saves/" + GBMultiSys[x] + "/" + GBMultiSave[x]
                     newSaveFile = "/userdata/saves/" + system.name + "/" + GBMultiSave[x]
-                    GBMultiScript.write("           cp '" + newSaveFile + "' '" + saveFile + "'\n")
+                    GBMultiScript.write('           cp "' + newSaveFile + '" "' + saveFile + '"\n')
                 GBMultiScript.write("       fi\n")
                 # Deletes itself after running
                 GBMultiScript.write("       rm " + scriptFile + "\n")

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2487,6 +2487,13 @@ libretro:
       features: [netplay, rewind, autosave, latency_reduction, cheevos]
     tgbdual:
       features: [netplay, rewind, autosave, latency_reduction]
+      cfeatures:
+            sync_saves:
+                prompt:      SYNC SAVE FILES
+                description: Sync 2 player saves with single player versions (Default Off)
+                choices:
+                    "On":   1
+                    "Off":  0
     theodore:
       features: [netplay, rewind, autosave, latency_reduction, padtokeyboard]
     tic80:

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -236,7 +236,7 @@ gbc2players:
   manufacturer: Nintendo
   release: 1998
   hardware: portable
-  extensions: [gbc, zip, 7z]
+  extensions: [gbc, gb2, zip, 7z]
   platform:   gbc
   emulators:
     libretro:
@@ -247,7 +247,7 @@ gb2players:
   manufacturer: Nintendo
   release: 1989
   hardware: portable
-  extensions: [gb, zip, 7z]
+  extensions: [gb, gb2, zip, 7z]
   platform:   gb
   emulators:
     libretro:


### PR DESCRIPTION
Adds two additional features to gb2player/gbc2player:

* Allows the use of two different ROMs (ie Pokemon games)
* Allows syncing the 2 player save files with gb/gbc single player saves.

For 2 roms:
* Create a text file named [game name].gb2 - ie Pokemon Red & Blue.gb2
* Add 2 lines to the text file. If you are using ROMs in the current gb2player/gbc2player folder, then each line should just be the file name.
* If you are using ROMs from your gb/gbc ROM folders, prefix the name with gb: or gbc:. So if you were loading Pokemon Crystal from GBC and Pokemon Yellow from GB, the two lines would be:
gbc:Pokemon Crystal.zip
gb:Pokemon Yellow.zip

For save syncing:
* By default, it will be OFF to prevent overwriting any saves that may be wanted. It can be turned on per-game or per-system.
* At launch, it will determine where the single player save should be. First priority will be if the game was set using gb: or gbc:, second will be if it's running in gb2player or gbc2player.
* If a save file exists in /save/gb or /save/gbc, it will copy it to the 2 player save folder (overwriting existing saves).
* It will generate a script to run on game exit to copy the 2 player save file back over the single player ones. The script will only process if called by gb2player/gbc2player, and deletes itself after completion.
* It only copies the battery SRAM, not save states.

The combined changes will allow doing things like playing the Pokemon games single player, then trading between games.

The bulk of the changes are in the libretro generator script, it has a separate process to handle the alternate command line (using the subsystem option) and save file copy/script creation.

It has been tested with both single file games for GB & GBC, as well as dual and cross-system games.