### PR TITLE
Create S27earlycustom

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S27earlycustom
+++ b/board/batocera/fsoverlay/etc/init.d/S27earlycustom
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if test -e "/userdata/system/earlycustom.sh"; then
+    #bash interpreter executes scripts without x-flag e.g. for vFAT
+    bash /userdata/system/earlycustom.sh $1 &
+fi


### PR DESCRIPTION
Launch a custom script /userdata/system/earlycustom.sh after network and filesystems are available but before ES starts.
Better than using "dirty hacks" with S00bootcustom or use overlays, which will get removed when upgrading Batocera.