### PR TITLE
Libretro -  mGBA colorization modes for GB (HELP)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -802,6 +802,13 @@ def generateCoreSettings(coreSettings, system, rom):
         else:
             coreSettings.save('mgba_skip_bios', '"OFF"')
 
+        # GB: Colorization of GB games
+        if (system.name == 'gb'):
+            if system.isOptSet('gb_colors'):
+                coreSettings.save('mgba_gb_colors', '"' + system.config['gb_colors'] + '"')
+            else:
+                coreSettings.save('mgba_gb_colors', '"DMG Green"')
+
         if (system.name != 'gba'):
             # GB / GBC: Use Super Game Boy borders
             if system.isOptSet('sgb_borders') and system.config['sgb_borders'] == "True":


### PR DESCRIPTION
With the new bumped mGBA version, now there is the palette mode support for GB. But now it shows a big problem that i cannot solve because of a low experience on python.
Some palettes uses arrow symbols on their own value and when i try to start a rom by using a palette with one of arrow symbol, retroarch crashes, go back to es and on the es_launch_stderr.log file i can see this error:

```
    coreSettings.save('mgba_gb_colors', '"' + system.config['gb_colors'] + '"')
  File "/usr/lib/python2.7/site-packages/configgen/settings/unixSettings.py", line 58, in save
    eslog.debug("Writing {0} = {1} to {2}".format(name, value, self.settingsFile))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2191' in position 9: ordinal not in range(128)
2021-08-30 20:00:28 INFO (emulatorlauncher.py:308):<module>: Exiting configgen with status -1
```

So, it's a py script error that it cannot print unicode character. @nadenislamarre can you fix it?

The values used for arrows symbols are these:

```
← = \u2190
↑ = \u2191
→ = \u2192
↓ = \u2193
```