### PR TITLE
Add "stretch" aspect ratio to Dolphin

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -235,12 +235,14 @@ class DolphinGenerator(Generator):
 
 # Ratio
 def getGfxRatioFromConfig(config, gameResolution):
-    # 2: 4:3 ; 1: 16:9  ; 0: auto
+    # 3: stretch; 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:
         if config["ratio"] == "4/3":
             return 2
         if config["ratio"] == "16/9":
             return 1
+        if config["ratio"] == "custom":
+            return 3
     return 0
 
 # Seem to be only for the gamecube. However, while this is not in a gamecube section

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -235,14 +235,12 @@ class DolphinGenerator(Generator):
 
 # Ratio
 def getGfxRatioFromConfig(config, gameResolution):
-    # 3: stretch; 2: 4:3 ; 1: 16:9  ; 0: auto
+    # 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:
         if config["ratio"] == "4/3":
             return 2
         if config["ratio"] == "16/9":
             return 1
-        if config["ratio"] == "custom":
-            return 3
     return 0
 
 # Seem to be only for the gamecube. However, while this is not in a gamecube section


### PR DESCRIPTION
This adds the "stretch" aspect ratio option to the "custom" aspect ratio in ES's options.