### PR TITLE
add 'resize_tattoo' option to tattoo 2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -138,10 +138,27 @@ def tatooImage(input_png, output_png, system):
   back = back.convert("RGBA")
   w,h = fast_image_size(input_png)
   tw,th = fast_image_size(tattoo_file)
-  tatwidth = int(240/1920 * w) # 240 = half of the difference between 4:3 and 16:9 on 1920px (0.5*1920/16*4)
-  pcent = float(tatwidth / tw)
-  tatheight = int(float(th) * pcent)
-  tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
+  if system.isOptSet('bezel.resize_tattoo') and system.config['bezel.resize_tattoo'] == "original":
+    # Failsafe for if the image is too large.
+    if tw > w or th > h:
+      # Limit width to that of the bezel and crop the rest.
+      pcent = float(w / tw)
+      tatheight = int(float(th) * pcent)
+      # Resize the tattoo to the calculated size.
+      tattoo = tattoo.resize((w,tatheight), Image.ANTIALIAS)
+  elif system.isOptSet('bezel.resize_tattoo') and system.config['bezel.resize_tattoo'] == "240/1920":
+    # Resize to the bezel's column.
+    tatwidth = int(240/1920 * w) # 240 = half of the difference between 4:3 and 16:9 on 1920px (0.5*1920/16*4).
+    pcent = float(tatwidth / tw)
+    tatheight = int(float(th) * pcent)
+    tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
+  else:
+    # Resize to slightly smaller than the bezel's column.
+    tatwidth = int(225/1920 * w) # 225 = arbitrary number I chose.
+    pcent = float(tatwidth / tw)
+    tatheight = int(float(th) * pcent)
+    tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
+
   alpha = back.split()[-1]
   alphatat = tattoo.split()[-1]
   if system.isOptSet('bezel.tattoo_corner'):


### PR DESCRIPTION
Second iteration of https://github.com/batocera-linux/batocera.linux/pull/5161

"original" = original size of the image (no resize)
"240/1920" = resize proportionally to 240th of a 1920 px screen
"225/1920" or "auto" = resize proportionally to 225th of a 1920 px screen
The reason it's "#/1920" is because it's proportional to the bezel, not the screen itself, and our included bezels are 1920. This also includes if the user chooses to stretch the bezel (hopefully) or if another resolution is being used altogether.

Complements https://github.com/batocera-linux/batocera-emulationstation/pull/1063