### PR TITLE
Really fix xbox one usb dongle

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S98xboxone
+++ b/board/batocera/fsoverlay/etc/init.d/S98xboxone
@@ -1,7 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if test "$1" = "start"
 then
     # kernel option for xbox one controllers
     echo 1 > /sys/module/bluetooth/parameters/disable_ertm
+    # xbox one usb dongle: force daemon to start if dongle detected and not already started
+    if [[ $(pgrep xow) == "" && $(lsusb | grep "045e:02e6") != "" || $(lsusb | grep "045e:02fe") != "" ]]; then
+        nohup /usr/bin/xow-daemon &
+    fi
 fi

--- a/package/batocera/utils/xow/99-xow.rules
+++ b/package/batocera/utils/xow/99-xow.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", RUN+="/usr/bin/xow-daemon"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", RUN+="/usr/bin/xow-daemon"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", RUN+="/usr/bin/xow-daemon"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", RUN+="/usr/bin/xow-daemon"

--- a/package/batocera/utils/xow/xow-daemon
+++ b/package/batocera/utils/xow/xow-daemon
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-killall xow
-nohup /usr/bin/xow >/dev/null 2>/dev/null &
+if pregp xow; then
+    killall xow
+fi
+nohup /usr/bin/xow >/dev/null 2>&1 &
+pid=$!
+# Give xow a chance to start before sending pairing signal
+sleep 3
+kill -s SIGUSR1 $pid

--- a/package/batocera/utils/xow/xow.mk
+++ b/package/batocera/utils/xow/xow.mk
@@ -3,7 +3,7 @@
 # xow
 #
 ################################################################################
-XOW_VERSION = 700529b2517df7d17ad5a2fa0bd679143ac48666
+XOW_VERSION = cd271644ead198dcbfeafd3c3411092850adfd3a
 XOW_SITE = $(call github,medusalix,xow,$(XOW_VERSION))
 XOW_DEPENDENCIES = host-libcurl host-cabextract libusb
 
@@ -13,10 +13,8 @@ endef
 
 define XOW_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/xow $(TARGET_DIR)/usr/bin/xow
-	$(INSTALL) -D -m 0644 $(@D)/install/udev.rules $(TARGET_DIR)/etc/udev/rules.d/99-xow.rules
-	$(INSTALL) -D -m 0644 $(@D)/install/modules.conf $(TARGET_DIR)/etc/modules-load.d/xow-uinput.conf
-	$(INSTALL) -D -m 0644 $(@D)/install/modprobe.conf $(TARGET_DIR)/etc/modprobe.d/xow-blacklist.conf
 	$(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/xow/xow-daemon $(TARGET_DIR)/usr/bin/xow-daemon
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/xow/99-xow.rules $(TARGET_DIR)/etc/udev/rules.d
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/utils/xow/xow.mk
+++ b/package/batocera/utils/xow/xow.mk
@@ -3,7 +3,7 @@
 # xow
 #
 ################################################################################
-XOW_VERSION = cd271644ead198dcbfeafd3c3411092850adfd3a
+XOW_VERSION = 700529b2517df7d17ad5a2fa0bd679143ac48666
 XOW_SITE = $(call github,medusalix,xow,$(XOW_VERSION))
 XOW_DEPENDENCIES = host-libcurl host-cabextract libusb
 
@@ -13,6 +13,7 @@ endef
 
 define XOW_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/xow $(TARGET_DIR)/usr/bin/xow
+	$(INSTALL) -m 0755 -D $(@D)/install/modprobe.conf $(TARGET_DIR)/etc/modprobe.d/xow-blacklist.conf
 	$(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/xow/xow-daemon $(TARGET_DIR)/usr/bin/xow-daemon
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/xow/99-xow.rules $(TARGET_DIR)/etc/udev/rules.d
 endef


### PR DESCRIPTION
This commit reverts the recent xbox dongle branch which breaks usb support and then adds the changes that I have been testing for the last two days.

I do not think everything is perfect given circumstances; xow is no long maintained and the behavior across systems varies a lot. It seems luck plays a part in how reliable xow is. However, I think these changes improve things and give xbox one controllers a better chance to run reliably on Batocera.

I would love if other people would test this and give feedback.

Changes:
* Update xow to latest commit
* Move modprobe conf file to proper location on build (this had the biggest impact on fixing things)
* Add ACTION to udev rule; this can help keep spurious events from happening
* Start daemon on boot if dongle detected and xow did not automatically start
* Send pairing signal to daemon on startup which helps when you're connecting first time that boot cycle

How to pair:
* If the dongle is working properly it should be blinking shortly after boot or being plugged in; I personally think booting with dongle plugged in is more reliable
* If dongle is blinking you can put controller in pairing mode or, if paired before, you can just hit the home button.
* If light on dongle and controller is solid you can configure the controller in the GUI like usual; thins are pretty reliable at this point

Testing and observations:
* I compiled xow myself for each system and moved the appropriate files over manually, saved overlay, reboot, and then experiment
* I have ran my code on two different Pi4s and one x86_64 system (i5-6500 with HP motherboard)
* I tested with one controller and one dongle (productId=02e6)
* The best chance for success seems to plug dongle in and then boot system; it seemed more reliable without a bunch of hot plugging/unplugging
* The behavior of xow and the dongle varied across all systems; some systems didn't need all the code to work but it definitely helped on some systems
* Pairing mode helps the first connection
* Pairing mode seems to run indefinitely until a first connection is made; once a controller is connected, xow seems pretty stable for the duration of a boot
* Reboots can sometimes help transient issues
* Swapping USB can sometimes help transient issues
* Hot plugging/unplugging has been observed to work but I cannot say its reliable on every system I tested