### PR TITLE
Option to hide borders on Vice C64 (now shown by default)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vice/viceConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vice/viceConfig.py
@@ -42,12 +42,15 @@ def setViceConfig(viceConfigFile, system):
     viceConfig.set(systemCore, "SaveResourcesOnExit",    "1")
     viceConfig.set(systemCore, "SoundDeviceName",        "alsa")
 
-    viceConfig.set(systemCore, "SDLGLAspectMode",        "0")
+    if system.isOptSet('noborder') and system.getOptBoolean('noborder') == True:
+        viceConfig.set(systemCore, "SDLGLAspectMode",        "0")
+        viceConfig.set(systemCore, "VICIIBorderMode",        "3")
+    else:
+        viceConfig.set(systemCore, "SDLGLAspectMode",        "2")
+        viceConfig.set(systemCore, "VICIIBorderMode",        "0")
     viceConfig.set(systemCore, "VICIIFullscreen",        "1")
     viceConfig.set(systemCore, "VICIISDLFullscreenMode", "0")
-    viceConfig.set(systemCore, "VICIIBorderMode",        "3")
     viceConfig.set(systemCore, "WarpMode",               "0")
-    
     viceConfig.set(systemCore, "JoyDevice1",             "4")
     viceConfig.set(systemCore, "JoyDevice2",             "4")
     viceConfig.set(systemCore, "JoyMapFile",  viceController)

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -940,8 +940,8 @@ libretro:
       features: [autosave, latency_reduction, padtokeyboard]
       cfeatures:
             fuse_hide_border:
-                prompt:      ZOOM (HIDES BORDER)
-                description: Making the game occupy the entire screen area
+                prompt:      ZOOM (HIDE BORDER)
+                description: Make the game fill the entire screen area
                 choices:
                     "Off":  disabled
                     "On":   enabled
@@ -3960,6 +3960,13 @@ cgenius:
 
 vice:
   features: [ratio, padtokeyboard]
+  cfeatures:
+        noborder:
+            prompt:      ZOOM (HIDE BORDERS)
+            description: Display only 200 scanlines, effectively removing borders on many games
+            choices:
+                "NO (DEFAULT)": 0
+                "YES":          1
 
 tsugaru:
   features: [pad2keyboard]


### PR DESCRIPTION
Better implementation for #4760 