### PR TITLE
Rollback libretro-vice for c64 (later commits all segfault)

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-vice/libretro-vice.mk
@@ -3,8 +3,8 @@
 # LIBRETRO-VICE
 #
 ################################################################################
-# Version.: Commits on Dec 8, 2021
-LIBRETRO_VICE_VERSION = 9a0ca16706fccc87f2b7cce074867e7b184be0c9
+# Version.: Commits on Oct 05, 2021 (later commits until Dec 27 lead to a segfault)
+LIBRETRO_VICE_VERSION = f290934c5efeaad73ea7850db0e73d437da9a088
 LIBRETRO_VICE_SITE = $(call github,libretro,vice-libretro,$(LIBRETRO_VICE_VERSION))
 LIBRETRO_VICE_LICENSE = GPLv2
 


### PR DESCRIPTION
I tried to investigate with more recent commits, but all seem to segfault (on x86_64 + OGS at least)