### PR TITLE
MAME Systems

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -2,7 +2,12 @@
         * new language : hebrew
         * add: .gbc2 is now an additional acceptable extension for both GB2Player and GBC2Player dual-rom playlists
         * add: FSR & DLSS support for Wine (x86_64)
+		* add: Adventure Vision & CD-i via MAME (x86_64)
+		* add: LCD Games system (MAME & lr-gw on x86_64, lr-gw on all others)
         * change: RPi3 default audio buffer to 96ms, gb/gbc to 196ms
+		* change: MAME no-nag patch (x86_64)
+		* change: MAME DS3 d-pad button mappings (x86_64)
+		* change: Game & Watch will group with LCD Games if enabled, and MAME is enabled for x86_64
         * es: English spelling/grammar overhaul, multiple option names updated
         * es: added Xemu widescreen and render scale in advanced options
         * es: option to launch a game automatically at boot

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -16,3 +16,12 @@ n64dd:
 sgb:
   emulator: libretro
   core:     mesen-s
+lcdgames:
+  emulator: mame
+  core:     mame
+cdi:
+  emulator: mame
+  core:     mame
+advision:
+  emulator: mame
+  core:     mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -153,6 +153,11 @@ kodi:
   emulator: kodi
   options:
     videomode: default
+lcdgames:
+  emulator: libretro
+  core:     gw
+  options:
+    forceNoBezel: true
 lutro:
   emulator: libretro
   core:     lutro

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -344,15 +344,31 @@ virtualboy:
     libretro:
       vb: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_BEETLE_VB] }
 
+lcdgames:
+  name:       LCD Games
+  manufacturer: Various
+  release: 1979
+  hardware: portable
+  extensions: [mgw, zip, 7z]
+  group:      lcdgames
+  emulators:
+    libretro:
+      gw:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GW]                                   }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME], incompatible_extensions: [mgw]          }
+
 gameandwatch:
   name:       Game and Watch
   manufacturer: Nintendo
   release: 1980
   hardware: portable
   extensions: [mgw, zip, 7z]
+  group:      lcdgames
   emulators:
     libretro:
-      gw: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GW] }
+      gw:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GW]                                   }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME], incompatible_extensions: [mgw]          }
 
 dreamcast:
   name:       Sega Dreamcast
@@ -2071,3 +2087,27 @@ uzebox:
   emulators:
     libretro:
       uzem: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_UZEM] }
+
+cdi:
+  name:       CD-i
+  manufacturer: Philips
+  release: 1990
+  hardware: console
+  extensions: [chd cue, toc, nrg, gdi, iso, cdr]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file cdimono1.zip or .7z in either cdi or BIOS folder.
+
+advision:
+  name:       Adventure Vision
+  manufacturer: Entex
+  release: 1982
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file advision.zip or .7z in either advision or BIOS folder.

--- a/package/batocera/emulators/mame/005-mame-no-nag-screens.patch
+++ b/package/batocera/emulators/mame/005-mame-no-nag-screens.patch
@@ -1,0 +1,11 @@
+--- a/src/frontend/mame/ui/ui.cpp	Wed May 26 15:42:03 2021
++++ b/src/frontend/mame/ui/ui.cpp	Sun Oct  3 15:45:07 2021
+@@ -413,6 +413,8 @@
+ 	// or if we are debugging, or if there's no mame window to send inputs to
+ 	if (!first_time || (str > 0 && str < 60*5) || &machine().system() == &GAME_NAME(___empty) || (machine().debug_flags & DEBUG_FLAG_ENABLED) != 0 || video_none)
+ 		show_gameinfo = show_warnings = show_mandatory_fileman = false;
++	
++	show_gameinfo = show_warnings = show_mandatory_fileman = false;
+ 
+ #if defined(__EMSCRIPTEN__)
+ 	// also disable for the JavaScript port since the startup screens do not run asynchronously

--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -214,6 +214,10 @@ endef
 define MAME_EVMAPY
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/advision.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/cdi.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/lcdgames.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gameandwatch.mame.keys
 endef
 
 MAME_POST_INSTALL_TARGET_HOOKS += MAME_EVMAPY


### PR DESCRIPTION
* Adds Adventure Vision & CD-i
* Adds LCD Games, enables MAME for Game & Watch, sets Game & Watch to group with LCD Games if enabled
* Enables DS3 D-Pad in MAME (uses buttons 13-16)
* MAME no-nag patch integrated

Adventure Vision & CD-i require BIOS files, they're the current MAME versions (advidion.zip & cdimono1.zip) and can be placed in the ROM folder or BIOS folder.

DS3 controls are untested as I don't have one available, basing it on feedback I was given.

Recommended setup for LCD Games/Game & Watch on x86_64 would be to set MAME as the default emulator and leave lr-gw ROMs unzipped so they can be recognized by extension. Most lr-gw games are duplicated in MAME, but there are some (mostly non-Nintendo) that are not.

No-nag patch will hide the various "this machine may have issues" warnings, otherwise many of the MESS systems will produce those on launch.

The important changes are in the MAME generator, it includes systems that don't require a BIOS (LCD games), systems that do (Adventure Vision, CD-i), systems where the Batocera name may not match MAME's (CD-i maps to cdimono1), and special control & config options for CD-i (map controller to mouse, change view to disable the LCD readout that takes up a chunk of the top of the screen otherwise).

Adventure Vision & Game & Watch use the standard MAME controls and don't need additional config.

Future systems should be able to adapt these changes. The CD-i config could possibly be spun off into a function, but these changes will likely be specific per-system and may not make sense to do in a generic way.