### PR TITLE
Revert disabling beetle_psx on RPI4

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -764,9 +764,7 @@ config BR2_PACKAGE_BATOCERA_CONSOLE_SYSTEMS
 	select BR2_PACKAGE_LIBRETRO_PCSX                if  !BR2_PACKAGE_BATOCERA_TARGET_RPI3       && \
                                                         !BR2_PACKAGE_BATOCERA_TARGET_RK3326_ANY
 
-        select BR2_PACKAGE_LIBRETRO_BEETLE_PSX          if !BR2_PACKAGE_BATOCERA_TARGET_RPI1    && \
-                                                           !BR2_PACKAGE_BATOCERA_TARGET_RPI2    && \
-                                                           !BR2_PACKAGE_BATOCERA_TARGET_RPI3    && \
+    select BR2_PACKAGE_LIBRETRO_BEETLE_PSX          if  !BR2_PACKAGE_BATOCERA_RPI_ANY           && \
                                                         !BR2_PACKAGE_BATOCERA_TARGET_CHA        && \
                                                         !BR2_PACKAGE_BATOCERA_TARGET_RK3326_ANY
 


### PR DESCRIPTION
As i said on developer channel on Batocera Discord server, it's unnecessary to have a core like beetle_psx that works good for an handful of games on RPI4. So, i want to revert its disabling.