### PR TITLE
Dolphin defaults adjustments

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -160,8 +160,8 @@ def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
 
 def generateControllerConfig_gamecube(system, playersControllers,rom):
     gamecubeMapping = {
-        'y':            'Buttons/Y',     'b':             'Buttons/B',
-        'x':            'Buttons/X',     'a':             'Buttons/A',
+        'y':            'Buttons/B',     'b':             'Buttons/A',
+        'x':            'Buttons/Y',     'a':             'Buttons/X',
         'pagedown':     'Buttons/Z',     'start':         'Buttons/Start',
         'l2':           'Triggers/L',    'r2':            'Triggers/R',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -166,13 +166,13 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
 
         # Ubershaders (synchronous_ubershader by default)
-        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "synchronous_ubershader":
-            if system.config["ubershaders"] == "asynchronous_ubershader":
+        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "synchronous":
+            if system.config["ubershaders"] == "synchronous_ubershader":
+                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"1"')
+            elif system.config["ubershaders"] == "asynchronous_ubershader":
                 dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"2"')
-            elif system.config["ubershaders"] == "synchronous":
-                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"0"')
         else:
-            dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"1"')
+            dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"0"')
 
         # Shader pre-caching
         if system.isOptSet('wait_for_shaders') and system.getOptBoolean('wait_for_shaders'):

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -25,3 +25,9 @@ cdi:
 advision:
   emulator: mame
   core:     mame
+gamecube:
+  options:
+    ubershaders: asynchronous_ubershader
+wii:
+  options:
+    ubershaders: asynchronous_ubershader

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3189,11 +3189,11 @@ dolphin:
                 "Vulkan": Vulkan
         ubershaders:
             prompt:      UBERSHADERS
-            description: Improve performance with Ubershaders (may not work on all hardware); asynchronous is preferred, synchronous is more compatible
+            description: Improve performance with Ubershaders (may not work well on all hardware); asynchronous is preferred, synchronous is more compatible
             choices:
                 "No Ubershaders":                          synchronous
-                "Ubershaders with synchronous (default)":  synchronous_ubershader
-                "Ubershaders with asynchronous":           asynchronous_ubershader
+                "Ubershaders (synchronous)":               synchronous_ubershader
+                "Ubershaders (asynchronous)":              asynchronous_ubershader
         wait_for_shaders:
             prompt:      PRE-CACHE SHADERS
             description: Wait for shaders to compile completely before starting the game, can reduce micro-freezes


### PR DESCRIPTION
More testing with the new Ubershader settings from other users have come in, there are some situations where extremely low-end hardware (such as integrated graphics, legacy GPUs, SBCs) exhibit _more_ stuttering with Ubershaders on (this is what Ubershaders is meant to be fighting against). In light of this, I have changed the default behaviour in the config generator to not use Ubershaders and have added an exception to x86_64's defaults to use Asynchronous Ubershaders. For reference, my testing for this setting was done on both a low-end Nvidia 750Ti and a mid-range AMD Radeon RX 580 GPU, both of which displayed no more stuttering when Ubershaders were enabled. It is still possible for users of those extremely low-end hardware to manually turn off Ubershaders if they want to, but the defaults should dramatically improve performance across the board for the massive majority of use cases. The label on this option should make that obvious enough.

Reverts controller layout changes made in https://github.com/batocera-linux/batocera.linux/pull/4826/files. After more research, it seems more logical to prioritise the physical layout of the buttons over Dolphin's defaults. Original reasoning here: https://discord.com/channels/357518249883205632/524321176068161554/903832439313551401 and the conclusion here: https://discord.com/channels/357518249883205632/524321176068161554/903965874493485056