### PR TITLE
Fix Amiga controller mapping (HELP!)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -180,6 +180,70 @@ def generateCoreSettings(coreSettings, system, rom):
 
     # Commodore AMIGA
     if (system.config['core'] == 'puae'):
+        # Functional mapping for Amiga system
+        # If you want to change them, you can add
+        # some strings to batocera.conf by using
+        # this syntax: SYSTEMNAME.retroarchcore.puae_mapper_BUTTONNAME=VALUE
+        if system.name != 'amigacd32':
+            # Controller mapping for A500 and A1200
+            uae_mapping = { 'aspect_ratio_toggle': "---",
+                'mouse_toggle': "RETROK_RCTRL",
+                'statusbar': "RETROK_F11",
+                'vkbd': "---",
+                'reset': "---",
+                'zoom_mode_toggle': "RETROK_F12",
+                'a': "JOYSTICK_FIRE",
+                'b': "JOYSTICK_2ND_FIRE",
+                'x': "RETROK_SPACE",
+                'y': "RETROK_LCTRL",
+                'l': "RETROK_ESCAPE",
+                'l2': "MOUSE_LEFT_BUTTON",
+                'l3': "SWITCH_JOYMOUSE",
+                'ld': "---",
+                'll': "---",
+                'lr': "---",
+                'lu': "---",
+                'r': "RETROK_F1",
+                'r2': "MOUSE_RIGHT_BUTTON",
+                'r3': "TOGGLE_STATUSBAR",
+                'rd': "---",
+                'rl': "---",
+                'rr': "---",
+                'ru': "---",
+                'select': "TOGGLE_VKBD",
+                'start': "RETROK_RETURN",}
+            for key in uae_mapping:
+                coreSettings.save('puae_mapper_' + key, uae_mapping[key])
+        else:
+            # Controller mapping for CD32
+            uae_mapping = { 'aspect_ratio_toggle': "---",
+                'mouse_toggle': "RETROK_RCTRL",
+                'statusbar': "RETROK_F11",
+                'vkbd': "---",
+                'reset': "---",
+                'zoom_mode_toggle': "RETROK_F12",
+                'a': "---",
+                'b': "---",
+                'x': "---",
+                'y': "---",
+                'l': "---",
+                'l2': "MOUSE_LEFT_BUTTON",
+                'l3': "SWITCH_JOYMOUSE",
+                'ld': "---",
+                'll': "---",
+                'lr': "---",
+                'lu': "---",
+                'r': "---",
+                'r2': "MOUSE_RIGHT_BUTTON",
+                'r3': "TOGGLE_STATUSBAR",
+                'rd': "---",
+                'rl': "---",
+                'rr': "---",
+                'ru': "---",
+                'select': "---",
+                'start': "---",}
+            for key in uae_mapping:
+                coreSettings.save('puae_mapper_' + key, uae_mapping[key])
         # Show Video Options
         coreSettings.save('puae_video_options_display ', '"enabled"')
         # Amiga Model


### PR DESCRIPTION
Inspired by this pr https://github.com/batocera-linux/batocera.linux/pull/4857 and this issue post https://github.com/batocera-linux/batocera.linux/issues/4801, I've decided to make a good Amiga controller mapping. By using CD32 systems, it resets all the buttons originally used by its own controller.
But there is a small problem: I want to add this condition when you are selecting CD32 pad as a Controller Type (Added by me time ago, because of whdload games with cd32 pad support), but libretroOptions.py cannot read variables and strings from libretroConfig.py. Any idea?

input_libretro_device_p1 and input_libretro_device_p2 uses '517' as a value to select the CD32 pad