### PR TITLE
add 'setRate' to batocera-resolution.xorg

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -75,6 +75,19 @@ case "${ACTION}" in
 	    xrandr --output "${OUTPUT}" --mode "${MODE}"
 	fi
 	;;
+	"setRate")
+	RATE=$1
+	MODE=$(xrandr --listModes | grep -E '\*$' | sed -e s+'\*$'++ | sed -e s+'\*$'++ -e s+'^[^ ]* '++)
+
+	if echo "${MODE}" | grep -qE 'max-' # special max-widthxheight
+	then
+	    SPMODE=$(echo "${MODE}" | sed -e s+"^max-"++)
+	    f_minTomaxResolution "${SPMODE}"
+	else
+	    OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
+	    xrandr --output "${OUTPUT}" --mode "${MODE}" --rate "${RATE}"
+	fi
+	;;
     "currentMode")
 	xrandr --listModes | grep -E '\*$' | sed -e s+'\*$'++ | sed -e s+'\*$'++ -e s+'^[^ ]* '++
 	;;


### PR DESCRIPTION
Allows the user to specify a specific refresh rate, useful for PAL games.

eg. `batocera-resolution setRate 50`

This brings it up to parity with batocera-resolution.drm, although it does it in a different method (such are the differences between the way drm handles refresh rate and the way xorg handles refresh rate).