### PR TITLE
Add .gbc2 as an acceptable extension for both GB2Player and GBC2Player

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -59,7 +59,7 @@ class LibretroGenerator(Generator):
             GBMultiSys = list()
             romGBName, romExtension = os.path.splitext(romName)
             # If ROM file is a .gb2 text, retrieve the filenames
-            if romExtension.lower() == '.gb2':
+            if romExtension.lower() == '.gb2' or '.gbc2':
                 with open(rom) as fp:
                     for line in fp:
                         GBMultiText = line.strip()

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -59,7 +59,7 @@ class LibretroGenerator(Generator):
             GBMultiSys = list()
             romGBName, romExtension = os.path.splitext(romName)
             # If ROM file is a .gb2 text, retrieve the filenames
-            if romExtension.lower() == '.gb2' or '.gbc2':
+            if romExtension.lower() in ['.gb2', '.gbc2']:
                 with open(rom) as fp:
                     for line in fp:
                         GBMultiText = line.strip()

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -282,7 +282,7 @@ gbc2players:
   manufacturer: Nintendo
   release: 1998
   hardware: portable
-  extensions: [gbc, gb2, zip, 7z]
+  extensions: [gbc, gb2, gbc2, zip, 7z]
   platform:   gbc
   emulators:
     libretro:
@@ -297,7 +297,7 @@ gb2players:
   manufacturer: Nintendo
   release: 1989
   hardware: portable
-  extensions: [gb, gb2, zip, 7z]
+  extensions: [gb, gb2, gbc2, zip, 7z]
   platform:   gb
   emulators:
     libretro:


### PR DESCRIPTION
Expands the generator code and es_systems to accept both `.gb2` _or_ `.gbc2` file extensions for both the GB2Player and GBC2Player systems, reducing confusion and potential unnecessary future troubleshooting.