### PR TITLE
really fix Dolphin aspect ratio's

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -139,8 +139,13 @@ class DolphinGenerator(Generator):
         if not dolphinGFXSettings.has_section("Hardware"):
             dolphinGFXSettings.add_section("Hardware")  
             
-        dolphinGFXSettings.set("Settings", "AspectRatio", str(getGfxRatioFromConfig(system.config, gameResolution)))
-
+        # Graphics setting Aspect Ratio
+        if system.isOptSet('dolphin_aspect_ratio'):
+            dolphinGFXSettings.set("Settings", "AspectRatio", system.config["dolphin_aspect_ratio"])
+        else:
+            # set to zero, which is 'Auto' in Dolphin & Batocera
+            dolphinGFXSettings.set("Settings", "AspectRatio", '"0"')
+        
         # Show fps
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
             dolphinGFXSettings.set("Settings", "ShowFPS", '"True"')
@@ -253,18 +258,6 @@ class DolphinGenerator(Generator):
             commandArray = ["dolphin-emu-nogui", "-p", system.config["platform"], "-e", rom]
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
-
-# Ratio
-def getGfxRatioFromConfig(config, gameResolution):
-    # 3: stretch ; 2: 4:3 ; 1: 16:9  ; 0: auto
-    if "ratio" in config:
-        if config["ratio"] == "4/3":
-            return 2
-        if config["ratio"] == "16/9":
-            return 1
-        if config["ratio"] == "full":
-            return 3
-    return 0
 
 # Seem to be only for the gamecube. However, while this is not in a gamecube section
 # It may be used for something else, so set it anyway

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -28,7 +28,8 @@ def readBytes(f, x):
 
 def readString(f, x):
     bytes = f.read(x)
-    return str(bytes)
+    decodedbytes = bytes.decode('utf-8')
+    return str(decodedbytes)
 
 def readInt8(f):
     bytes = f.read(1)
@@ -44,7 +45,7 @@ def readWriteEntry(f, setval):
     itemType       = (itemHeader & 0xe0) >> 5
     itemNameLength = (itemHeader & 0x1f) + 1
     itemName       = readString(f, itemNameLength)
-
+    
     if itemName in setval:
         if itemType == 3: # byte
             itemValue = setval[itemName]
@@ -83,7 +84,7 @@ def readWriteFile(filepath, setval):
         f = open(filepath, "rb")
     else:
         f = open(filepath, "r+b")
-
+    
     try:
         version    = readString(f, 4) # read SCv0
         numEntries = readBEInt16(f)   # num entries
@@ -107,13 +108,11 @@ def getWiiLangFromEnvironment():
 
 def getRatioFromConfig(config, gameResolution):
     # Sets the setting available to the Wii's internal NAND. Only has two values:
-    # 0: 4/3, 1: 16/9
-    if "ratio" in config:
-        if config["ratio"] == "4/3" or (gameResolution["width"] / float(gameResolution["height"])) < ((16.0 / 9.0) - 0.1):
-            if config["ratio"] == "16/9":
-                return 1
-            return 0
-    return 1
+    # 0: 4:3 ; 1: 16:9
+    if config["tv_mode"] == "1":
+        return 1
+    else:
+        return 0
 
 def update(config, filepath, gameResolution):
     arg_setval = { "IPL.LNG": getWiiLangFromEnvironment(), "IPL.AR": getRatioFromConfig(config, gameResolution) }

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3226,7 +3226,6 @@ devilutionx:
   features: [ratio, padtokeyboard]
 
 dolphin:
-  features: [ratio]
   cfeatures:
         gfxbackend:
             archs_include: [x86, x86_64, rpi4, rk3326, gameforce]
@@ -3235,6 +3234,25 @@ dolphin:
             choices:
                 "OpenGL": OGL
                 "Vulkan": Vulkan
+        internal_resolution:
+            prompt:      VIDEO RESOLUTION
+            description: Improve the fidelity of 3D models (does not affect 2D sprites)
+            choices:
+                "1x native (640x528)":  1
+                "2x 720p (1280x1056)":  2
+                "3x 1080p (1920x1584)": 3
+                "4x 1440p (2560x2112)": 4
+                "5x (3200x2640)":       5
+                "6x 4K (3840x3168)":    6
+                "7x (4480x3696)":       7
+                "8x 5K (5120x4224)":    8
+        dolphin_aspect_ratio:
+            prompt:      ASPECT RATIO
+            description: Video graphics aspect ratio
+            choices:
+                "Force 16:9": 1
+                "Force 4:3": 2
+                "Stretch to window": 3
         ubershaders:
             prompt:      UBERSHADERS
             description: Improve performance with Ubershaders (may not work well on all hardware); asynchronous is preferred, synchronous is more compatible
@@ -3260,18 +3278,6 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
-        internal_resolution:
-            prompt:      VIDEO RESOLUTION
-            description: Improve the fidelity of 3D models (does not affect 2D sprites)
-            choices:
-                "1x native (640x528)":  1
-                "2x 720p (1280x1056)":  2
-                "3x 1080p (1920x1584)": 3
-                "4x 1440p (2560x2112)": 4
-                "5x (3200x2640)":       5
-                "6x 4K (3840x3168)":    6
-                "7x (4480x3696)":       7
-                "8x 5K (5120x4224)":    8
         anisotropic_filtering:
             prompt:      ANISOTROPIC FILTERING
             description: Enhance the quality of distant perspective textures
@@ -3365,12 +3371,18 @@ dolphin:
   systems:
     wii:
         cfeatures:
+            tv_mode:
+                prompt:      WII TV MODE
+                description: Wii TV type / mode
+                choices:
+                    "4:3": 0
+                    "16:9": 1
             emulatedwiimotes:
                 prompt:      EMULATE WIIMOTE
                 description: Use your gamepad like a vertical Wiimote in game
                 choices:
-                    "Off":                       0
-                    "On":                        1
+                    "Off": 0
+                    "On": 1
             controller_mode:
                 prompt:      CUSTOMIZE WIIMOTE & GAMEPAD
                 description: Emulate a Wiimote Sideway with L2 for Shake and Nunchuk on R-stick


### PR DESCRIPTION
A couple of changes & explanation:

1. Dolphin doesn't support all the various aspect ratio's using the global ratio - so I have matched what's in Dolphin
2. Dolphin allows you to set a graphics ratio (as per 1) and also set the ratio for the Wii based on the TV type - so we create an option there too, thus match Dolphin's config option.
3. The Wii ratio is boolean: 0 = 4:3, 1 = 16:9, There are no other values for the SYCONF parameter
- see source code in Dolphin: const Info<bool> SYSCONF_WIDESCREEN{{System::SYSCONF, "IPL", "AR"}, true};
4. Pass the correct value to dolphinSYSCONF.py as per above
5. Fix the readString definition so it's a UTF-8 string & not a binary string - now it will write the updated value to SYSCONF correctly. i.e. 1 for 16:9 (if selected) rather than the default 0.