### PR TITLE
Added syncthing to ARM64 SBCs (probably ARM 32 bits too)

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -189,8 +189,8 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_FLATPAK                              if BR2_PACKAGE_BATOCERA_TARGET_X86_64 # flatpak app packaging system
 	select BR2_PACKAGE_BAUH                                 if BR2_PACKAGE_BATOCERA_TARGET_X86_64 # flatpak gui
 	select BR2_PACKAGE_RYZENADJ                             if BR2_PACKAGE_BATOCERA_TARGET_X86_64 # ryzen apu configuration
-	select BR2_PACKAGE_SYNCTHING                            if BR2_PACKAGE_BATOCERA_TARGET_X86_64 # sync files
-	select BR2_PACKAGE_RCLONE                               if BR2_PACKAGE_BATOCERA_TARGET_X86_64 # sync files in cloud
+	select BR2_PACKAGE_SYNCTHING                            # sync files across multiple batoceras
+	select BR2_PACKAGE_RCLONE                               if BR2_PACKAGE_BATOCERA_CORES_EXPERIMENTAL # sync files in the cloud
 
 	# RaspberryPi Firmwares
 	select BR2_PACKAGE_RPI_FIRMWARE             if BR2_PACKAGE_BATOCERA_RPI_ANY # rpi firmwares

--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -10,17 +10,7 @@ SYNCTHING_LICENSE = MPLv2
 SYNCTHING_LICENSE_FILES = LICENSE
 
 ifeq ($(BR2_arm),y)
-    ifeq ($(BR2_cortex_a7),y)
-                GOARCH= arm
-    else ifeq ($(BR2_cortex_a9),y)
-                GOARCH= arm
-    else ifeq ($(BR2_cortex_a15),y)
-                GOARCH= arm
-    else ifeq ($(BR2_cortex_a17),y)
-                GOARCH= arm
-    else ifeq ($(BR2_cortex_a53),y)
-                GOARCH= arm
-    endif
+GOARCH= arm
 endif
 ifeq ($(BR2_aarch64),y)
 GOARCH=arm64

--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -4,26 +4,48 @@
 #
 ################################################################################
 
-SYNCTHING_VERSION = v1.18.3
+SYNCTHING_VERSION = v1.18.4
 SYNCTHING_SITE = $(call github,syncthing,syncthing,$(SYNCTHING_VERSION))
 SYNCTHING_LICENSE = MPLv2
 SYNCTHING_LICENSE_FILES = LICENSE
 
+ifeq ($(BR2_arm),y)
+    ifeq ($(BR2_cortex_a7),y)
+                GOARCH= arm
+    else ifeq ($(BR2_cortex_a9),y)
+                GOARCH= arm
+    else ifeq ($(BR2_cortex_a15),y)
+                GOARCH= arm
+    else ifeq ($(BR2_cortex_a17),y)
+                GOARCH= arm
+    else ifeq ($(BR2_cortex_a53),y)
+                GOARCH= arm
+    endif
+endif
+ifeq ($(BR2_aarch64),y)
+GOARCH=arm64
+endif
+ifeq ($(BR2_x86_64),y)
+GOARCH=amd64
+endif
+
 SYNCTHING_TARGET_ENV = \
 	PATH=$(BR_PATH) \
-	GOROOT="$(HOST_GO_ROOT)" \
-	GOPATH="$(HOST_GO_GOPATH)" \
-	GOCACHE="$(HOST_GO_TARGET_CACHE)"
+	CGO_ENABLED=1 \
+	GOCACHE="$(HOST_GO_TARGET_CACHE)" \
+	GOMODCACHE="$(@D)" \
+	CC_FOR_TARGET="$(TARGET_CC)" \
+	CXX_FOR_TARGET="$(TARGET_CXX)"
 
 define SYNCTHING_BUILD_CMDS
-	cd $(@D) && $(SYNCTHING_TARGET_ENV) $(GO_BIN) run build.go
+	cd $(@D) && $(SYNCTHING_TARGET_ENV) $(GO_BIN) run build.go -goos linux -goarch $(GOARCH) build
 endef
 
 define SYNCTHING_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin
-
-	$(INSTALL) -D $(@D)/bin/syncthing $(TARGET_DIR)/usr/bin/syncthing
-    $(INSTALL) -Dm755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/syncthing/S27syncthing       $(TARGET_DIR)/etc/init.d/
+	mkdir -p $(TARGET_DIR)/etc/init.d
+	$(INSTALL) -D $(@D)/syncthing $(TARGET_DIR)/usr/bin/syncthing
+	$(INSTALL) -Dm755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/syncthing/S27syncthing       $(TARGET_DIR)/etc/init.d/
 endef
 
 $(eval $(golang-package))


### PR DESCRIPTION
Syncthing is now ported to ARM64, it probably also compile and works on ARM (32 bits) too but I have no device to test. Please let me know if it poses a problem.

Tested on OGA, with cross-sync between x86_64 and OGA. 

At the same time, I put rclone as experimental, I don't think we're ready to ship it yet. And honestly, synching is easy enough and should cover the need for saves sync up across Batocera devices. 