### PR TITLE
Fix wifi regulatory database

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -48,6 +48,8 @@ wifi_configure_all() {
 wifi_enable() {
     # WLAN enabled?
     settingsWlan="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.enabled)"
+    settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
+    [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
     if [ "$settingsWlan" != "1" ];then
 	connmanctl disable wifi 2>/dev/null
 	return

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -122,6 +122,8 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_WPA_SUPPLICANT_WPA3                  # wifi
 	select BR2_PACKAGE_WPA_SUPPLICANT_NL80211               # wpa_supplicant driver
 	select BR2_PACKAGE_WPA_SUPPLICANT_WEXT                  # wpa_supplicant driver
+	select BR2_PACKAGE_WIRELESS_REGDB                       # wireless regulatory DB
+	select BR2_PACKAGE_IW                                   # wireless country config for regulatoryDB
 	select BR2_PACKAGE_DROPBEAR                             # ssh server
 	select BR2_PACKAGE_PM_UTILS                             # suspend
 	select BR2_PACKAGE_QTSIXA_SHANWAN                       # ps3 pad


### PR DESCRIPTION
First, this PR fixes kernel error messages like:
> [    7.945594] platform regulatory.0: Direct firmware load for regulatory.db failed with error -2 
> [    7.945604] cfg80211: failed to load regulatory.db 

Then, you can now add a 2-letter country code (ISO 3166-1 alpha-2) in `batocera.conf` to lookup the wifi regulatory settings for your country, like `wifi.country=US`, to fix some wifi issues.