### PR TITLE
Bump lr_dosbox-pure

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on Oct 20, 2021
-LIBRETRO_DOSBOX_PURE_VERSION = 0.20
+# Version.: Commits on Dec 13, 2021
+LIBRETRO_DOSBOX_PURE_VERSION = 0.21
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
Changes in 0.21:

- Remove legacy timing mode
- Variable latency mode when using the experimental timing which behaves similar to the old timing mode
- Fix 'SVGA Mode' core option not showing (https://github.com/schellingb/dosbox-pure/issues/215)
- Incorporate latest changes from vanilla DOSBox SVN

The new timing mode with better timing and video synchronization which was introduced in version 0.18 is now always active and the old behavior and all its code have been removed. If you encounter issues with it, please report them in https://github.com/schellingb/dosbox-pure/issues/184

Some new options are available in the core options under the category Emulation:

- `Force 60 FPS Output`: Enable this to force output at 60FPS.
- `Show Performance Statistics`: Shows some frame time statistics on screen.
- `Advanced > Input Latency`: Has two advanced modes which modify the cores behavior:
     - `Default`: Recommended mode with high performance and good input latency
     - `Lowest Latency`: Get a tiny bit of input latency reduction but needs to be manually tweaked
     - `Irregular Latency`: Behaves similar to the previous versions, can sometimes add a frame of input latency and flickering on-screen-keyboard