### PR TITLE
pi4 config & overclock updates

### DIFF
--- a/board/batocera/raspberrypi/boot/config_mesa3d.txt
+++ b/board/batocera/raspberrypi/boot/config_mesa3d.txt
@@ -178,6 +178,8 @@ dtoverlay=vc4-kms-v3d
 [pi4]
 # 64-bit mode
 arm_64bit=1
+# Run as fast as firmware / board allows
+arm_boost=1
 
 start_file=start4x.elf
 fixup_file=fixup4x.dat

--- a/package/batocera/core/batocera-scripts/scripts/batocera-overclock
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-overclock
@@ -50,12 +50,12 @@ doList() {
 	    echo "extreme EXTREME (1500Mhz)"
 	    ;;
 	"rpi4")
-	    echo "none NONE (1500Mhz)"
-	    echo "high HIGH (HEATSINK - 1700Mhz)"
-	    echo "turbo TURBO (HEATSINK - 1800Mhz)"
+	    echo "none NONE (B0 - 1500Mhz or C0 - 1800MHz)"
+	    echo "high HIGH (B0 HEATSINK - 1700Mhz)"
+	    echo "turbo TURBO (B0 HEATSINK - 1800Mhz)"
 		echo "extreme EXTREME (HEATSINK & FAN 1950Mhz)"
 		echo "ruinsane INSANE (HEATSINK & FAN 2100Mhz)"
-		echo "cm4 CAUTION (CM4 only - HEATSINK & FAN 2275Mhz)"
+		echo "cm4 CAUTION (C0 stepping only - HEATSINK & FAN 2275Mhz)"
 	    ;;
 	"s922x")
 	    MODEL=$(cat /sys/firmware/devicetree/base/model)


### PR DESCRIPTION
The latest Pi4 firmware allows c0 stepping chips to be clocked at 1800MHz
- Pi400, Compute Module 4 & the latest Pi4 boards.
- The original boards using the B0 stepping will run at 1500Mhz 
Rename some of the overclock options as a result