### PR TITLE
increase default audio_latency on Pi 4

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -1,3 +1,7 @@
+default:
+  options:
+    audio_latency: 96
+
 nds:
   emulator: drastic
   core:     drastic


### PR DESCRIPTION
Users have reported slow-down/audio cutting with default audio latency on Pi 4. Increasing audio latency slightly fixes it.

Alternative solution might be to change audio driver for RPi family, but no testing has been done. This is a sufficient workaround for now.