### PR TITLE
enable variable refresh rate for libretro

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -32,6 +32,7 @@
         * add: Mega Bezel shaders by HyperspaceMadness
         * add: libretro-vice x64sc, xplus4 (for Commodore Plus4), x128 (Commodore 128), xvic (VIC-20), xpet (PET)
         * add: batocera-resolution can now adjust refresh rate on xorg (PC x86_64)
+        * add: variable refresh rate enabled and on by default for libretro, turn off with global.retroarch.vrr_run_loop = 0
         * fix: borders are now shown on Vice C64, also fixed default aspect ratio
         * fix: duckstation quick menu can now actually be accessed with hotkey+south
         * fix: RetroArch FSUAE options now functional in amiga500, amiga1200, atarist and sharpx68000.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -140,6 +140,12 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution):
     else:
         retroarchConfig['video_threaded'] = 'false'
 
+    # variable refresh rate
+    if system.isOptSet("vrr_runloop_enable") and system.getOptBoolean("vrr_runloop_enable") == False:
+        retroarchConfig['vrr_runloop_enable'] = 'false'
+    else:
+        retroarchConfig['vrr_runloop_enable'] = 'true'
+
     # required at least for vulkan (to get the correct resolution)
     retroarchConfig['video_fullscreen_x'] = gameResolution["width"]
     retroarchConfig['video_fullscreen_y'] = gameResolution["height"]


### PR DESCRIPTION
I've also tested this option on non-VRR compatible displays and RetroArch handles it quite nicely; it will simply not use VRR.

If a user prefers not to use VRR, they can add `global.retroarch.vrr_runloop_enable=0` to their `batocera.conf` to disable it.