### PR TITLE
MAME Config fixes & Improvements

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -91,21 +91,38 @@ class MameGenerator(Generator):
 
         # MAME saves a lot of stuff, we need to map this on /userdata/saves/mame/<subfolder> for each one
         commandArray += [ "-nvram_directory" ,    "/userdata/saves/mame/nvram/" ]
+
+        # Set custom config path if option is selected or default path if not
+        if system.isOptSet("customcfg"):
+            customCfg = system.getOptBoolean("customcfg")
+        else:
+            customCfg = False
+
+        if system.name == "mame":
+            if customCfg:
+                cfgPath = "/userdata/system/configs/mame/custom/"
+            else:
+                cfgPath = "/userdata/system/configs/mame/"
+            if not os.path.exists("/userdata/system/configs/mame/"):
+                os.makedirs("/userdata/system/configs/mame/")    
+        else:
+            if customCfg:
+                cfgPath = "/userdata/system/configs/mame/" + messSysName[messMode]+ "/custom/"
+            else:
+                cfgPath = "/userdata/system/configs/mame/" + messSysName[messMode] + "/"
+            if not os.path.exists("/userdata/system/configs/mame/" + messSysName[messMode] + "/"):
+                os.makedirs("/userdata/system/configs/mame/" + messSysName[messMode] + "/")    
+        if not os.path.exists(cfgPath):
+            os.makedirs(cfgPath)
+
         # MAME will create custom configs per game for MAME ROMs and MESS ROMs with no system attached (LCD games, TV games, etc.)
         # This will allow an alternate config path per game for MESS console/computer ROMs that may need additional config.
-        if system.name == "mame":
-            cfgPath = "/userdata/system/configs/mame/"
-        else:
-            cfgPath = "/userdata/system/configs/mame/" + system.name + "/"
-            if not os.path.exists(cfgPath):
-                os.makedirs(cfgPath)
-
         if system.isOptSet("pergamecfg") and system.getOptBoolean("pergamecfg"):
             if not messMode == -1:
                 if not messSysName[messMode] == "":
                     if not os.path.exists("/userdata/system/configs/mame/" + messSysName[messMode] + "/"):
-                        os.makedirs("/userdata/system/configs/mame/" + messSysName[messMode] + "/")
-                    cfgPath = "/userdata/system/configs/mame/" + messSysName[messMode] + "/" + romBasename + "/"
+                        os.makedirs("/userdata/system/configs/mame/" + messSysName[messMode]+ "/")
+                    cfgPath = "/userdata/system/configs/mame/" + messSysName[messMode]+ "/" + romBasename + "/"
                     if not os.path.exists(cfgPath):
                         os.makedirs(cfgPath)
         commandArray += [ "-cfg_directory"   ,    cfgPath ]
@@ -114,6 +131,7 @@ class MameGenerator(Generator):
         commandArray += [ "-snapshot_directory" , "/userdata/screenshots/" ]
         commandArray += [ "-diff_directory" ,     "/userdata/saves/mame/diff/" ]
         commandArray += [ "-comment_directory",   "/userdata/saves/mame/comments/" ]
+        commandArray += [ "-noreadconfig"]
 
         # TODO These paths are not handled yet
         # TODO -homepath            path to base folder for plugin data (read/write)
@@ -235,16 +253,11 @@ class MameGenerator(Generator):
                 buttonLayout = 10 # Q*Bert stick settings
             else:
                 buttonLayout = 0 # Default layout if it's not a recognized game
-        
-        if system.isOptSet("customcfg"):
-            overwriteCfg = system.config["customcfg"]
-        else:
-            overwriteCfg = 0
-        
+                
         if messMode == -1:
-            mameControllers.generatePadsConfig(cfgPath, playersControllers, "", dpadMode, buttonLayout, overwriteCfg)
+            mameControllers.generatePadsConfig(cfgPath, playersControllers, "", dpadMode, buttonLayout, customCfg)
         else:
-            mameControllers.generatePadsConfig(cfgPath, playersControllers, messSysName[messMode], dpadMode, buttonLayout, overwriteCfg)
+            mameControllers.generatePadsConfig(cfgPath, playersControllers, messSysName[messMode], dpadMode, buttonLayout, customCfg)
         
         # bezels
         if 'bezel' not in system.config or system.config['bezel'] == '':

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4147,28 +4147,13 @@ mame:
             choices:
                 "Off (Default)":    0
                 "DS3 Orientation":  1
