### PR TITLE
Libretro - New stuff added

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -154,9 +154,19 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     if(system.config['core'] in coreToP2Device):
         retroarchConfig['input_libretro_device_p2'] = coreToP2Device[system.config['core']]
 
-    ## AMICA CD32
-    if system.config['core'] == 'puae' and system.name == 'amigacd32':
-        retroarchConfig['input_libretro_device_p1'] = '517'     # CD 32 Pad
+    ## AMIGA OCS-ECS/AGA/CD32
+    if system.config['core'] == 'puae':
+        if system.name != 'amigacd32':
+            if system.isOptSet('controller1_puae'):
+                retroarchConfig['input_libretro_device_p1'] = system.config['controller1_puae']
+            else:
+                retroarchConfig['input_libretro_device_p1'] = '1'
+            if system.isOptSet('controller2_puae'):
+                retroarchConfig['input_libretro_device_p2'] = system.config['controller2_puae']
+            else:
+                retroarchConfig['input_libretro_device_p2'] = '1'
+        else:          
+            retroarchConfig['input_libretro_device_p1'] = '517'     # CD 32 Pad
 
     ## BlueMSX choices by System
     if(system.name in systemToBluemsx):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -371,6 +371,9 @@ libretro:
                     "32MB":                 32
                     "48MB":                 48
                     "64MB":                 64
+                    "96MB":                 96
+                    "128MB":                128
+                    "224MB":                224
             pure_machine:
                 prompt:      GRAPHICS CHIP TYPE
                 description: Video card graphic chip type
@@ -2179,6 +2182,24 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     enabled
+                    controller1_puae:
+                        prompt:      CONTROLLER 1 TYPE
+                        description: Select controller type for Amiga P1
+                        choices:
+                            "Retropad":            1
+                            "CD32 Pad":            517
+                            "Analog Joystick":     773
+                            "Joystick":            261
+                            "Keyboard":            259
+                    controller2_puae:
+                        prompt:      CONTROLLER 2 TYPE
+                        description: Select controller type for Amiga P2
+                        choices:
+                            "Retropad":            1
+                            "CD32 Pad":            517
+                            "Analog Joystick":     773
+                            "Joystick":            261
+                            "Keyboard":            259
             amiga1200:
                 cfeatures:
                     puae_floppy_speed:
@@ -2211,6 +2232,24 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     enabled
+                    controller1_puae:
+                        prompt:      CONTROLLER 1 TYPE
+                        description: Select controller type for Amiga P1
+                        choices:
+                            "Retropad":            1
+                            "CD32 Pad":            517
+                            "Analog Joystick":     773
+                            "Joystick":            261
+                            "Keyboard":            259
+                    controller2_puae:
+                        prompt:      CONTROLLER 2 TYPE
+                        description: Select controller type for Amiga P2
+                        choices:
+                            "Retropad":            1
+                            "CD32 Pad":            517
+                            "Analog Joystick":     773
+                            "Joystick":            261
+                            "Keyboard":            259
             amigacd32:
                 cfeatures:
                     puae_cd_startup_delayed_insert:


### PR DESCRIPTION
PUAE:
- Added controller type selection.
There is a logical explanation for this: There are tons of games in whd format where there is precise mapping in case you are using a cd32 gamepad or a similar four button gamepad. Selecting the controller solves this problem. I also added other types of controllers, all explained here (taken from the libretro site):
```
RetroPad - Joypad - Standard one or two fire button joystick + customizable buttons with keyboard keys and hotkeys.
CD32 Pad - Joypad - Standard CD32 controller with unused buttons available for RetroPad extra mappings.
Analog Joystick - Joypad - Standard Analog joystick with unused buttons available for RetroPad extra mappings.
Joystick - Joypad - Standard one or two fire button joystick.
Keyboard - Keyboard - Keyboard input is always active. Has keymapper support.
```

Obviously, the type of controller is not selectable on CD32, as it is forcibly set to use its own controller (CD32 gamepad).

dosbox-pure:
- Added more ram values selectable (from latest version 0.16)
