### PR TITLE
custom es options via batocera.conf

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -89,9 +89,10 @@ do
     forcedresolution="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf es.forcedresolution)"
     if test -n "${forcedresolution}"
     then
-	export DISPLAY=:0.0
 	batocera-resolution forceMode "${forcedresolution}"
     fi
+
+    CUSTOMESOPTIONS="$(/usr/bin/batocera-settings-get es.customsargs)"
 
     #####################
     ## CUSTOMISATIONS ###
@@ -114,6 +115,6 @@ do
     #####################
     
     cd /userdata # es need a PWD
-    %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS%
+    %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
 done
 exit 0


### PR DESCRIPTION
example:
add in batocera.conf :
es.customsargs=--screenoffset 50 100


Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>