### PR TITLE
Add .m3u support for multicart pico-8 roms

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -23,7 +23,6 @@ class LexaloffleGenerator(Generator):
         # the command to run
         commandArray = [BIN_PATH]
         commandArray.extend(["-desktop", "/userdata/screenshots"])  # screenshots
-        commandArray.extend(["-root_path", "/userdata/roms/pico8"]) # store carts from splore
         commandArray.extend(["-windowed", "0"])                     # full screen
         # Display FPS
         if system.config['showFPS'] == 'true':
@@ -31,9 +30,20 @@ class LexaloffleGenerator(Generator):
         else:
                 commandArray.extend(["-show_fps", "0"])
 
-        rombase=os.path.basename(rom) 
-        idx=rombase.index('.')
-        rombase=rombase[:idx]
+        basename = os.path.basename(rom)
+        rombase, romext = os.path.splitext(basename)
+
+        # .m3u support for multi-cart pico-8
+        if (romext.lower() == ".m3u"):
+            with open(rom, "r") as fpin:
+                lines = fpin.readlines()
+            fullpath = os.path.dirname(os.path.abspath(rom)) + '/' + lines[0].strip()
+            localpath, localrom = os.path.split(fullpath)
+            commandArray.extend(["-root_path", localpath])
+            rom = fullpath
+        else:
+            commandArray.extend(["-root_path", "/userdata/roms/pico8"]) # store carts from splore
+
         if (rombase.lower() == "splore" or rombase.lower() == "console"):
             commandArray.extend(["-splore"])
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -154,8 +154,17 @@ class LibretroGenerator(Generator):
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], os.path.join(rom, romDOSName + ".bat")]
             else:
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
+        # Pico-8 multi-carts (might work only with official Lexaloffe engine right now)
+        elif system.name == 'pico8':
+            romext = os.path.splitext(romName)[1]
+            if (romext.lower() == ".m3u"):
+                with open (rom, "r") as fpin:
+                    lines = fpin.readlines()
+                rom = os.path.dirname(os.path.abspath(rom)) + '/' + lines[0].strip()
+            commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
         else:
             commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
+
 
         configToAppend = []
 

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -989,7 +989,7 @@ pico8:
   manufacturer: Fantasy
   release: 2015
   hardware: console
-  extensions: [p8, png]
+  extensions: [p8, png, m3u]
   emulators:
     libretro:
       retro8: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_RETRO8] }


### PR DESCRIPTION
Example with Another world demake (https://freds72.itch.io/another-world):

Extract all the games files into a directory, for example `/userdata/roms/pico8/aw/`. You'll have multiple `.p8` carts from the .zip fiile.

At the main pico-8 ROM level, create a file `/userdata/roms/pico8/Another_world.m3u` with for its first line the relative path of the main cart to load `aw/aw.p8`. Load this `Another_world.m3u` file from ES to launch the game. Only the first line matters, every sub-cart will be loaded from the main one.

Works fine with the official Lexaloffle engine, I haven't found a multi-cart game that runs with the retro-8 emulator, but still implemented the same logic.