### PR TITLE
fix sdl pad : configName should not be used. Use realName instead

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -114,7 +114,7 @@ def _generateSdlGameControllerConfig(controller, sdlMapping=_DEFAULT_SDL_MAPPING
     """Returns an SDL_GAMECONTROLLERCONFIG-formatted string for the given configuration."""
     config = []
     config.append(controller.guid)
-    config.append(controller.configName)
+    config.append(controller.realName)
     config.append("platform:Linux")
 
     def add_mapping(input):


### PR DESCRIPTION
when a pad configuration is approximative in our database, the configName reflect the name of the pad in the database, while realName the hardware pad.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>