### PR TITLE
batocera-audio: fix syntax error and formatting

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -59,22 +59,23 @@ case "${ACTION}" in
 		*)
 		    if echo "${VOLUME}" | grep -qE '^[0-9]+$'
 		    then
-			if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
-			then
-				pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%" || exit 1
-				exit 0
-			fi
-		    else if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
-		    then
-				let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
-				test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
-				test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
-				pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%" || exit 1
-				exit 0
+		      if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
+		      then
+		        pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%" || exit 1
+		        exit 0
+		      fi
+		    else
+		      if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
+		      then
+		        let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
+		        test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
+		        test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
+		        pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%" || exit 1
+		        exit 0
+		      fi
+		      echo "invalid volume value" >&2
+		      exit 1
 		    fi
-			echo "invalid volume value" >&2
-			exit 1
-			fi
 	    esac
 	    ;;
 

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-rk3326
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-rk3326
@@ -67,23 +67,23 @@ case "${ACTION}" in
 		*)
 		    if echo "${VOLUME}" | grep -qE '^[0-9]+$'
 		    then
-			if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
-			then
-				pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%"
-				exit 0
-			fi
-			fi
-			else if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
-			then
-				let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
-				test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
-				test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
-				pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%"
-				exit 0
-			fi
-			echo "invalid volume value" >&2
-			exit 1
-			fi
+		      if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
+		      then
+		        pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%"
+		        exit 0
+		      fi
+		    else
+		      if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
+		      then
+		        let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
+		        test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
+		        test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
+		        pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%"
+		        exit 0
+		      fi
+		      echo "invalid volume value" >&2
+		      exit 1
+		    fi
 	    esac
 	    ;;
 

--- a/package/batocera/core/batocera-audio/alsa/batocera-audio-rk3399
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio-rk3399
@@ -51,23 +51,23 @@ case "${ACTION}" in
 		*)
 		    if echo "${VOLUME}" | grep -qE '^[0-9]+$'
 		    then
-			if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
-			then
-				pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%"
-				exit 0
-			fi
-			fi
-			else if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
-			then
-				let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
-				test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
-				test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
-				pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%"
-				exit 0
-			fi
-			echo "invalid volume value" >&2
-			exit 1
-			fi
+		      if test "${VOLUME}" -ge 0 -a "${VOLUME}" -le "${MAX_VOLUME}"
+		      then
+		        pactl set-sink-volume @DEFAULT_SINK@ "${VOLUME}%"
+		        exit 0
+		      fi
+		    else
+		      if echo "${VOLUME}" | grep -qE '^[+-][0-9]+$'
+		      then
+		        let NEWVOLUME=${DETECT_VOLUME}${VOLUME}
+		        test "${NEWVOLUME}" -lt 0 && NEWVOLUME=0
+		        test "${NEWVOLUME}" -gt "${MAX_VOLUME}" && NEWVOLUME=${MAX_VOLUME}
+		        pactl set-sink-volume @DEFAULT_SINK@ "${NEWVOLUME}%"
+		        exit 0
+		      fi
+		      echo "invalid volume value" >&2
+		      exit 1
+		    fi
 	    esac
 	    ;;
 


### PR DESCRIPTION
Fix syntax error in batocera-audio-rk3326 and batocera-audio-rk3399.
Fix formatting of setSystemVolume in 3 files.