### PR TITLE
RPi3 defaults change from audio_latency to audio driver tinyalsa

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,7 +1,7 @@
 default:
   options:
     video_threaded: true
-    audio_latency: 96
+    retroarch.audio_driver: tinyalsa
 
 psp:
   options:
@@ -16,7 +16,7 @@ psx:
     gpu_software: true
 gb:
   options:
-    audio_latency: 196
+    audio_latency: 96
 gbc:
   options:
-    audio_latency: 196
+    audio_latency: 96


### PR DESCRIPTION
Alternative to https://github.com/batocera-linux/batocera.linux/pull/4662

In similar vein to https://github.com/batocera-linux/batocera.linux/pull/5009 , switching the audio driver to tinyalsa instead of increasing the audio_latency might work for RPi3 as well. But this needs testing and I don't have access to my Pi3 right now to do so. Will leave as a draft until then.