### PR TITLE
.squashfs available only for Scummvm standalone

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -579,7 +579,7 @@ scummvm:
     scummvm:
       scummvm: { requireAnyOf: [BR2_PACKAGE_SCUMMVM]          }
     libretro:
-      scummvm: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SCUMMVM] }
+      scummvm: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SCUMMVM], incompatible_extensions: [squashfs] }
   comment_en: |
     Put scummvm games foders in this folder.
 


### PR DESCRIPTION
Tagged .squashfs file extension as incompatible for libretro Scummvm. Only available for standalone version.

Thanks to the user @wadiebs for testing.