-                "X360 Orientation": 2
-        altlayout:
-            prompt:      SPECIAL CONTROL LAYOUTS
-            description: Controls for 5/6 button games and other unique controls
-            choices:
-                "Default Only":                 0
-                "Street Fighter (SNES)":        1
-                "Street Fighter (Modern)":      4
-                "Mortal Kombat (SNES)":         2
-                "Killer Instinct (SNES)":       3
-                "Genesis 6-Button (Retroarch)": 5
-                "Neo Geo (Neo Geo Mini Pad)":   6
-                "Neo Geo (Neo Geo CD Pad)":     7
-                "Neo Geo (Offset Fightstick)":  8
-                "Twin Stick with Triggers":     9
-                "Rotated 4-Way Stick (Q*Bert)": 10
+                "X360 Orientation": 2      
         customcfg:
             prompt:      CUSTOM MAME CONFIG
-            description: Don't overwrite default config on launch
+            description: Set system-wide controls via MAME menu
             choices:
-                "On":                                         1
-                "Off (Will erase system config next launch)": 0
+                "On":  1
+                "Off": 0
   systems:
        apfm1000:
             cfeatures:
@@ -4224,7 +4209,7 @@ mame:
                         "Disk (Drive 2)": flop2
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4249,7 +4234,7 @@ mame:
                         "Disk (Drive 2)": flop2
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4275,7 +4260,7 @@ mame:
                         "Cartridge (Slot 4)": cart4
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4296,7 +4281,7 @@ mame:
                         "Cartridge":   cart
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4316,7 +4301,7 @@ mame:
                         "Cartridge":   cart
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4336,7 +4321,7 @@ mame:
                         "Cartridge":   cart
                 enableui:
                     prompt:      UI KEYS
-                    description: Open with hotkey + D-pad up or Scroll Lock in-game.
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
                     choices:
                         "Off at Start": 0
                         "On at Start":  1
@@ -4346,6 +4331,40 @@ mame:
                     choices:
                         "On":  1
                         "Off": 0
+       mame: 
+            cfeatures:
+                altlayout:
+                    prompt:      SPECIAL CONTROL LAYOUTS
+                    description: Controls for 5/6 button games and other unique controls
+                    choices:
+                        "Default Only":                 0
+                        "Street Fighter (SNES)":        1
+                        "Street Fighter (Modern)":      4
+                        "Mortal Kombat (SNES)":         2
+                        "Killer Instinct (SNES)":       3
+                        "Genesis 6-Button (Retroarch)": 5
+                        "Neo Geo (Neo Geo Mini Pad)":   6
+                        "Neo Geo (Neo Geo CD Pad)":     7
+                        "Neo Geo (Offset Fightstick)":  8
+                        "Twin Stick with Triggers":     9
+                        "Rotated 4-Way Stick (Q*Bert)": 10
+       neogeo: 
+            cfeatures:
+                altlayout:
+                    prompt:      SPECIAL CONTROL LAYOUTS
+                    description: Controls for 5/6 button games and other unique controls
+                    choices:
+                        "Default Only":                 0
+                        "Street Fighter (SNES)":        1
+                        "Street Fighter (Modern)":      4
+                        "Mortal Kombat (SNES)":         2
+                        "Killer Instinct (SNES)":       3
+                        "Genesis 6-Button (Retroarch)": 5
+                        "Neo Geo (Neo Geo Mini Pad)":   6
+                        "Neo Geo (Neo Geo CD Pad)":     7
+                        "Neo Geo (Offset Fightstick)":  8
+                        "Twin Stick with Triggers":     9
+                        "Rotated 4-Way Stick (Q*Bert)": 10  
 
 wine:
   features: [padtokeyboard, decoration]


### PR DESCRIPTION
* Fixed CD-i config generation
* Fixed Q*Bert stick control generation
* Modified custom MAME config behavior - will now create a /custom subfolder in MAME or MESS system's config folder to maintain a separate copy.
* Moved alternate control options to MAME & Neo Geo systems only
* Corrected description for hotkey mode