### PR TITLE
Ensure altlayout parameter is converted to int before using it

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -229,7 +229,7 @@ class MameGenerator(Generator):
         
         # Controls for games with 5-6 buttons or other unusual controls
         if system.isOptSet("altlayout"):
-            buttonLayout = system.config["altlayout"] # Option was manually selected
+            buttonLayout = int(system.config["altlayout"]) # Option was manually selected
         else:
             capcomList = set(open(mameCapcom).read().split())
             mkList = set(open(mameMKombat).read().split())


### PR DESCRIPTION
Currently MAME alt controller layouts are not working for me without this fix. 

\cc @TVsIan