### PR TITLE
MESS Systems, Part 2

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -5,15 +5,18 @@
         * new language : hebrew
         * add: .gbc2 is now an additional acceptable extension for both GB2Player and GBC2Player dual-rom playlists
         * add: FSR & DLSS support for Wine (x86_64)
-        * add: Adventure Vision & CD-i via MAME (x86_64)
-        * add: LCD Games system (MAME & lr-gw on x86_64, lr-gw on all others)
+		* add: Adventure Vision, CD-i, CreatiVision, PV-1000, Game.com, Gamate, TV Games (P&P Consoles), Fujitsu FM-7, Game Pocket Computer, APF M-1000, BBC Micro, Coleco ADAM, Arcadia 2001, Game Master, Bally Astrocade, TI-99, Tomy Tutor, Tandy Color Computer, & Mega Duck via MAME (x86_64)
+		* add: LCD Games system (MAME & lr-gw on x86_64, lr-gw on all others)
+		* add: Media Type option for MAME systems with multiple ROM types (floppy, CD, cassette, etc.) (x86_64)
+		* add: Toggle for UI mode in MAME via Hotkey + D-Pad Up or Scroll Lock, plus per-system/game setting for MAME computer systems (x86_64)
+		* add: Per-game config option for MAME systems with a keyboard or keypad (set controls via MAME's UI) (x86_64)
         * add: "roms/port" folder now exists by default
         * fix: gamecube now uses dolphin's default controls
         * fix: borders are now shown on Vice C64, also fixed default aspect ratio
         * fix: duckstation quick menu can now actually be accessed with hotkey+south
         * change: RPi3 default audio buffer to 96ms, gb/gbc to 196ms
         * change: MAME no-nag patch (x86_64)
-        * change: MAME DS3 d-pad button mappings (x86_64)
+        * change: Option for MAME controllers that use buttons as D-Pad directions (DS3, X360 dongle) (x86_64)
         * change: Game & Watch will group with LCD Games if enabled, and MAME is enabled for x86_64
         * change: The "amlogic/s905gen3/tvbox" image is now titled "amlogic/s905gen3/tvbox-gen3"
         * es: English spelling/grammar overhaul, multiple option names updated

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -45,11 +45,13 @@ class MameGenerator(Generator):
             os.makedirs("/userdata/saves/mame/comments/")
 
         # Define systems that will use the MESS executable instead of MAME
-        messSystems = [ "lcdgames", "gameandwatch", "cdi", "advision" ]
+        messSystems = [ "lcdgames", "gameandwatch", "cdi", "advision", "tvgames", "megaduck", "crvision", "gamate", "pv1000", "gamecom" , "fm7", "xegs", "gamepock", "aarch", "atom", "apfm1000", "bbc", "camplynx", "adam", "arcadia", "supracan", "gmaster", "astrocde", "ti99", "tutor", "coco", "socrates" ]
         # If it needs a system name defined, use it here. Add a blank string if it does not (ie non-arcade, non-system ROMs)
-        messSysName = [ "", "", "cdimono1", "advision" ]
+        messSysName = [ "", "", "cdimono1", "advision", "", "megaduck", "crvision", "gamate", "pv1000", "gamecom", "fm7", "xegs", "gamepock", "aa310", "atom", "apfm1000", "bbcb", "lynx48k", "adam", "arcadia", "supracan", "gmaster", "astrocde", "ti99_4a", "tutor", "coco", "socrates" ]
         # For systems with a MAME system name, the type of ROM that needs to be passed on the command line (cart, tape, cdrm, etc)
-        messRomType = [ "", "", "cdrm", "cart" ]
+        # If there are multiple ROM types (ie a computer w/disk & tape), select the default or primary type here.
+        messRomType = [ "", "", "cdrm", "cart", "", "cart", "cart", "cart", "cart", "cart1", "flop1", "cart", "cart", "flop", "cass", "cart", "flop1", "cass", "cass1", "cart", "cart", "cart", "cart", "cart", "cart", "cart", "cart" ]
+        messAutoRun = [ "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", 'mload""\\n', "", "", "", "", "", "", "", "", "" ]
         
         # Identify the current system, select MAME or MESS as needed.
         try:
@@ -67,19 +69,31 @@ class MameGenerator(Generator):
         if messMode == -1:
             commandArray += [ "-rompath",      romDirname ]
         else:
-            commandArray += [ "-rompath",      romDirname + ";/userdata/bios" ]
+            commandArray += [ "-rompath",      romDirname + ";/userdata/bios/;/userdata/roms/mame/" ]
 
         # MAME various paths we can probably do better
         commandArray += [ "-bgfx_path",    "/usr/bin/mame/bgfx/" ]          # Core bgfx files can be left on ROM filesystem
         commandArray += [ "-fontpath",     "/usr/bin/mame/" ]               # Fonts can be left on ROM filesystem
         commandArray += [ "-languagepath", "/usr/bin/mame/language/" ]      # Translations can be left on ROM filesystem
+        commandArray += [ "-pluginspath", "/usr/bin/mame/plugins/" ]
         commandArray += [ "-cheatpath",    "/userdata/cheats/mame/" ]       # Should this point to path or cheat.7z file ?
         commandArray += [ "-samplepath",   "/userdata/bios/mame/samples/" ] # Current batocera storage location for MAME samples
-        commandArray += [ "-artpath",       "/userdata/decorations/;/var/run/mame_artwork/;/usr/bin/mame/artwork/" ] # first for systems ; second for overlays
+        commandArray += [ "-artpath",       "/userdata/decorations/;/var/run/mame_artwork/;/usr/bin/mame/artwork/;/userdata/bios/mame/artwork/" ] # first for systems ; second for overlays
 
         # MAME saves a lot of stuff, we need to map this on /userdata/saves/mame/<subfolder> for each one
         commandArray += [ "-nvram_directory" ,    "/userdata/saves/mame/nvram/" ]
-        commandArray += [ "-cfg_directory"   ,    "/userdata/system/configs/mame/" ]
+        # MAME will create custom configs per game for MAME ROMs and MESS ROMs with no system attached (LCD games, TV games, etc.)
+        # This will allow an alternate config path per game for MESS console/computer ROMs that may need additional config.
+        cfgPath = "/userdata/system/configs/mame/"
+        if system.isOptSet("pergamecfg") and system.getOptBoolean("pergamecfg"):
+            if not messMode == -1:
+                if not messSysName[messMode] == "":
+                    if not os.path.exists("/userdata/system/configs/mame/" + messSysName[messMode] + "/"):
+                        os.makedirs("/userdata/system/configs/mame/" + messSysName[messMode] + "/")
+                    cfgPath = "/userdata/system/configs/mame/" + messSysName[messMode] + "/" + romBasename + "/"
+                    if not os.path.exists(cfgPath):
+                        os.makedirs(cfgPath)
+        commandArray += [ "-cfg_directory"   ,    cfgPath ]
         commandArray += [ "-input_directory" ,    "/userdata/saves/mame/input/" ]
         commandArray += [ "-state_directory" ,    "/userdata/saves/mame/state/" ]
         commandArray += [ "-snapshot_directory" , "/userdata/screenshots/" ]
@@ -130,7 +144,13 @@ class MameGenerator(Generator):
             commandArray += [ "-autoror" ]
         if system.isOptSet("rotation") and system.config["rotation"] == "autorol":
             commandArray += [ "-autorol" ]
-
+        
+        # UI enable - for computer systems, the default sends all keys to the emulated system.
+        # This will enable hotkeys, but some keys may pass through to MAME and not be usable in the emulated system.
+        # Hotkey + D-Pad Up will toggle this when in use (scroll lock key)
+        if not (system.isOptSet("enableui") and not system.getOptBoolean("enableui")):
+            commandArray += [ "-ui_active" ]
+        
         # Finally we pass game name
         # MESS will use the full filename and pass the system & rom type parameters if needed.
         if messMode == -1:
@@ -139,21 +159,55 @@ class MameGenerator(Generator):
             if messSysName[messMode] == "":
                 commandArray += [ romBasename ]
             else:
-                commandArray += [ messSysName[messMode] ]
-                commandArray += [ "-" + messRomType[messMode] ]
+                # Alternate system for machines that have different configs (ie computers with different hardware)
+                if system.isOptSet("altmodel"):
+                    commandArray += [ system.config["altmodel"] ]
+                else:
+                    commandArray += [ messSysName[messMode] ]
+                # Autostart computer games where applicable
+                # Generic boot if only one type is available
+                if messAutoRun[messMode] != "":
+                    commandArray += [ "-autoboot_delay", "2", "-autoboot_command", messAutoRun[messMode] ]
+                # bbc has different boots for floppy & cassette, no special boot for carts
+                if system.name == "bbc":
+                    if system.isOptSet("altromtype"):
+                        if system.config["altromtype"] == "cass":
+                            commandArray += [ '-autoboot_delay', '2', '-autoboot_command', '*tape\\nchain""\\n' ]
+                        elif left(system.config["altromtype"], 4) == "flop":
+                            commandArray += [ '-autoboot_delay',  '3',  '-autoboot_command', '*cat\\n*exec !boot\\n' ]
+                    else:
+                        commandArray += [ '-autoboot_delay',  '3',  '-autoboot_command', '*cat\\n*exec !boot\\n' ]
+                # fm7 boots floppies, needs cassette loading
+                if system.name == "fm7" and system.isOptSet("altromtype") and system.config["altromtype"] == "cass":
+                    commandArray += [ '-autoboot_delay', '5', '-autoboot_command', 'LOADM”“,,R\\n' ]
+                # Alternate ROM type for systems with mutiple media (ie cassette & floppy)
+                if system.isOptSet("altromtype"):
+                    commandArray += [ "-" + system.config["altromtype"] ]
+                else:
+                    commandArray += [ "-" + messRomType[messMode] ]
+                # Use the full filename for MESS ROMs
                 commandArray += [ rom ]
         
         
         # config file
         config = minidom.Document()
-        configFile = "/userdata/system/configs/mame/default.cfg"
+        configFile = cfgPath + "default.cfg"
         if os.path.exists(configFile):
             try:
                 config = minidom.parse(configFile)
             except:
                 pass # reinit the file
-
-        MameGenerator.generatePadsConfig(config, playersControllers, system.name)
+        
+        # Alternate D-Pad Mode
+        if system.isOptSet("altdpad"):
+            dpadMode = system.config["altdpad"]
+        else:
+            dpadMode = 0
+        
+        if messMode == -1:
+            MameGenerator.generatePadsConfig(config, playersControllers, "", dpadMode, cfgPath)
+        else:
+            MameGenerator.generatePadsConfig(config, playersControllers, messSysName[messMode], dpadMode, cfgPath)
 
         # save the config file
         #mameXml = open(configFile, "w")
@@ -209,7 +263,7 @@ class MameGenerator(Generator):
             old.unlink()
 
     @staticmethod
-    def generatePadsConfig(config, playersControllers, sysName):
+    def generatePadsConfig(config, playersControllers, sysName, dpadMode, cfgPath):
         mappings = {
             "JOYSTICK_UP":    "joystick1up",
             "JOYSTICK_DOWN":  "joystick1down",
@@ -247,8 +301,36 @@ class MameGenerator(Generator):
         MameGenerator.removeSection(config, xml_system, "input")
         xml_input = config.createElement("input")
         xml_system.appendChild(xml_input)
-
+        
+        # Open or create alternate config file for systems with special controllers/settings
+        # If the system/game is set to per game config, don't try to open/reset an existing file, only write if it's blank or going to the shared cfg folder
+        if sysName in ("cdimono1", "apfm1000", "astrocde", "adam", "arcadia", "gamecom", "tutor", "crvision", "bbcb"):
+            config_alt = minidom.Document()
+            configFile_alt = cfgPath + sysName + ".cfg"
+            if os.path.exists(configFile_alt) and cfgPath == "/userdata/system/configs/mame/":
+                writeConfig = True
+                try:
+                    config_alt = minidom.parse(configFile_alt)
+                except:
+                    pass # reinit the file
+            elif not os.path.exists(configFile_alt):
+                writeConfig = True
+            else:
+                writeConfig = False
+                try:
+                    config_alt = minidom.parse(configFile_alt)
+                except:
+                    pass # reinit the file
+            xml_mameconfig_alt = MameGenerator.getRoot(config_alt, "mameconfig")
+            xml_system_alt = MameGenerator.getSection(config_alt, xml_mameconfig_alt, "system")
+            xml_system_alt.setAttribute("name", sysName)
+            
+            MameGenerator.removeSection(config_alt, xml_system_alt, "input")
+            xml_input_alt = config_alt.createElement("input")
+            xml_system_alt.appendChild(xml_input_alt)
+        
         nplayer = 1
+        maxplayers = len(playersControllers)
         for playercontroller, pad in sorted(playersControllers.items()):
             mappings_use = mappings
             if "joystick1up" not in pad.inputs:
@@ -259,52 +341,226 @@ class MameGenerator(Generator):
                 
             for mapping in mappings_use:
                 if mappings_use[mapping] in pad.inputs:
-                    xml_input.appendChild(MameGenerator.generatePortElement(config, nplayer, pad.index, mapping, mappings_use[mapping], pad.inputs[mappings_use[mapping]], False))
+                    xml_input.appendChild(MameGenerator.generatePortElement(config, nplayer, pad.index, mapping, mappings_use[mapping], pad.inputs[mappings_use[mapping]], False, dpadMode))
                 else:
                     rmapping = MameGenerator.reverseMapping(mappings_use[mapping])
                     if rmapping in pad.inputs:
-                        xml_input.appendChild(MameGenerator.generatePortElement(config, nplayer, pad.index, mapping, mappings_use[mapping], pad.inputs[rmapping], True))
+                        xml_input.appendChild(MameGenerator.generatePortElement(config, nplayer, pad.index, mapping, mappings_use[mapping], pad.inputs[rmapping], True, dpadMode))
                 
             # Special case for CD-i - doesn't use default controls, map special controller
             # Keep orginal mapping functions for menus etc, create system-specific config file dor CD-i.
-            # Possibly spin this off into another routine if we need to re-use this for other systems with special control configs.
-            if nplayer == 1 and sysName == "cdi":
-                # Open/create CD-i config file
-                config_cdi = minidom.Document()
-                configFile_cdi = "/userdata/system/configs/mame/cdimono1.cfg"
-                if os.path.exists(configFile_cdi):
-                    try:
-                        config_cdi = minidom.parse(configFile_cdi)
-                    except:
-                        pass # reinit the file
-                xml_mameconfig_cdi = MameGenerator.getRoot(config_cdi, "mameconfig")
-                xml_system_cdi = MameGenerator.getSection(config_cdi, xml_mameconfig_cdi, "system")
-                xml_system_cdi.setAttribute("name", "cdimono1")
-                
-                MameGenerator.removeSection(config_cdi, xml_system_cdi, "input")
-                xml_input_cdi = config_cdi.createElement("input")
-                xml_system_cdi.appendChild(xml_input_cdi)
-                
-                xml_input_cdi.appendChild(MameGenerator.generateSpecialPortElement(config_cdi, ':slave_hle:MOUSEBTN', nplayer, pad.index, "P1_BUTTON1", int(pad.inputs["b"].id) + 1, "1", "0"))
-                xml_input_cdi.appendChild(MameGenerator.generateSpecialPortElement(config_cdi, ':slave_hle:MOUSEBTN', nplayer, pad.index, "P1_BUTTON2", int(pad.inputs["y"].id) + 1, "2", "0"))
-                xml_input_cdi.appendChild(MameGenerator.generateIncDecPortElement(config_cdi, ':slave_hle:MOUSEX', nplayer, pad.index, "P1_MOUSE_X", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15", "1023", "0", "10"))
-                xml_input_cdi.appendChild(MameGenerator.generateIncDecPortElement(config_cdi, ':slave_hle:MOUSEY', nplayer, pad.index, "P1_MOUSE_Y", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "1023", "0", "10"))
+            if nplayer == 1 and sysName == "cdimono1":
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':slave_hle:MOUSEBTN', nplayer, pad.index, "P1_BUTTON1", int(pad.inputs["b"].id) + 1, "1", "0"))
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':slave_hle:MOUSEBTN', nplayer, pad.index, "P1_BUTTON2", int(pad.inputs["y"].id) + 1, "2", "0"))
+                if dpadMode == 0:
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEX', nplayer, pad.index, "P1_MOUSE_X", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT", "1023", "0", "10"))
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEY', nplayer, pad.index, "P1_MOUSE_Y", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP", "1023", "0", "10"))
+                elif dpadMode == 1:
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEX', nplayer, pad.index, "P1_MOUSE_X", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15", "1023", "0", "10"))
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEY', nplayer, pad.index, "P1_MOUSE_Y", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "1023", "0", "10"))
+                else:
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEX', nplayer, pad.index, "P1_MOUSE_X", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON12", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON11", "1023", "0", "10"))
+                    xml_input_alt.appendChild(MameGenerator.generateIncDecPortElement(config_alt, ':slave_hle:MOUSEY', nplayer, pad.index, "P1_MOUSE_Y", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "1023", "0", "10"))
                 
                 #Hide LCD display
