### PR TITLE
preliminary support for shader sets in Dolphin

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -205,6 +205,27 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
                 dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")  
 
+        # Post-processing
+        if system.isOptSet('shaderset'):
+            if system.config["shaderset"] == "curvature":
+                dolphinGFXSettings.set("Enhancements", "PostProcessingShader", "lens_distortion")
+            #elif system.config["shaderset"] == "enhanced":
+                #dolphinGFXSettings.remove_option("Enhancements", "PostProcessingShader")
+            elif system.config["shaderset"] == "flatten-glow":
+                dolphinGFXSettings.set("Enhancements", "PostProcessingShader", "bad_bloom")
+            elif system.config["shaderset"] == "retro":
+                dolphinGFXSettings.set("Enhancements", "PostProcessingShader", "32bit")
+            # These scanline shaders are a third party one available at https://gist.github.com/mariodivece/cfa3ec1352c13e5dd00d685528e4edac#file-mad-scanlines-crt-glsl , however it will not be included yet as it is not official/maintained.
+            #elif system.config["shaderset"] == "scanlines":
+                #dolphinGFXSettings.set("Enhancements", "PostProcessingShader", "mad-scanlines-crt-static")
+            #elif system.config["shaderset"] == "zfast":
+                # Same as scanlines, will leave as a separate elif in case a better shader becomes available in the future.
+                #dolphinGFXSettings.set("Enhancements", "PostProcessingShader", "mad-scanlines-crt-static")
+            #elif system.config["shaderset"] == "none":
+                #dolphinGFXSettings.remove_option("Enhancements", "PostProcessingShader")
+            else:
+                dolphinGFXSettings.remove_option("Enhancements", "PostProcessingShader")
+
         # Internal resolution settings
         if system.isOptSet('internal_resolution'):
             dolphinGFXSettings.set("Settings", "InternalResolution", system.config["internal_resolution"])

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3211,7 +3211,7 @@ devilutionx:
   features: [ratio, padtokeyboard]
 
 dolphin:
-  features: [ratio]
+  features: [ratio, shaders]
   cfeatures:
         gfxbackend:
             archs_include: [x86, x86_64, rpi4, odroidgoa, gameforce]


### PR DESCRIPTION
Primarily a placeholder, but if it's possible to patch in extra shaders at no maintainence cost then this list could be expanded to include mad-scanlines-crt for the scanline sets too.

It doesn't seem feasible to support actual *sets* in Dolphin as Dolphin doesn't seem to be able to load them.

All of this has been tested and working fine. But it's totally understand if this addition is inappropriate and for this PR to not be accepted.