### PR TITLE
Fix SDL VSync

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -228,6 +228,13 @@ def main(args, maxnbplayers):
             mouseChanged = True
             videoMode.changeMouse(True)
 
+        # SDL VSync is a big deal on OGA and RPi4
+        if system.isOptSet('sdlvsync') and system.getOptBoolean('sdlvsync') == False:
+            system.config["sdlvsync"] = '0'
+        else:
+            system.config["sdlvsync"] = '1'
+        os.environ.update({'SDL_RENDER_VSYNC': system.config["sdlvsync"]})
+
         # run a script before emulator starts
         callExternalScripts("/usr/share/batocera/configgen/scripts", "gameStart", [systemName, system.config['emulator'], effectiveCore, effectiveRom])
         callExternalScripts("/userdata/system/scripts", "gameStart", [systemName, system.config['emulator'], effectiveCore, effectiveRom])


### PR DESCRIPTION
Thanks to @iconoclusterdotexe for the analysis. It's an absolute game changer on OGA and RPi4 on many SDL-powered emulators.
If, for whatever reason, you need to disable it, you can do that in `batocera.conf`, with for example `mame.sdlvsync=0`. I did some testing on x86_64 and didn't see any regression.