### PR TITLE
add "m3u" to dolphin

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1492,7 +1492,7 @@ gamecube:
   manufacturer: Nintendo
   release: 2001
   hardware: console
-  extensions: [gcm, iso, gcz, ciso, wbfs, rvz, elf, dol]
+  extensions: [gcm, iso, gcz, ciso, wbfs, rvz, elf, dol, m3u]
   platform:   gc
   theme:      gc
   emulators:
@@ -1510,7 +1510,7 @@ wii:
   manufacturer: Nintendo
   release: 2006
   hardware: console
-  extensions: [gcm, iso, gcz, ciso, wbfs, wad, rvz, elf, dol]
+  extensions: [gcm, iso, gcz, ciso, wbfs, wad, rvz, elf, dol, m3u]
   emulators:
     dolphin:
       dolphin:  { requireAnyOf: [BR2_PACKAGE_DOLPHIN_EMU]       }


### PR DESCRIPTION
Dolphin supports playlists for multi-disc games and their automatic swapping. However, there is currently no way to manually swap a disc. This feature should still be available for the few that know how to use it, though. There is no harm is simply adding the extension to the list of accepted formats.