### PR TITLE
Fix X11 crash for small CRT resolutions.

### DIFF
--- a/board/batocera/patches/sdl2/sdl2_force_modes_refresh.patch
+++ b/board/batocera/patches/sdl2/sdl2_force_modes_refresh.patch
@@ -1,0 +1,43 @@
+diff --git a/src/video/SDL_video.c b/src/video/SDL_video.c
+index 07c7aa5ea..f03851c25 100644
+--- a/src/video/SDL_video.c
++++ b/src/video/SDL_video.c
+@@ -831,6 +831,6 @@ SDL_AddDisplayMode(SDL_VideoDisplay * display,  const SDL_DisplayMode * mode)
+ static int
+ SDL_GetNumDisplayModesForDisplay(SDL_VideoDisplay * display)
+ {
+-    if (!display->num_display_modes && _this->GetDisplayModes) {
++    if (_this->GetDisplayModes) {
+         _this->GetDisplayModes(_this, display);
+         SDL_qsort(display->display_modes, display->num_display_modes,
+                   sizeof(SDL_DisplayMode), cmpmodes);
+diff --git a/src/video/kmsdrm/SDL_kmsdrmvideo.c b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+index 95198fb49..6e8410470 100644
+--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
++++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+@@ -1147,7 +1164,24 @@ KMSDRM_SetDisplayMode(_THIS, SDL_VideoDisplay * display, SDL_DisplayMode * mode)
+ 
+     /* Take note of the new mode to be set, and leave the CRTC modeset pending
+        so it's done in SwapWindow. */
+-    dispdata->fullscreen_mode = conn->modes[modedata->mode_index];
++    /* Browse all modes, since SDL_Add_Display doesn't update the driver data */
++    //dispdata->fullscreen_mode = conn->modes[modedata->mode_index];
++    for (i = 0; i < conn->count_modes; i++) {
++        printf("CONN: %dx%d@%d index %d vs %dx%d@%d index %d\n",
++            conn->modes[i].hdisplay,
++            conn->modes[i].vdisplay,
++            conn->modes[i].vrefresh,
++            i,
++            mode->w,
++            mode->h,
++            mode->refresh_rate,
++            modedata->mode_index);
++        if (mode->w != conn->modes[i].hdisplay || mode->h != conn->modes[i].vdisplay || mode->refresh_rate != conn->modes[i].vrefresh)
++                continue;
++        dispdata->fullscreen_mode = conn->modes[i];
++        printf("Assigned mode\n");
++        break;
++    }
+ 
+     for (i = 0; i < viddata->num_windows; i++) {
+         KMSDRM_DirtySurfaces(viddata->windows[i]);


### PR DESCRIPTION
As requested by @Redemp,. This should address https://github.com/libsdl-org/SDL/issues/4840 with CRT resolutions lower than 320x200 (patch ported from RetroLX).

Please confirm it works, I don't have any CRT screen to test.