### PR TITLE
switch from ANTIALIAS to BICUBIC in bezels.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -73,7 +73,7 @@ def resizeImage(input_png, output_png, screen_width, screen_height):
     if imgin.mode != "RGBA":
         alphaPaste(input_png, output_png, imgin, fillcolor, (screen_width, screen_height))
     else:
-        imgout = imgin.resize((screen_width, screen_height), Image.ANTIALIAS)
+        imgout = imgin.resize((screen_width, screen_height), Image.BICUBIC)
         imgout.save(output_png, mode="RGBA", format="PNG")
 
 def padImage(input_png, output_png, screen_width, screen_height, bezel_width, bezel_height):
@@ -135,13 +135,13 @@ def tatooImage(input_png, output_png, system):
           pcent = float(w / tw)
           th = int(float(th) * pcent)
           # Resize the tattoo to the calculated size.
-          tattoo = tattoo.resize((w,th), Image.ANTIALIAS)
+          tattoo = tattoo.resize((w,th), Image.BICUBIC)
   else:
       # Resize to be slightly smaller than the bezel's column.
       twtemp = int((225/1920) * w)
       pcent = float(twtemp / tw)
       th = int(float(th) * pcent)
-      tattoo = tattoo.resize((twtemp,th), Image.ANTIALIAS)
+      tattoo = tattoo.resize((twtemp,th), Image.BICUBIC)
       tw = twtemp
   # Create a new blank canvas that is the same size as the bezel for later compositing (they are required to be the same size).
   tattooCanvas = Image.new("RGBA", back.size)


### PR DESCRIPTION
Switches the resizing filters used in bezels.py from ANTIALIAS to BICUBIC, producing cleaner results.

> Right now we use the default ANTIALIAS image filter for resizing bezels and bezel elements. This uses the Lanczos filter, which is supposedly the highest quality for both upscaling and downscaling images. However, in my testing, I have found that Lanczos has a tendency to oversharpen the resulting image, creating "highlights" that weren't there in the original image.
>
> Specifically look at this example, the BICUBIC filter is used on the left, and the LANCZOS filter is used on the right. Notice how the pixels right on either side of the latter T character are slightly brighter? You might also noticed the increased (artificial) contrast on the bezel decoration in the background.
>
> ![unknown](https://user-images.githubusercontent.com/67527064/147997912-b5441b1d-f17e-4c1b-a18d-15cb45013552.png)
>
> This is most noticeable on the faded out circle in the bottom right: you can see pixels that are brighter than they are supposed to be right on the inside of the ring.

In addition, ANTIALIAS is a depreciated term and should no longer be used anyway: https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html?#image-resizing-filters