### PR TITLE
Rendering mode setting to ppsspp

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -43,6 +43,12 @@ def createPPSSPPConfig(iniConfig, system):
     else:
         iniConfig.set("Graphics", "GraphicsBackend", "0 (OPENGL)")
 
+    # Buffered rendering
+    if system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
+        iniConfig.set("Graphics", "RenderingMode", "0")
+    else:
+        iniConfig.set("Graphics", "RenderingMode", "1")
+
     # Display FPS
     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
         iniConfig.set("Graphics", "ShowFPSCounter", "3") # 1 for Speed%, 2 for FPS, 3 for both

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -43,12 +43,6 @@ def createPPSSPPConfig(iniConfig, system):
     else:
         iniConfig.set("Graphics", "GraphicsBackend", "0 (OPENGL)")
 
-    # Buffered rendering
-    if system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
-        iniConfig.set("Graphics", "RenderingMode", "0")
-    else:
-        iniConfig.set("Graphics", "RenderingMode", "1")
-
     # Display FPS
     if system.isOptSet('showFPS') and system.getOptBoolean('showFPS') == True:
         iniConfig.set("Graphics", "ShowFPSCounter", "3") # 1 for Speed%, 2 for FPS, 3 for both
@@ -59,26 +53,35 @@ def createPPSSPPConfig(iniConfig, system):
     iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not percent
     if system.isOptSet("frameskip") and not system.config["frameskip"] == "automatic":
         iniConfig.set("Graphics", "FrameSkip", str(system.config["frameskip"]))
+    elif system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
+        iniConfig.set("Graphics", "FrameSkip", "0")
     else:
         iniConfig.set("Graphics", "FrameSkip", "2")
 
-    # Auto frameskip
-    if system.isOptSet("autoframeskip") and system.getOptBoolean("autoframeskip") == False:
+    # Buffered rendering
+    if system.isOptSet('rendering_mode') and system.getOptBoolean('rendering_mode') == False:
+        iniConfig.set("Graphics", "RenderingMode", "0")
+        # Have to force autoframeskip off here otherwise PPSSPP sets rendering mode back to 1.
         iniConfig.set("Graphics", "AutoFrameSkip", "False")
     else:
-        iniConfig.set("Graphics", "AutoFrameSkip", "True")
+        iniConfig.set("Graphics", "RenderingMode", "1")
+        # Both internal resolution and auto frameskip are dependent on buffered rendering being on, only check these if the user is actually using buffered rendering.
+        # Internal Resolution
+        if system.isOptSet('internal_resolution'):
+            iniConfig.set("Graphics", "InternalResolution", str(system.config["internal_resolution"]))
+        else:
+            iniConfig.set("Graphics", "InternalResolution", "1")
+        # Auto frameskip
+        if system.isOptSet("autoframeskip") and system.getOptBoolean("autoframeskip") == False:
+            iniConfig.set("Graphics", "AutoFrameSkip", "False")
+        else:
+            iniConfig.set("Graphics", "AutoFrameSkip", "True")
 
     # VSync Interval
     if system.isOptSet('vsyncinterval') and system.getOptBoolean('vsyncinterval') == False:
         iniConfig.set("Graphics", "VSyncInterval", "False")
     else:
         iniConfig.set("Graphics", "VSyncInterval", "True")
-
-    # Internal Resolution
-    if system.isOptSet('internal_resolution'):
-        iniConfig.set("Graphics", "InternalResolution", str(system.config["internal_resolution"]))
-    else:
-        iniConfig.set("Graphics", "InternalResolution", "1")
 
     # Texture Scaling Level
     if system.isOptSet('texture_scaling_level'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3898,7 +3898,7 @@ ppsspp:
                 "Vulkan":               3 (VULKAN)
         rendering_mode:
             prompt:      RENDERING MODE
-            description: Skipping buffered effects is faster, but certain effects may be missing.
+            description: Skip buffer disables auto frameskip and renders at display output resolution.
             choices:
                 "Buffered rendering":   1
                 "Skip buffer effects":  0

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3779,10 +3779,10 @@ pcsx2:
                 "Software":    13
         fullboot:
             prompt:      SHOW BIOS BOOTLOGO
-            description: Off is safer, On for specific games.
+            description: Some games have issues when the animation is shown, others require it.
             choices:
-                "Show":         1
-                "Skip":         0
+                "Show (specific games)": 1
+                "Skip (safer)":          0
         internal_resolution:
             prompt:      RENDERING RESOLUTION
             description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
@@ -3896,6 +3896,12 @@ ppsspp:
             choices:
                 "OpenGL":               0 (OPENGL)
                 "Vulkan":               3 (VULKAN)
+        rendering_mode:
+            prompt:      RENDERING MODE
+            description: Skipping buffered effects is faster, but certain effects may be missing.
+            choices:
+                "Buffered rendering":   1
+                "Skip buffer effects":  0
         internal_resolution:
             prompt:      RENDERING RESOLUTION
             description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.


### PR DESCRIPTION
Allows the user to choose between buffered rendering and skip buffer mode. This can dramatically improve the framerates at minimal fidelity loss for certain games/hardware. Also made the label for a PCSX2 setting clearer.