### PR TITLE
Add pad2key for MAME standalone custom user keyboard shortcut access

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3111,7 +3111,7 @@ cemu:
                 "5 Sideway Wiimote":           3
 
 citra:
-  features: [ratio]
+  features: [ratio, padtokeyboard]
   cfeatures:
         citra_screen_layout:
             prompt:      SCREEN LAYOUT
@@ -3981,7 +3981,7 @@ tsugaru:
                 "YES":            1
 
 mame:
-  features: [decoration]
+  features: [decoration, padtokeyboard]
   cfeatures:
         video:
             prompt:      GRAPHICS BACKEND

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3111,7 +3111,7 @@ cemu:
                 "5 Sideway Wiimote":           3
 
 citra:
-  features: [ratio, padtokeyboard]
+  features: [ratio]
   cfeatures:
         citra_screen_layout:
             prompt:      SCREEN LAYOUT


### PR DESCRIPTION
Allows the user to use pad2key for access to these standalone programs' keyboard shortcuts which are otherwise inaccessible from controller. Suggest and tested by @Redemp (Rion on Discord).

Useful shortcuts: F9 in Citra to switch screens, ability to "Pause" in MAME (basically, set any shortcut you want).

For Citra, it might be better to implement this as a part of the config generator instead.