### PR TITLE
Fix SCV OGA Build

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-emuscv/003-remove-io-header.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-emuscv/003-remove-io-header.patch
@@ -1,0 +1,25 @@
+diff --git a/src/common.h b/src/common.h
+index 7bf6441..2717ee3 100755
+--- a/src/common.h
++++ b/src/common.h
+@@ -122,7 +122,7 @@
+ #elif defined(_OSX)
+     #include <sys/uio.h>
+ #else
+-    #include <sys/io.h>
++    //#include <sys/io.h>
+ #endif
+ #ifdef _MSC_VER
+ 	#include <typeinfo.h>
+diff --git a/src/vm/debugger.cpp b/src/vm/debugger.cpp
+index 222cee5..453529d 100755
+--- a/src/vm/debugger.cpp
++++ b/src/vm/debugger.cpp
+@@ -13,7 +13,7 @@
+ #elif defined(_OSX)
+     #include <sys/uio.h>
+ #else
+-    #include <sys/io.h>
++    //#include <sys/io.h>
+ #endif
+ #include <fcntl.h>


### PR DESCRIPTION
For fix : 

```
In file included from src/emuscv.h:25,
                 from src/libretro.cpp:11:
src/common.h:125:14: fatal error: sys/io.h: No such file or directory
  125 |     #include <sys/io.h>
      |              ^~~~~~~~~~
compilation terminated.
make[1]: *** [Makefile.libretro:786: src/libretro.o] Error 1
In file included from src/emuscv.h:25,
                 from src/emuscv.cpp:10:
src/common.h:125:14: fatal error: sys/io.h: No such file or directory
  125 |     #include <sys/io.h>
      |              ^~~~~~~~~~
compilation terminated.
```