### PR TITLE
amend mistakes made with dolphinsysconf.py (even though it doesn't matter)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -110,6 +110,8 @@ def getRatioFromConfig(config, gameResolution):
     # 0: 4/3, 1: 16/9
     if "ratio" in config:
         if config["ratio"] == "4/3" or (gameResolution["width"] / float(gameResolution["height"])) < ((16.0 / 9.0) - 0.1):
+            if config["ratio"] == "16/9":
+                return 1
             return 0
     return 1
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -106,14 +106,12 @@ def getWiiLangFromEnvironment():
         return availableLanguages["en_US"]
 
 def getRatioFromConfig(config, gameResolution):
-    # 0: 4:3 ; 1: 16:9
+    # Sets the setting available to the Wii's internal NAND. Only has two values:
+    # 0: 4/3, 1: 16/9
     if "ratio" in config:
-        if config["ratio"] == "4/3" or (config["ratio"] == "auto" and gameResolution["width"] / float(gameResolution["height"]) < (16.0 / 9.0) - 0.1): # let a marge):
-            if config["ratio"] == "full":
-                return 3
-            else:
-                return 1
-    return 0
+        if config["ratio"] == "4/3" or (gameResolution["width"] / float(gameResolution["height"])) < ((16.0 / 9.0) - 0.1):
+            return 0
+    return 1
 
 def update(config, filepath, gameResolution):
     arg_setval = { "IPL.LNG": getWiiLangFromEnvironment(), "IPL.AR": getRatioFromConfig(config, gameResolution) }


### PR DESCRIPTION
Corrects mistake made in https://github.com/batocera-linux/batocera.linux/pull/5094 (which were kind of worked around in https://github.com/batocera-linux/batocera.linux/pull/5099 )

I hadn't realised that this setting was specific to only Wii games, not GameCube. I was testing a GameCube game to see my changes, so nothing wrong happened. This is why I have added the one comment to this function, to clarify what its intention is.

After further testing, I have uncovered an issue: sysconf fails to set the Wii's aspect ratio setting at all. No matter with the original code, my modified code, or the https://github.com/batocera-linux/batocera.linux/pull/5099 commit. Dolphin will always just use whatever was last set in its standalone config.

Being able to fix it is beyond me, but this PR will at least set the code up to what it should have always been and undo my mistakes (which, since this code effectively does nothing, no harm even came of it).

Issue has been reported at https://github.com/batocera-linux/batocera.linux/issues/5102