### PR TITLE
Fix Steam Exit

### DIFF
--- a/package/batocera/utils/batocera-steam/batocera-steam
+++ b/package/batocera/utils/batocera-steam/batocera-steam
@@ -17,7 +17,7 @@ else
 	do
 	    echo "${LINE}"
 	    # steam has no option to exit when quitting a game.
-	    if echo "${LINE}" | grep -E '^Exiting app '
+	    if echo "${LINE}" | grep -E '^Exiting app |^Game process removed'
 	    then
 		su - batocera -c "DISPLAY=:0.0 flatpak run com.valvesoftware.Steam -shutdown"
 	    fi


### PR DESCRIPTION
Work 
Tested on Proton Game OK (Cube World)
Tested on Linux Game OK (SOR4)
With this pr you support other languages than English. 

Step to reproduce run Steam Games from ES (not from Big Picture).

Because steam don't declare `Exiting app` but `Game process removed: AppID xxxxxx`
Actually this bug lock your screen and `batocera-es-swissknife --emukill` can't help you.
For simple user only reboot fix the issue.
For most advanced users you can run flatpak kill as batocera or just a steam -shutdown.

Im validating the fix on users

Free game for test : https://store.steampowered.com/app/1218210/Coromon/