### PR TITLE
add SSAA antialiasing mode to Dolphin part 2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -232,6 +232,12 @@ class DolphinGenerator(Generator):
         else:
             dolphinGFXSettings.set("Settings", "MSAA", '"0"')
 
+        # Anti aliasing mode
+        if system.isOptSet('use_ssaa') and system.getOptBoolean('use_ssaa'):
+            dolphinGFXSettings.set("Settings", "SSAA", '"True"')
+        else:
+            dolphinGFXSettings.set("Settings", "SSAA", '"False"')
+
         # Save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:
             dolphinGFXSettings.write(configfile)

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3253,6 +3253,12 @@ dolphin:
                 "2x":  2
                 "4x":  4
                 "8x":  8
+        use_ssaa:
+            prompt:      ANTI-ALIASING MODE
+            description: Toggle MSAA/SSAA. Depends on anti-aliasing being enabled.
+            choices:
+                "MSAA (default)": 0
+                "SSAA":           1
         hires_textures:
             prompt:      HIRES TEXTURES
             description: Use HD texture packs


### PR DESCRIPTION
It's https://github.com/batocera-linux/batocera.linux/pull/4849 but without the typo. Also changed the batocera.conf name from "ssaa" to "use_ssaa" to add some more context.

For reference, the setting in Dolphin itself is just called "SSAA" and it can be "True" or "False". https://wiki.dolphin-emu.org/index.php?title=GameINI#Anti-Aliasing