### PR TITLE
Change SPU Decoder default to ASMJIT

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -70,7 +70,7 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Miscellaneous"] = {}  
 
         # Set the Default Core Values we need
-        rpcs3ymlconfig["Core"]['SPU Decoder'] = 'Interpreter (fast)'
+        rpcs3ymlconfig["Core"]['SPU Decoder'] = 'ASMJIT Recompiler'
         rpcs3ymlconfig["Core"]['Lower SPU thread priority'] = False
         rpcs3ymlconfig["Core"]['SPU Cache'] = False
         rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True     


### PR DESCRIPTION
Shouldn't be using the Interpreter (Fast) as the default option, that's more a last-resort option for getting a game to boot. To quote: "Games rarely need this option." https://wiki.rpcs3.net/index.php?title=Help:Default_Settings