### PR TITLE
Fix arrow keys in C64 controller mapping & other libretro-vice settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -160,6 +160,11 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('vice_external_palette', system.config['external_palette'])
         else:
             coreSettings.save('vice_external_palette', '"colodore"')
+        # Button options
+        if system.isOptSet('button_options_c64'):
+            coreSettings.save('vice_retropad_options', '"' + system.config['button_options_c64'] + '"')
+        else:
+            coreSettings.save('vice_retropad_options', '"jump"')
         # Select Controller Port
         if system.isOptSet('vice_joyport'):
             coreSettings.save('vice_joyport', '"' + system.config['vice_joyport'] + '"')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -105,10 +105,12 @@ def generateCoreSettings(coreSettings, system, rom):
         coreSettings.save('vice_read_vicerc',       '"disabled"')
         # Select Joystick Type
         coreSettings.save('vice_Controller',        '"joystick"')
+        # Disable Turbo Fire
+        coreSettings.save('vice_turbo_fire',        '"disabled"')
         # Controller options for c64 are in libretroControllers.py
-        c64_mapping = { 'a': "RETROK_SPACE",
+        c64_mapping = { 'a': "---",
                 'aspect_ratio_toggle': "---",
-                'b': "JOYSTICK_FIRE",
+                'b': "---",
                 'joyport_switch': "RETROK_F10",
                 'l': "RETROK_ESCAPE",
                 'l2': "RETROK_F11",
@@ -129,8 +131,9 @@ def generateCoreSettings(coreSettings, system, rom):
                 'statusbar': "RETROK_F9",
                 'vkbd': "RETROK_F12",
                 'warp_mode': "RETROK_F11",
-                'x': "RETROK_n",
-                'y': "RETROK_y" }
+                'turbo_fire_toggle': "RETROK_RCTRL",
+                'x': "RETROK_RCTRL",
+                'y': "RETROK_SPACE" }
         for key in c64_mapping:
             coreSettings.save('vice_mapper_' + key, c64_mapping[key])
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -97,6 +97,8 @@ def generateCoreSettings(coreSettings, system, rom):
 
         # Activate Jiffydos
         coreSettings.save('vice_jiffydos',          '"enabled"')
+        # Enable Automatic Load Warp
+        coreSettings.save('vice_autoloadwarp',      '"enabled"')
         # Disable Datasette Hotkeys
         coreSettings.save('vice_datasette_hotkeys', '"disabled"')
         # Not Read 'vicerc'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -119,7 +119,6 @@ def generateCoreSettings(coreSettings, system, rom):
                 'lu': "---",
                 'r': "RETROK_PAGEUP",
                 'r2': "RETROK_LSHIFT",
-                'r3': "RETROK_F12",
                 'rd': "RETROK_F7",
                 'reset': "---",
                 'rl': "RETROK_F3",
@@ -128,11 +127,10 @@ def generateCoreSettings(coreSettings, system, rom):
                 'select': "TOGGLE_VKBD",
                 'start': "RETROK_RETURN",
                 'statusbar': "RETROK_F9",
-                'vkbd': "---",
+                'vkbd': "RETROK_F12",
                 'warp_mode': "RETROK_F11",
                 'x': "RETROK_n",
-                'y': "RETROK_y",
-                'zoom_mode_toggle': "RETROK_F12"}
+                'y': "RETROK_y" }
         for key in c64_mapping:
             coreSettings.save('vice_mapper_' + key, c64_mapping[key])
 
@@ -148,9 +146,12 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('vice_aspect_ratio', '"pal"')
         # Zoom Mode
         if system.isOptSet('zoom_mode_c64'):
-            coreSettings.save('vice_zoom_mode', system.config['zoom_mode_c64'])
+            if system.config['zoom_mode_c64'] == 'automatic':
+                coreSettings.save('vice_zoom_mode', '"auto"')
+            else:
+                coreSettings.save('vice_zoom_mode', system.config['zoom_mode_c64'])
         else:
-            coreSettings.save('vice_zoom_mode', '"medium"')
+            coreSettings.save('vice_zoom_mode', '"auto_disable"')
         # External palette
         if system.isOptSet('external_palette'):
             coreSettings.save('vice_external_palette', system.config['external_palette'])

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -97,8 +97,8 @@ def generateCoreSettings(coreSettings, system, rom):
 
         # Activate Jiffydos
         coreSettings.save('vice_jiffydos',          '"enabled"')
-        # Enable Datasette Hotkeys
-        coreSettings.save('vice_datasette_hotkeys', '"enabled"')
+        # Disable Datasette Hotkeys
+        coreSettings.save('vice_datasette_hotkeys', '"disabled"')
         # Not Read 'vicerc'
         coreSettings.save('vice_read_vicerc',       '"disabled"')
         # Select Joystick Type
@@ -107,12 +107,6 @@ def generateCoreSettings(coreSettings, system, rom):
         c64_mapping = { 'a': "RETROK_SPACE",
                 'aspect_ratio_toggle': "---",
                 'b': "JOYSTICK_FIRE",
-                'datasette_forward': "RETROK_RIGHT",
-                'datasette_reset': "---",
-                'datasette_rewind': "RETROK_LEFT",
-                'datasette_start': "RETROK_UP",
-                'datasette_stop': "RETROK_DOWN",
-                'datasette_toggle_hotkeys': "---",
                 'joyport_switch': "RETROK_F10",
                 'l': "RETROK_ESCAPE",
                 'l2': "RETROK_F11",

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2909,6 +2909,12 @@ libretro:
                     "small":                    small
                     "medium":                   medium
                     "maximum":                  maximum
+            button_options_c64:
+                prompt:      JUMP ON A
+                description: Makes second fire button press up instead.
+                choices:
+                    "Off":                      disabled
+                    "On":                       jump
             vice_joyport:
                 prompt:      CONTROLLER PORT
                 description: Most games use port 2, some use port 1.

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2903,7 +2903,9 @@ libretro:
                 prompt:      ZOOM (HIDE BORDERS)
                 description: Hides borders on many games. Some games used the borders.
                 choices:
-                    "Off":                      none
+                    "Auto-disable zoom":        auto_disable
+                    "Auto zoom":                automatic
+                    "Off":                      disabled
                     "small":                    small
                     "medium":                   medium
                     "maximum":                  maximum


### PR DESCRIPTION
Remove datasette actions from C64 controller mappings.
This fixes arrow keys.

@Kugelblitz360 has thinks arrow keys should not be mapped to datasette actions.