-                MameGenerator.removeSection(config_cdi, xml_system_cdi, "video")
-                xml_video_cdi = config_cdi.createElement("video")                
-                xml_system_cdi.appendChild(xml_video_cdi)
+                MameGenerator.removeSection(config_alt, xml_system_alt, "video")
+                xml_video_alt = config_alt.createElement("video")                
+                xml_system_alt.appendChild(xml_video_alt)
                 
-                xml_screencfg_cdi = config_cdi.createElement("target")
-                xml_screencfg_cdi.setAttribute("index", "0")
-                xml_screencfg_cdi.setAttribute("view", "Main Screen Standard (4:3)")
-                xml_video_cdi.appendChild(xml_screencfg_cdi)
+                xml_screencfg_alt = config_alt.createElement("target")
+                xml_screencfg_alt.setAttribute("index", "0")
+                xml_screencfg_alt.setAttribute("view", "Main Screen Standard (4:3)")
+                xml_video_alt.appendChild(xml_screencfg_alt)
                 
-                # Write CD-i config
-                mameXml_cdi = codecs.open(configFile_cdi, "w", "utf-8")
-                dom_string_cdi = os.linesep.join([s for s in config_cdi.toprettyxml().splitlines() if s.strip()]) # remove ugly empty lines while minicom adds them...
-                mameXml_cdi.write(dom_string_cdi)
+            # Special case for APFM1000 - uses numpad controllers
+            if nplayer <= 2 and sysName == "apfm1000":
+                if nplayer == 1:
+                    # Based on Colecovision button mapping, changed slightly since Enter = Fire
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "OTHER", int(pad.inputs["a"].id) + 1, "32", "32"))        # Clear
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "OTHER", int(pad.inputs["b"].id) + 1, "32", "32"))        # Enter/Fire
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "OTHER", int(pad.inputs["x"].id) + 1, "16", "16"))        # 1
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "OTHER", int(pad.inputs["y"].id) + 1, "16", "16"))        # 2
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "OTHER", int(pad.inputs["pagedown"].id) + 1, "16", "16")) # 3
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "OTHER", int(pad.inputs["pageup"].id) + 1, "64", "64"))   # 4
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "OTHER", int(pad.inputs["r2"].id) + 1, "64", "64"))       # 5
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "OTHER", int(pad.inputs["l2"].id) + 1, "64", "64"))       # 6
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "OTHER", int(pad.inputs["r3"].id) + 1, "128", "128"))     # 7
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "OTHER", int(pad.inputs["l3"].id) + 1, "128", "128"))     # 8
+                    xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy.2', "OTHER", "5", "128", "128"))                                                  # 9
+                    xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy.0', "OTHER", "1", "32", "32"))                                                    # 0
+                elif nplayer == 2:
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["a"].id) + 1, "2", "2"))        # Clear
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["b"].id) + 1, "2", "2"))        # Enter/Fire
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["x"].id) + 1, "1", "1"))        # 1
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["y"].id) + 1, "1", "1"))        # 2
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["pagedown"].id) + 1, "1", "1")) # 3
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["pageup"].id) + 1, "4", "4"))   # 4
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["r2"].id) + 1, "4", "4"))       # 5
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.2', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["l2"].id) + 1, "4", "4"))       # 6
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.0', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["r3"].id) + 1, "8", "8"))       # 7
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy.3', nplayer, pad.index, "TYPE_OTHER(243,1)", int(pad.inputs["l3"].id) + 1, "8", "8"))       # 8
+                    xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy.2', "TYPE_OTHER(243,1)", "6", "8", "8"))                                                    # 9
+                    xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy.0', "TYPE_OTHER(243,1)", "2", "2", "2"))                                                    # 0
+            # Special case for Astrocade - numpad on console
+            if nplayer == 1 and sysName == "astrocde":
+                # Based on Colecovision button mapping, keypad is on the console
+                # A auto maps to Fire, using B for 0, Select for 9, Start for = (which is the "enter" key)
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD2', nplayer, pad.index, "KEYPAD", int(pad.inputs["b"].id) + 1, "32", "0"))        # 0
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD3', nplayer, pad.index, "KEYPAD", int(pad.inputs["x"].id) + 1, "16", "0"))        # 1
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD2', nplayer, pad.index, "KEYPAD", int(pad.inputs["y"].id) + 1, "16", "0"))        # 2
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD1', nplayer, pad.index, "KEYPAD", int(pad.inputs["pagedown"].id) + 1, "16", "0")) # 3
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD3', nplayer, pad.index, "KEYPAD", int(pad.inputs["pageup"].id) + 1, "8", "0"))    # 4
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD2', nplayer, pad.index, "KEYPAD", int(pad.inputs["r2"].id) + 1, "8", "0"))        # 5
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD1', nplayer, pad.index, "KEYPAD", int(pad.inputs["l2"].id) + 1, "8", "0"))        # 6
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD3', nplayer, pad.index, "KEYPAD", int(pad.inputs["r3"].id) + 1, "4", "0"))        # 7
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':KEYPAD2', nplayer, pad.index, "KEYPAD", int(pad.inputs["l3"].id) + 1, "4", "0"))        # 8
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':KEYPAD1', "KEYPAD", "6", "4", "0"))                                                     # 9
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':KEYPAD0', "KEYPAD", "1", "32", "0"))                                                    # = (Start)
+            
+            # Special case for Adam - numpad
+            if nplayer == 1 and sysName == "adam":
+                # Based on Colecovision button mapping - not enough buttons to map 0 & 9
+                # Fire 1 & 2 map to A & B
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["x"].id) + 1, "2", "2"))          # 1
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["a"].id) + 1, "4", "4"))          # 2
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["pagedown"].id) + 1, "8", "8"))   # 3
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["pageup"].id) + 1, "16", "16"))   # 4
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["r2"].id) + 1, "32", "32"))       # 5
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["l2"].id) + 1, "64", "64"))       # 6
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["r3"].id) + 1, "128", "128"))     # 7
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["l3"].id) + 1, "512", "512"))     # 8
+                # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", int(pad.inputs["l3"].id) + 1, "128", "128"))     9
+                # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':joy1:hand:KEYPAD', nplayer, pad.index, "KEYPAD", , "1", ""))                                      0                
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy1:hand:KEYPAD', "KEYPAD", "1", "1024", "0"))                                                   # #
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':joy1:hand:KEYPAD', "KEYPAD", "5", "2048", "0"))                                                   # *
+            
+            # Special case for Arcadia
+            if nplayer <= 2 and sysName == "arcadia":
+                if nplayer == 1:
+                    # Based on Colecovision button mapping - not enough buttons to map clear, enter
+                    # No separate fire button, Start + Select on console (automapped), Option button also on console.
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["a"].id) + 1, "8", "0"))        # 1
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["b"].id) + 1, "8", "0"))        # 2
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["x"].id) + 1, "8", "0"))        # 3
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["y"].id) + 1, "4", "0"))        # 4
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["pagedown"].id) + 1, "4", "0")) # 5
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["pageup"].id) + 1, "4", "0"))   # 6
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["r2"].id) + 1, "2", "0"))       # 7
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["l2"].id) + 1, "2", "0"))       # 8
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["r3"].id) + 1, "2", "0"))       # 9
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["l3"].id) + 1, "1", "0"))       # 0
+                    # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col1', nplayer, pad.index, "KEYPAD", , "1", "0"))                                 # Clear
+                    # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col3', nplayer, pad.index, "KEYPAD", , "1", "0"))                                 # Enter
+                elif nplayer == 2:
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["a"].id) + 1, "8", "0"))        # 1
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["b"].id) + 1, "8", "0"))        # 2
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["x"].id) + 1, "8", "0"))        # 3
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["y"].id) + 1, "4", "0"))        # 4
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["pagedown"].id) + 1, "4", "0")) # 5
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["pageup"].id) + 1, "4", "0"))   # 6
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col1', nplayer, pad.index, "KEYPAD", int(pad.inputs["r2"].id) + 1, "2", "0"))       # 7
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col2', nplayer, pad.index, "KEYPAD", int(pad.inputs["l2"].id) + 1, "2", "0"))       # 8
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["r3"].id) + 1, "2", "0"))       # 9
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller2_col3', nplayer, pad.index, "KEYPAD", int(pad.inputs["l3"].id) + 1, "1", "0"))       # 0
+                    # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col1', nplayer, pad.index, "KEYPAD", , "1", "0"))                                 # Clear
+                    # xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':controller1_col3', nplayer, pad.index, "KEYPAD", , "1", "0"))                                 # Enter
+            
+            # Special case for Gamecom - buttons don't map normally
+            if nplayer == 1 and sysName == "gamecom":
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':IN0', nplayer, pad.index, "P1_BUTTON1", int(pad.inputs["y"].id) + 1, "128", "128")) # A
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':IN1', nplayer, pad.index, "P1_BUTTON2", int(pad.inputs["x"].id) + 1, "1", "1"))     # B
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':IN1', nplayer, pad.index, "P1_BUTTON3", int(pad.inputs["b"].id) + 1, "2", "2"))     # C
+                xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':IN2', nplayer, pad.index, "P1_BUTTON4", int(pad.inputs["a"].id) + 1, "2", "2"))     # D
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':IN0', "OTHER", "5", "16", "16"))                                                    # Menu
+                xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':IN0', "OTHER", "1", "32", "32"))                                                    # Pause
+            
+            # Special case for Tomy Tutor - directions don't map normally
+            # Also maps arrow keys to directional input & enter to North button to get through the initial menu without a keyboard
+            if nplayer <= 2 and sysName == "tutor":
+                if nplayer == 1:
+                    if dpadMode == 0:
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN", "16", "0"))     # Down
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT", "128", "0")) # Right
+                    elif dpadMode == 1:
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "16", "0"))     # Down
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16", "128", "0")) # Right
+                    else:                        
+                        xml_input_dChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON11", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE4_alt', nplayer, pad.index, "P1_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON12", "128", "0")) # Right
+                    xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':LINE6', pad.index, "KEYBOARD", "ENTER", int(pad.inputs["a"].id) + 1, "16", "0"))      # Enter Key
+                    xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':LINE7', pad.index, "KEYBOARD", "DOWN", int(pad.inputs["pagedown"].id) + 1, "4", "0")) # Down Arrow
+                elif nplayer == 2:
+                    if dpadMode == 0:
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN", "16", "0"))     # Down
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT", "128", "0")) # Right
+                    elif dpadMode == 1:
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "16", "0"))     # Down
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16", "128", "0")) # Right
+                    else:
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "16", "0"))     # Down
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON11", "32", "0"))     # Left
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "64", "0"))           # Up
+                        xml_input_alt.appendChild(MameGenerator.generateDirectionPortElement(config_alt, ':LINE2_alt', nplayer, pad.index, "P2_JOYSTICK_RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON12", "128", "0")) # Right
+            
+            # Special case for crvision - maps the 4 corner buttons + 2nd from upper right since MAME considers that button 2.
+            if nplayer <= 2 and sysName == "crvision":
+                if nplayer == 1:
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA1.7', nplayer, pad.index, "P1_BUTTON1", int(pad.inputs["y"].id) + 1, "128", "128"))  # P1 Button 1 (Shift)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA0.7', nplayer, pad.index, "P1_BUTTON2", int(pad.inputs["x"].id) + 1, "128", "128"))  # P1 Button 2 (Control)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA0.2', nplayer, pad.index, "KEYBOARD", int(pad.inputs["pagedown"].id) + 1, "8", "8")) # P1 Upper Right (1)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA1.1', nplayer, pad.index, "KEYBOARD", int(pad.inputs["b"].id) + 1, "4", "4"))        # P1 Lower Left (B)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA1.4', nplayer, pad.index, "KEYBOARD", int(pad.inputs["a"].id) + 1, "64", "64"))      # P1 Lower Right (6)
+                    xml_input_alt.appendChild(MameGenerator.generateKeycodePortElement(config_alt, ':NMI', "P1_START", "1", "1", "0"))                                                      # Reset/Start
+                elif nplayer == 2:
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA3.7', nplayer, pad.index, "P2_BUTTON1", int(pad.inputs["y"].id) + 1, "128", "128"))  # P2 Button 1 (-/=)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA2.7', nplayer, pad.index, "P2_BUTTON2", int(pad.inputs["x"].id) + 1, "128", "128"))  # P2 Button 2 (Right)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA2.2', nplayer, pad.index, "KEYBOARD", int(pad.inputs["pagedown"].id) + 1, "8", "8")) # P2 Upper Right (Space)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA3.1', nplayer, pad.index, "KEYBOARD", int(pad.inputs["b"].id) + 1, "4", "4"))        # P2 Lower Left (7)
+                    xml_input_alt.appendChild(MameGenerator.generateSpecialPortElement(config_alt, ':PA3.1', nplayer, pad.index, "KEYBOARD", int(pad.inputs["a"].id) + 1, "64", "64"))      # P2 Lower Right (N)
+            
+            # BBC Micro - joystick not emulated/supported for most games, map some to gamepad
+            if nplayer == 1 and sysName == "bbcb":
+                xml_kbenable_alt = config_alt.createElement("keyboard")
+                xml_kbenable_alt.setAttribute("tag", ":")
+                xml_kbenable_alt.setAttribute("enabled", "1")
+                xml_input_alt.appendChild(xml_kbenable_alt)
+                xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':COL8', pad.index, "KEYBOARD", "QUOTE", int(pad.inputs["y"].id) + 1, "64", "64"))        # *
+                xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':COL8', pad.index, "KEYBOARD", "SLASH", int(pad.inputs["x"].id) + 1, "16", "16"))        # ?
+                xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':COL1', pad.index, "KEYBOARD", "Z", int(pad.inputs["b"].id) + 1, "64", "64"))            # Z
+                xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':COL2', pad.index, "KEYBOARD", "X", int(pad.inputs["a"].id) + 1, "16", "16"))            # X
+                xml_input_alt.appendChild(MameGenerator.generateComboPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "ENTER", int(pad.inputs["pagedown"].id) + 1, "16", "16")) # Enter
+                if dpadMode == 0:
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN", "4", "4"))       # Down
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT", "2", "2"))       # Left
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP", "8", "8"))           # Up
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT", "128", "128")) # Right
+                elif dpadMode == 1:
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "4", "4"))       # Down
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15", "2", "2"))       # Left
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "8", "8"))           # Up
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16", "128", "128")) # Right
+                else:
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "DOWN", "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14", "4", "4"))       # Down
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "LEFT", "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON11", "2", "2"))       # Left
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "UP", "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13", "8", "8"))           # Up
+                    xml_input_alt.appendChild(MameGenerator.generateComboDirPortElement(config_alt, ':COL9', pad.index, "KEYBOARD", "RIGHT", "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON12", "128", "128")) # Right
+            
             nplayer = nplayer + 1
