### PR TITLE
Add amigacd32 puae core retropad input mapping

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -180,6 +180,71 @@ def generateCoreSettings(coreSettings, system, rom):
 
     # Commodore AMIGA
     if (system.config['core'] == 'puae'):
+        # Functional mapping for Amiga system
+        # If you want to change them, you can add
+        # some strings to batocera.conf by using
+        # this syntax: SYSTEMNAME.retroarchcore.puae_mapper_BUTTONNAME=VALUE
+        if ( system.isOptSet('use_cd32_puae_mapping') and system.getOptBoolean("use_cd32_puae_mapping") == True ) or system.name == 'amigacd32':
+            # Controller mapping for CD32
+            uae_mapping = { 'aspect_ratio_toggle': "---",
+                'mouse_toggle': "RETROK_RCTRL",
+                'statusbar': "RETROK_F11",
+                'vkbd': "---",
+                'reset': "---",
+                'zoom_mode_toggle': "RETROK_F12",
+                'a': "---",
+                'b': "---",
+                'x': "---",
+                'y': "---",
+                'l': "---",
+                'l2': "MOUSE_LEFT_BUTTON",
+                'l3': "SWITCH_JOYMOUSE",
+                'ld': "---",
+                'll': "---",
+                'lr': "---",
+                'lu': "---",
+                'r': "---",
+                'r2': "MOUSE_RIGHT_BUTTON",
+                'r3': "TOGGLE_STATUSBAR",
+                'rd': "---",
+                'rl': "---",
+                'rr': "---",
+                'ru': "---",
+                'select': "---",
+                'start': "---",}
+            for key in uae_mapping:
+                coreSettings.save('puae_mapper_' + key, uae_mapping[key])
+        elif system.name != 'amigacd32':
+            # Controller mapping for A500 and A1200
+            uae_mapping = { 'aspect_ratio_toggle': "---",
+                'mouse_toggle': "RETROK_RCTRL",
+                'statusbar': "RETROK_F11",
+                'vkbd': "---",
+                'reset': "---",
+                'zoom_mode_toggle': "RETROK_F12",
+                'a': "---",
+                'b': "---",
+                'x': "RETROK_SPACE",
+                'y': "RETROK_LCTRL",
+                'l': "RETROK_ESCAPE",
+                'l2': "MOUSE_LEFT_BUTTON",
+                'l3': "SWITCH_JOYMOUSE",
+                'ld': "---",
+                'll': "---",
+                'lr': "---",
+                'lu': "---",
+                'r': "RETROK_F1",
+                'r2': "MOUSE_RIGHT_BUTTON",
+                'r3': "TOGGLE_STATUSBAR",
+                'rd': "---",
+                'rl': "---",
+                'rr': "---",
+                'ru': "---",
+                'select': "TOGGLE_VKBD",
+                'start': "RETROK_RETURN",}
+            for key in uae_mapping:
+                coreSettings.save('puae_mapper_' + key, uae_mapping[key])
+
         # Show Video Options
         coreSettings.save('puae_video_options_display ', '"enabled"')
         # Amiga Model

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2301,6 +2301,12 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     enabled
+                    use_cd32_puae_mapping:
+                        prompt:      USE CD32 PUAE MAPPING
+                        description: Use the CD32 pad mapping by default in PUAE core options > Retropad mapping
+                        choices:
+                            "Off":    0
+                            "On":     1
                     controller1_puae:
                         prompt:      CONTROLLER 1 TYPE
                         description: Select controller type for Amiga P1
@@ -2351,6 +2357,12 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     enabled
+                    use_cd32_puae_mapping:
+                        prompt:      USE CD32 PUAE MAPPING
+                        description: Use the CD32 pad mapping by default in PUAE core options > Retropad mapping
+                        choices:
+                            "Off":    0
+                            "On":     1
                     controller1_puae:
                         prompt:      CONTROLLER 1 TYPE
                         description: Select controller type for Amiga P1


### PR DESCRIPTION
Alternative to https://github.com/batocera-linux/batocera.linux/pull/4875

Adds the preconfigured mappings for AmigaCD32 and automatically uses them for AmigaCD32, created by @iconoclusterdotexe.

If the user is using Amiga500 or Amiga1200, they have the option to manually activate this option in case they are intending on using CD32 pads:
![screenshot-2021 11 08-17h19 55](https://user-images.githubusercontent.com/67527064/140703407-9c5d491c-0484-447a-82ef-288aef6e34df.png)

![screenshot-2021 11 08-17h20 17](https://user-images.githubusercontent.com/67527064/140703411-9bf31da7-af30-4d98-bce7-62bc6ab326f0.png)