### PR TITLE
Update configgen-defaults-x86_64.yml

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -3,6 +3,7 @@ default:
   core:
   options:
     hud_support: true
+    retroarch.video_frame_delay_auto: true
 
 pcengine:
   emulator: libretro


### PR DESCRIPTION
Turns `video_frame_delay_auto` on by default for just the x86_64 platform. Previously, it defaulted to being true for all platforms (https://github.com/batocera-linux/batocera.linux/pull/4998), however some changes were made to the globals because of one platform having issues with it (which are worth investigating on their own) (https://github.com/batocera-linux/batocera.linux/pull/5119).