+            
+        # Write alt config (if used, custom config is turned off or file doesn't exist yet)
+        if sysName in ("cdimono1", "apfm1000", "astrocde", "adam", "arcadia", "gamecom", "tutor", "crvision", "bbcb") and writeConfig:
+            mameXml_alt = codecs.open(configFile_alt, "w", "utf-8")
+            dom_string_alt = os.linesep.join([s for s in config_alt.toprettyxml().splitlines() if s.strip()]) # remove ugly empty lines while minicom adds them...
+            mameXml_alt.write(dom_string_alt)
 
     @staticmethod
     def reverseMapping(key):
@@ -319,17 +575,20 @@ class MameGenerator(Generator):
         return None
 
     @staticmethod
-    def generatePortElement(config, nplayer, padindex, mapping, key, input, reversed):
+    def generatePortElement(config, nplayer, padindex, mapping, key, input, reversed, dpadMode):
+        # Generic input
         xml_port = config.createElement("port")
         xml_port.setAttribute("type", "P{}_{}".format(nplayer, mapping))
         xml_newseq = config.createElement("newseq")
         xml_newseq.setAttribute("type", "standard")
         xml_port.appendChild(xml_newseq)
-        value = config.createTextNode(MameGenerator.input2definition(key, input, padindex + 1, reversed))
+        value = config.createTextNode(MameGenerator.input2definition(key, input, padindex + 1, reversed, dpadMode))
         xml_newseq.appendChild(value)
         return xml_port
 
