### PR TITLE
Improve configgen logging

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -4,19 +4,20 @@ import batoceraFiles
 from settings.unixSettings import UnixSettings
 import xml.etree.ElementTree as ET
 import shlex
-from utils.logger import eslog
+from utils.logger import get_logger
 import yaml
 import collections
 
-class Emulator():
+eslog = get_logger(__name__)
 
+class Emulator():
     def __init__(self, name, rom):
         self.name = name
 
         # read the configuration from the system name
         self.config = Emulator.get_system_config(self.name, "/usr/share/batocera/configgen/configgen-defaults.yml", "/usr/share/batocera/configgen/configgen-defaults-arch.yml")
         if "emulator" not in self.config or self.config["emulator"] == "":
-            eslog.log("no emulator defined. exiting.")
+            eslog.error("no emulator defined. exiting.")
             raise Exception("No emulator found")
 
         system_emulator = self.config["emulator"]
@@ -38,7 +39,7 @@ class Emulator():
         Emulator.updateConfiguration(self.config, systemSettings)
         Emulator.updateConfiguration(self.config, gameSettings)
         self.updateFromESSettings()
-        eslog.log("uimode: {}".format(self.config['uimode']))
+        eslog.debug("uimode: {}".format(self.config['uimode']))
 
         # forced emulators ?
         self.config["emulator-forced"] = False

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Evmapy.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Evmapy.py
@@ -4,8 +4,10 @@ import subprocess
 import json
 import re
 import os
-from utils.logger import eslog
+from utils.logger import get_logger
 import evdev
+
+eslog = get_logger(__name__)
 
 class Evmapy():
     # evmapy is a process that map pads to keyboards (for pygame for example)
@@ -37,7 +39,7 @@ class Evmapy():
                 "/usr/share/evmapy/{}.keys" .format (system)
         ]:
             if os.path.exists(keysfile) and not (os.path.isdir(rom) and keysfile == "{}.keys" .format (rom)): # "{}.keys" .format (rom) is forbidden for directories, it must be inside
-                eslog.log("evmapy on {}".format(keysfile))
+                eslog.debug("evmapy on {}".format(keysfile))
                 subprocess.call(["batocera-evmapy", "clear"])
     
                 padActionConfig = json.load(open(keysfile))
@@ -47,7 +49,7 @@ class Evmapy():
                 for playercontroller, pad in sorted(playersControllers.items()):
                     if "actions_player"+str(nplayer) in padActionConfig:
                         configfile = "/var/run/evmapy/{}.json" .format (os.path.basename(pad.dev))
-                        eslog.log("config file for keysfile is {} (from {})" .format (configfile, keysfile))
+                        eslog.debug("config file for keysfile is {} (from {})" .format (configfile, keysfile))
     
                         # create mapping
                         padConfig = {}

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -9,7 +9,9 @@ import zipfile
 from settings.unixSettings import UnixSettings
 from generators.libretro import libretroControllers
 from os.path import dirname
-from utils.logger import eslog
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 class AmiberryGenerator(Generator):
 
@@ -19,7 +21,7 @@ class AmiberryGenerator(Generator):
             os.makedirs(dirname(batoceraFiles.amiberryRetroarchCustom))
         
         romType = self.getRomType(rom)
-        eslog.log("romType: "+romType)
+        eslog.debug("romType: "+romType)
         if romType != 'UNKNOWN' :           
             commandArray = [ batoceraFiles.batoceraBins[system.config['emulator']], "-G" ]
             if romType != 'WHDL' :
@@ -159,7 +161,7 @@ class AmiberryGenerator(Generator):
                         if extension == "info":
                             return 'WHDL'
                         elif extension == 'lha' :
-                            eslog.log("Amiberry doesn't support .lha inside a .zip")
+                            eslog.warning("Amiberry doesn't support .lha inside a .zip")
                             return 'UNKNOWN'
                         elif extension == 'adf' :
                             return 'DISK'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cannonball/cannonballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cannonball/cannonballGenerator.py
@@ -6,7 +6,6 @@ import os
 from xml.dom import minidom
 import codecs
 import Command
-from utils.logger import eslog
 from . import cannonballControllers
 
 class CannonballGenerator(Generator):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuControllers.py
