### PR TITLE
Libretro - mGBA colorization mode (HELP)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -802,6 +802,13 @@ def generateCoreSettings(coreSettings, system, rom):
         else:
             coreSettings.save('mgba_skip_bios', '"OFF"')
 
+        # GB: Colorization of GB games
+        if (system.name == 'gb'):
+            if system.isOptSet('gb_colors'):
+                coreSettings.save('mgba_gb_colors', '"' + system.config['gb_colors'] + '"')
+            else:
+                coreSettings.save('mgba_gb_colors', '"DMG Green"')
+
         if (system.name != 'gba'):
             # GB / GBC: Use Super Game Boy borders
             if system.isOptSet('sgb_borders') and system.config['sgb_borders'] == "True":

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1295,6 +1295,58 @@ libretro:
                         choices:
                             "Off": OFF
                             "On":  GBA
+                    gb_colors:
+                        prompt:      COLORIZATION
+                        description: Set the Game Boy palettes to use
+                        choices:
+                            "Off":                              Grayscale
+                            "DMG Green":                        DMG Green
+                            "GB Pocket":                        GB Pocket
+                            "GB Light":                         GB Light
+                            "GBC Brown":                        GBC Brown ↑
+                            "GBC Red":                          GBC Red ↑A
+                            "GBC Dark Brown":                   GBC Dark Brown ↑B
+                            "GBC Pale Yellow":                  GBC Pale Yellow ↓
+                            "GBC Orange":                       GBC Orange ↓A
+                            "GBC Yellow":                       GBC Yellow ↓B
+                            "GBC Blue":                         GBC Blue ←
+                            "GBC Dark Blue":                    GBC Dark Blue ←A
+                            "GBC Gray":                         GBC Gray ←B
+                            "GBC Green":                        GBC Green →
+                            "GBC Dark Green":                   GBC Dark Green →A
+                            "GBC Reverse":                      GBC Reverse →B
+                            "SGB 1-A":                          SGB 1-A
+                            "SGB 1-B":                          SGB 1-B
+                            "SGB 1-C":                          SGB 1-C
+                            "SGB 1-D":                          SGB 1-D
+                            "SGB 1-E":                          SGB 1-E
+                            "SGB 1-F":                          SGB 1-F
+                            "SGB 1-G":                          SGB 1-G
+                            "SGB 1-H":                          SGB 1-H
+                            "SGB 2-A":                          SGB 2-A
+                            "SGB 2-B":                          SGB 2-B
+                            "SGB 2-C":                          SGB 2-C
+                            "SGB 2-D":                          SGB 2-D
+                            "SGB 2-E":                          SGB 2-E
+                            "SGB 2-F":                          SGB 2-F
+                            "SGB 2-G":                          SGB 2-G
+                            "SGB 2-H":                          SGB 2-H
+                            "SGB 3-A":                          SGB 3-A
+                            "SGB 3-B":                          SGB 3-B
+                            "SGB 3-C":                          SGB 3-C
+                            "SGB 3-D":                          SGB 3-D
+                            "SGB 3-E":                          SGB 3-E
+                            "SGB 3-F":                          SGB 3-F
+                            "SGB 3-G":                          SGB 3-G
+                            "SGB 3-H":                          SGB 3-H
+                            "SGB 4-A":                          SGB 4-A
+                            "SGB 4-B":                          SGB 4-B
+                            "SGB 4-C":                          SGB 4-C
+                            "SGB 4-D":                          SGB 4-D
+                            "SGB 4-E":                          SGB 4-E
+                            "SGB 4-F":                          SGB 4-F
+                            "SGB 4-G":                          SGB 4-G
+                            "SGB 4-H":                          SGB 4-H
             gbc:
                 cfeatures:
                     sgb_borders:


### PR DESCRIPTION
With the last version of mGBA, there is the palette modes for GB. But there is a problem that cannot solve due to my low experience on python.
Some palettes has "arrow symbols" on their assigned values and the py script cannot print them because they are UNICODE characters. On the es_launch_stderr.log there is this error:

```
    coreSettings.save('mgba_gb_colors', '"' + system.config['gb_colors'] + '"')
  File "/usr/lib/python2.7/site-packages/configgen/settings/unixSettings.py", line 58, in save
    eslog.debug("Writing {0} = {1} to {2}".format(name, value, self.settingsFile))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2191' in position 9: ordinal not in range(128)
2021-08-30 20:00:28 INFO (emulatorlauncher.py:308):<module>: Exiting configgen with status -1
```

And the "arrows symbols" values are these:

```
← = \u2190
↑ = \u2191
→ = \u2192
↓ = \u2193
```

@nadenislamarre can you help me to solve this? Obviously, other palettes without arrow symbols normally works.