### PR TITLE
Update vice core defaults

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vice/viceConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vice/viceConfig.py
@@ -42,10 +42,10 @@ def setViceConfig(viceConfigFile, system):
     viceConfig.set(systemCore, "SaveResourcesOnExit",    "1")
     viceConfig.set(systemCore, "SoundDeviceName",        "alsa")
 
-    viceConfig.set(systemCore, "SDLGLAspectMode",        "0")
+    viceConfig.set(systemCore, "SDLGLAspectMode",        "2")
     viceConfig.set(systemCore, "VICIIFullscreen",        "1")
     viceConfig.set(systemCore, "VICIISDLFullscreenMode", "0")
-    viceConfig.set(systemCore, "VICIIBorderMode",        "3")
+    viceConfig.set(systemCore, "VICIIBorderMode",        "0")
     viceConfig.set(systemCore, "WarpMode",               "0")
     
     viceConfig.set(systemCore, "JoyDevice1",             "4")


### PR DESCRIPTION
Changes the border mode to 0 (more accurate to the original hardware), changes the default aspect ratio to be core provided "2" instead of stretched (this should probably be made an if-do condition in the future but this is a good default for now).