### PR TITLE
Fixin' libretro stuff...

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -367,6 +367,21 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         else:
             retroarchConfig['input_libretro_device_p1'] = '1'
 
+    ## ZX Spectrum
+    if (system.config['core'] == 'fuse'):
+        if system.isOptSet('controller1_zxspec'):
+            retroarchConfig['input_libretro_device_p1'] = system.config['controller1_zxspec']
+        else:
+            retroarchConfig['input_libretro_device_p1'] = '769'                               #Sinclair 1 controller - most used on games
+        if system.isOptSet('controller2_zxspec'):
+            retroarchConfig['input_libretro_device_p2'] = system.config['controller2_zxspec']
+        else:
+            retroarchConfig['input_libretro_device_p2'] = '1025'                              #Sinclair 2 controller 
+        if system.isOptSet('controller3_zxspec'):
+            retroarchConfig['input_libretro_device_p3'] = system.config['controller3_zxspec']
+        else:
+            retroarchConfig['input_libretro_device_p3'] = '0'
+
     # Smooth option
     if system.isOptSet('smooth') and system.getOptBoolean('smooth') == True:
         retroarchConfig['video_smooth'] = 'true'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -305,6 +305,13 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('puae_mouse_speed', system.config['mouse_speed'])
         else:
             coreSettings.save('puae_mouse_speed', '"200"')
+        # Jump on B
+        if system.isOptSet('pad_options'):
+            coreSettings.save('puae_retropad_options', system.config['pad_options'])
+        elif system.name == 'amigacdtv':
+            coreSettings.save('puae_retropad_options', '"disabled"')
+        else:
+            coreSettings.save('puae_retropad_options', '"jump"')
 
         if (system.name == 'amiga500') or (system.name == 'amiga1200'):
             # Floppy Turbo Speed
@@ -322,11 +329,6 @@ def generateCoreSettings(coreSettings, system, rom):
                 coreSettings.save('puae_use_whdload_prefs', system.config['whdload'])
             else:
                 coreSettings.save('puae_use_whdload_prefs', '"config"')
-            # Jump on B
-            if system.isOptSet('pad_options'):
-                coreSettings.save('puae_retropad_options', system.config['pad_options'])
-            else:
-                coreSettings.save('puae_retropad_options', '"jump"')
             # Disable Emulator Joystick for Pad2Key
             if system.isOptSet('disable_joystick'):
                 coreSettings.save('puae_physical_keyboard_pass_through', system.config['disable_joystick'])
@@ -874,6 +876,8 @@ def generateCoreSettings(coreSettings, system, rom):
                 coreSettings.save('gambatte_gbc_color_correction', system.config['gbc_color_correction'])
             else:
                 coreSettings.save('gambatte_gbc_color_correction', '"disabled"')
+        elif (system.name == 'gb'):
+            coreSettings.save('gambatte_gbc_color_correction', '"disabled"')
 
         if (system.name == 'gb'):
             # GB: Colorization of GB games

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1027,8 +1027,7 @@ libretro:
                 description: Required for certain visual effects.
                 choices:
                     "Off":                     disabled
-                    "Simple (Accurate)":       mix
-                    "Simple (Fast)":           mix_fast
+                    "Simple":                  mix
                     "LCD Ghosting (Accurate)": lcd_ghosting
                     "LCD Ghosting (Fast)":     lcd_ghosting_fast
       systems:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -982,6 +982,38 @@ libretro:
                 choices:
                     "Off":  disabled
                     "On":   enabled
