### PR TITLE
add Ubershaders option to GameCube/Wii

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -165,6 +165,30 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
 
+        # Ubershaders (asynchronous with shader caching before boot enabled)
+#        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "asynchronous_ubershader":
+#            if system.config["ubershaders"] == "synchronous_ubershader":
+#                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"1"')
+#                dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"False"')
+#            elif system.config["ubershaders"] == "synchronous":
+#                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"0"')
+#                dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"False"')
+#        else:
+#            dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"2"')
+#            dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"True"')
+
+        # Ubershaders
+        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "synchronous_ubershader":
+            if system.config["ubershaders"] == "asynchronous_ubershader":
+                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"2"')
+                dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"True"')
+            elif system.config["ubershaders"] == "synchronous":
+                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"0"')
+                dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"False"')
+        else:
+            dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"1"')
+            dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", '"False"')
+
         # Various performance hacks - Default Off
         if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
             dolphinGFXSettings.set("Hacks", "BBoxEnable", '"False"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3187,9 +3187,16 @@ dolphin:
             choices:
                 "OpenGL": OGL
                 "Vulkan": Vulkan
+        ubershaders:
+            prompt:      UBERSHADERS
+            description: Improve performance with Ubershaders (may not work on all hardware). Asynchronous is preferred, synchronous is more compatible.
+            choices:
+                "Ubershaders with asynchronous": asynchronous_ubershader
+                "Ubershaders with synchronous":  synchronous_ubershader
+                "No Ubershaders":                synchronous
         perf_hacks:
             prompt:      PERFORMANCE HACKS
-            description: Increase emulator performance
+            description: Increase emulator performance, at the cost of accuracy/stability
             choices:
                 "Off": 0
                 "On":  1


### PR DESCRIPTION
Adds the "Ubershaders" option to GameCube/Wii's advanced system options.

Fixes https://github.com/batocera-linux/batocera.linux/issues/4294