### PR TITLE
lr-mame Control Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -27,7 +27,7 @@ systemToSwapDisable = {'amigacd32', 'amigacdtv', 'naomi', 'atomiswave', 'megadri
 
 # Write a configuration for a specified controller
 # Warning, function used by amiberry because it reads the same retroarch formatting
-def writeControllersConfig(retroconfig, system, controllers):
+def writeControllersConfig(retroconfig, system, controllers, lightgun):
     # Map buttons to the corresponding retroarch specials keys
     retroarchspecials = {'x': 'load_state', 'y': 'save_state', 'a': 'reset', 'start': 'exit_emulator', \
                          'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', 'right': 'hold_fast_forward', \
@@ -55,7 +55,7 @@ def writeControllersConfig(retroconfig, system, controllers):
         del retroarchspecials['b']
 
     for controller in controllers:
-        writeControllerConfig(retroconfig, controllers[controller], controller, system, retroarchspecials)
+        writeControllerConfig(retroconfig, controllers[controller], controller, system, retroarchspecials, lightgun)
     writeHotKeyConfig(retroconfig, controllers)
 
 # Remove all controller configurations
@@ -73,8 +73,8 @@ def writeHotKeyConfig(retroconfig, controllers):
 
 
 # Write a configuration for a specified controller
-def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarchspecials):
-    generatedConfig = generateControllerConfig(controller, retroarchspecials, system)
+def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarchspecials, lightgun):
+    generatedConfig = generateControllerConfig(controller, retroarchspecials, system, lightgun)
     for key in generatedConfig:
         retroconfig.save(key, generatedConfig[key])
 
@@ -83,7 +83,7 @@ def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarc
 
 
 # Create a configuration for a given controller
-def generateControllerConfig(controller, retroarchspecials, system):
+def generateControllerConfig(controller, retroarchspecials, system, lightgun):
 # Map an emulationstation button name to the corresponding retroarch name
     retroarchbtns = {'a': 'a', 'b': 'b', 'x': 'x', 'y': 'y', \
                      'pageup': 'l', 'pagedown': 'r', 'l2': 'l2', 'r2': 'r2', \
@@ -108,12 +108,13 @@ def generateControllerConfig(controller, retroarchspecials, system):
             input = controller.inputs[btnkey]
             config['input_player%s_%s_%s' % (controller.player, btnvalue, typetoname[input.type])] = getConfigValue(
                 input)
-    for btnkey in retroarchGunbtns: # Gun Mapping
-        btnvalue = retroarchGunbtns[btnkey]
-        if btnkey in controller.inputs:
-            input = controller.inputs[btnkey]
-            config['input_player%s_gun_%s_%s' % (controller.player, btnvalue, typetoname[input.type])] = getConfigValue(
-                input)
+    if lightgun:
+        for btnkey in retroarchGunbtns: # Gun Mapping
+            btnvalue = retroarchGunbtns[btnkey]
+            if btnkey in controller.inputs:
+                input = controller.inputs[btnkey]
+                config['input_player%s_gun_%s_%s' % (controller.player, btnvalue, typetoname[input.type])] = getConfigValue(
+                    input)
     for dirkey in retroarchdirs:
         dirvalue = retroarchdirs[dirkey]
         if dirkey in controller.inputs:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -121,9 +121,10 @@ def generateControllerConfig(controller, retroarchspecials, system, lightgun):
             input = controller.inputs[dirkey]
             config['input_player%s_%s_%s' % (controller.player, dirvalue, typetoname[input.type])] = getConfigValue(
                 input)
-            # Gun Mapping
-            config['input_player%s_gun_dpad_%s_%s' % (controller.player, dirvalue, typetoname[input.type])] = getConfigValue(
-                input)
+            if lightgun:
+                # Gun Mapping
+                config['input_player%s_gun_dpad_%s_%s' % (controller.player, dirvalue, typetoname[input.type])] = getConfigValue(
+                    input)
     for jskey in retroarchjoysticks:
         jsvalue = retroarchjoysticks[jskey]
         if jskey in controller.inputs:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -32,7 +32,15 @@ class LibretroGenerator(Generator):
                 libretroRetroarchCustom.generateRetroarchCustom()
             #  Write controllers configuration files
             retroconfig = UnixSettings(batoceraFiles.retroarchCustom, separator=' ')
-            libretroControllers.writeControllersConfig(retroconfig, system, playersControllers)
+            if system.isOptSet['lightgun_map']:
+                lightgun = system.getOptBoolean['lightgun_map']
+            else:
+                # Lightgun button mapping breaks lr-mame's inputs, disable if left on auto
+                if system.config['core'] == "mame":
+                    lightgun = False
+                else:
+                    lightgun = True
+            libretroControllers.writeControllersConfig(retroconfig, system, playersControllers, lightgun)
             # force pathes
             libretroRetroarchCustom.generateRetroarchCustomPathes(retroconfig)
             # Write configuration to retroarchcustom.cfg

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -32,8 +32,8 @@ class LibretroGenerator(Generator):
                 libretroRetroarchCustom.generateRetroarchCustom()
             #  Write controllers configuration files
             retroconfig = UnixSettings(batoceraFiles.retroarchCustom, separator=' ')
-            if system.isOptSet['lightgun_map']:
-                lightgun = system.getOptBoolean['lightgun_map']
+            if system.isOptSet('lightgun_map'):
+                lightgun = system.getOptBoolean('lightgun_map')
             else:
                 # Lightgun button mapping breaks lr-mame's inputs, disable if left on auto
                 if system.config['core'] == "mame":

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -75,7 +75,12 @@ libretro:
         choices:
             "On":   "true"
             "Off":  "false"
-
+    lightgun_map:
+        prompt:      CONTROLLER TO LIGHTGUN
+        description: Map controller inputs to lightgun inputs
+        choices:
+            "On":   "true"
+            "Off":  "false"
   cores:
     '81':
       features: [netplay, rewind, autosave, padtokeyboard]


### PR DESCRIPTION
Fixing controls for lr-mame:

By default, lr-mame maps lightgun buttons as secondary activators for joystick buttons. Unlike any other core (that I've found), pressing a button will register both the controller and lightgun button. Batocera's libretro generator maps the controller to the lightgun aim and buttons, the end result is that Retropad A pushes MAME buttons 1&2 together, making some games unplayable.

The fix was to create a "Map Lightgun" option for Retroarch-based emulators. If left on auto, the mame core will leave the lightgun unmapped, every other core will map as it normally does. It can be toggled manually for lightgun games or other systems where it might not need to be mapped.

This results in lr-mame controls working as expected, and no disruption to any other core.