### PR TITLE
splash option cleaning

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -8,7 +8,7 @@
 [ "$1" = "stop" ] || exit 0
 
 set --
-for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled splash.screen.sound splash.video.rotation
+for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled
 do
     value="$(/usr/bin/batocera-settings-get "$key")" || continue
     if [ "$value" != "$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf "$key")" ]

--- a/package/batocera/core/batocera-splash/Ssplash-ffplay
+++ b/package/batocera/core/batocera-splash/Ssplash-ffplay
@@ -10,11 +10,6 @@ FM_VIDEO=".*\.\(mp4\|MP4\)"
 . /etc/profile.d/xdg.sh
 . /etc/profile.d/dbus.sh
 
-soundDisabled()
-{
-    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
-}
-
 do_filerandomize ()
 {
     local array
@@ -54,9 +49,12 @@ do_videostart ()
     video="$1"
     printf 'Video: %s: ' "$video"
     ffplay_opt=
-    if soundDisabled
-    then
-        ffplay_opt=-an
+    soundDisabled=$(batocera-settings-get splash.screen.sound)
+    if [[ $? -eq 0 ]]; then
+	if test "${soundDisabled}" = 0
+	then
+	    ffplay_opt=-an
+	fi
     fi
     start-stop-daemon -S -b -q -m -p /var/run/user-splash.pid --exec /usr/bin/ffplay -- $ffplay_opt -sync video -autoexit -vcodec h264_v4l2m2m -i "$video"
 }

--- a/package/batocera/core/batocera-splash/Ssplash-mpv.template
+++ b/package/batocera/core/batocera-splash/Ssplash-mpv.template
@@ -10,11 +10,6 @@ FM_VIDEO=".*\.\(mp4\|MP4\)"
 . /etc/profile.d/xdg.sh
 . /etc/profile.d/dbus.sh
 
-soundDisabled()
-{
-    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
-}
-
 do_angels_conversion ()
 {
     [[ $1 -lt 0 || $1 -gt 3 ]] && echo 0 || echo $(($1*90))
@@ -60,18 +55,22 @@ do_videostart ()
     video="$1"
     printf 'Video: %s: ' "$video"
     mpv_audio=
-    if soundDisabled
-    then
-        mpv_audio=--no-audio
+
+    soundDisabled=$(batocera-settings-get splash.screen.sound)
+    if [[ $? -eq 0 ]]; then
+	if test "${soundDisabled}" = 0
+	then
+            mpv_audio=--no-audio
+	fi
     fi
 
     mpv_video=
-    video_rotation=$(batocera-settings-get -f /boot/batocera-boot.conf splash.video.rotation)
+    video_rotation=$(batocera-settings-get display.rotate)
     if [[ $? -eq 0 ]]; then
         video_rotation=$(do_angels_conversion $video_rotation)
         [[ $? -eq 0 ]] && mpv_video=--video-rotate=${video_rotation}
     fi
-    video_resize=$(batocera-settings-get -f /boot/batocera-boot.conf splash.video.resize)
+    video_resize=$(batocera-settings-get splash.screen.resize)
     if [[ $? -eq 0 ]]; then
         resize=$(echo "${video_resize}" | sed "s/x/:/")
         mpv_video="${mpv_video} --vf=scale=${resize}"

--- a/package/batocera/core/batocera-splash/Ssplash-omx
+++ b/package/batocera/core/batocera-splash/Ssplash-omx
@@ -10,11 +10,6 @@ FM_VIDEO=".*\.\(mp4\|MP4\)"
 . /etc/profile.d/xdg.sh
 . /etc/profile.d/dbus.sh
 
-soundDisabled()
-{
-    grep -qE "^[ ]*splash.screen.sound[ ]*=[ ]*0[ ]*$" /boot/batocera-boot.conf
-}
-
 do_angels_conversion ()
 {
     [[ $1 -lt 0 || $1 -gt 3 ]] && echo 0 || echo $(($1*90))
@@ -64,9 +59,12 @@ do_videostart ()
     omx_srt="--no-ghost-box --lines=1 --align=left $omx_fnt --font-size=20 --subtitles=/usr/share/batocera/splash/splash.srt"
 
     omx_nosound=
-    if soundDisabled
-    then
-        omx_nosound="-n -1"
+    soundDisabled=$(batocera-settings-get splash.screen.sound)
+    if [[ $? -eq 0 ]]; then
+	if test "${soundDisabled}" = 0
+	then
+	    omx_nosound="-n -1"
+	fi
     fi
 
     start-stop-daemon -S -b -q -m -p /var/run/user-splash.pid --exec /usr/bin/omxplayer -- -o both $omx_opt $omx_srt $omx_nosound "$video"

--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -41,13 +41,12 @@ kodi.xbutton=1
 ## Extend visible time of video/pictures
 ## Possible values are:
 ## auto:      All the video will be played but not longer than 90s
-## i[0-90]:   Time after ES will load in background, for RPi platform ONLY!
 ## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
 ## fastboot:  Stop video as soon as ES is ready to start
 #splash.screen.length=auto
 
 ## Enable video rotation (if supported) values 0,1,2,3 rotate to 0,90,180 and 270 clockwise
-#splash.video.rotation=0
+#display.rotate=0
 
 # ------------ A1 - Platform Specific Options ----------- #
 ## ODROID-C2


### PR DESCRIPTION
- reuse display.rotate option for splas
- all splash options in batocera.conf only (except splash.screen.enabled in batocera-boot.conf)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>