### PR TITLE
Bump lr_dosbox-pure to version 0.22

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on Dec 13, 2021
-LIBRETRO_DOSBOX_PURE_VERSION = 0.21
+# Version.: Commits on Jan 5, 2022
+LIBRETRO_DOSBOX_PURE_VERSION = 0.22
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
Changes in 0.22:

* Update automatic key mappings via Keyb2Joypad Project
* Auto start DOSBOX.BAT if it exists
* Improve audio sync
* Spelling fixes

See https://github.com/schellingb/dosbox-pure/releases/tag/0.22