### PR TITLE
Workarounds for v33 stable (don't merge until rc)

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
@@ -5,7 +5,6 @@ default:
     retroarch.video_rotation: 0 # for people upgrading
     # menu retroarch
     retroarch.menu_driver: rgui
-    video_frame_delay_auto: false
 n64:
   options:
     mupen64plus.Video-General.Rotate: 0 # for people upgrading

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidgoa.yml
@@ -5,7 +5,7 @@ default:
     retroarch.video_rotation: 0 # for people upgrading
     # menu retroarch
     retroarch.menu_driver: rgui
-
+    video_frame_delay_auto: false
 n64:
   options:
     mupen64plus.Video-General.Rotate: 0 # for people upgrading

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,3 +1,6 @@
+default:
+  options:
+    audio_latency: 96
 nds:
   emulator: drastic
   core:     drastic
@@ -9,3 +12,9 @@ psx:
   core:     duckstation
   options:
     gpu_software: true
+gb:
+  options:
+    audio_latency: 192
+gbc:
+  options:
+    audio_latency: 192

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -391,6 +391,9 @@ vitaquake2:
 wii:
   emulator: dolphin
   core:     dolphin
+    # Issue with decorations showing when they shouldn't on auto settings. This is a workaround.
+    options:
+      bezel: none
 wiiu:
   emulator: cemu
   core:     cemu


### PR DESCRIPTION
Workarounds for current issues with Batocera on particular platforms. Don't merge this so that the issue can be properly fixed, unless the release candidate is coming up and there is no longer any time to do so.