### PR TITLE
add 'setRate' to batocera-resolution.xorg try 2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -13,9 +13,12 @@ eslog = get_logger(__name__)
 # Set a specific video mode
 def changeMode(videomode):
     if checkModeExists(videomode):
-        cmd = "batocera-resolution setMode \"{}\"".format(videomode)
-        if cmd is not None:
-            eslog.debug("setVideoMode({}): {} ".format(videomode, cmd))
+        cmd = "batocera-resolution setMode"
+        arguments = videomode.split()
+        for argument in arguments:
+            cmd += f" {argument}"
+        if cmd != "batocera-resolution setMode":
+            eslog.debug(f"setVideoMode({videomode}): {cmd} ")
             os.system(cmd)
 
 def getCurrentMode():

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -69,7 +69,7 @@ case "${ACTION}" in
 	    for subitem in $LINE
 	    do
 	        if [[ ! $(echo $subitem | grep "x") ]]; then
-	            echo $RES $subitem Hz:$RES $subitem Hz
+	            echo "${RES} ${subitem}:${RES} ${subitem}Hz"
 	        fi
 	    done
 	done
@@ -88,7 +88,18 @@ case "${ACTION}" in
 	fi
 	;;
     "currentMode")
-	xrandr --listModes | grep -E '\*$' | sed -e s+'\*$'++ | sed -e s+'\*$'++ -e s+'^[^ ]* '++
+	#xrandr --listModes | grep -E '\*$' | sed -e s+'\*$'++ | sed -e s+'\*$'++ -e s+'^[^ ]* '++
+	for item in $(xrandr -q | grep "   " | sed -e s+'\+'+''+ | sed -e s+' '+'-'+g | xargs -n1)
+	do
+	    LINE=$(echo $item | sed -e s+'-'+' '+g)
+	    RES=$(echo $LINE | awk {'print $1'})
+	    for subitem in $LINE
+        do
+	        if [[ $(echo $subitem | grep "*") ]]; then
+	            echo $RES $subitem | sed -e s+'\*'+''+
+	        fi
+	    done
+	done
 	;;
     "currentResolution")
 	xrandr --currentResolution | tail -n1

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -61,10 +61,22 @@ case "${ACTION}" in
     "listModes")
 	echo "max-1920x1080:maximum 1920x1080"
 	echo "max-640x480:maximum 640x480"
-	xrandr --listModes | sed -e s+'\*$'++ | sed -e s+'^[^ ]* \(.*\)$'+'\1:\1'+
+	#xrandr --listModes | sed -e s+'\*$'++ | sed -e s+'^[^ ]* \(.*\)$'+'\1:\1'+
+	for item in $(xrandr -q | grep "   " | sed -e s+'\*'+''+ | sed -e s+'\+'+''+ | sed -e s+' '+'-'+g | xargs -n1)
+	do
+	    LINE=$(echo $item | sed -e s+'-'+' '+g)
+	    RES=$(echo $LINE | awk {'print $1'})
+	    for subitem in $LINE
+	    do
+	        if [[ ! $(echo $subitem | grep "x") ]]; then
+	            echo $RES $subitem:$RES $subitem Hz
+	        fi
+	    done
+	done
 	;;
     "setMode")
 	MODE=$1
+	RATE=$2
 
 	if echo "${MODE}" | grep -qE 'max-' # special max-widthxheight
 	then
@@ -72,7 +84,7 @@ case "${ACTION}" in
 	    f_minTomaxResolution "${SPMODE}"
 	else # normal mode
 	    OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
-	    xrandr --output "${OUTPUT}" --mode "${MODE}"
+	    xrandr --output "${OUTPUT}" --mode "${MODE}" --rate "${RATE}"
 	fi
 	;;
     "currentMode")

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -76,13 +76,13 @@ case "${ACTION}" in
 	;;
     "setMode")
 	MODE=$1
-	RATE=$2
 
 	if echo "${MODE}" | grep -qE 'max-' # special max-widthxheight
 	then
 	    SPMODE=$(echo "${MODE}" | sed -e s+"^max-"++)
 	    f_minTomaxResolution "${SPMODE}"
 	else # normal mode
+	    RATE=$2
 	    OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
 	    xrandr --output "${OUTPUT}" --mode "${MODE}" --rate "${RATE}"
 	fi

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.xorg
@@ -69,7 +69,7 @@ case "${ACTION}" in
 	    for subitem in $LINE
 	    do
 	        if [[ ! $(echo $subitem | grep "x") ]]; then
-	            echo $RES $subitem:$RES $subitem Hz
+	            echo $RES $subitem Hz:$RES $subitem Hz
 	        fi
 	    done
 	done


### PR DESCRIPTION
Improvement to https://github.com/batocera-linux/batocera.linux/pull/5278

Lists all the modes with their refresh rate too for xorg, exactly like the drm service already does it as well.

![Capture](https://user-images.githubusercontent.com/67527064/147231409-9945ba25-2385-4dce-8619-1231fd5e6672.PNG)
![screenshot-2021 12 23-22h02 39](https://user-images.githubusercontent.com/67527064/147231468-c1c399b6-edce-4dad-a4da-c31a6b130695.png)

