### PR TITLE
Amd dsg for radeon

### DIFF
--- a/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
+++ b/board/batocera/x86/fsoverlay/etc/X11/xinit/xinitrc
@@ -37,4 +37,12 @@ then
     fi
 fi
 
+### radeon ###
+# variable for AMD Dynamic Switchable Graphics to take amd-radeon gpu over intel cards when such hybrid cards are available
+radeon_prime="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf radeon-prime)"
+if test "${radeon_prime}" = "true"
+then
+    export DRI_PRIME=1
+fi
+
 openbox --config-file /etc/openbox/rc.xml --startup "emulationstation-standalone"

--- a/package/batocera/core/batocera-system/batocera-boot.conf
+++ b/package/batocera/core/batocera-system/batocera-boot.conf
@@ -11,6 +11,9 @@ autoresize=true
 #nvidia-driver=true
 #nvidia-prime=true
 
+# radeon-prime enables the amd-radeon gpu over the intel gpu in case you've an amd-radeon hybrid gpu
+#radeon-prime=true
+
 # force i965 driver (to override iris driver for example)
 #intel-i965-driver=true
 


### PR DESCRIPTION
Add variable for AMD Dynamic Switchable Graphics to take amd-radeon gpu over intel cards when such hybrid cards are available.

I have a "HP ProBook 4740s" with Intel and AMD Radeon hybrid cards.
Now I am able to use the AMD Radeon card in Batocera.

I tested with .xinitrc in the home folder of root to overwrite /etc/X11/xinit/xinitrc and this works perfect.

If you need proof I can send screenshots.