+    @staticmethod
     def generateSpecialPortElement(config, tag, nplayer, padindex, mapping, key, mask, default):
+        # Special button input (ie mouse button to gamepad)
         xml_port = config.createElement("port")
         xml_port.setAttribute("tag", tag)
         xml_port.setAttribute("type", mapping)
@@ -342,7 +601,69 @@ class MameGenerator(Generator):
         xml_newseq.appendChild(value)
         return xml_port
 
+    @staticmethod
+    def generateKeycodePortElement(config, tag, mapping, key, mask, default):
+        # Map a keyboard key instead of a button (for start/select due to auto pad2key)
+        xml_port = config.createElement("port")
+        xml_port.setAttribute("tag", tag)
+        xml_port.setAttribute("type", mapping)
+        xml_port.setAttribute("mask", mask)
+        xml_port.setAttribute("defvalue", default)
+        xml_newseq = config.createElement("newseq")
+        xml_newseq.setAttribute("type", "standard")
+        xml_port.appendChild(xml_newseq)
+        value = config.createTextNode("KEYCODE_{}".format(key))
+        xml_newseq.appendChild(value)
+        return xml_port
+
+    @staticmethod
+    def generateComboPortElement(config, tag, padindex, mapping, key, button, mask, default):
+        # Maps a keycode + button - for important keyboard keys when available
+        xml_port = config.createElement("port")
+        xml_port.setAttribute("tag", tag)
+        xml_port.setAttribute("type", mapping)
+        xml_port.setAttribute("mask", mask)
+        xml_port.setAttribute("defvalue", default)
+        xml_newseq = config.createElement("newseq")
+        xml_newseq.setAttribute("type", "standard")
+        xml_port.appendChild(xml_newseq)
+        value = config.createTextNode("KEYCODE_{} OR JOYCODE_{}_BUTTON{}".format(key, padindex + 1, button))
+        xml_newseq.appendChild(value)
+        return xml_port
+
+    @staticmethod
+    def generateComboDirPortElement(config, tag, padindex, mapping, key, buttontext, mask, default):
+        # Maps a keyboard key + directional input - for keyboard arrow keys
+        xml_port = config.createElement("port")
+        xml_port.setAttribute("tag", tag)
+        xml_port.setAttribute("type", mapping)
+        xml_port.setAttribute("mask", mask)
+        xml_port.setAttribute("defvalue", default)
+        xml_newseq = config.createElement("newseq")
+        xml_newseq.setAttribute("type", "standard")
+        xml_port.appendChild(xml_newseq)
+        value = config.createTextNode("KEYCODE_{} OR ".format(key) + buttontext.format(padindex + 1, padindex + 1, padindex + 1))
+        xml_newseq.appendChild(value)
+        return xml_port
+
+    @staticmethod
+    def generateDirectionPortElement(config, tag, nplayer, padindex, mapping, key, mask, default):
+        # Special direction mapping for emulated controllers
+        xml_port = config.createElement("port")
+        xml_port.setAttribute("tag", tag)
+        xml_port.setAttribute("type", mapping)
+        xml_port.setAttribute("mask", mask)
+        xml_port.setAttribute("defvalue", default)
+        xml_newseq = config.createElement("newseq")
+        xml_newseq.setAttribute("type", "standard")
+        xml_port.appendChild(xml_newseq)
+        value = config.createTextNode(key.format(padindex + 1, padindex + 1, padindex + 1))
+        xml_newseq.appendChild(value)
+        return xml_port
+
+    @staticmethod
     def generateIncDecPortElement(config, tag, nplayer, padindex, mapping, inckey, deckey, mask, default, delta):
