### PR TITLE
Add "full" ratio to Libretro and Dolphin

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -235,12 +235,14 @@ class DolphinGenerator(Generator):
 
 # Ratio
 def getGfxRatioFromConfig(config, gameResolution):
-    # 2: 4:3 ; 1: 16:9  ; 0: auto
+    # 3: stretch ; 2: 4:3 ; 1: 16:9  ; 0: auto
     if "ratio" in config:
         if config["ratio"] == "4/3":
             return 2
         if config["ratio"] == "16/9":
             return 1
+        if config["ratio"] == "full":
+            return 3
     return 0
 
 # Seem to be only for the gamecube. However, while this is not in a gamecube section

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -23,7 +23,7 @@ def defined(key, dict):
 # Warning the values in the array must be exactly at the same index than
 # https://github.com/libretro/RetroArch/blob/master/gfx/video_driver.c#L132
 ratioIndexes = ["4/3", "16/9", "16/10", "16/15", "21/9", "1/1", "2/1", "3/2", "3/4", "4/1", "4/4", "5/4", "6/5", "7/9", "8/3",
-                "8/7", "19/12", "19/14", "30/17", "32/9", "config", "squarepixel", "core", "custom"]
+                "8/7", "19/12", "19/14", "30/17", "32/9", "config", "squarepixel", "core", "custom", "full"]
 
 # Define system emulated by bluemsx core
 systemToBluemsx = {'msx': '"MSX2"', 'msx1': '"MSX2"', 'msx2': '"MSX2"', 'colecovision': '"COL - ColecoVision"' };


### PR DESCRIPTION
Collaborates with the https://github.com/batocera-linux/batocera-emulationstation/pull/1008 PR in batocera-emulationstation to add "full" as a ratio. This ratio stretches the image to fill the screen.