### PR TITLE
Libretro - Fix widget scaling

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -604,6 +604,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
         retroarchConfig['menu_widget_scale_factor_windowed'] = '2.0000'
     else:
         retroarchConfig['video_font_size'] = '32'
+        retroarchConfig['menu_widget_scale_auto'] = 'true'
         # don't force any so that the user can choose
         #retroarchConfig['menu_driver'] = 'ozone'
         # force the assets directory while it was wrong in some beta versions


### PR DESCRIPTION
I've added `retroarchConfig['menu_widget_scale_auto'] = 'true'` because when you are using a lower resolution than 480p (width or height) and next you goes back to higher resolution, notification widget size stills big. Maybe this line was forgotten.