### PR TITLE
Enhancement: Expose PCSX2 micro VU speedhacks

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3605,6 +3605,17 @@ pcsx2:
             choices:
                 "Off":      0
                 "On":       1
+        micro_vu:
+            prompt:     "MICRO VU SPEED HACKS"
+            description: Good speedup and high compatibility; recommended but may cause issues
+            # The value for each choice is the same as the corresponding PCSX2 ini key
+            choices:
+                "mVU Flag Hack: May cause bad graphics [Recommended]":  vuFlagHack
+                "MTVU: May cause hanging [Recommended on 3+ cores]":    vuThread
+                "Instant VU1: May cause some graphical errors":         vu1Instant
+                # Valid combos; MTVU + Instant VU1 is not supported by PCSX2
+                "mVU Flag Hack + MTVU":                                 "vuFlagHack,vuThread"
+                "mVU Flag Hack + Instant VU1":                          "vuFlagHack,vu1Instant"
         EmuCore_EnableCheats:
             prompt:      GAMES CHEATS
             description: For cheating in games with Action Replay


### PR DESCRIPTION
The micro VU speedhacks can considerably improve performance, particularly MTVU. This option previously could only be toggled through the GUI via F1. This PR exposes the micro VU hacks and applies reasonable settings based on system requirements.

* Explicitly set speedhacks considered safe by the PCSX2 devs; these are already set in Batocera PCSX2 by default
* Expose all the micro VU hacks in the UI; use combinations to reduce menu entries
* On `Auto` setting, set micro VU speedhacks appropriately; 3+ cores required for MTVU, no invalid combinations, etc.

In my own tests, with MTVU enabled, ~20 FPS gain was achieved in God of War II on i5-6500 / GT 1030 and i7-6700 / GTX 960M systems. And so on `Auto`, Batocera will better configure capable systems without user involvement.

I think I have set everything up correctly. I cobbled things together for testing but it seemed to work correctly e.g. update `batocera.conf`, modify `PCSX2_vm.ini`, etc.