### PR TITLE
change RPCS3 SPU decoder to Recompiler (LLVM)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -70,7 +70,7 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Miscellaneous"] = {}  
 
         # Set the Default Core Values we need
-        rpcs3ymlconfig["Core"]['SPU Decoder'] = 'Recompiler (ASMJIT)'
+        rpcs3ymlconfig["Core"]['SPU Decoder'] = 'Recompiler (LLVM)'
         rpcs3ymlconfig["Core"]['Lower SPU thread priority'] = False
         rpcs3ymlconfig["Core"]['SPU Cache'] = False
         rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True     


### PR DESCRIPTION
This seems to function perfectly fine and is the default of RPCS3 itself, there's only a handful of games that even need this to be different.
Considering that this dramatically improves performance on all hardware it should be the default. I will investigate implementing this as an option into ES itself in the meantime.