### PR TITLE
Amiberry - New sound buffer size value

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -93,6 +93,10 @@ class AmiberryGenerator(Generator):
             commandArray.append("-s")
             commandArray.append("gfx_center_vertical=smart")
 
+            # fix sound buffer
+            commandArray.append("-s")
+            commandArray.append("sound_max_buff=4096")
+
             os.chdir("/usr/share/amiberry")
             return Command.Command(array=commandArray)
         # otherwise, unknown format


### PR DESCRIPTION
Sound buffer size value changed from 8192 (default value. Shows as 8 on Amiberry menu settings) to 4096 (as 4).
With this new value, it fixes the sound latency issue.

Tested and worked.