+        # Mapping analog to digital (mouse, etc)
         xml_port = config.createElement("port")
         xml_port.setAttribute("tag", tag)
         xml_port.setAttribute("type", mapping)
@@ -362,7 +683,7 @@ class MameGenerator(Generator):
         return xml_port
 
     @staticmethod
-    def input2definition(key, input, joycode, reversed):
+    def input2definition(key, input, joycode, reversed, dpadMode):
         if input.type == "button":
             return "JOYCODE_{}_BUTTON{}".format(joycode, int(input.id)+1)
         elif input.type == "hat":
@@ -376,13 +697,29 @@ class MameGenerator(Generator):
                 return "JOYCODE_{}_HAT1LEFT".format(joycode)
         elif input.type == "axis":
             if key == "joystick1up" or key == "up":
-                return "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13".format(joycode, joycode, joycode)
+                if dpadMode == 0:
+                    return "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP".format(joycode, joycode)
+                else:
+                    return "JOYCODE_{}_YAXIS_UP_SWITCH OR JOYCODE_{}_HAT1UP OR JOYCODE_{}_BUTTON13".format(joycode, joycode, joycode)
             if key == "joystick1down" or key == "down":
-                return "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14".format(joycode, joycode, joycode)
+                if dpadMode == 0:
+                    return "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN".format(joycode, joycode)
+                else:
+                    return "JOYCODE_{}_YAXIS_DOWN_SWITCH OR JOYCODE_{}_HAT1DOWN OR JOYCODE_{}_BUTTON14".format(joycode, joycode, joycode)
             if key == "joystick1left" or key == "left":
