### PR TITLE
add default ratio to ps3

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -111,3 +111,6 @@ class Rpcs3Generator(Generator):
             commandArray.append("--no-gui")
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_CACHE_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
+
+    def getInGameRatio(self, config, gameResolution):
+        return 16/9


### PR DESCRIPTION
Avoids ps3 automatically using 4:3 ratio with bezels, cutting off the sides (ps3 games are widescreen by default).

Before this change:
![screenshot-2021 12 12-09h53 58](https://user-images.githubusercontent.com/67527064/145694043-1150dd04-b543-4879-96e2-f89310c6793a.png)

After this change:
![screenshot-2021 12 12-09h52 15](https://user-images.githubusercontent.com/67527064/145694010-6af31429-c685-4b32-88a4-3ec516e156f6.png)

