### PR TITLE
FM-77AV Support

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -5,7 +5,7 @@
         * new language : hebrew
         * add: .gbc2 is now an additional acceptable extension for both GB2Player and GBC2Player dual-rom playlists
         * add: FSR & DLSS support for Wine (x86_64)
-		* add: Adventure Vision, CD-i, CreatiVision, PV-1000, Game.com, Gamate, TV Games (P&P Consoles), Fujitsu FM-7, Game Pocket Computer, APF M-1000, BBC Micro, Coleco ADAM, Arcadia 2001, Game Master, Bally Astrocade, TI-99, Tomy Tutor, Tandy Color Computer, & Mega Duck via MAME (x86_64)
+		* add: Adventure Vision, CD-i, CreatiVision, PV-1000, Game.com, Gamate, TV Games (P&P Consoles), Fujitsu FM-7/FM-77AV, Game Pocket Computer, APF M-1000, BBC Micro, Coleco ADAM, Arcadia 2001, Game Master, Bally Astrocade, TI-99, Tomy Tutor, Tandy Color Computer, & Mega Duck via MAME (x86_64)
 		* add: LCD Games system (MAME & lr-gw on x86_64, lr-gw on all others)
 		* add: Media Type option for MAME systems with multiple ROM types (floppy, CD, cassette, etc.) (x86_64)
 		* add: Toggle for UI mode in MAME via Hotkey + D-Pad Up or Scroll Lock, plus per-system/game setting for MAME computer systems (x86_64)

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4099,6 +4099,12 @@ mame:
                         "Off": 0
        fm7:
             cfeatures:
+                altmodel:
+                    prompt:      ALTERNATE MODEL
+                    description: Type of FM-7 to emulate
+                    choices:
+                        "FM-7":     fm7
+                        "FM-77AV":  fm77av
                 altromtype:
                     prompt:      MEDIA TYPE
                     description: Type of ROM file (Disk 1 default)

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2198,6 +2198,7 @@ fm7:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
           Requires MAME BIOS file fm7.zip or .7z in either fm7 or BIOS folder.
+          Optionally fm77av.zip or .7z for FM-77AV support.
 
 apfm1000:
   name:       APF M-1000


### PR DESCRIPTION
Adds the FM-77AV as an alternate model option under Fujitsu FM-7, since some games will only run on that model but it isn't emulated as accurately.