-                return "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15".format(joycode, joycode, joycode)
+                if dpadMode == 0:
+                    return "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT".format(joycode, joycode)
+                elif dpadMode == 1:
+                    return "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON15".format(joycode, joycode, joycode)
+                else:
+                    return "JOYCODE_{}_YAXIS_LEFT_SWITCH OR JOYCODE_{}_HAT1LEFT OR JOYCODE_{}_BUTTON11".format(joycode, joycode, joycode)
             if key == "joystick1right" or key == "right":
-                return "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16".format(joycode, joycode, joycode)
+                if dpadMode == 0:
+                    return "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT".format(joycode, joycode)
+                elif dpadMode == 1:
+                    return "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON16".format(joycode, joycode, joycode)
+                else:
+                    return "JOYCODE_{}_YAXIS_RIGHT_SWITCH OR JOYCODE_{}_HAT1RIGHT OR JOYCODE_{}_BUTTON12".format(joycode, joycode, joycode)
             if key == "joystick2up":
                 return "JOYCODE_{}_RYAXIS_NEG_SWITCH OR JOYCODE_{}_BUTTON4".format(joycode, joycode)
             if key == "joystick2down":

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -25,3 +25,54 @@ cdi:
 advision:
   emulator: mame
   core:     mame
+tvgames:
+  emulator: mame
+  core:     mame
+megaduck:
+  emulator: mame
+  core:     mame
+pv1000:
+  emulator: mame
+  core:     mame
+gamate:
+  emulator: mame
+  core:     mame
+crvision:
+  emulator: mame
+  core:     mame
+gamecom:
+  emulator: mame
+  core:     mame
+fm7:
+  emulator: mame
+  core:     mame
+gamepock:
+  emulator: mame
+  core:     mame
+apfm1000:
+  emulator: mame
+  core:     mame
+bbc:
+  emulator: mame
+  core:     mame
+adam:
+  emulator: mame
+  core:     mame
+arcadia:
+  emulator: mame
+  core:     mame
+gmaster:
+  emulator: mame
+  core:     mame
+astrocde:
+  emulator: mame
+  core:     mame
+ti99:
+  emulator: mame
+  core:     mame
+tutor:
+  emulator: mame
+  core:     mame
+coco:
+  emulator: mame
+  core:     mame

