### PR TITLE
Added '-o' tar option

### DIFF
--- a/package/batocera/emulators/wine/dxvk-nvapi/dxvk-nvapi.mk
+++ b/package/batocera/emulators/wine/dxvk-nvapi/dxvk-nvapi.mk
@@ -10,7 +10,7 @@ DXVK_NVAPI_SITE = https://github.com/jp7677/dxvk-nvapi/releases/download/v$(DXVK
 DXVK_NVAPI_LICENSE = zlib/libpng
 
 define DXVK_NVAPI_EXTRACT_CMDS
-	mkdir -p $(@D)/target && cd $(@D)/target && tar xf $(DL_DIR)/$(DXVK_NVAPI_DL_SUBDIR)/$(DXVK_NVAPI_SOURCE)
+	mkdir -p $(@D)/target && cd $(@D)/target && tar xfo $(DL_DIR)/$(DXVK_NVAPI_DL_SUBDIR)/$(DXVK_NVAPI_SOURCE)
 endef
 
 define DXVK_NVAPI_INSTALL_TARGET_CMDS

--- a/package/batocera/emulators/wine/dxvk/dxvk.mk
+++ b/package/batocera/emulators/wine/dxvk/dxvk.mk
@@ -10,7 +10,7 @@ DXVK_SITE = https://github.com/doitsujin/dxvk/releases/download/v$(DXVK_VERSION)
 DXVK_LICENSE = zlib/libpng
 
 define DXVK_EXTRACT_CMDS
-	mkdir -p $(@D)/target && cd $(@D)/target && tar xf $(DL_DIR)/$(DXVK_DL_SUBDIR)/$(DXVK_SOURCE)
+	mkdir -p $(@D)/target && cd $(@D)/target && tar xfo $(DL_DIR)/$(DXVK_DL_SUBDIR)/$(DXVK_SOURCE)
 endef
 
 define DXVK_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Preventing compiling errors issued by "un"-TAR permission restrictions when using unprivileged containers to compile (e.g. Ubuntu 20.04 as a "Proxmox" container).
FYI: This will not affect negatively compiling on a non-container system (e.g. bare metal or VM).