### PR TITLE
fix issues #4130 and #3412

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -164,13 +164,16 @@ def _keyToSdlGameControllerConfig(keyname, name, type, id, value=None):
         'leftshoulder:b6'
 
       _keyToSdlGameControllerConfig('dpleft', 'left', 'hat', 0, 8)
-        'dpleft:h0.9'
+        'dpleft:h0.8'
 
       _keyToSdlGameControllerConfig('lefty', 'joystick1up', 'axis', 1, -1)
         'lefty:a1'
 
       _keyToSdlGameControllerConfig('lefty', 'joystick1up', 'axis', 1, 1)
-        'lefty:a1'
+        'lefty:a1~'
+
+      _keyToSdlGameControllerConfig('dpup', 'up', 'axis', 1, -1)
+        'dpup:-a1'
     """
     if type == 'button':
         return '{}:b{}'.format(keyname, id)
@@ -179,6 +182,8 @@ def _keyToSdlGameControllerConfig(keyname, name, type, id, value=None):
     elif type == 'axis':
         if 'joystick' in name:
             return '{}:a{}{}'.format(keyname, id, '~' if int(value) > 0 else '')
+        elif keyname in ('dpup', 'dpdown', 'dpleft', 'dpright'):
+            return '{}:{}a{}'.format(keyname, '-' if int(value) < 0 else '+', id)
         else:
             return '{}:a{}'.format(keyname, id)
     elif type == 'key':


### PR DESCRIPTION
Proposition to fix issue #4130 and probably issue #3412

The joystick doesn't work on PPSSSP because of a problem in the gamecontrollerdb.txt : the dpdown value (a1) and the dpup value (a1) are the same, the two of them are positive. Idem for dpleft and dpright value (a0).

We need to respect the sign for dpad "axis" in order to have : dpdown:+a1,dpup:-a1,dpleft:-a0,dpright:+a0