### PR TITLE
Enable Retroachievements activation per Retroarch core

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -33,7 +33,7 @@ systemToRetroachievements = {'atari2600', 'atari7800', 'jaguar', 'colecovision',
 
 # Define Retroarch Core compatible with retroachievements
 # List taken from https://docs.libretro.com/guides/retroachievements/#cores-compatibility
-coreToRetroachievements = {'beetle-saturn', 'blastem', 'bluemsx', 'bsnes', 'bsnes_hd', 'desmume', 'fbneo', 'fceumm', 'freeintv', 'gambatte', 'genesisplusgx', 'genesisplusgx-wide', 'handy', 'kronos', 'mednafen_lynx', 'mednafen_ngp', 'mednafen_supergrafx', 'mednafen_wswan', 'melonds', 'mesens', 'mgba', 'mupen64plus-next', 'nestopia', 'o2em', 'parallel_n64', 'pce', 'pce_fast', 'pcfx', 'picodrive', 'pokemini', 'potator', 'ppsspp', 'prosystem', 'quasi88', 'snes9x', 'snes9x_next', 'stella', 'stella2014', 'vb', 'vba-m', 'vecx', 'virtualjaguar'}
+coreToRetroachievements = {'beetle-saturn', 'blastem', 'bluemsx', 'bsnes', 'bsnes_hd', 'desmume', 'duckstation', 'fbneo', 'fceumm', 'freeintv', 'gambatte', 'genesisplusgx', 'genesisplusgx-wide', 'handy', 'kronos', 'mednafen_lynx', 'mednafen_ngp', 'mednafen_psx', 'mednafen_supergrafx', 'mednafen_wswan', 'melonds', 'mesens', 'mgba', 'mupen64plus-next', 'nestopia', 'o2em', 'opera', 'parallel_n64', 'pce', 'pce_fast', 'pcfx', 'pcsx_rearmed', 'picodrive', 'pokemini', 'potator', 'ppsspp', 'prosystem', 'quasi88', 'snes9x', 'snes9x_next', 'stella', 'stella2014', 'swanstation', 'vb', 'vba-m', 'vecx', 'virtualjaguar'}
 
 # Define systems NOT compatible with rewind option
 systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'saturn'};

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -33,7 +33,7 @@ systemToRetroachievements = {'atari2600', 'atari7800', 'jaguar', 'colecovision',
 
 # Define Retroarch Core compatible with retroachievements
 # List taken from https://docs.libretro.com/guides/retroachievements/#cores-compatibility
-coreToRetroachievements = {'beetle-saturn', 'blastem', 'bluemsx', 'bluemsx', 'bsnes', 'bsnes_hd', 'desmume', 'fbneo', 'fceumm', 'freeintv', 'gambatte', 'genesisplusgx', 'genesisplusgx-wide', 'handy', 'kronos', 'mednafen_lynx', 'mednafen_ngp', 'mednafen_supergrafx', 'mednafen_wswan', 'melonds', 'mesens', 'mgba', 'mupen64plus-next', 'nestopia', 'o2em', 'parallel_n64', 'pce', 'pce_fast', 'pcfx', 'picodrive', 'pokemini', 'potator', 'ppsspp', 'prosystem', 'quasi88', 'snes9x', 'snes9x_next', 'stella', 'stella2014', 'vb', 'vba-m', 'vecx', 'virtualjaguar'}
+coreToRetroachievements = {'beetle-saturn', 'blastem', 'bluemsx', 'bsnes', 'bsnes_hd', 'desmume', 'fbneo', 'fceumm', 'freeintv', 'gambatte', 'genesisplusgx', 'genesisplusgx-wide', 'handy', 'kronos', 'mednafen_lynx', 'mednafen_ngp', 'mednafen_supergrafx', 'mednafen_wswan', 'melonds', 'mesens', 'mgba', 'mupen64plus-next', 'nestopia', 'o2em', 'parallel_n64', 'pce', 'pce_fast', 'pcfx', 'picodrive', 'pokemini', 'potator', 'ppsspp', 'prosystem', 'quasi88', 'snes9x', 'snes9x_next', 'stella', 'stella2014', 'vb', 'vba-m', 'vecx', 'virtualjaguar'}
 
 # Define systems NOT compatible with rewind option
 systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'saturn'};

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -31,6 +31,10 @@ systemToBluemsx = {'msx': '"MSX2"', 'msx1': '"MSX2"', 'msx2': '"MSX2"', 'colecov
 # Define systems compatible with retroachievements
 systemToRetroachievements = {'atari2600', 'atari7800', 'jaguar', 'colecovision', 'nes', 'snes', 'virtualboy', 'n64', 'sg1000', 'mastersystem', 'megadrive', 'segacd', 'sega32x', 'saturn', 'pcengine', 'pcenginecd', 'supergrafx', 'psx', 'mame', 'fbneo', 'neogeo', 'lightgun', 'apple2', 'lynx', 'wswan', 'wswanc', 'gb', 'gbc', 'gba', 'nds', 'pokemini', 'gamegear', 'ngp', 'ngpc', 'supervision', 'sufami', 'pc88', 'pcfx', '3do', 'intellivision', 'odyssey2', 'vectrex', 'wonderswan', 'psp', 'snes-msu1'};
 
+# Define Retroarch Core compatible with retroachievements
+# List taken from https://docs.libretro.com/guides/retroachievements/#cores-compatibility
+coreToRetroachievements = {'beetle-saturn', 'blastem', 'bluemsx', 'bluemsx', 'bsnes', 'bsnes_hd', 'desmume', 'fbneo', 'fceumm', 'freeintv', 'gambatte', 'genesisplusgx', 'genesisplusgx-wide', 'handy', 'kronos', 'mednafen_lynx', 'mednafen_ngp', 'mednafen_supergrafx', 'mednafen_wswan', 'melonds', 'mesens', 'mgba', 'mupen64plus-next', 'nestopia', 'o2em', 'parallel_n64', 'pce', 'pce_fast', 'pcfx', 'picodrive', 'pokemini', 'potator', 'ppsspp', 'prosystem', 'quasi88', 'snes9x', 'snes9x_next', 'stella', 'stella2014', 'vb', 'vba-m', 'vecx', 'virtualjaguar'}
+
 # Define systems NOT compatible with rewind option
 systemNoRewind = {'sega32x', 'psx', 'zxspectrum', 'n64', 'dreamcast', 'atomiswave', 'naomi', 'saturn'};
 # 'odyssey2', 'mame', 'neogeocd', 'fbneo'
@@ -437,7 +441,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['cheevos_auto_screenshot'] = 'false'
 
     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
-        if(system.name in systemToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
+        if(system.name in systemToRetroachievements) or (system.config['core'] in coreToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
             retroarchConfig['cheevos_enable'] = 'true'
             retroarchConfig['cheevos_username'] = systemConfig.get('retroachievements.username', "")
             retroarchConfig['cheevos_password'] = systemConfig.get('retroachievements.password', "")


### PR DESCRIPTION
Instead of listing individual systems that support Cheevos in `systemToRetroachievements`, this lists all cores that support Cheevos in `coreToRetroachievements`.

List of supported cores was taken from https://docs.libretro.com/guides/retroachievements/#cores-compatibility
with addition of `ppsspp`, which is supported but WIKI was not yet updated.

This will avoid periodically adding systems to `systemToRetroachievements` and instead rely on which core is used to activate Cheevos. And also, if user has custom "Hack" or "Translation" systems added to ES, this will automagically activate Cheevos if supported core is used.

If this concept gets accepted, a bit more work is left to clean up `libretroConfig.py`.

This PR is just a suggestion so fell free to close it without merging.