### PR TITLE
fix savestate slot incrementing when it shouldn't

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -220,7 +220,7 @@ def main(args, maxnbplayers):
 
         # autosave arguments
         if args.state_slot is not None:
-            system.config["state_slot"] = args.state_slot
+            system.config["state_slot"] = int(args.state_slot) - 1
         if args.autosave is not None:
             system.config["autosave"] = args.autosave
 


### PR DESCRIPTION
fixes https://github.com/batocera-linux/batocera.linux/issues/4738 
User found that the user-made save state slot was incrementing whenever the user made a new save state and relaunched the game from emulationstation.

ie. user plays a game, saves state to slot 0 (automatically select), exits game, re-launches game, and now the save state slot has been increased to 1

The selected slot was always one ahead of the last user save, instead of the actual user save itself. This fixes that to always select the right one.

This needs some testing, especially in the case of a user having no prior save states.