### PR TITLE
Bump cemu to 1.26.0d

### DIFF
--- a/package/batocera/emulators/cemu/cemu/cemu.hash
+++ b/package/batocera/emulators/cemu/cemu/cemu.hash
@@ -1,2 +1,2 @@
 # Locally calculated after checking pgp signature
-sha256 46a7188e7b5b98ec608481ca3b9d9543dedd429ecf5e54ad30d19af26310412f  cemu_1.25.6.zip
+sha256 c5275a6ff31f4fa72ab45157156e2a74ed673156a57722ec32fb7278b0ac045c  cemu_1.26.0.zip

--- a/package/batocera/emulators/cemu/cemu/cemu.mk
+++ b/package/batocera/emulators/cemu/cemu/cemu.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-# version 1.25.6
-CEMU_VERSION = 1.25.6
+# version 1.26.0
+CEMU_VERSION = 1.26.0
 CEMU_SOURCE = cemu_$(CEMU_VERSION).zip
 CEMU_SITE = https://cemu.info/releases
 


### PR DESCRIPTION
Team Cemu has released the new version 1.26.0 on 12-24-2021. There are many bugfixes and improvements. They have also completely reworked the input system, which potentially closes [#4375](https://github.com/batocera-linux/batocera.linux/issues/4375).
For full changelog see https://cemu.info/changelog/cemu_1_26_0.txt