### PR TITLE
Revert "Bump Ruffle"

### DIFF
--- a/package/batocera/emulators/ruffle/ruffle.mk
+++ b/package/batocera/emulators/ruffle/ruffle.mk
@@ -3,8 +3,8 @@
 # RUFFLE
 #
 ################################################################################
-# Version.: Commits on Aug 22, 2021
-RUFFLE_VERSION = 2f07363aa7df1157f3ae0634af1fdf524920ec0c
+# Version.: Commits on Aug 14, 2021
+RUFFLE_VERSION = 5dee7f163c4ba033ba747079533fd4d588e679d9
 RUFFLE_SITE = $(call github,ruffle-rs,ruffle,$(RUFFLE_VERSION))
 RUFFLE_LICENSE = GPLv2
 RUFFLE_DEPENDENCIES = host-rustc openssl


### PR DESCRIPTION
Reverts batocera-linux/batocera.linux#4422 as it doesn't compile