### PR TITLE
Offer an option to change audio latency in ES (v32)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -86,7 +86,9 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['quit_press_twice'] = 'false'               # not aligned behavior on other emus
     retroarchConfig['menu_show_restart_retroarch'] = 'false'    # this option messes everything up on Batocera if ever clicked
     retroarchConfig['video_driver'] = '"gl"'                    # needed for the ozone menu
-    retroarchConfig['audio_latency'] = '128'                    # best balance with audio perf
+    retroarchConfig['audio_latency'] = '64'                     #best balance with audio perf
+    if (system.isOptSet("audio_latency")):
+        retroarchConfig['audio_latency'] = system.config['audio_latency']
 
     with open("/usr/share/batocera/batocera.arch") as fb:
         arch = fb.readline().strip()

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11,6 +11,17 @@ libretro:
       choices:
         "OpenGL": opengl
         "Vulkan": vulkan
+    audio_latency:
+      prompt:      AUDIO LATENCY
+      description: Audio latency in millisec, turn it up if you hear crackles
+      choices:
+        "256":    256
+        "192":    192
+        "128":    128
+        "64":     64
+        "32":     32
+        "16":     16
+        "8":      8
 
   cores:
     '81':

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -13,7 +13,7 @@ libretro:
         "Vulkan": vulkan
     audio_latency:
       prompt:      AUDIO LATENCY
-      description: Audio latency in millisec, turn it up if you hear crackles
+      description: Audio latency in milliseconds, turn it up if you hear crackles
       choices:
         "256":    256
         "192":    192


### PR DESCRIPTION
And back to default=64 by popular demand (@Rion and @Hew-ux actually)