### PR TITLE
improved aspect ratio guesser

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -587,10 +587,15 @@ def signal_handler(signal, frame):
         proc.kill()
 
 def getAspectRatio(width, height):
-    # Warning the values in the array must be exactly at the same index than
-    # https://github.com/libretro/RetroArch/blob/master/gfx/video_driver.c#L188
-    ratioIndexes = ["4/3", "16/9", "16/10", "16/15", "21/9", "1/1", "2/1", "3/2", "3/4", "4/1", "9/16", "5/4", "6/5", "7/9", "8/3",
-                    "8/7", "19/12", "19/14", "30/17", "32/9", "config", "squarepixel", "core", "custom", "full"]
+    # Import the currently available ratios from libretroConfig.
+    from generators.libretro.libretroConfig import ratioIndexes
+
+    gameAspectRatio = videoMode.getCurrentAspectRatio()
+    # It is necessary to invert 2/3 due to Retroarch nomenclature
+    if gameAspectRatio == "2/3":
+        gameAspectRatio == "3/2"
+    if gameAspectRatio in ratioIndexes:
+        return gameAspectRatio
 
     def gcd(a, b):
         return a if b == 0 else gcd(b, a % b)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -34,6 +34,12 @@ def getCurrentResolution():
     vals = out.decode().split("x")
     return { "width": int(vals[0]), "height": int(vals[1]) }
 
+def getCurrentAspectRatio():
+    proc = subprocess.Popen(["batocera-resolution currentAspectRatio"], stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    val = out.decode().strip("\n")
+    return val
+
 def checkModeExists(videomode):
     proc = subprocess.Popen(["batocera-resolution listModes"], stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -5,6 +5,7 @@ f_usage() {
     echo "${0} setMode <MODE>" >&2
     echo "${0} currentMode" >&2
     echo "${0} currentResolution" >&2
+    echo "${0} currentAspectRatio" >&2
     echo "${0} listOutputs" >&2
     echo "${0} setOutput <output>" >&2
     echo "${0} minTomaxResolution" >&2
@@ -80,6 +81,13 @@ case "${ACTION}" in
 	;;
     "currentResolution")
 	xrandr --currentResolution | tail -n1
+	;;
+    "currentAspectRatio")
+	OUTPUT=$(xrandr --listConnectedOutputs | sed -e s+"*$"++)
+	INFO=$(xrandr | grep $OUTPUT)
+	HORASP=$(echo $INFO | awk {'print $12'} | sed -e s+"00mm$"++)
+	VERASP=$(echo $INFO | awk {'print $14'} | sed -e s+"00mm$"++)
+	echo $HORASP"/"$VERASP
 	;;
     "listOutputs")
 	xrandr --listConnectedOutputs | sed -e s+"*$"++


### PR DESCRIPTION
Adds the ability to see the aspect ratio to `batocera-resolution` on xorg with `batocera-resolution currentAspectRatio`.
Adds functionality to `videoMode.py` to grab that aspect ratio as a simple string in the same format as libretro expects.
Grabs this aspect ratio, if it exists, and uses it when user has set "auto" as their aspect ratio.
Imports the `ratioIndexes` straight from libretroConfig instead of using magic numbers.

Elaborates on https://github.com/Hew-ux/batocera.linux/commit/b98484133ac60ec83f25c8cad6586319bc8957a1#diff-14db8ec0b78538cba4d509a4eba754175d983666ae5e4af746fa3a19a2b6896dR438

In the future, I plan on changing the default option selected by ES by default to be "core provided", as that's what seems like should be the default.