### PR TITLE
Fix pcsx2 auto game fixes and widescreen patches

### DIFF
--- a/package/batocera/emulators/pcsx2/pcsx2.mk
+++ b/package/batocera/emulators/pcsx2/pcsx2.mk
@@ -33,7 +33,9 @@ PCSX2_CONF_OPTS += -DUSE_VTUNE=OFF
 
 define PCSX2_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/pcsx2/PCSX2 $(TARGET_DIR)/usr/PCSX/bin/PCSX2
-	cp -pr $(@D)/bin/Langs      $(TARGET_DIR)/usr/PCSX/bin
+	cp -pr $(@D)/bin/Langs      	$(TARGET_DIR)/usr/PCSX/bin
+	cp -p  $(@D)/bin/GameIndex.yaml $(TARGET_DIR)/usr/PCSX/bin
+	cp -p  $(@D)/bin/cheats_ws.zip 	$(TARGET_DIR)/usr/PCSX/bin
         mkdir -p $(TARGET_DIR)/usr/PCSX/bin/plugins
 	cp -pr $(@D)/plugins/*/*.so $(TARGET_DIR)/usr/PCSX/bin/plugins
 endef

--- a/package/batocera/emulators/pcsx2_avx2/pcsx2_avx2.mk
+++ b/package/batocera/emulators/pcsx2_avx2/pcsx2_avx2.mk
@@ -33,7 +33,9 @@ PCSX2_AVX2_CONF_OPTS += -DUSE_VTUNE=OFF
 
 define PCSX2_AVX2_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/pcsx2/PCSX2 $(TARGET_DIR)/usr/PCSX_AVX2/bin/PCSX2
-	cp -pr $(@D)/bin/Langs      $(TARGET_DIR)/usr/PCSX_AVX2/bin
+	cp -pr $(@D)/bin/Langs      	$(TARGET_DIR)/usr/PCSX_AVX2/bin
+	cp -p  $(@D)/bin/GameIndex.yaml $(TARGET_DIR)/usr/PCSX_AVX2/bin
+	cp -p  $(@D)/bin/cheats_ws.zip 	$(TARGET_DIR)/usr/PCSX_AVX2/bin
         mkdir -p $(TARGET_DIR)/usr/PCSX_AVX2/bin/plugins
 	cp -pr $(@D)/plugins/*/*.so $(TARGET_DIR)/usr/PCSX_AVX2/bin/plugins
 endef


### PR DESCRIPTION
* These missing files fix automatic game fixes and widescreen patches in standalone PCSX2
* I tested this on v.32 beta on i5-6500 with GT 1030
* I did not do testing with libretro-PCSX2 but it appears [they bundle these files in the core](https://github.com/libretro/pcsx2/pull/47)
* I am not sure why github is messing up the whitespace; looks good in `git diff` and vim