--- a/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
+++ b/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
@@ -363,9 +363,9 @@ class EsSystemConf:
                 if not firstExt:
                     extension += " "
                 firstExt = False
-                extension += "." + item.lower()
+                extension += "." + str(item).lower()
                 if uppercase == True:
-                    extension += " ." + item.upper()
+                    extension += " ." + str(item).upper()
         return extension
 
     # Returns group to emulator rom folder

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4045,6 +4045,185 @@ mame:
                 "Off":             null
                 "Rotate 90":       autoror
                 "Rotate 270":      autorol
+        altdpad:
+            prompt:      ALT DPAD MODE
+            description: If the D-Pad does not work properly
+            choices:
+                "Off (Default)":    0
+                "DS3 Orientation":  1
+                "X360 Orientation": 2
+  systems:
+       apfm1000:
+            cfeatures:
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       arcadia:
+            cfeatures:
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       astrocde:
+            cfeatures:
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       crvision:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Cartridge default)
+                    choices:
+                        "Cartridge":   cart
+                        "Cassette":    cass
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       fm7:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Disk 1 default)
+                    choices:
+                        "Cassette":       cass
+                        "Disk (Drive 1)": flop1
+                        "Disk (Drive 2)": flop2
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       bbc:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Floppy 1 default)
+                    choices:
+                        "Cassette":       cass
+                        "ROM (Slot 1)":   rom1
+                        "ROM (Slot 2)":   rom2
+                        "ROM (Slot 3)":   rom3
+                        "ROM (Slot 4)":   rom4
+                        "Disk (Drive 1)": flop1
+                        "Disk (Drive 2)": flop2
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       adam:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Cassette 1 default)
+                    choices:
+                        "Cassette 1":         cass1
+                        "Cassette 2":         cass2
+                        "Disk (Drive 1)":     flop1
+                        "Disk (Drive 2)":     flop2
+                        "Cartridge (Slot 1)": cart1
+                        "Cartridge (Slot 2)": cart2
+                        "Cartridge (Slot 3)": cart3
+                        "Cartridge (Slot 4)": cart4
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       ti99:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Cartridge default)
+                    choices:
+                        "Cassette 1":  cass1
+                        "Cassette 2":  cass2
+                        "Cartridge":   cart
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       tutor:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Cartridge default)
+                    choices:
+                        "Cassette":    cass
+                        "Cartridge":   cart
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
+       coco:
+            cfeatures:
+                altromtype:
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file (Cartridge default)
+                    choices:
+                        "Cassette":    cass
+                        "Cartridge":   cart
+                enableui:
+                    prompt:      UI KEYS
+                    description: Hotkey + D-Pad Up or Scroll Lock to toggle in game
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    prompt:      CUSTOM CONFIG
+                    description: Enable per-game custom configuration via MAME menu
+                    choices:
+                        "On":  1
+                        "Off": 0
 
 wine:
   features: [padtokeyboard]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2226,7 +2226,7 @@ bbc:
 adam:
   name:       Coleco ADAM
   manufacturer: Coleco
