### PR TITLE
Libretro - Fixing some stuff

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -140,6 +140,11 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['input_libretro_device_p1'] = '1'           # Default devices choices
     retroarchConfig['input_libretro_device_p2'] = '1'
 
+    # D-pad = Left analog stick forcing on PUAE and VICE (New D2A system on RA doesn't work with these cores.)
+    if system.config['core'] == 'puae' or system.config['core'] == 'vice_x64':
+        retroarchConfig['input_player1_analog_dpad_mode'] = '3'
+        retroarchConfig['input_player2_analog_dpad_mode'] = '3'
+
     # force notification messages
     retroarchConfig['video_font_enable'] = '"true"'
 
@@ -221,8 +226,28 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             else:
                 retroarchConfig['input_player2_analog_dpad_mode'] = '1'
 
+    if (system.config['core'] == 'swanstation'):               # Swanstation Duckstation
+        if system.isOptSet('duckstation_Controller1'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['duckstation_Controller1']
+            if system.config['duckstation_Controller1'] != '1':
+                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player1_analog_dpad_mode'] = '3'
+        if system.isOptSet('duckstation_Controller2'):
+            retroarchConfig['input_libretro_device_p2'] = system.config['duckstation_Controller2']
+            if system.config['duckstation_Controller2'] != '1':
+                retroarchConfig['input_player2_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player2_analog_dpad_mode'] = '3'
+
     ## Sega Dreamcast controller
     if system.config['core'] == 'flycast':
+        if system.name != 'dreamcast':
+            retroarchConfig['input_player1_analog_dpad_mode'] = '3'
+            retroarchConfig['input_player2_analog_dpad_mode'] = '3'
+        else:
+            retroarchConfig['input_player1_analog_dpad_mode'] = '1'
+            retroarchConfig['input_player2_analog_dpad_mode'] = '1'
         if system.isOptSet('controller1_dc'):
             retroarchConfig['input_libretro_device_p1'] = system.config['controller1_dc']
         else:
@@ -273,12 +298,33 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     if (system.config['core'] == 'dosbox_pure'):               # Dosbox-Pure
         if system.isOptSet('controller1_dosbox_pure'):
             retroarchConfig['input_libretro_device_p1'] = system.config['controller1_dosbox_pure']
-        else:
-            retroarchConfig['input_libretro_device_p1'] = '1'
+            if system.config['controller1_dosbox_pure'] != '3':
+                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player1_analog_dpad_mode'] = '3'
         if system.isOptSet('controller2_dosbox_pure'):
             retroarchConfig['input_libretro_device_p2'] = system.config['controller2_dosbox_pure']
+            if system.config['controller2_dosbox_pure'] != '3':
+                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player1_analog_dpad_mode'] = '3'
+
+    ## Libretro PORTS
+    ## Quake
+    if (system.config['core'] == 'tyrquake'):
+        if system.isOptSet('tyrquake_controller1'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['tyrquake_controller1']
+            retroarchConfig['input_player1_analog_dpad_mode'] = '0'
         else:
-            retroarchConfig['input_libretro_device_p2'] = '1'
+            retroarchConfig['input_libretro_device_p1'] = '1'
+
+    ## DOOM
+    if (system.config['core'] == 'prboom'):
+        if system.isOptSet('prboom_controller1'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['prboom_controller1']
+            retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+        else:
+            retroarchConfig['input_libretro_device_p1'] = '1'
 
     # Smooth option
     if system.isOptSet('smooth') and system.getOptBoolean('smooth') == True:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -236,6 +236,8 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         else:
             retroarchConfig['input_player1_analog_dpad_mode'] = '1'
             retroarchConfig['input_player2_analog_dpad_mode'] = '1'
+            retroarchConfig['input_player3_analog_dpad_mode'] = '1'
+            retroarchConfig['input_player4_analog_dpad_mode'] = '1'
         if system.isOptSet('controller1_dc'):
             retroarchConfig['input_libretro_device_p1'] = system.config['controller1_dc']
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -226,20 +226,6 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             else:
                 retroarchConfig['input_player2_analog_dpad_mode'] = '1'
 
-    if (system.config['core'] == 'swanstation'):               # Swanstation Duckstation
-        if system.isOptSet('duckstation_Controller1'):
-            retroarchConfig['input_libretro_device_p1'] = system.config['duckstation_Controller1']
-            if system.config['duckstation_Controller1'] != '1':
-                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
-            else:
-                retroarchConfig['input_player1_analog_dpad_mode'] = '3'
-        if system.isOptSet('duckstation_Controller2'):
-            retroarchConfig['input_libretro_device_p2'] = system.config['duckstation_Controller2']
-            if system.config['duckstation_Controller2'] != '1':
-                retroarchConfig['input_player2_analog_dpad_mode'] = '0'
-            else:
-                retroarchConfig['input_player2_analog_dpad_mode'] = '3'
-
     ## Sega Dreamcast controller
     if system.config['core'] == 'flycast':
         if system.name != 'dreamcast':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -245,6 +245,8 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         if system.name != 'dreamcast':
             retroarchConfig['input_player1_analog_dpad_mode'] = '3'
             retroarchConfig['input_player2_analog_dpad_mode'] = '3'
+            retroarchConfig['input_player3_analog_dpad_mode'] = '3'
+            retroarchConfig['input_player4_analog_dpad_mode'] = '3'
         else:
             retroarchConfig['input_player1_analog_dpad_mode'] = '1'
             retroarchConfig['input_player2_analog_dpad_mode'] = '1'
@@ -305,9 +307,9 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         if system.isOptSet('controller2_dosbox_pure'):
             retroarchConfig['input_libretro_device_p2'] = system.config['controller2_dosbox_pure']
             if system.config['controller2_dosbox_pure'] != '3':
-                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+                retroarchConfig['input_player2_analog_dpad_mode'] = '0'
             else:
-                retroarchConfig['input_player1_analog_dpad_mode'] = '3'
+                retroarchConfig['input_player2_analog_dpad_mode'] = '3'
 
     ## Libretro PORTS
     ## Quake

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -311,12 +311,15 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             else:
                 retroarchConfig['input_player2_analog_dpad_mode'] = '3'
 
-    ## Libretro PORTS
+    ## PORTS
     ## Quake
     if (system.config['core'] == 'tyrquake'):
         if system.isOptSet('tyrquake_controller1'):
             retroarchConfig['input_libretro_device_p1'] = system.config['tyrquake_controller1']
-            retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            if system.config['tyrquake_controller1'] == '773' or system.config['tyrquake_controller1'] == '3':
+                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player1_analog_dpad_mode'] = '1'
         else:
             retroarchConfig['input_libretro_device_p1'] = '1'
 
@@ -324,7 +327,10 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     if (system.config['core'] == 'prboom'):
         if system.isOptSet('prboom_controller1'):
             retroarchConfig['input_libretro_device_p1'] = system.config['prboom_controller1']
-            retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            if system.config['prboom_controller1'] != '1' or system.config['prboom_controller1'] == '3':
+                retroarchConfig['input_player1_analog_dpad_mode'] = '0'
+            else:
+                retroarchConfig['input_player1_analog_dpad_mode'] = '1'
         else:
             retroarchConfig['input_libretro_device_p1'] = '1'
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2107,6 +2107,13 @@ libretro:
                     "1920x1200":  1920x1200
                     "2240x1400":  2240x1400
                     "2560x1600":  2560x1600
+            prboom_controller1:
+                prompt:      CONTROLLER TYPE
+                description: Select controller type
+                choices:
+                    "Gamepad Classic":    1
+                    "Gamepad Modern":     773
+                    "Keyboard + Mouse":  3
     prosystem:
       features: [rewind, autosave, latency_reduction, cheevos]
     puae:
@@ -2594,6 +2601,14 @@ libretro:
                 choices:
                     "Off":        disabled
                     "On":         enabled
+            tyrquake_controller1:
+                prompt:      CONTROLLER TYPE
+                description: Select controller type
+                choices:
+                    "Gamepad Classic":        1
+                    "Gamepad Classic Alt":    513
+                    "Gamepad Modern":         773
+                    "Keyboard + Mouse":       3
     vb:
       features: [netplay, rewind, autosave, latency_reduction, cheevos]
       cfeatures:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -448,28 +448,28 @@ libretro:
                 prompt:      CONTROLLER 1 TYPE
                 description: Select Keyboard, Joysticks or Gravis GamePad mode
                 choices:
-                    "Gravis GamePad (D-pad, 4 Buttons)":                    1
-                    "Generic Keyboard Binding":                             257
-                    "Keyboard + Mouse (Left Analog)":                       513
-                    "Keyboard + Mouse (Right Analog)":                      769
-                    "First Joystick (2 Axes, 2 Buttons)":                   1281
-                    # "Second Joystick (2 Axes, 2 Buttons)":                  1537
-                    "ThrustMaster Flight Stick (3 Axes, 4 Buttons, 1 Hat)": 1793
-                    "Both DOS Joysticks (4 Axes, 4 Buttons)":               2049
-                    "Custom Keyboard Bindings (best for Batocera Pad2Key)": 3
+                    "Gravis GamePad (D-pad + 4 Btns)":                      1
+                    "Generic Keyboard Binds":                               257
+                    "Keyboard + Mouse (Left An.)":                          513
+                    "Keyboard + Mouse (Right An.)":                         769
+                    "1st Joystick (2 Axes, 2 Btns)":                        1281
+                    # "2nd Joystick (2 Axes, 2 Btns)":                        1537
+                    "Flight Stick (3 Axes, 4 Btns, 1 Hat)":                 1793
+                    "Both Joysticks (4 Axes, 4 Btns)":                      2049
+                    "Custom Keyboard Binds (best for Pad2Key)":             3
             controller2_dosbox_pure:
                 prompt:      CONTROLLER 2 TYPE
                 description: Select Keyboard, Joysticks or Gravis GamePad mode
                 choices:
-                    "Gravis GamePad (D-pad, 4 Buttons)":                    1
-                    "Generic Keyboard Binding":                             257
-                    "Keyboard + Mouse (Left Analog)":                       513
-                    "Keyboard + Mouse (Right Analog)":                      769
-                    # "First Joystick (2 Axes, 2 Buttons)":                   1281
-                    "Second Joystick (2 Axes, 2 Buttons)":                  1537
-                    "ThrustMaster Flight Stick (3 Axes, 4 Buttons, 1 Hat)": 1793
-                    "Both DOS Joysticks (4 Axes, 4 Buttons)":               2049
-                    "Custom Keyboard Bindings (best for Batocera Pad2Key)": 3
+                    "Gravis GamePad (D-pad + 4 Btns)":                      1
+                    "Generic Keyboard Binds":                               257
+                    "Keyboard + Mouse (Left An.)":                          513
+                    "Keyboard + Mouse (Right An.)":                         769
+                    # "1st Joystick (2 Axes, 2 Btns)":                        1281
+                    "2nd Joystick (2 Axes, 2 Btns)":                        1537
+                    "Flight Stick (3 Axes, 4 Btns, 1 Hat)":                 1793
+                    "Both Joysticks (4 Axes, 4 Btns)":                      2049
+                    "Custom Keyboard Binds (best for Pad2Key)":             3
     swanstation:
       features: [autosave, latency_reduction, cheevos]
       cfeatures:
@@ -698,7 +698,12 @@ libretro:
                 description: Improve the fidelity of 3D models (does not affect 2D sprites)
                 choices:
                     "640x480":    640x480
+                    "800x600":    800x600
+                    "960x720":    960x720
+                    "1024x768":   1024x768
                     "1280x960":   1280x960
+                    "1440x1080":  1440x1080
+                    "1600x1200":  1600x1200
                     "1920x1440":  1920x1440
                     "2560x1920":  2560x1920
                     "3200x2400":  3200x2400
@@ -709,14 +714,6 @@ libretro:
                     "6400x4800":  6400x4800
                     "7040x5280":  7040x5280
                     "7680x5760":  7680x5760
-                    "8320x6240":  8320x6240
-                    "8960x6720":  8960x6720
-                    "9600x7200":  9600x7200
-                    "10240x7680": 10240x7680
-                    "10880x8160": 10880x8160
-                    "11520x8640": 11520x8640
-                    "12160x9120": 12160x9120
-                    "12800x9600": 12800x9600
             reicast_mipmapping:
                 prompt:      TEXTURE MIP-MAPPING (BLUR)
                 description: Smooths out textures on 3D objects
@@ -870,7 +867,7 @@ libretro:
             gb:
                 cfeatures:
                     gb_colorization:
-                        prompt:      COLORISATION
+                        prompt:      COLORIZATION
                         description: Set the Game Boy palettes to use
                         choices:
                             "Off":                              none


### PR DESCRIPTION
**Flycast:**

- Removed 12k internal resolution. Added 800x600, 960x720 and 1024x768. These resolutions don't affect performance on sbc like RPI3b+/RPI4 and are a good choice for a good hires image (I suggest to use max 960x720 on RPI. Higher resolutions makes graphical glitches)

**dosbox_pure:**

- Shortened controller names.
- Fixed controller type support. Now gamepad automatic mapping, pad2key and sticks type controllers works better (no analogs conflicts with own and dpad mapping that they work together)

**PUAE and Vice:**

- Forcing Digital-to-Analog to Left Analog. These cores don't support the new Digital-to-Analog mode on Retroarch. So they must be forced to value 3 (Left Analog)

**Flycast:**

- Added forcing Digital-to-Analog to Left Analog on Naomi and Atomiswave.

**Libretro Ports:**

- Added PrBoom and TyrQuake controller type selection with a strength D2A forcing to Left Analog only on Gamepad Classic and Gamepad Classic Alternative