### PR TITLE
switch from jpg to png for screenshots on x86

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-screenshot.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-screenshot.xorg
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 export DISPLAY=:0.0
-OUTPUT="/userdata/screenshots/screenshot-$(date +%Y.%m.%d-%Hh%M.%S).jpg"
+OUTPUT="/userdata/screenshots/screenshot-$(date +%Y.%m.%d-%Hh%M.%S).png"
 mkdir -p /userdata/screenshots || exit 1
 
 ffmpeg -f x11grab -i :0.0 -vframes 1 "${OUTPUT}" 2>/dev/null || exit 1


### PR DESCRIPTION
jpgs lose image information, pngs are a lossless format. If image compression is required, the user can always convert png to jpg later.