### PR TITLE
Libretro - Gambatte GB colorization fixed

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -923,82 +923,9 @@ libretro:
                             "Special 1":                        Special 1
                             "Special 2":                        Special 2
                             "Special 3":                        Special 3
-                            "TWB01 - 756 Production":           TWB01 - 756 Production
-                            "TWB02 - AKB48 Pink":               TWB02 - AKB48 Pink
-                            "TWB03 - Angry Volcano":            TWB03 - Angry Volcano
-                            "TWB04 - Anime Expo":               TWB04 - Anime Expo
-                            "TWB05 - Aqours Blue":              TWB05 - Aqours Blue
-                            "TWB06 - Aquatic Iro":              TWB06 - Aquatic Iro
-                            "TWB07 - Bandai Namco":             TWB07 - Bandai Namco
-                            "TWB08 - Blossom Pink":             TWB08 - Blossom Pink
-                            "TWB09 - Bubbles Blue":             TWB09 - Bubbles Blue
-                            "TWB10 - Builder Yellow":           TWB10 - Builder Yellow
-                            "TWB11 - Buttercup Green":          TWB11 - Buttercup Green
-                            "TWB12 - Camouflage":               TWB12 - Camouflage
-                            "TWB13 - Cardcaptor Pink":          TWB13 - Cardcaptor Pink
-                            "TWB14 - Christmas":                TWB14 - Christmas
-                            "TWB15 - Crunchyroll Orange":       TWB15 - Crunchyroll Orange
-                            "TWB16 - Digivice":                 TWB16 - Digivice
-                            "TWB17 - Do The Dew":               TWB17 - Do The Dew
-                            "TWB18 - Eevee Brown":              TWB18 - Eevee Brown
-                            "TWB19 - Fruity Orange":            TWB19 - Fruity Orange
-                            "TWB20 - Game.com":                 TWB20 - Game.com
-                            "TWB21 - Game Grump Orange":        TWB21 - Game Grump Orange
-                            "TWB22 - GameKing":                 TWB22 - GameKing
-                            "TWB23 - Game Master":              TWB23 - Game Master
-                            "TWB24 - Ghostly Aoi":              TWB24 - Ghostly Aoi
-                            "TWB25 - Golden Wild":              TWB25 - Golden Wild
-                            "TWB26 - Green Banana":             TWB26 - Green Banana
-                            "TWB27 - Greenscale":               TWB27 - Greenscale
-                            "TWB28 - Halloween":                TWB28 - Halloween
-                            "TWB29 - Hero Yellow":              TWB29 - Hero Yellow
-                            "TWB30 - Hokage Orange":            TWB30 - Hokage Orange
-                            "TWB31 - Labo Fawn":                TWB31 - Labo Fawn
-                            "TWB32 - Legendary Super Saiyan":   TWB32 - Legendary Super Saiyan
-                            "TWB33 - Lemon Lime Green":         TWB33 - Lemon Lime Green
-                            "TWB34 - Lime Midori":              TWB34 - Lime Midori
-                            "TWB35 - Mania Plus Green":         TWB35 - Mania Plus Green
-                            "TWB36 - Microvision":              TWB36 - Microvision
-                            "TWB37 - Million Live Gold":        TWB37 - Million Live Gold
-                            "TWB38 - Miraitowa Blue":           TWB38 - Miraitowa Blue
-                            "TWB39 - NASCAR":                   TWB39 - NASCAR
-                            "TWB40 - Neo Geo Pocket":           TWB40 - Neo Geo Pocket
-                            "TWB41 - Neon Blue":                TWB41 - Neon Blue
-                            "TWB42 - Neon Green":               TWB42 - Neon Green
-                            "TWB43 - Neon Pink":                TWB43 - Neon Pink
-                            "TWB44 - Neon Red":                 TWB44 - Neon Red
-                            "TWB45 - Neon Yellow":              TWB45 - Neon Yellow
-                            "TWB46 - Nick Orange":              TWB46 - Nick Orange
-                            "TWB47 - Nijigasaki Orange":        TWB47 - Nijigasaki Orange
-                            "TWB48 - Odyssey Gold":             TWB48 - Odyssey Gold
-                            "TWB49 - Patrick Star Pink":        TWB49 - Patrick Star Pink
-                            "TWB50 - Pikachu Yellow":           TWB50 - Pikachu Yellow
-                            "TWB51 - Pocket Tales":             TWB51 - Pocket Tales
-                            "TWB52 - Pokemon mini":             TWB52 - Pokemon mini
-                            "TWB53 - Pretty Guardian Gold":     TWB53 - Pretty Guardian Gold
-                            "TWB54 - S.E.E.S. Blue":            TWB54 - S.E.E.S. Blue
-                            "TWB55 - Saint Snow Red":           TWB55 - Saint Snow Red
-                            "TWB56 - Scooby-Doo Mystery":       TWB56 - Scooby-Doo Mystery
-                            "TWB57 - Shiny Sky Blue":           TWB57 - Shiny Sky Blue
-                            "TWB58 - Sidem Green":              TWB58 - Sidem Green
-                            "TWB59 - Slime Blue":               TWB59 - Slime Blue
-                            "TWB60 - Spongebob Yellow":         TWB60 - Spongebob Yellow
-                            "TWB61 - Stone Orange":             TWB61 - Stone Orange
-                            "TWB62 - Straw Hat Red":            TWB62 - Straw Hat Red
-                            "TWB63 - Superball Ivory":          TWB63 - Superball Ivory
-                            "TWB64 - Super Saiyan Blue":        TWB64 - Super Saiyan Blue
-                            "TWB65 - Super Saiyan Rose":        TWB65 - Super Saiyan Rose
-                            "TWB66 - Supervision":              TWB66 - Supervision
-                            "TWB67 - Survey Corps Brown":       TWB67 - Survey Corps Brown
-                            "TWB68 - Tea Midori":               TWB68 - Tea Midori
-                            "TWB69 - TI-83":                    TWB69 - TI-83
-                            "TWB70 - Tokyo Midtown":            TWB70 - Tokyo Midtown
-                            "TWB71 - Travel Wood":              TWB71 - Travel Wood
-                            "TWB72 - Virtual Boy":              TWB72 - Virtual Boy
-                            "TWB73 - VMU":                      TWB73 - VMU
-                            "TWB74 - Wisteria Murasaki":        TWB74 - Wisteria Murasaki
-                            "TWB75 - WonderSwan":               TWB75 - WonderSwan
-                            "TWB76 - Yellow Banana":            TWB76 - Yellow Banana
+                            "Special 4 (TI-83 Legacy)":         Special 4 (TI-83 Legacy)
+                            "TWB64 - Pack 1":                   TWB75 - WonderSwan
+                            "TWB64 - Pack 2":                   TWB76 - Yellow Banana
     genesisplusgx-wide:
       features: [netplay, rewind, autosave, latency_reduction, cheevos]
     genesisplusgx:


### PR DESCRIPTION
- Removed all the TWB palettes, now unavailable with the new bumped version of gambatte, and substituted with "TWB64 Pack 1 and 2" (customizable via core options)
- Added "Special 4 (TI-83 Legacy)" palette