### PR TITLE
add option to enable/disable challenge indicators for retroachievements

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -450,6 +450,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     retroarchConfig['cheevos_leaderboards_enable'] = 'false'
     retroarchConfig['cheevos_verbose_enable'] = 'false'
     retroarchConfig['cheevos_auto_screenshot'] = 'false'
+    retroarchConfig['cheevos_challenge_indicators'] = 'false'
 
     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
         if(system.name in systemToRetroachievements) or (system.config['core'] in coreToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
@@ -476,6 +477,11 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
                 retroarchConfig['cheevos_auto_screenshot'] = 'true'
             else:
                 retroarchConfig['cheevos_auto_screenshot'] = 'false'
+            # retroarchievements_challenge_indicators
+            if system.isOptSet('retroachievements.challenge_indicators') and system.getOptBoolean('retroachievements.challenge_indicators') == True:
+                retroarchConfig['cheevos_challenge_indicators'] = 'true'
+            else:
+                retroarchConfig['cheevos_challenge_indicators'] = 'false'
     else:
         retroarchConfig['cheevos_enable'] = 'false'
 

--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -238,6 +238,7 @@ updates.type=stable
 #global.retroachievements.leaderboards=0
 #global.retroachievements.verbose=0
 #global.retroachievements.screenshot=0
+#global.retroachievements.challenge_indicators=0
 #global.retroachievements.username=
 #global.retroachievements.password=
 #global.retroachievements.sound=


### PR DESCRIPTION
Adds the option to turn off the challenge indicator icons in the bottom right of the screen when retroachievements are activated:
![screenshot-2021 11 30-20h53 56](https://user-images.githubusercontent.com/67527064/144163692-cca2ae9d-e041-4deb-a59f-e9ddc49be5e5.png)

Complements https://github.com/batocera-linux/batocera-emulationstation/pull/1062