### PR TITLE
Add auto frame delay to libretro config generator

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -39,6 +39,7 @@
         * es: English spelling/grammar overhaul, multiple option names updated
         * es: added Xemu widescreen and render scale in advanced options
         * es: added Dolphin Ubershaders and SSAA in advanced options
+        * es: added libretro video_frame_delay_auto to latency settings
         * es: option to launch a game automatically at boot
         * es: option to show/hide border for Vice C64
         * es: enabled retroachievements for libretro ppsspp, freeintv, o2em, pcfx and libretro/melonds

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -412,6 +412,12 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
           if system.isOptSet('secondinstance') and system.getOptBoolean('secondinstance') == True:
               retroarchConfig['run_ahead_secondary_instance'] = 'true'
 
+    # Auto frame delay (input delay reduction via frame timing)
+    if system.isOptSet('video_frame_delay_auto') and system.getOptBoolean('video_frame_delay_auto') == False:
+        retroarchConfig['video_frame_delay_auto'] = 'false'
+    else:
+        retroarchConfig['video_frame_delay_auto'] = 'true'
+
     # Retroachievement option
     if system.isOptSet("retroachievements.sound") and system.config["retroachievements.sound"] != "none":
         retroarchConfig['cheevos_unlock_sound_enable'] = 'true'


### PR DESCRIPTION
Adds `video_frame_delay_auto` from RetroArch 1.9.13: https://www.libretro.com/index.php/retroarch-1-9-13-automatic-frame-delay/
Discussion: https://discord.com/channels/357518249883205632/524321176068161554/907025124442648618
Complements https://github.com/batocera-linux/batocera-emulationstation/pull/1033

Unable to test currently as the latest RetroArch build has not been pushed to distribution. Have written the foundational code which should work when it does. Will convert to proper PR once tested.