### PR TITLE
Remove lr-swanstation from all but RPi3

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -751,10 +751,7 @@ config BR2_PACKAGE_BATOCERA_CONSOLE_SYSTEMS
                                                         !BR2_PACKAGE_BATOCERA_TARGET_CHA    && \
                                                         !BR2_PACKAGE_BATOCERA_TARGET_RK3326_ANY
 
-	select BR2_PACKAGE_LIBRETRO_SWANSTATION         if  !BR2_PACKAGE_BATOCERA_TARGET_X86	    && \
-	                                                    !BR2_PACKAGE_BATOCERA_TARGET_CHA        && \
-                                                        !BR2_PACKAGE_BATOCERA_TARGET_RPI1       && \
-                                                        !BR2_PACKAGE_BATOCERA_TARGET_RPI2
+	select BR2_PACKAGE_LIBRETRO_SWANSTATION         if  BR2_PACKAGE_BATOCERA_TARGET_RPI3
 
 	select BR2_PACKAGE_LIBRETRO_DUCKSTATION         if  !BR2_PACKAGE_BATOCERA_TARGET_X86	    && \
 	                                                    !BR2_PACKAGE_BATOCERA_TARGET_CHA        && \


### PR DESCRIPTION
An alternative to https://github.com/batocera-linux/batocera.linux/pull/4619 where Swanstation is instead on all systems but the RPi3.