### PR TITLE
n2 overclocking in batocera-boot.conf

### DIFF
--- a/board/batocera/amlogic/s922x/fsoverlay/etc/init.d/S02overclock
+++ b/board/batocera/amlogic/s922x/fsoverlay/etc/init.d/S02overclock
@@ -17,7 +17,7 @@ do_overclock_n2plus() {
 
 if test "${1}" = "start"
 then
-    OVALUE=$(grep -E '^[ ]*overclocking[ ]*=[ ]*.*[ ]*$' /boot/config.ini | sed -e s+"^[ ]*overclocking[ ]*=[ ]*\(.*\)[ ]*$"+"\1"+)
+    OVALUE=$(grep -E '^[ ]*overclocking[ ]*=[ ]*.*[ ]*$' /boot/batocera-boot.conf | sed -e s+"^[ ]*overclocking[ ]*=[ ]*\(.*\)[ ]*$"+"\1"+)
     MODEL=$(cat /sys/firmware/devicetree/base/model)
 
     case "${MODEL}" in

--- a/package/batocera/core/batocera-scripts/scripts/batocera-overclock
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-overclock
@@ -7,7 +7,7 @@ f_usage() {
 
 ARCH="$(cat /usr/share/batocera/batocera.arch)"
 GRPICONFFILE="/boot/config.txt"
-GODROIDCONFFILE="/boot/config.ini"
+GODROIDCONFFILE="/boot/batocera-boot.conf"
 
 if test "${ARCH}" = "rpi3"
 then


### PR DESCRIPTION
because boot.ini is erased at each update

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>