### PR TITLE
Fix missing "ports" directory on a fresh install

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/roms/ports/_info.txt
+++ b/package/batocera/emulationstation/batocera-es-system/roms/ports/_info.txt
@@ -1,0 +1,7 @@
+## SYSTEM PORTS ##
+-------------------------------------------------------------------------------
+Here you can find Linux games and apps, launched by shell scripts ending in
+".sh". Only the ".sh" scripts appear in EmulationStation.
+-------------------------------------------------------------------------------
+Vous trouverez ici des jeux et applications Linux, qui sont lancés par des scripts
+shell en ".sh". Seuls les scripts en ".sh" apparaissent dans EmulationStation.


### PR DESCRIPTION
Fix #4777 (making the Content Downloader fail)