### PR TITLE
Multimedia Keys edition for OGS

### DIFF
--- a/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys_Hardkernel_ODROID_GO3.conf
+++ b/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys_Hardkernel_ODROID_GO3.conf
@@ -1,7 +1,7 @@
 BTN_TRIGGER_HAPPY3 1            batocera-brightness - 5
 BTN_TRIGGER_HAPPY4 1            batocera-brightness + 5
 KEY_VOLUMEUP 1                  batocera-audio setSystemVolume +5
-KEY_VOLUMEDOWN 1                batocera-audio setSystemVolume +5
+KEY_VOLUMEDOWN 1                batocera-audio setSystemVolume -5
 KEY_POWER       1               /sbin/shutdown -h now
 # display some information on X displays
 KEY_F2          1               /usr/bin/batocera-info --short | HOME=/userdata/system XAUTHORITY=/var/lib/.Xauthority DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4


### PR DESCRIPTION
As of the latest beta/32dev version, using either the VOLUMEUP or VOLUMEDOWN key on OGS increases the volume. This should fix this (editing the file does for me at least.).

This is also a pull request meant to see if I remember how to do those.