### PR TITLE
Amiberry - Display corrections

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -89,9 +89,21 @@ class AmiberryGenerator(Generator):
             commandArray.append("-s")
             commandArray.append("joyport2=")
 
+            # display line mode
+            commandArray.append("-s")
+            commandArray.append("gfx_linemode=double")
+
+            # remove interlace artifacts
+            commandArray.append("-s")
+            commandArray.append("gfx_flickerfixer=true")
+
             # display vertical centering
             commandArray.append("-s")
             commandArray.append("gfx_center_vertical=smart")
+
+            # auto height
+            commandArray.append("-s")
+            commandArray.append("amiberry.gfx_auto_height=true")
 
             # fix sound buffer
             commandArray.append("-s")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -101,10 +101,6 @@ class AmiberryGenerator(Generator):
             commandArray.append("-s")
             commandArray.append("gfx_center_vertical=smart")
 
-            # auto height
-            commandArray.append("-s")
-            commandArray.append("amiberry.gfx_auto_height=true")
-
             # fix sound buffer
             commandArray.append("-s")
             commandArray.append("sound_max_buff=4096")


### PR DESCRIPTION
- Enabled "Double line mode" (No pixelated hi res images. Check Agony start screen or Team17 logo screen).
- Enabled "Remove interlace artifacts": Correct workbench and some games high-res laced screen mode flickering. Maybe it can create some conflicts with "Centering Vertical Screen" together enabled, but this happens in a very few games screen.
- Enabled "Auto Height" : Auto zoom, cutting excessive and useless vertical screen borders (like in PUAE, but only on vertical). Useful for handhelds or small screens. On 16:9 or wide aspect ratio you can see not a proper 4:3 screen with black borders, but is an normal thing. On 4:3 or 5:4 aspect ratio needed some test (unfortunately i don't have a 4:3 or 5:4 display screen)