### PR TITLE
Fix mesen-s not having options in ES (probably)

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -243,7 +243,7 @@ gbc:
       gambatte: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GAMBATTE] }
       mgba:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MGBA] }
       vba-m:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_VBA_M] }
-      mesens:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS] }
+      mesen-s:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS] }
   comment_en: |
     For more info: https://wiki.batocera.org/systems:gbc
   comment_fr: |
@@ -260,7 +260,7 @@ gb:
       gambatte: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GAMBATTE] }
       mgba:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MGBA] }
       vba-m:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_VBA_M] }
-      mesens:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS] }
+      mesen-s:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS] }
   comment_en: |
     For more info: https://wiki.batocera.org/systems:gb
   comment_fr: |
@@ -1655,7 +1655,7 @@ satellaview:
     libretro:
       pocketsnes:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_POCKETSNES] }
       snes9x:       { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SNES9X]     }
-      mesens:       { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS]     }
+      mesen-s:      { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS]     }
 
 sufami:
   name:       SuFami Turbo


### PR DESCRIPTION
I think this was just a typo.

But this might also fix Mesen-S's options not appearing in the Game Boy's advanced system settings:
![screenshot-2021 12 11-12h40 59](https://user-images.githubusercontent.com/67527064/145674300-775889dd-e324-41f8-9da4-ee654361549c.png)
![screenshot-2021 12 11-12h41 18](https://user-images.githubusercontent.com/67527064/145674309-c483f124-8cff-468c-8b9f-47ed0f4acad2.png)

For reference, Mesen-S's options appear fine in the Super Game Boy system game list:
![screenshot-2021 12 11-21h44 11](https://user-images.githubusercontent.com/67527064/145674333-cbdbb4b4-e6f7-44d1-a9aa-821c6ddbe02d.png)

