### PR TITLE
RPi4 default settings: remove audio latency, replace with audio_driver: tinyalsa

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -1,6 +1,6 @@
 default:
   options:
-    audio_latency: 96
+    retroarch.audio_driver: tinyalsa
 
 nds:
   emulator: drastic


### PR DESCRIPTION
Alternative to the increased audio latency workaround I employed earlier: https://github.com/batocera-linux/batocera.linux/pull/4937 , iconocluster.exe has confirmed the tinyalsa audio driver performs better (no crackling) without needing the increased latency.

Fundamentally, the audio issue (crackling/distortion on default settings on RPi4) still needs to be sorted out, but this is a better workaround than what's currently employed.