+            controller1_zxspec:
+                prompt:      CONTROLLER TYPE 1
+                description: Sinclair 1 controller set to AUTO.
+                choices:
+                    "None":                    0
+                    "Retropad":                1
+                    "Cursor Joystick":         257
+                    "Kempston Joystick":       513
+                    "Sinclair 1 Joystick":     769
+                    "Sinclair 2 Joystick":     1025
+                    "Timex 1 Joystick":        1281
+                    "Timex 2 Joystick":        1537
+                    "Fuller Joystick":         1793
+            controller2_zxspec:
+                prompt:      CONTROLLER TYPE 2
+                description: Sinclair 2 controller set to AUTO.
+                choices:
+                    "None":                    0
+                    "Retropad":                1
+                    "Cursor Joystick":         257
+                    "Kempston Joystick":       513
+                    "Sinclair 1 Joystick":     769
+                    "Sinclair 2 Joystick":     1025
+                    "Timex 1 Joystick":        1281
+                    "Timex 2 Joystick":        1537
+                    "Fuller Joystick":         1793
+            controller3_zxspec:
+                prompt:      KEYBOARD SUPPORT
+                description: Set controller 1 and 2 to None to use it standalone.
+                choices:
+                    "Off":                     0
+                    "On":                      259
     gambatte:
       features: [rewind, autosave, cheevos]
       cfeatures:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2279,6 +2279,12 @@ libretro:
                     "150%":       150
                     "170%":       170
                     "200%":       200
+            pad_options:
+                prompt:      JUMP ON B
+                description: Makes second fire button press up instead.
+                choices:
+                    "Off":    disabled
+                    "On":     jump
       systems:
             amiga500:
                 cfeatures:
@@ -2300,12 +2306,6 @@ libretro:
                         choices:
                             "Off":    disabled
                             "On":     config
-                    pad_options:
-                        prompt:      JUMP ON B
-                        description: Makes second fire button press up instead.
-                        choices:
-                            "Off":    disabled
-                            "On":     jump
                     disable_joystick:
                         prompt:      DISABLE EMULATOR JOYSTICK
                         description: Passes all physical keyboard events for Pad2Key.


### PR DESCRIPTION
- Added 'Jump on B' support to CDTV (`AUTO` is set to `OFF` to this system. CDTV pad has two buttons and a lot of games support them)
- Fixed 'Game Boy Classic' color correction bug. Now it's hardcoded as 'disabled' and screen shows more greenish.
- Added ZX Spectrum Controller Type selection. This is the most difficult, because FUSE has a bizarre and complex controller support. To use Keyboard only just set `Controller Type 1` and `2` to `NONE` and set `Keyboard Support` to `ON`. `AUTO` is set to `Sinclair 1 Controller` to the **Controller 1** and` Sinclair 2 Controller` to the **Controller 2**.  Added Type 1 and 2 of Sinclair and Timex to all the two players because some games request this (maybe for port switching, dunno.)

Read the documentation from libretro docs:

```
There are seven types of joysticks emulated:

- Cursor
- Kempston
- Sinclair 1
- Sinclair 2
- Timex 1
- Timex 2
- Fuller Joystick

Users can configure their joystick types in the input configuration on the front end. However, fuse-libretro allows for two joysticks at maximum so only users one and two can actually use theirs in the emulation.

Users 1 and 2 can choose any of the joysticks as their device types, user 3 can only choose the Sinclair Keyboard.

Buttons A, X and Y are mapped to the joystick's fire button, and button B is mapped to the UP directional button. Buttons L1 and R1 are mapped to RETURN and SPACE, respectively. The SELECT button brings up the embedded, on-screen keyboard which is useful if you only have controllers attached to your box.

There are some conflicts in the way the input devices interact because of the use of the physical keyboard keys as joystick buttons. For a good gaming experience, set the user device types as follows:

- For joystick games: Set user 1 to a joystick type. Optionally, set user 2 to another joystick type (local cooperative games). Set user 3 to none. This way, you can use L1 as RETURN, R1 as SPACE, and SELECT to bring the embedded keyboard.
- For keyboard games: Set users 1 and 2 to none, and user 3 to Sinclair Keyboard. You won't have any joystick and the embedded keyboard won't work, but the entire physical keyboard will be available for you to type in those text adventure commands.

If you set a joystick along with the keyboard, the joystick will work just fine except for the bindings to RETURN and SPACE, and the keyboard won't register the keys assigned to the Cursor joystick, or to the L1 and R1 buttons for all other joystick types.
```

Tested and worked.