### PR TITLE
Sonic Keys Fix

### DIFF
--- a/package/batocera/ports/sonic2013/sonicretro.sonic2013.keys
+++ b/package/batocera/ports/sonic2013/sonicretro.sonic2013.keys
@@ -3,7 +3,7 @@
 	{
             "trigger": ["hotkey", "start"],
             "type": "exec",
-            "target": "killall -9 sonic2013"
+            "target": "killall -9 sonic2013; killall -9 soniccd"
 	}
     ]
 }

--- a/package/batocera/ports/soniccd/sonicretro.soniccd.keys
+++ b/package/batocera/ports/soniccd/sonicretro.soniccd.keys
@@ -3,7 +3,7 @@
 	{
             "trigger": ["hotkey", "start"],
             "type": "exec",
-            "target": "killall -9 soniccd"
+            "target": "killall -9 sonic2013; killall -9 soniccd"
 	}
     ]
 }


### PR DESCRIPTION
Update to recent keys cleanup - closes both emulators on hotkey + start (previous change killed Sonic CD exit). Modified both keys files to cover any unusual user settings.

This is a side effect of the generator auto-selecting the proper emulator, but that can't be avoided without complicating things for the end user.