### PR TITLE
configgen: Separate NES sprite limit and overscan

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -898,10 +898,19 @@ def generateCoreSettings(coreSettings, system, rom):
         # Reduce Sprite Flickering
         if system.isOptSet('nestopia_nospritelimit') and system.config['nestopia_nospritelimit'] == "disabled":
             coreSettings.save('nestopia_nospritelimit', '"disabled"')
-            coreSettings.save('nestopia_overscan_h',    '"disabled"')
-            coreSettings.save('nestopia_overscan_v',    '"disabled"')
         else:
             coreSettings.save('nestopia_nospritelimit', '"enabled"')
+        # Crop Overscan
+        if system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "none":
+            coreSettings.save('nestopia_overscan_h',    '"disabled"')
+            coreSettings.save('nestopia_overscan_v',    '"disabled"')
+        elif system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "h":
+            coreSettings.save('nestopia_overscan_h',    '"enabled"')
+            coreSettings.save('nestopia_overscan_v',    '"disabled"')
+        elif system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "v":
+            coreSettings.save('nestopia_overscan_h',    '"disabled"')
+            coreSettings.save('nestopia_overscan_v',    '"enabled"')
+        else:
             coreSettings.save('nestopia_overscan_h',    '"enabled"')
             coreSettings.save('nestopia_overscan_v',    '"enabled"')
         # Palette Choice
@@ -931,10 +940,19 @@ def generateCoreSettings(coreSettings, system, rom):
         # Reduce Sprite Flickering
         if system.isOptSet('fceumm_nospritelimit') and system.config['fceumm_nospritelimit'] == "disabled":
             coreSettings.save('fceumm_nospritelimit', '"disabled"')
-            coreSettings.save('fceumm_overscan_h',    '"disabled"')
-            coreSettings.save('fceumm_overscan_v',    '"disabled"')
         else:
             coreSettings.save('fceumm_nospritelimit', '"enabled"')
+        # Crop Overscan
+        if system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "none":
+            coreSettings.save('fceumm_overscan_h',    '"disabled"')
+            coreSettings.save('fceumm_overscan_v',    '"disabled"')
+        elif system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "h":
+            coreSettings.save('fceumm_overscan_h',    '"enabled"')
+            coreSettings.save('fceumm_overscan_v',    '"disabled"')
+        elif system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "v":
+            coreSettings.save('fceumm_overscan_h',    '"disabled"')
+            coreSettings.save('fceumm_overscan_v',    '"enabled"')
+        else:
             coreSettings.save('fceumm_overscan_h',    '"enabled"')
             coreSettings.save('fceumm_overscan_v',    '"enabled"')
         # Palette Choice

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -625,6 +625,14 @@ libretro:
                 choices:
                     "Off":                  disabled
                     "On":                   enabled
+            fceumm_cropoverscan:
+                prompt:      CROP OVERSCAN
+                description: Crops out video edge hidden under bezel of analog TV
+                choices:
+                    "None":                 none
+                    "Horizontal":           h
+                    "Vertical":             v
+                    "Both":                 both
             fceumm_palette:
                 prompt:      COLOR PALETTE
                 description: Choose which color palette is going to be used
@@ -1497,6 +1505,14 @@ libretro:
                 choices:
                     "Off":                  disabled
                     "On":                   enabled
+            nestopia_cropoverscan:
+                prompt:      CROP OVERSCAN
+                description: Crops out video edge hidden under bezel of analog TV
+                choices:
+                    "None":                 none
+                    "Horizontal":           h
+                    "Vertical":             v
+                    "Both":                 both
             nestopia_palette:
                 prompt:      COLOR PALETTE
                 description: Choose which color palette is going to be used


### PR DESCRIPTION
Separate NES/FDS sprite limit and overscan settings.
Some people can like no sprite limit to be on and crop overscan to be off. Crop overscan in some games hides important info under on screen bezels. Separating settings allows better visibility without turning off bezels.