### PR TITLE
add SPU decoder selection to ES for RPCS3

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -48,6 +48,7 @@
         * es: English spelling/grammar overhaul, multiple option names updated
         * es: added Xemu widescreen and render scale in advanced options
         * es: added Dolphin Ubershaders and SSAA in advanced options
+        * es: added RPCS3 SPU decoder selection in advanced options
         * es: added libretro video_frame_delay_auto to latency settings
         * es: option to launch a game automatically at boot
         * es: option to show/hide border for Vice C64

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -69,8 +69,14 @@ class Rpcs3Generator(Generator):
         if "Miscellaneous" not in rpcs3ymlconfig:
             rpcs3ymlconfig["Miscellaneous"] = {}  
 
+
+        # Set the SPU Decoder based on config
+        if system.isOptSet("spudecoder"):
+            rpcs3ymlconfig["Core"]['SPU Decoder'] = system.config["spudecoder"]
+        else:
+            rpcs3ymlconfig["Core"]['SPU Decoder'] = 'Recompiler (LLVM)'
+
         # Set the Default Core Values we need
-        rpcs3ymlconfig["Core"]['SPU Decoder'] = 'Recompiler (ASMJIT)'
         rpcs3ymlconfig["Core"]['Lower SPU thread priority'] = False
         rpcs3ymlconfig["Core"]['SPU Cache'] = False
         rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True     

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3921,6 +3921,14 @@ rpcs3:
             choices:
                 "OpenGL":   OpenGL
                 "Vulkan":   Vulkan
+        spudecoder:
+            prompt:      SPU DECODER
+            description: LLVM used by default. Use ASMJIT if game crashes; then Interpreter (fast) if still crashing.
+            choices:
+                "Recompiler (LLVM)":      Recompiler (LLVM)
+                "Recompiler (ASMJIT)":    Recompiler (ASMJIT)
+                "Interpreter (fast)":     Interpreter (fast)
+                "Interpreter (precise)":  Interpreter (precise)
 
 scummvm:
   features: [ratio, padtokeyboard]


### PR DESCRIPTION
Allows the user to choose which SPU decoder they'd like to use. More info here: https://wiki.rpcs3.net/index.php?title=Help:Default_Settings All options have been tested and they work as intended.

Improvement to https://github.com/batocera-linux/batocera.linux/pull/5117