### PR TITLE
Revert "Fix libpulse-simple dep for moonlight"

### DIFF
--- a/package/batocera/utils/pulseaudio-utils/pulseaudio-utils.mk
+++ b/package/batocera/utils/pulseaudio-utils/pulseaudio-utils.mk
@@ -33,12 +33,12 @@ else
 PULSEAUDIO_UTILS_CONF_OPTS += --disable-samplerate
 endif
 
-# ifeq ($(BR2_PACKAGE_GDBM),y)
-# PULSEAUDIO_UTILS_CONF_OPTS += --with-database=gdbm
-# PULSEAUDIO_UTILS_DEPENDENCIES += gdbm
-# else
+ifeq ($(BR2_PACKAGE_GDBM),y)
+PULSEAUDIO_UTILS_CONF_OPTS += --with-database=gdbm
+PULSEAUDIO_UTILS_DEPENDENCIES += gdbm
+else
 PULSEAUDIO_UTILS_CONF_OPTS += --with-database=simple
-# endif
+endif
 
 ifeq ($(BR2_PACKAGE_JACK2),y)
 PULSEAUDIO_UTILS_CONF_OPTS += --enable-jack
@@ -151,8 +151,6 @@ define PULSEAUDIO_UTILS_INSTALL_TARGET_CMDS
 	cp $(@D)/src/.libs/libpulse.so $(TARGET_DIR)/usr/lib/
 	ln -sf libpulse.so $(TARGET_DIR)/usr/lib/libpulse.so.0
 	cp $(@D)/src/.libs/libpulsecommon-$(PULSEAUDIO_UTILS_VERSION).so $(TARGET_DIR)/usr/lib/
-	cp $(@D)/src/.libs/libpulse-simple.so $(TARGET_DIR)/usr/lib/
-	ln -sf libpulse-simple.so $(TARGET_DIR)/usr/lib/libpulse-simple.so.0
 endef
 
 $(eval $(autotools-package))


### PR DESCRIPTION
Reverts batocera-linux/batocera.linux#4468

This seems to make ES extremely slow at loading on x86_64 (while it works on OGA). Need to find another fix as the Moonlight 2.5.1 upgrade needs this.