### PR TITLE
tattoo code cleanup + resize functionality

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -749,7 +749,7 @@ def writeBezelConfig(bezel, retroarchConfig, rom, gameResolution, system):
         overlay_png_file = output_png_file # replace by the new file (recreated or cached in /tmp)
         if system.isOptSet('bezel.tattoo') and system.config['bezel.tattoo'] != "0":
             output_png = "/tmp/bezel_tattooed.png"
-            bezelsUtil.tatooImageAdapt(overlay_png_file, output_png_file, system)
+            bezelsUtil.tatooImage(overlay_png_file, output_png_file, system)
             overlay_png_file = output_png_file
     else:
         if viewPortUsed:
@@ -761,7 +761,8 @@ def writeBezelConfig(bezel, retroarchConfig, rom, gameResolution, system):
         retroarchConfig['video_message_pos_y']    = infos["messagey"]
         if system.isOptSet('bezel.tattoo') and system.config['bezel.tattoo'] != "0":
             output_png = "/tmp/bezel_tattooed.png"
-            bezelsUtil.tatooImage(overlay_png_file, system)
+            bezelsUtil.tatooImage(overlay_png_file, output_png, system)
+            overlay_png_file = output_png
 
     eslog.debug("Bezel file set to {}".format(overlay_png_file))
     writeBezelCfgConfig(overlay_cfg_file, overlay_png_file)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -112,7 +112,7 @@ def padImage(input_png, output_png, screen_width, screen_height, bezel_width, be
       imgout = ImageOps.expand(imgin, border=(borderw, borderh, xoffset-borderw, yoffset-borderh), fill=fillcolor)
       imgout.save(output_png, mode="RGBA", format="PNG")
 
-def tatooImageAdapt(input_png, output_png, system):
+def tatooImage(input_png, output_png, system):
   if system.config['bezel.tattoo'] == 'system':
       try:
           tattoo_file = '/usr/share/batocera/controller-overlays/'+system.name+'.png'
@@ -138,10 +138,22 @@ def tatooImageAdapt(input_png, output_png, system):
   back = back.convert("RGBA")
   w,h = fast_image_size(input_png)
   tw,th = fast_image_size(tattoo_file)
-  tatwidth = int(225/1920 * w)
-  pcent = float(tatwidth / tw)
-  tatheight = int(float(th) * pcent)
-  tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
+  if system.isOptSet('bezel.resize_tattoo') and system.getOptBoolean('bezel.resize_tattoo') == False:
+      # Maintain the image's original size.
+      # Failsafe for if the image is too large.
+      if tw > w or th > h:
+          # Limit width to that of the bezel and crop the rest.
+          pcent = float(w / tw)
+          tatheight = int(float(th) * pcent)
+          # Resize the tattoo to the calculated size.
+          tattoo = tattoo.resize((w,tatheight), Image.ANTIALIAS)
+  else:
+      # Resize to be slightly smaller than the bezel's column.
+      tatwidth = int(225/1920 * w)
+      pcent = float(tatwidth / tw)
+      tatheight = int(float(th) * pcent)
+      tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
+
   alpha = back.split()[-1]
   alphatat = tattoo.split()[-1]
   if system.isOptSet('bezel.tattoo_corner'):
@@ -159,51 +171,3 @@ def tatooImageAdapt(input_png, output_png, system):
   imgnew = Image.new("RGBA", (w,h), (0,0,0,255))
   imgnew.paste(back, (0,0,w,h))
   imgnew.save(output_png, mode="RGBA", format="PNG")
-
-def tatooImage(input_png, system):
-  if system.config['bezel.tattoo'] == 'system':
-      try:
-          tattoo_file = '/usr/share/batocera/controller-overlays/'+system.name+'.png'
-          if not os.path.exists(tattoo_file):
-              tattoo_file = '/usr/share/batocera/controller-overlays/generic.png'
-          tattoo = Image.open(tattoo_file)
-      except:
-          eslog.error("Error opening controller overlay: {}".format('tattoo_file'))
-  elif system.config['bezel.tattoo'] == 'custom' and os.path.exists(system.config['bezel.tattoo_file']):
-      try:
-          tattoo_file = system.config['bezel.tattoo_file']
-          tattoo = Image.open(tattoo_file)
-      except:
-          eslog.error("Error opening custom file: {}".format('tattoo_file'))
-  else:
-      try:
-          tattoo_file = '/usr/share/batocera/controller-overlays/generic.png'
-          tattoo = Image.open(tattoo_file)
-      except:
-          eslog.error("Error opening custom file: {}".format('tattoo_file'))
-  back = Image.open(input_png)
-  tattoo = tattoo.convert("RGBA")
-  back = back.convert("RGBA")
-  w,h = fast_image_size(input_png)
-  tw,th = fast_image_size(tattoo_file)
-  tatwidth = int(225/1920 * w)
-  pcent = float(tatwidth / tw)
-  tatheight = int(float(th) * pcent)
-  tattoo = tattoo.resize((tatwidth,tatheight), Image.ANTIALIAS)
-  alpha = back.split()[-1]
-  alphatat = tattoo.split()[-1]
-  if system.isOptSet('bezel.tattoo_corner'):
-      corner = system.config['bezel.tattoo_corner']
-  else:
-      corner = 'NW'
-  if (corner.upper() == 'NE'):
-      back.paste(tattoo, (w-tatwidth,20), alphatat) # 20 pixels vertical margins (on 1080p)
-  elif (corner.upper() == 'SE'):
-      back.paste(tattoo, (w-tatwidth,h-tatheight-20), alphatat)
-  elif (corner.upper() == 'SW'):
-      back.paste(tattoo, (0,h-tatheight-20), alphatat)
-  else: # default = NW
-      back.paste(tattoo, (0,20), alphatat)
-  imgnew = Image.new("RGBA", (w,h), (0,0,0,255))
-  imgnew.paste(back, (0,0,w,h))
-  imgnew.save(input_png, mode="RGBA", format="PNG")


### PR DESCRIPTION
Clean up the code from my previous fix, the two functions can be simplified into one by the presence of a simple if condition.

Change 'tattoo resize' option in ES to be a simple toggle.