### PR TITLE
include "skip draw" option in ubershader + rename

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -171,11 +171,13 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "wideScreenHack", '"False"')
 
         # Ubershaders (synchronous_ubershader by default)
-        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "synchronous":
-            if system.config["ubershaders"] == "synchronous_ubershader":
+        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "no_ubershader":
+            if system.config["ubershaders"] == "exclusive_ubershader":
                 dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"1"')
-            elif system.config["ubershaders"] == "asynchronous_ubershader":
+            elif system.config["ubershaders"] == "hybrid_ubershader":
                 dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"2"')
+            elif system.config["ubershaders"] == "skip_draw":
+                dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"3"')
         else:
             dolphinGFXSettings.set("Settings", "ShaderCompilationMode", '"0"')
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3263,11 +3263,12 @@ dolphin:
                 "Stretch to window": 3
         ubershaders:
             prompt:      UBERSHADERS
-            description: Improve performance with Ubershaders (may not work well on all hardware); asynchronous is preferred, synchronous is more compatible
+            description: Improve performance with Ubershaders (may not work well on all hardware); hybrid is preferred, "no ubershaders" is more compatible
             choices:
-                "No Ubershaders":                          synchronous
-                "Ubershaders (synchronous)":               synchronous_ubershader
-                "Ubershaders (asynchronous)":              asynchronous_ubershader
+                "No Ubershaders":                          no_ubershader
+                "Exclusive Ubershaders":                   exclusive_ubershader
+                "Hybrid Ubershaders":                      hybrid_ubershader
+                "Skip Drawing":                            skip_draw
         wait_for_shaders:
             prompt:      PRE-CACHE SHADERS
             description: Wait for shaders to compile completely before starting the game, can reduce micro-freezes


### PR DESCRIPTION
Adds the "skip draw" option to Ubershaders in Dolphin. Also renames the existing ones to match the option labels in `dolphin-emu-config`.

Since this option was added in this beta I think it's fine to rename the existing options to have them make more sense.