### PR TITLE
use core provided as default aspect ratio for libretro

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -427,7 +427,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
             retroarchConfig['video_aspect_ratio_auto'] = 'false'
         else:
             retroarchConfig['video_aspect_ratio_auto'] = 'true'
-            retroarchConfig['aspect_ratio_index'] = ''
+            retroarchConfig['aspect_ratio_index'] = '22'
 
     # Rewind option
     retroarchConfig['rewind_enable'] = 'false'


### PR DESCRIPTION
By default, RetroArch will use a 4:3 aspect ratio when no aspect ratio index is provided. This is what happens in Batocera when the user leaves the "GAME ASPECT RATIO" setting on "AUTO". This is suitable for most systems.

However, systems such as the Game Boy and various vertical Arcade games that use different aspect ratios outside of 4:3, and look weird and distorted when forced to 4:3. Attached is an example of Game Boy being stretched to 4:3 (the current way Batocera treats the "AUTO" setting):

![screenshot-2022 01 03-22h09 45](https://user-images.githubusercontent.com/67527064/147924280-2f38ac08-03f3-41a9-aac6-aae92073fb9c.png)

and after the fix:

![screenshot-2022 01 03-22h10 03](https://user-images.githubusercontent.com/67527064/147924300-b3e9ee00-9b16-4e51-b070-e10bf43e46fe.png)

Note that this change will not affect anything when decorations are turned on, as they use their own viewport settings. This is only for when decorations are set to "NONE".