### PR TITLE
configgen: Split picodrive sprite limit, overscan

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1265,10 +1265,13 @@ def generateCoreSettings(coreSettings, system, rom):
         # Reduce sprite flickering
         if system.isOptSet('picodrive_sprlim') and system.config['picodrive_sprlim'] == 'disabled':
             coreSettings.save('picodrive_sprlim',   '"disabled"')
-            coreSettings.save('picodrive_overscan', '"disabled"')
         else:
             coreSettings.save('picodrive_sprlim',   '"enabled"')
+        # Crop Overscan: the setting in picodrive shows overscan when enabled
+        if system.isOptSet('picodrive_cropoverscan') and system.config['picodrive_cropoverscan'] == 'disabled':
             coreSettings.save('picodrive_overscan', '"enabled"')
+        else:
+            coreSettings.save('picodrive_overscan', '"disabled"')
         # 6 Button Controller 1
         if system.isOptSet('picodrive_controller1'):
             coreSettings.save('picodrive_sprlim', '"' + system.config['picodrive_controller1'] + '"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1955,6 +1955,12 @@ libretro:
                 choices:
                     "Off":             disabled
                     "On":              enabled
+            picodrive_cropoverscan:
+                prompt:      CROP OVERSCAN
+                description: Crops out video edge hidden under bezel of analog TV
+                choices:
+                    "Off":             disabled
+                    "On":              enabled
             picodrive_controller1:
                 prompt:      CONTROLLER 1 TYPE
                 description: Select 3 or 6 button controller


### PR DESCRIPTION
Separate picodrive sprite limit and overscan settings.
Some people can like no sprite limit to be on and crop overscan to be off. Crop overscan in some games hides important info under on screen bezels. Separating settings allows better visibility without turning off bezels.
Similar PR for NES/FDS #4528