### PR TITLE
Fix evmapy default configs

### DIFF
--- a/package/batocera/utils/evmapy-system-config/evmapy-system-config.mk
+++ b/package/batocera/utils/evmapy-system-config/evmapy-system-config.mk
@@ -9,10 +9,6 @@ EVMAPY_SYSTEM_CONFIG_SOURCE =
 
 define EVMAPY_SYSTEM_CONFIG_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/amiga500.keys
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/amiga1200.keys
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/atarist.keys
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/x68000.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/hotkey.keys $(TARGET_DIR)/usr/share/evmapy/windows.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/windows_installers.keys
 endef

--- a/package/batocera/utils/evmapy-system-config/mouse.keys
+++ b/package/batocera/utils/evmapy-system-config/mouse.keys
@@ -8,7 +8,7 @@
         {
             "trigger": "r3",
             "type": "key",
-            "target": "BTN_LEFT"
+            "target": "BTN_RIGHT"
         },
         {
             "trigger": "joystick2",


### PR DESCRIPTION
As i request a lot of time ago, now i've found the solution to fix this.
I'm removing generated evmapy default configuration in these systems because it's broken.

The system list:
Amiga 500 (except Amiberry)
Amiga 1200 (except Amiberry)
AtariST
Sharp X68000

I don't know if FSUAE needs a evmapy, but i believe not, because it uses START button to call menu for exit and configuring ingame (switch controllers, change disks etc.)

Amiberry has its own evmapy named amiga500.amiberry.keys, amiga1200.amiberry.keys and amigacd32.amiberry.keys and those files works with or without these generated default evmapy configs. So, they can be removed without any damage.