### PR TITLE
add a bunch of directory navigation readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Batocera Linux is an open-source and completely free retro-gaming distribution t
  - :art: No need to be a developer, you can also [help with translations](https://wiki.batocera.org/help_with_translation), talk about our project on [Youtube](https://www.youtube.com/channel/UClFpqHKoXsOIV-GjyZqoZcw/featured) or [Twitter](https://twitter.com/batocera_linux/), create [themes for EmulationStation](https://wiki.batocera.org/themes)
  - :dollar: Finally, you can help us with a [Paypal donation](https://www.paypal.com/paypalme/nadenislamarre), it's always appreciated!
 
+## Directory navigation
+
+ - `board` Platform-specific build configuration. This is where to include special patches/configuration files needed to have particular components work on a particular platform. It is instead encouraged to apply patches at the location of the package itself, but this may not always be possible.
+ - `buildroot` Buildroot, the tool used to create the final compiled images. For newcomers, you can safely ignore this folder. Compilation instructions can be found [on the wiki](https://wiki.batocera.org/compile_batocera.linux).
+ - `configs` Build flags, which define what components will be built with your image depending on your chose architecture. If you're trying to port Batocera to a new architecture (device, platform, new bit mode, etc.) this is the file you'll need to edit. More information on [the build configuration section on the buildroot compiling page](https://wiki.batocera.org/batocera.linux_buildroot_modifications#define_your_configuration).
+ - `package` The "meat and potatoes" of Batocera. This is where the majority of emulator data, config generators, core packages, system utilities, etc. all go into. This is the friendliest place to start dev-work for new devs, as most of it is handled by Python and Makefile.
+ - `scripts` Various miscellanous scripts that handle aspects external to Batocera, such as the report data sent to the [compatibility page](https://batocera.org/compatibility.php) or info about the Bezel Project.
+
+A cheatsheet of notable files/folders can be found [on the wiki](https://wiki.batocera.org/notable_files).

--- a/board/batocera/README.md
+++ b/board/batocera/README.md
@@ -1,0 +1,3 @@
+Platform-specific build configuration.
+
+The `fsoverlay` folders contain the files copied over to the boot partition, there is one for each platform and [one for global files](https://github.com/batocera-linux/batocera.linux/tree/master/board/batocera/fsoverlay). Try to keep this as small as possible, only the minimum required to boot the device, and handle the rest with [packages](https://github.com/batocera-linux/batocera.linux/tree/master/package/batocera).

--- a/package/batocera/README.md
+++ b/package/batocera/README.md
@@ -1,0 +1,10 @@
+## Directory navigation
+
+ - `boot` These are the makefiles for building the boot partition. Usually just a manner of copying files over from the below directory, but sometimes require a bit more complex instructions.
+ - `controllers` Support for extraneous controllers that EmulationStation/Batocera can't recognize by default.
+ - `core` The "meat and potatoes" of Batocera. This contains most "batocera-<X>" packages, such as the config generators, ES system configurations, system utilities, splash, etc.
+ - `emulators` Contains the makefiles and `git` information required for including [emulators](https://wiki.batocera.org/systems) in Batocera. This is the preferred location to apply per-emulator [patches](https://wiki.batocera.org/coding_rules#patches).
+ - `gpu` Graphics drivers for all the possible hardware supported by Batocera that aren't already included in the Linux kernel by default.
+ - `network` Network adapter drivers that aren't already included in the Linux kernel by default.
+ - `ports` Contains the makefiles and `git` information required for including [ports](https://wiki.batocera.org/systems#port) in Batocera. This is the preferred location to apply per-port [patches](https://wiki.batocera.org/coding_rules#patches).
+ - `utils` Various utilities used by Batocera, such as [case support](https://wiki.batocera.org/add_powerdevices_rpi_only), [Syncthing](https://wiki.batocera.org/syncthing), [batocera-steam](https://wiki.batocera.org/systems:steam), etc.

--- a/package/batocera/core/README.md
+++ b/package/batocera/core/README.md
@@ -1,0 +1,17 @@
+## Core packages
+
+Batocera's essential packages. These include the makefiles to compile the packages at build time, configuration of the packages themselves and the script files put into `/etc/init.d` which starts these services.
+
+## Directory navigation
+
+ - `batocera-audio` All of the audio handling. This is where Pipewire is configured.
+ - `batocera-configgen` The master folder that contains the config generators and their build configs.
+ - `batocera-controller-overlays` The "system controller" tattoos.
+ - `batocera-desktopapps` The "Applications" found when pressing F1 in the system list. These allow the user to manually configure standalone emulators or use certain utility applications.
+ - `batocera-drm` For devices that use `drm` instead of `xrandr` to resize the screen, this package required.
+ - `batocera-image` For the image/screenshot viewer.
+ - `batocera-notice` Download the PDF from https://github.com/batocera-linux/batocera-notice to use as the user manual.
+ - `batocera-scripts` A lot of scripts that are just scripts, not packages, located in `/usr/bin` in the final image.
+ - `batocera-settings` The [batocera-settings](https://wiki.batocera.org/usage_of_batocera-settings) utility.
+ - `batocera-system` Some essential utilities, Batocera version number, profile.d variables and the template `batocera.conf` and `batocera-boot.conf` in the final image.
+ - `batocera-triggerhappy` Adding functionality to function keys (such as on various supported handhelds, or keyboard volume keys).

--- a/package/batocera/core/batocera-configgen/README.md
+++ b/package/batocera/core/batocera-configgen/README.md
@@ -1,0 +1,5 @@
+## Directory navigation
+
+ - `configgen` Go here for the generators themselves.
+ - `configs` A set of default settings, for both global and per-platform. If defining a new emulator/system, it will need to be defined in [configgen-defaults](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml).
+ - `datainit` Some extraneous files required for emulators.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/README.md
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/README.md
@@ -1,0 +1,6 @@
+## Directory navigation
+
+ - `generators` The infamous Python configuration generators, bane of the end-user who's used to modifying INI and XML files directly. These are what create the necessary configuration files, controller profiles and any other necessary INI/CFG file an emulator uses upon launching an emulator. Used in conjunction with [ES features](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulationstation/batocera-es-system/es_features.yml) to make these generated configs based on the options the user has set in ES. If creating a new one, don't forget to [define](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py) it as well.
+ - `batoceraFiles.py` The paths used by emulators for their configuration files, saves, etc.
+ - `Emulator.py` How do we grab all the settings? And in what order?
+ - `emulatorlauncher.py` The main launcher.

--- a/package/batocera/emulationstation/README.md
+++ b/package/batocera/emulationstation/README.md
@@ -1,0 +1,5 @@
+## Directory navigation
+
+ - `batocera-emulationstation` Build configuration and patches for [batocera-emulationstation](https://github.com/batocera-linux/batocera-emulationstation). Also contains [All the controller presets that ES automatically recognizes](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg) in [controllers](https://github.com/batocera-linux/batocera.linux/tree/master/package/batocera/emulationstation/batocera-emulationstation/controllers).
+ - `batocera-es-system` Includes the YMLs which are used to generate `es_features.cfg`, `es_systems.cfg`, `es_settings.cfg`, etc.
+ - `es-theme-carbon` Build configuration for Batocera's default theme, [Carbon](https://github.com/fabricecaruso/es-theme-carbon).

--- a/package/batocera/emulationstation/batocera-es-system/README.md
+++ b/package/batocera/emulationstation/batocera-es-system/README.md
@@ -1,0 +1,6 @@
+## Directory navigation
+
+ - `roms` Batocera's pre-bundled ROMs, and other necessary files for the ROMs directory.
+ - `batocera-es-system.py` The Python script which generates `es_features.cfg` and `es_systems.cfg` based on the `es_features.yml` and `es_systems.yml` YML files.
+ - `es_systems.yml` The systems that ES recognizes and shows on the system list when the user has installed the appropriate ROMs. Contains some metadata about the system, such as full name and manufacture date. This is the file you'd want to edit if you want to put a comment in the generated roms/<system>/_info.txt file.
+ - `es_features.yml` The configuration file EmulationStation uses to show which options are available for each system (in “features”). Also includes the advanced per-system settings (in “cfeatures” as their own unique entries). Used in conjunction with the [config generators](https://github.com/batocera-linux/batocera.linux/tree/master/package/batocera/core/batocera-configgen/configgen/configgen/generators) to define new options. The user may override this with a custom file.


### PR DESCRIPTION
To assist newcomer devs with navigating the source code. Descriptions have been kept brief and non-descript such that they won't need to be updated.

Folders whose labels are obvious or self-evident have been excluded.