@@ -6,7 +6,6 @@ import os
 from os import path
 import codecs
 from Emulator import Emulator
-from utils.logger import eslog
 import configparser
 import json
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -5,10 +5,12 @@ import batoceraFiles
 import os
 import codecs
 from Emulator import Emulator
-from utils.logger import eslog
+from utils.logger import get_logger
 import glob
 import configparser
 import re
+
+eslog = get_logger(__name__)
 
 # Create the controller configuration file
 def generateControllerConfig(system, playersControllers, rom):
@@ -151,8 +153,8 @@ def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
                 wiiMapping.update(res)
                 line = cconfig.readline()
 
-    eslog.log("Extra Options: {}".format(extraOptions))
-    eslog.log("Wii Mappings: {}".format(wiiMapping))
+    eslog.debug("Extra Options: {}".format(extraOptions))
+    eslog.debug("Wii Mappings: {}".format(wiiMapping))
 
     generateControllerConfig_any(system, playersControllers, "WiimoteNew.ini", "Wiimote", wiiMapping, wiiReverseAxes, None, extraOptions)
 
@@ -354,24 +356,24 @@ def generateControllerConfig_any_auto(f, pad, anyMapping, anyReverseAxes, anyRep
 def generateControllerConfig_any_from_profiles(f, pad):
     for profileFile in glob.glob("/userdata/system/configs/dolphin-emu/Profiles/GCPad/*.ini"):
         try:
-            eslog.log("Looking profile : {}".format(profileFile))
+            eslog.debug("Looking profile : {}".format(profileFile))
             profileConfig = configparser.ConfigParser(interpolation=None)
             # To prevent ConfigParser from converting to lower case
             profileConfig.optionxform = str
             profileConfig.read(profileFile)
             profileDevice = profileConfig.get("Profile","Device")
-            eslog.log("Profile device : {}".format(profileDevice))
+            eslog.debug("Profile device : {}".format(profileDevice))
 
             deviceVals = re.match("^([^/]*)/[0-9]*/(.*)$", profileDevice)
             if deviceVals is not None:
                 if deviceVals.group(1) == "evdev" and deviceVals.group(2).strip() == pad.realName.strip():
-                    eslog.log("Eligible profile device found")
+                    eslog.debug("Eligible profile device found")
                     for key, val in profileConfig.items("Profile"):
                         if key != "Device":
                             f.write("{} = {}\n".format(key, val))
                     return True
         except:
-            eslog.log("profile {} : FAILED".format(profileFile))
+            eslog.error("profile {} : FAILED".format(profileFile))
 
     return False
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -4,6 +4,9 @@
 from struct import pack
 from struct import unpack
 from os     import environ
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 def readBEInt16(f):
     bytes = f.read(2)
@@ -72,7 +75,7 @@ def readWriteEntry(f, setval):
             raise Exception("unknown type {}".format(itemType))
 
     if not setval or itemName in setval:
-        print('{:12s} = {}'.format(itemName, itemValue))
+        eslog.debug('{:12s} = {}'.format(itemName, itemValue))
 
 def readWriteFile(filepath, setval):
     # open in read read/write depending of the action

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -7,8 +7,10 @@ import configparser
 import os.path
 import httplib2
 import json
-from utils.logger import eslog
+from utils.logger import get_logger
 from os import environ
+
+eslog = get_logger(__name__)
 
 class DuckstationGenerator(Generator):
     def generate(self, system, rom, playersControllers, gameResolution):
@@ -184,16 +186,16 @@ class DuckstationGenerator(Generator):
             try:
                 cnx = httplib2.Http()
             except:
-                eslog.log("ERROR: Unable to connect to " + login_url)
+                eslog.error("ERROR: Unable to connect to " + login_url)
             try:
                 res, rout = cnx.request(login_url + login_cmd, method="GET", body=None, headers=headers)
                 if (res.status != 200):
-                    eslog.log("ERROR: RetroAchievements.org responded with #{} [{}] {}".format(res.status, res.reason, rout))
+                    eslog.warning("ERROR: RetroAchievements.org responded with #{} [{}] {}".format(res.status, res.reason, rout))
                     settings.set("Cheevos", "Enabled",  "false")
                 else:
                     parsedout = json.loads((rout.decode('utf-8')))
                     if not parsedout['Success']:
-                        eslog.log("ERROR: RetroAchievements login failed with ({})".format(str(parsedout)))
+                        eslog.warning("ERROR: RetroAchievements login failed with ({})".format(str(parsedout)))
                     token = parsedout['Token']
                     settings.set("Cheevos", "Enabled",       "true")
                     settings.set("Cheevos", "Username",      username)
@@ -208,9 +210,9 @@ class DuckstationGenerator(Generator):
                     #settings.set("Cheevos", "RichPresence",  "true")             # Enable rich presence information will be collected and sent to the server where supported
                     #settings.set("Cheevos", "TestMode",      "false")            # DuckStation will assume all achievements are locked and not send any unlock notifications to the server.
 
-                    eslog.log ("Duckstation RetroAchievements enabled for {}".format(username))
+                    eslog.debug("Duckstation RetroAchievements enabled for {}".format(username))
             except Exception as e:
-                eslog.log("ERROR: Impossible to get a RetroAchievements token ({})".format(e))
+                eslog.error("ERROR: Impossible to get a RetroAchievements token ({})".format(e))
                 settings.set("Cheevos", "Enabled",           "false")
         else:
             settings.set("Cheevos", "Enabled",               "false")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
@@ -4,7 +4,9 @@ import sys
 import os
 import configparser
 import batoceraFiles
-from utils.logger import eslog
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
@@ -73,7 +75,7 @@ def generateControllerConfig(controller):
         if input.type not in flycastMapping[input.name]:
             continue
         var = flycastMapping[input.name][input.type]
-        eslog.log("Var: {}".format(var))
+        eslog.debug("Var: {}".format(var))
         for i in sections:
             if var in sections[i]:
                 section = i
@@ -94,7 +96,7 @@ def generateControllerConfig(controller):
                 code = input.code
                 Config.set(section, var, code)
             else:
-                eslog.log("code not found for key " + input.name + " on pad " + controller.realName + " (please reconfigure your pad)")
+                eslog.warning("code not found for key " + input.name + " on pad " + controller.realName + " (please reconfigure your pad)")
 
     Config.write(cfgfile)
     cfgfile.close()

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
@@ -3,12 +3,14 @@
 from generators.Generator import Generator
 import Command
 import controllersConfig
-from utils.logger import eslog
+from utils.logger import get_logger
 import batoceraFiles
 import os
 
 import subprocess
 import sys
+
+eslog = get_logger(__name__)
 
 class FpinballGenerator(Generator):
 
@@ -25,12 +27,12 @@ class FpinballGenerator(Generator):
             env = {"W_CACHE": "/userdata/bios", "LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX":"/userdata/saves/fpinball" }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/wsh57.done", "w") as f:
                 f.write("done")
 
@@ -129,12 +131,12 @@ class FpinballGenerator(Generator):
         env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX":"/userdata/saves/fpinball" }
         env.update(os.environ)
         env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-        eslog.log("command: {}".format(str(cmd)))
+        eslog.debug("command: {}".format(str(cmd)))
         proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = proc.communicate()
         exitcode = proc.returncode
-        eslog.log(out.decode())
-        eslog.log(err.decode())
+        eslog.debug(out.decode())
+        eslog.error(err.decode())
 
         return Command.Command(
             array=commandArray,

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
@@ -7,6 +7,9 @@ import shutil
 from generators.Generator import Generator
 from os import path
 from . import fsuaeControllers
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 class FsuaeGenerator(Generator):
 
@@ -72,11 +75,11 @@ class FsuaeGenerator(Generator):
                 if (d.endswith("ipf") or d.endswith("adf") or d.endswith("dms") or d.endswith("adz")):
                     diskNames.append(name)
 
-            print("Amount of disks in zip " + str(len(diskNames)))
+            eslog.debug("Amount of disks in zip " + str(len(diskNames)))
 
         # if 2+ files, we have a multidisk ZIP (0=no zip)
         if (len(diskNames) > 1):
-            print("extracting...")
+            eslog.debug("extracting...")
             shutil.rmtree(TEMP_DIR, ignore_errors=True) # cleanup
             zf.extractall(TEMP_DIR)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
@@ -5,7 +5,9 @@ from generators.Generator import Generator
 from settings.unixSettings import UnixSettings
 import controllersConfig
 import os
+from utils.logger import get_logger
 
+eslog = get_logger(__name__)
 CONFIGDIR  = batoceraFiles.CONF + '/GSplus'
 CONFIGFILE = CONFIGDIR + '/config.txt'
 
@@ -18,7 +20,7 @@ class GSplusGenerator(Generator):
 
         rombase=os.path.basename(rom)
         romext=os.path.splitext(rombase)[1]
-        print ("_____ ROMEXT: "+romext)
+        eslog.debug("_____ ROMEXT: "+romext)
         if (romext.lower() == '.dsk'):
             config.save("s6d1", rom)
             config.save("s5d1", '')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
@@ -3,10 +3,12 @@
 import Command
 from generators.Generator import Generator
 import controllersConfig
-from utils.logger import eslog
+from utils.logger import get_logger
 import os
 import configparser
 import batoceraFiles
+
+eslog = get_logger(__name__)
 
 class HatariGenerator(Generator):
 
@@ -157,9 +159,9 @@ class HatariGenerator(Generator):
                 for v_language in l_lang:
                     filename = "tos{}{}.img".format(v_tos_version, v_language)
                     if os.path.exists("{}/{}".format(biosdir, filename)):
-                        eslog.log("tos filename: {}".format(filename))
+                        eslog.debug("tos filename: {}".format(filename))
                         return filename
                     else:
-                        eslog.log("tos filename {} not found".format(filename))
+                        eslog.warning("tos filename {} not found".format(filename))
 
         raise Exception("no bios found for machine {}".format(machine))

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -2,10 +2,11 @@
 import Command
 import batoceraFiles
 from generators.Generator import Generator
-from utils.logger import eslog
+from utils.logger import get_logger
 import controllersConfig
 import os
 
+eslog = get_logger(__name__)
 BIN_PATH="/userdata/bios/pico-8/pico8"
 CONTROLLERS="/userdata/system/.lexaloffle/pico-8/sdl_controllers.txt"
 
@@ -13,10 +14,10 @@ CONTROLLERS="/userdata/system/.lexaloffle/pico-8/sdl_controllers.txt"
 class LexaloffleGenerator(Generator):
     def generate(self, system, rom, playersControllers, gameResolution):
         if not os.path.exists(BIN_PATH):
-            eslog.log("Lexaloffle official pico-8 binary not found at {}".format(BIN_PATH))
+            eslog.error("Lexaloffle official pico-8 binary not found at {}".format(BIN_PATH))
             return -1
         if not os.access(BIN_PATH, os.X_OK):
-            eslog.log("File {} is not set as executable".format(BIN_PATH))
+            eslog.error("File {} is not set as executable".format(BIN_PATH))
             return -1
 
         # the command to run

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -7,10 +7,11 @@ from Emulator import Emulator
 import settings
 from settings.unixSettings import UnixSettings
 import json
-from utils.logger import eslog
+from utils.logger import get_logger
 from PIL import Image, ImageOps
 import utils.bezels as bezelsUtil
 
+eslog = get_logger(__name__)
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 
@@ -634,7 +635,7 @@ def writeBezelConfig(bezel, retroarchConfig, systemName, rom, gameResolution, be
             if create_new_bezel_file is True:
                 # Padding left and right borders for ultrawide screens (larger than 16:9 aspect ratio)
                 # or up/down for 4K
-                eslog.log("Generating a new adapted bezel file {}".format(output_png_file))
+                eslog.debug("Generating a new adapted bezel file {}".format(output_png_file))
                 fillcolor = 'black'
 
                 borderw = 0
@@ -668,7 +669,7 @@ def writeBezelConfig(bezel, retroarchConfig, systemName, rom, gameResolution, be
         retroarchConfig['video_message_pos_x']    = infos["messagex"]
         retroarchConfig['video_message_pos_y']    = infos["messagey"]
 
-    eslog.log("Bezel file set to {}".format(overlay_png_file))
+    eslog.debug("Bezel file set to {}".format(overlay_png_file))
     writeBezelCfgConfig(overlay_cfg_file, overlay_png_file)
 
 def isLowResolution(gameResolution):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -9,7 +9,9 @@ from generators.Generator import Generator
 import os
 import stat
 from settings.unixSettings import UnixSettings
-from utils.logger import eslog
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 class LibretroGenerator(Generator):
 
@@ -181,10 +183,10 @@ class LibretroGenerator(Generator):
                 shaderFilename = renderConfig['shader'] + ".slangp"
             else:
                 shaderFilename = renderConfig['shader'] + ".glslp"
-            eslog.log("searching shader {}".format(shaderFilename))
+            eslog.debug("searching shader {}".format(shaderFilename))
             if os.path.exists("/userdata/shaders/" + shaderFilename):
                 video_shader_dir = "/userdata/shaders"
-                eslog.log("shader {} found in /userdata/shaders".format(shaderFilename))
+                eslog.debug("shader {} found in /userdata/shaders".format(shaderFilename))
             else:
                 video_shader_dir = "/usr/share/batocera/shaders"
             video_shader = video_shader_dir + "/" + shaderFilename

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -5,7 +5,7 @@ import batoceraFiles
 import Command
 import shutil
 import os
-from utils.logger import eslog
+from utils.logger import get_logger
 from os import path
 from os import environ
 import configparser
@@ -15,6 +15,8 @@ import shutil
 import utils.bezels as bezelsUtil
 import subprocess
 from xml.dom import minidom
+
+eslog = get_logger(__name__)
 
 class MameGenerator(Generator):
 
@@ -288,7 +290,7 @@ class MameGenerator(Generator):
                 return "JOYCODE_{}_RXAXIS_NEG_SWITCH OR JOYCODE_{}_BUTTON3".format(joycode, joycode)
             if key == "joystick2right":
                 return "JOYCODE_{}_RXAXIS_POS_SWITCH OR JOYCODE_{}_BUTTON2".format(joycode, joycode)
-        eslog.log("unable to find input2definition for {} / {}".format(input.type, key))
+        eslog.warning("unable to find input2definition for {} / {}".format(input.type, key))
         return "unknown"
 
     @staticmethod

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
@@ -4,12 +4,14 @@ from generators.Generator import Generator
 import Command
 import os
 import batoceraFiles
-from utils.logger import eslog
+from utils.logger import get_logger
 import subprocess
 import sys
 import shutil
 import stat
 import configparser
+
+eslog = get_logger(__name__)
 
 class Model2EmuGenerator(Generator):
 
@@ -31,12 +33,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/d3dcompiler_42.done", "w") as f:
                 f.write("done")
 
@@ -45,12 +47,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/d3dx9_42.done", "w") as f:
                 f.write("done")
 
@@ -59,12 +61,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/d3dcompiler_43.done", "w") as f:
                 f.write("done")
 
@@ -73,12 +75,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/d3dx9_43.done", "w") as f:
                 f.write("done")
     
@@ -87,12 +89,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/d3dx9.done", "w") as f:
                 f.write("done")
 
@@ -101,12 +103,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/xact.done", "w") as f:
                 f.write("done")
 
@@ -115,12 +117,12 @@ class Model2EmuGenerator(Generator):
             env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/lutris/lib/wine", "WINEPREFIX": wineprefix }
             env.update(os.environ)
             env["PATH"] = "/usr/wine/lutris/bin:/bin:/usr/bin"
-            eslog.log("command: {}".format(str(cmd)))
+            eslog.debug("command: {}".format(str(cmd)))
             proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             out, err = proc.communicate()
             exitcode = proc.returncode
-            eslog.log(out.decode())
-            eslog.log(err.decode())
+            eslog.debug(out.decode())
+            eslog.error(err.decode())
             with open(wineprefix + "/xact_x64.done", "w") as f:
                 f.write("done")
         

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
@@ -1,4 +1,6 @@
-from utils.logger import eslog
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 def generateControllerConfig(config, playersControllers, core):
     if core == "openbor4432":
@@ -35,7 +37,7 @@ def JoystickValue(key, pad, joy_max_inputs, invertAxis = False):
     if input.type != "keyboard":
         value += 600
 
-    #eslog.log("input.type={} input.id={} input.value={} => result={}".format(input.type, input.id, input.value, value))
+    #eslog.debug("input.type={} input.id={} input.value={} => result={}".format(input.type, input.id, input.value, value))
     return value
 
 def setupControllers(config, playersControllers, joy_max_inputs):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
@@ -6,8 +6,10 @@ from generators.Generator import Generator
 import os
 import re
 from settings.unixSettings import UnixSettings
-from utils.logger import eslog
+from utils.logger import get_logger
 from . import openborControllers
+
+eslog = get_logger(__name__)
 
 class OpenborGenerator(Generator):
 
@@ -25,7 +27,7 @@ class OpenborGenerator(Generator):
         core = system.config['core']
         if system.config["core-forced"] == False:
             core = OpenborGenerator.guessCore(rom)
-        eslog.log("core taken is {}".format(core))
+        eslog.debug("core taken is {}".format(core))
 
         # config file
         configfilename = "config6510.ini"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -9,6 +9,9 @@ import re
 import configparser
 import io
 import controllersConfig
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 class Pcsx2Generator(Generator):
 
@@ -36,7 +39,7 @@ class Pcsx2Generator(Generator):
 
         # Fullboot
         if system.isOptSet('fullboot') and system.config['fullboot'] == '0':
-            print("Fast Boot and skip BIOS")
+            eslog.debug("Fast Boot and skip BIOS")
         else:
             commandArray.append("--fullboot")
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
@@ -5,6 +5,9 @@ import sys
 import os
 import configparser
 import batoceraFiles
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 ppssppControlsIni  = batoceraFiles.CONF + '/ppsspp/PSP/SYSTEM/controls.ini'
 ppssppControlsInit = batoceraFiles.HOME_INIT + 'configs/ppsspp/PSP/SYSTEM/controls.ini'
@@ -149,7 +152,7 @@ def generateControllerConfig(controller):
             pspcode = axisToCode(nkAxisId, int(input.value))
             val = "{}-{}".format( DEVICE_ID_PAD_0 + padnum, pspcode )
             val = optionValue(Config, section, var, val)
-            print("Adding {} to {}".format(var, val))
+            eslog.debug("Adding {} to {}".format(var, val))
             Config.set(section, var, val)
             
             # Skip the rest if it's an axis dpad

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
@@ -2,7 +2,9 @@ import os
 import batoceraFiles
 from os import path
 import codecs
-from utils.logger import eslog
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
 
 def generateControllerConfig(system, controllers, rom):
     generateConfigInputYml(controllers)
@@ -43,7 +45,7 @@ def generateInputConfigs(controllers):
                 if key is not None:
                     f.write("{}: {}\n".format(key, rpcs3_mappingValue(input.name, input.type, input.code, int(input.value))))
                 else:
-                    eslog.log("no rpcs3 mapping found for {}".format(input.name))
+                    eslog.warning("no rpcs3 mapping found for {}".format(input.name))
 
                 # write the reverse
                 if input.name == "joystick1up" or input.name == "joystick1left" or input.name == "joystick2up" or input.name == "joystick2left":
@@ -52,7 +54,7 @@ def generateInputConfigs(controllers):
                     if key is not None:
                         f.write("{}: {}\n".format(key, rpcs3_mappingValue(reversedName, input.type, input.code, int(input.value)*-1)))
                     else:
-                        eslog.log("no rpcs3 mapping found for {}".format(input.name))
+                        eslog.warning("no rpcs3 mapping found for {}".format(input.name))
                     
             rpcs3_otherKeys(f, controller)
             f.close()
@@ -118,7 +120,7 @@ def rpcs3_mappingValue(name, type, code, value):
             return ""
         res = int(code)+1000
         if value < 0:
-            eslog.log("name = {} and value = {}".format(name, value))
+            eslog.debug("name = {} and value = {}".format(name, value))
             res = res * -1
         return res
     return None

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -5,7 +5,6 @@ import batoceraFiles
 import Command
 import shutil
 import os
-from utils.logger import eslog
 from os import path
 from os import environ
 import configparser

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/solarus/solarusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/solarus/solarusGenerator.py
@@ -7,7 +7,6 @@ import batoceraFiles
 import codecs
 import os
 import zipfile
-from utils.logger import eslog
 
 class SolarusGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/tsugaru/tsugaruGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/tsugaru/tsugaruGenerator.py
@@ -3,7 +3,6 @@
 import Command
 from generators.Generator import Generator
 import controllersConfig
-from utils.logger import eslog
 import os
 import configparser
 import batoceraFiles

--- a/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
@@ -4,8 +4,9 @@ import configparser
 import os
 import re
 import io
-from configgen.utils.logger import eslog
+from configgen.utils.logger import get_logger
 
+eslog = get_logger(__name__)
 __source__ = os.path.basename(__file__)
 
 class UnixSettings():
@@ -32,7 +33,7 @@ class UnixSettings():
 
             self.config.readfp(file)
         except IOError as e:
-            eslog.debug(str(e))
+            eslog.error(str(e))
 
     def write(self):
         fp = open(self.settingsFile, 'w')
@@ -43,7 +44,7 @@ class UnixSettings():
             # PSX Mednafen writes beetle_psx_hw_cpu_freq_scale = "100%(native)"
             # Python 2.7 is EOL and ConfigParser 2.7 takes "%(" as a won't fix error
             # TODO: clean that up when porting to Python 3
-            eslog.debug("Wrong value detected (after % char maybe?), ignoring.")
+            eslog.error("Wrong value detected (after % char maybe?), ignoring.")
         fp.close()
 
     def save(self, name, value):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/logger.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/logger.py
@@ -1,144 +1,24 @@
-#!/usr/bin/env python
-#
-# Simple wrapper for Python logging module. Adds information about location
-# emitting the debug information (file, line, function) and timestamp.
-#
-# Copyright (C) 2010, 2011 Senko Rasic <senko.rasic@dobarkod.hr>
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-
-import os.path
 import logging
-import traceback
-
-from logging import DEBUG, WARNING, ERROR, INFO
+import sys
 
 
-class Logger(object):
-    """
-    Logger mixin/base class adding verbose logging to subclasses.
-    Subclasses get info(), debug(), warning() and error() methods which, alongside
-    the information given, also show location of the message (file, line and
-    function).
-
-    By default, the logging mechanism will only show warning and error messages
-    without any timestamping. A static method Logger.basicConfig() is provided
-    for basic usage with all debugging turned on and showing debuglevel and
-    timestamps. See the documentation of logging module for information how to
-    customize debug levels, formatters and outputs.
-
-    To activate the basic configuration:
-    >>> Logger.basicConfig()
-
-    Example mixin usage:
-
-    >>> class MyClass(Logger):
-    ...    def my_method(self):
-    ...        self.debug('called')
-    ...    def raises_exc(self):
-    ...        try:
-    ...            raise Exception("error message")
-    ...        except:
-    ...            self.error('got exception', exc_info=True)
-    ...
-    >>> x = MyClass()
-    >>> x.my_method()
-    >>> x.raises_exc()
-
-    Module also provides a singleton "logger" instance of Logger class, which
-    can be used when it's not feasible to use the mixin. The logger provides
-    the same debug(), warning() and error() methods.
-
-    Example singleton usage:
-
-    >>> logger.debug('This is a debug message')
-    """
-
-    show_source_location = True
-
-    # Formats the message as needed and calls the correct logging method
-    # to actually handle it
-    def _raw_log(self, logfn, message, exc_info):
-        cname = ''
-        loc = ''
-        fn = ''
-        tb = traceback.extract_stack()
-        if len(tb) > 2:
-            if self.show_source_location:
-                loc = '(%s:%d):' % (os.path.basename(tb[-3][0]), tb[-3][1])
-            fn = tb[-3][2]
-            if fn != '<module>':
-                if self.__class__.__name__ != Logger.__name__:
-                    fn = self.__class__.__name__ + '.' + fn
-                fn += '()'
-
-        logfn(loc + cname + fn + ': ' + message, exc_info=exc_info)
-
-    def info(self, message, exc_info=False):
-        """
-        Log a info-level message. If exc_info is True, if an exception
-        was caught, show the exception information (message and stack trace).
-        """
-        self._raw_log(logging.info, message, exc_info)
-
-    def debug(self, message, exc_info=False):
-        """
-        Log a debug-level message. If exc_info is True, if an exception
-        was caught, show the exception information (message and stack trace).
-        """
-        self._raw_log(logging.debug, message, exc_info)
-
-    """
-    Alias for info()
-    """
-    log = info
-
-    def warning(self, message, exc_info=False):
-        """
-        Log a warning-level message. If exc_info is True, if an exception
-        was caught, show the exception information (message and stack trace).
-        """
-        self._raw_log(logging.warning, message, exc_info)
-
-    def error(self, message, exc_info=False):
-        """
-        Log an error-level message. If exc_info is True, if an exception
-        was caught, show the exception information (message and stack trace).
-        """
-        self._raw_log(logging.error, message, exc_info)
-
-    @staticmethod
-    def basicConfig(level=DEBUG):
-        """
-        Apply a basic logging configuration which outputs the log to the
-        console (stderr). Optionally, the minimum log level can be set, one
-        of DEBUG, WARNING, ERROR (or any of the levels from the logging
-        module). If not set, DEBUG log level is used as minimum.
-        """
-        logging.basicConfig(level=level,
-            format='%(asctime)s %(levelname)s %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S')
-
-Logger.basicConfig(level=DEBUG)
-eslog = Logger()
-
-if __name__ == '__main__':
-    # Run the code from examples
-    import doctest
-    doctest.testmod()
+def get_logger(module_name: str) -> logging.Logger:
+    # The logging level that separates stdout from stderr: stdout < error_level <= stderr
+    error_level = logging.WARNING
+    # Common formatter shared by handlers
+    formatter = logging.Formatter("%(asctime)s %(levelname)s (%(filename)s:%(lineno)d):%(funcName)s %(message)s")
+    # Configure stdout handler
+    stdout = logging.StreamHandler(sys.stdout)
+    stdout.setFormatter(formatter)
+    stdout.setLevel(logging.DEBUG)
+    stdout.addFilter(lambda record: record.levelno < error_level)  # Keep error logs out of stdout
+    # Configure stderr handler
+    stderr = logging.StreamHandler(sys.stderr)
+    stderr.setFormatter(formatter)
+    stderr.setLevel(error_level)
+    # Configure logger
+    logger = logging.getLogger(module_name)
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(stdout)
+    logger.addHandler(stderr)
+    return logger

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -6,14 +6,16 @@ import re
 import time
 import subprocess
 import json
-from .logger import eslog
+from .logger import get_logger
+
+eslog = get_logger(__name__)
 
 # Set a specific video mode
 def changeMode(videomode):
     if checkModeExists(videomode):
         cmd = "batocera-resolution setMode \"{}\"".format(videomode)
         if cmd is not None:
-            eslog.log("setVideoMode({}): {} ".format(videomode, cmd))
+            eslog.debug("setVideoMode({}): {} ".format(videomode, cmd))
             os.system(cmd)
 
 def getCurrentMode():
@@ -43,7 +45,7 @@ def checkModeExists(videomode):
     return False
 
 def changeMouse(mode):
-    eslog.log("changeMouseMode({})".format(mode))
+    eslog.debug("changeMouseMode({})".format(mode))
     if mode:
         cmd = "unclutter-remote -s"
     else:


### PR DESCRIPTION
I was looking at a bug and the log files were confusing me due to stderr and stdout log files going all different directions; for example, the old configgen logger only output to stderr. This is an attempt to clean things up a little. There are still emulators with their own redirection issues (retroarch also only outputs to stderr) but at least configgen scripts are in a better place where a lot of logging happens. I tested the changes on Bato 31 on Pi4 and x64 systems. Logs look better in my eyes. There are a lot of changes so I didn't test everything but these changes are mostly just small refactors here and there. Feedback is definitely desired.

Main changes:
* Use Python3 logging with proper stdout/stderr streaming
* Refactor scripts to use module level logger, not root logger
* Refactor `eslog.log` statements to use appropriate log level functions
* Refactor `print`/`sys.stdout`/`sys.stderr` statements to use logger
* Add comment about `BrokenPipeError` for context

I took a common sense approach to refactoring legacy log statements:
* minimal changes necessary
* debug is default level
* warning for non-exception errors
* error for exceptions/non-zero return codes, subprocess error stream

I added a comment about a possible `BrokenPipeError` I ran into while testing. This is caused by head truncating output in the front-end system call [here](https://github.com/batocera-linux/batocera-emulationstation/blob/51875d7010742c7c3af9bd7dfd8796fa9025ec15/es-core/src/platform.cpp#L120). It confused me at first and may do so to the next person.