### PR TITLE
add "auto frameskip" option to ppsspp

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -50,16 +50,17 @@ def createPPSSPPConfig(iniConfig, system):
         iniConfig.set("Graphics", "ShowFPSCounter", "0")
 
     # Frameskip
-    iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not pourcent
-    iniConfig.set("Graphics", "AutoFrameSkip", "False")
-    if system.isOptSet("frameskip"):
-        if system.config["frameskip"] == "automatic":
-            iniConfig.set("Graphics", "AutoFrameSkip", "True")
-            iniConfig.set("Graphics", "FrameSkip",     "1")
-        else:
-            iniConfig.set("Graphics", "FrameSkip", str(system.config["frameskip"]))
+    iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not percent
+    if system.isOptSet("frameskip") and not system.config["frameskip"] == "automatic":
+        iniConfig.set("Graphics", "FrameSkip", str(system.config["frameskip"]))
     else:
-        iniConfig.set("Graphics", "FrameSkip",     "0")
+        iniConfig.set("Graphics", "FrameSkip", "2")
+
+    # Auto frameskip
+    if system.isOptSet("autoframeskip") and system.getOptBoolean("autoframeskip") == False:
+        iniConfig.set("Graphics", "AutoFrameSkip", "False")
+    else:
+        iniConfig.set("Graphics", "AutoFrameSkip", "True")
 
     # VSync Interval
     if system.isOptSet('vsyncinterval') and system.getOptBoolean('vsyncinterval') == False:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidc2.yml
@@ -41,6 +41,3 @@ cplus4:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -11,9 +11,6 @@ dreamcast:
     retroarch.video_hard_sync: 1
     # setting to fix Flycast performances on xu4
     reicast_synchronous_rendering: disabled
-psp:
-  options:
-    frameskip: automatic
 psx:
   options:
     # menu retroarch

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-orangepi-pc.yml
@@ -40,6 +40,3 @@ cplus4:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3288.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3288.yml
@@ -10,7 +10,3 @@ amigacd32:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic
-    frameskiptype: 2

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3326.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3326.yml
@@ -11,7 +11,6 @@ n64:
     mupen64plus.Video-General.Rotate: 0 # for people upgrading
 psp:
   options:
-    frameskip: automatic
     ppsspp.General.InternalScreenRotation: 0 # for people upgrading
 nds:
   emulator: drastic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,6 +1,3 @@
 nds:
   emulator: drastic
   core:     drastic
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -1,6 +1,3 @@
 nds:
   emulator: drastic
   core:     drastic
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s812.yml
@@ -41,6 +41,3 @@ cplus4:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s905.yml
@@ -41,6 +41,3 @@ cplus4:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s912.yml
@@ -1,3 +1,0 @@
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-tritium-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-tritium-h5.yml
@@ -40,6 +40,3 @@ cplus4:
 dos:
   emulator: dosbox
   core:     dosbox
-psp:
-  options:
-    frameskip: automatic

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3911,12 +3911,17 @@ ppsspp:
             description: Skip frames to improve performance, at the cost of choppy motion.
             choices:
                 "Off":                  0
-                "Autodetect":           automatic
                 "1":                    1
                 "2":                    2
                 "3":                    3
                 "4":                    4
                 "5":                    5
+        autoframeskip:
+            prompt:      AUTO FRAMESKIP
+            description: Automatically reduce frameskip if the system has spare overhead.
+            choices:
+                "On":                   1
+                "Off":                  0
         vsyncinterval:
             prompt:      VSYNC INTERVAL
             description: Enable for more fluidity, disable if screen tearing.


### PR DESCRIPTION
Being able to set this independently is critical, some people may prefer to have a frameskip that can go up to 2, 3 or even 4 frames with a base that stays as close to native as it can. This is currently not possible with Batocera. This patch fixes that.