### PR TITLE
fix: ecwolf back to main menu

### DIFF
--- a/package/batocera/emulators/ecwolf/ecwolf.keys
+++ b/package/batocera/emulators/ecwolf/ecwolf.keys
@@ -4,6 +4,11 @@
             "trigger": ["hotkey", "start"],
             "type": "key",
             "target": [ "KEY_LEFTALT", "KEY_F4" ]
+	},
+	{
+            "trigger": ["start"],
+            "type": "key",
+            "target": [ "KEY_ESC" ]
 	}
     ]
 }


### PR DESCRIPTION
Press START on PAD to jump back to main menu (via ESC press)
Not tested, but should work according https://github.com/crcerror/ECWolf-RPI/blob/master/ecwolf_keyboardpatch.diff
Or maybe include this patch?

Background:
On XBOX and PS3 the hotkey acts as ESC-button already and for these there is no additional key needed, 
But not all players have these controllers so it's better to keep a dedicated button to work.