### PR TITLE
Xbox360 guide button fix + rename

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -128,7 +128,7 @@
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="030000005e0400000a0b000005040000">
+	<inputConfig type="joystick" deviceName="Generic Xbox pad" deviceGUID="030000005e0400000a0b000005040000">
 		<input name="a" type="button" id="0" value="1" code="304" />
 		<input name="b" type="button" id="1" value="1" code="305" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
@@ -375,7 +375,7 @@
 		<input name="x" type="button" id="5" value="1" code="309" />
 		<input name="y" type="button" id="3" value="1" code="307" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Microsoft X-Box 360 pad" deviceGUID="030000005e0400008e02000014010000">
+	<inputConfig type="joystick" deviceName="Microsoft Xbox 360 pad" deviceGUID="030000005e0400008e02000014010000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
@@ -912,7 +912,7 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="0" value="1" code="304" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Microsoft X-Box One S pad" deviceGUID="030000005e040000ea02000001030000">
+	<inputConfig type="joystick" deviceName="Microsoft Xbox One S pad" deviceGUID="030000005e040000ea02000001030000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
@@ -977,7 +977,7 @@
 		<input name="x" type="button" id="2" value="1" code="307" />
 		<input name="y" type="button" id="3" value="1" code="308" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Microsoft X-Box One pad (Firmware 2015)" deviceGUID="030000005e040000dd02000003020000">
+	<inputConfig type="joystick" deviceName="Microsoft Xbox One pad (2015 firmware)" deviceGUID="030000005e040000dd02000003020000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
@@ -1180,7 +1180,7 @@
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Microsoft X-Box 360 pad" deviceGUID="030000005e0400008e02000010010000">
+	<inputConfig type="joystick" deviceName="Microsoft Xbox 360 pad" deviceGUID="030000005e0400008e02000010010000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
@@ -2272,7 +2272,7 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="2" value="1" code="306" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="030000006f0e0000b802000001010000">
+	<inputConfig type="joystick" deviceName="Generic Xbox pad" deviceGUID="030000006f0e0000b802000001010000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />
@@ -2594,7 +2594,7 @@
 		<input name="x" type="button" id="2" value="1" code="307" />
 		<input name="y" type="button" id="3" value="1" code="308" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="03000000632500008d05000003000000">
+	<inputConfig type="joystick" deviceName="Generic Xbox pad" deviceGUID="03000000632500008d05000003000000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -379,7 +379,7 @@
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
-		<input name="hotkey" type="button" id="6" value="1" code="314" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
@@ -1184,7 +1184,7 @@
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" code="16" />
-		<input name="hotkey" type="button" id="6" value="1" code="314" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />


### PR DESCRIPTION
Changed hotkey for xbox360 controller from select to guide, as it is with the other xbox360 pad.

Renamed "X-Box" to "Xbox", corrected grammar on "Firmware 2015" to "2015 firmware".