-  release: 1982
+  release: 1983
   hardware: computer
   extensions: [wav, ddp, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, rom, col, bin, zip, 7z]
   emulators:

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2108,6 +2108,206 @@ advision:
   comment_en: |
           Requires MAME BIOS file advision.zip or .7z in either advision or BIOS folder.
 
+tvgames:
+  name:       TV Games
+  manufacturer: Various
+  release: 2002
+  hardware: console
+  extensions: [zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+
+megaduck:
+  name:       Mega Duck
+  manufacturer: Welback Holdings
+  release: 1993
+  hardware: portable
+  extensions:  [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+
+pv1000:
+  name:       PV-1000
+  manufacturer: Casio
+  release: 1983
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+
+gamate:
+  name:       Gamate
+  manufacturer: Bitcorp
+  release: 1990
+  hardware: portable
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file gamate.zip or .7z in either gamate or BIOS folder.
+
+crvision:
+  name:       CreatiVision
+  manufacturer: VTech
+  release: 1982
+  hardware: console
+  extensions: [bin, rom, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file crvision.zip or .7z in either crvision or BIOS folder.
+
+gamecom:
+  name:       Game.com
+  manufacturer: Tiger Electronics
+  release: 1997
+  hardware: portable
+  extensions: [bin, tgc, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file gamecom.zip or .7z in either gamecom or BIOS folder.
+
+gamepock:
+  name:       Game Pocket Computer
+  manufacturer: Epoch
+  release: 1984
+  hardware: portable
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file gamepock.zip or .7z in either gamepock or BIOS folder.
+
+fm7:
+  name:       FM-7
+  manufacturer: Fujitsu
+  release: 1982
+  hardware: computer
+  extensions: [wav, t77, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file fm7.zip or .7z in either fm7 or BIOS folder.
+
+apfm1000:
+  name:       APF M-1000
+  manufacturer: APF Electronics
+  release: 1978
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file apfm1000.zip or .7z in either apfm or BIOS folder.
+
+bbc:
+  name:       BBC Micro
+  manufacturer: Acorn
+  release: 1981
+  hardware: computer
+  extensions: [mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, ima, img, ufi, 360, ipf, ssd, bbc, dsd, adf, ads, adm, adl, fsd, wav, tap, bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS files bbcb, bbc_acorn8271, & saa5050.zip or .7z in either bbc or BIOS folder.
+          Also sample pack bbc.zip or .7z in BIOS/mame/samples
+
+adam:
+  name:       Coleco ADAM
+  manufacturer: Coleco
+  release: 1982
+  hardware: computer
+  extensions: [wav, ddp, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, rom, col, bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires the following MAME BIOS files as zip or 7z in the adam or BIOS folder:
+          adam, adam_ddp, adam_fdc, adam_kb, & adam_prn
+
+arcadia:
+  name:       Arcadia 2001
+  manufacturer: Emerson
+  release: 1982
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+
+gmaster:
+  name:       Game Master
+  manufacturer: Hartung
+  release: 1990
+  hardware: portable
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file gmaster.zip or .7z in either gmaster or BIOS folder.
+
+astrocde:
+  name:       Astrocade
+  manufacturer: Bally
+  release: 1978
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file astrocde.zip or .7z in either astrocde or BIOS folder.
+
+ti99:
+  name:       TI-99
+  manufacturer: Texas Instruments
+  release: 1981
+  hardware: computer
+  extensions: [rpk, wav, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file ti99_4a.zip or .7z in either ti99 or BIOS folder.
+          Cartridges need to be in .rpk format and unzipped - the MAME software list files (.bin) will not run properly.
+
+tutor:
+  name:       Tomy Tutor
+  manufacturer: Tomy
+  release: 1983
+  hardware: computer
+  extensions: [bin, wav, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file tutor.zip or .7z in either tutor or BIOS folder.
+          To get through the loading menu, R1 will move down and A/East will select.
+
+coco:
+  name:       Color Computer
+  manufacturer: Tandy Radio Shack
+  release: 1980
+  hardware: computer
+  extensions: [wav, cas, ccc, rom, zip, 7z]
+  emulators:
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file coco.zip or .7z in either coco or BIOS folder.
+
 switch:
   name:       Switch
   manufacturer: Nintendo

--- a/package/batocera/emulators/mame/mame.mame.keys
+++ b/package/batocera/emulators/mame/mame.mame.keys
@@ -39,6 +39,11 @@
             "trigger": ["hotkey", "right"],
             "type": "key",
             "target": [ "KEY_PAGEDOWN" ]
+	},
+	{
+            "trigger": ["hotkey", "up"],
+            "type": "key",
+            "target": [ "KEY_SCROLLLOCK" ]
 	}
 
     ],

--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -218,6 +218,24 @@ define MAME_EVMAPY
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/cdi.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/lcdgames.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gameandwatch.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/tvgames.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/megaduck.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/crvision.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/pv1000.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gamate.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gamecom.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/fm7.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gamepock.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/apfm1000.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/bbc.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/adam.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/arcadia.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gmaster.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/astrocde.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/ti99.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/tutor.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/coco.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/socrates.mame.keys
 endef
 
 MAME_POST_INSTALL_TARGET_HOOKS += MAME_EVMAPY


### PR DESCRIPTION
* Adds additional systems - Creativision, Game.com, Gamate, FM-7, Game Pocket Computer, APF M-1000, BBC Micro, Adam, Arcadia 2001, Game Master, Astrocade, Tomy Tutor, Tandy Color Computer, TI-99, & Mega Duck
* Added special controller mapping as needed for non-standard inputs (keypads on controllers etc)
* Added auto commands for computers that require loading after launch
* Also adds TV Games system for P&P TV consoles
* Adds Media Type per-game option for systems with multiple media types (cassette, disk, cartridge, etc)
* Adds toggle for UI mode for keyboard-based MESS systems
* Maps UI mode toggle to hotkey+up & scroll lock
* Adds an option for per-game config for keyboard-based systems (uses MAME's internal menu & config, creates a folder and does not overwrite existing configs in it)
* Removed previous DS3 D-Pad fix, split into an option for MAME/MESS based systems - X360 dongle was outputting buttons on different button numbers and causing input issues.

There are a handful of systems that remain in the generator but not set as systems. Those had issues with emulation or launching games properly. The system definition can be re-added if the emulation improves.