### PR TITLE
Exit DOSBox Pure, TyrQuake, PrBoom when games exit

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -153,6 +153,9 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     # force notification messages
     retroarchConfig['video_font_enable'] = '"true"'
 
+    # prevent displaying "QUICK MENU" with "No Items" after DOSBox Pure, TyrQuake and PrBoom games exit
+    retroarchConfig['load_dummy_on_core_shutdown'] = '"false"'
+
     ## Specific choices
     if(system.config['core'] in coreToP1Device):
         retroarchConfig['input_libretro_device_p1'] = coreToP1Device[system.config['core']]


### PR DESCRIPTION
Set retroarch option to prevent displaying "QUICK MENU" with "No Items" after DOSBox Pure, TyrQuake or PrBoom game has exited.

A proper version of #4487, #4552, #4553 
This should not cause problems because it is setting RetroArch option and not doing code hacks.

@iconoclusterdotexe @crcerror 