### PR TITLE
es_features.yml single unicode character replacement

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3809,7 +3809,7 @@ ppsspp:
             description: Improve the fidelity of 3D models (does not affect 2D sprites)
             choices:
                 #"Automatic (1:1)":      0
-                "1x 480×272":           1
+                "1x 480x272":           1
                 "2x 960x544":           2
                 "3x 720p":              3
                 "4x 1080p":             4


### PR DESCRIPTION
This one "x" is actually a "×" character, whereas all the other entries use "x". Updating to make consistent.