### PR TITLE
Fix swiss knife script to touch files like ES does on reboots/shutdown

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -96,10 +96,12 @@ case ${1,,} in
 
         ES_PID=$(check_esrun)
         if [[ "${1,,}" == "--shutdown" && -n $ES_PID ]]; then
+            touch "/tmp/shutdown.please"
             kill $ES_PID
             smart_wait 0 $ES_PID
             shutdown -h now
         elif [[ "${1,,}" == "--reboot" && -n $ES_PID ]]; then
+            touch "/tmp/reboot.please"
             kill $ES_PID
             smart_wait 0 $ES_PID
             reboot
@@ -115,8 +117,8 @@ case ${1,,} in
         wait $!
         exitcode=$?
         [[ $exitcode -eq 0 ]] && /etc/init.d/S31emulationstation start
-        [[ $exitcode -eq 10 ]] && shutdown -r now
-        [[ $exitcode -eq 11 ]] && shutdown -h now
+        [[ $exitcode -eq 10 ]] && touch "/tmp/reboot.please"   && shutdown -r now
+        [[ $exitcode -eq 11 ]] && touch "/tmp/shutdown.please" && shutdown -h now
     ;;
 
     --version|--arch|--update)


### PR DESCRIPTION
- Fixes issue where cases like argonone do not power off properly when system is shutdown via `batocera-es-swissknife`
- I did not handle `/tmp/restart.please` because although ES touches this file on ES restart it is not used anywhere so far as I can tell