### PR TITLE
Fix PPSSPP cheats location

### DIFF
--- a/package/batocera/emulators/ppsspp/001-batocera-path.patch
+++ b/package/batocera/emulators/ppsspp/001-batocera-path.patch
@@ -32,7 +32,7 @@ index 16ae2808d..544e81ffb 100644
  	switch (directoryType) {
  	case DIRECTORY_CHEATS:
 -		return g_Config.memStickDirectory + "PSP/Cheats/";
-+		return "/userdata/cheats/";
++		return "/userdata/cheats/psp/";
  	case DIRECTORY_GAME:
  		return g_Config.memStickDirectory + "PSP/GAME/";
  	case DIRECTORY_SAVEDATA:


### PR DESCRIPTION
And added a new `psp-ppsspp-cheats` package in the Batocera Content Downloader to make it easier to install/manage.
Fix for #4398, thanks @wadiebs for the report!