### PR TITLE
use sharp-bilinear-simple by default

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -51,10 +51,13 @@ class Emulator():
 
         # update renderconfig
         self.renderconfig = {}
-        if "shaderset" in self.config and self.config["shaderset"] != "none":
-            self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults-arch.yml")
-        if "shaderset" not in self.config: # auto
-            self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/rendering-defaults-arch.yml")
+        if "shaderset" in self.config:
+            if self.config["shaderset"] != "none":
+                self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/" + self.config["shaderset"] + "/rendering-defaults-arch.yml")
+            elif self.config["shaderset"] == "none":
+                self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/rendering-defaults-arch.yml")
+        else:
+            self.renderconfig = Emulator.get_generic_config(self.name, "/usr/share/batocera/shaders/configs/sharp-bilinear-simple/rendering-defaults.yml", "/usr/share/batocera/shaders/configs/sharp-bilinear-simple/rendering-defaults-arch.yml")
 
         # for compatibility with earlier Batocera versions, let's keep -renderer
         # but it should be reviewed when we refactor configgen (to Python3?)

--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/batocera-shaders.mk
@@ -54,7 +54,7 @@ define BATOCERA_SHADERS_INSTALL_TARGET_CMDS
 	fi
 
 	# sets
-	for set in retro scanlines enhanced curvature zfast flatten-glow mega-bezel mega-bezel-lite mega-bezel-ultralite; do \
+	for set in sharp-bilinear-simple retro scanlines enhanced curvature zfast flatten-glow mega-bezel mega-bezel-lite mega-bezel-ultralite; do \
 		mkdir -p $(TARGET_DIR)/usr/share/batocera/shaders/configs/$$set; \
 		cp $(BATOCERA_SHADERS_DIRIN)/$$set/rendering-defaults.yml     $(TARGET_DIR)/usr/share/batocera/shaders/configs/$$set/; \
 		if test -e $(BATOCERA_SHADERS_DIRIN)/$$set/rendering-defaults-$(BATOCERA_SHADERS_SYSTEM).yml; then \

--- a/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/sharp-bilinear-simple/rendering-defaults.yml
+++ b/package/batocera/emulators/retroarch/shaders/batocera-shaders/configs/sharp-bilinear-simple/rendering-defaults.yml
@@ -1,0 +1,6 @@
+## SHARP-BILINEAR-SIMPLE
+default:
+  # shader affects retroarch shaders
+  shader: interpolation/sharp-bilinear-simple
+  # scanline affect fba2x
+  scanline: false


### PR DESCRIPTION
Changes the default shader set from "none" to "sharp-bilinear-simple". This also turns off "smooth games" by default, although the user can still manually turn it back on.

Compared to smooth games (the standard "bilinear filter"), the performance difference is negligible. Yet despite this, the "sharp-bilinear-simple" shader produces far sharper results. The following example images were taken from the [shader's github page](https://github.com/rsn8887/sharp-bilinear-shaders/releases).

Standard "smooth games" (before this patch):
![](https://camo.githubusercontent.com/5b2434062e9249bdbe9c37e9819bedd93afc6d3b0e98a9034e53493096074480/68747470733a2f2f696d6167652e6962622e636f2f6a687a44776b2f776974686f75745f7368616465722e706e67)

Same scene with "sharp-bilinear-simple" (after this patch):
![](https://camo.githubusercontent.com/2b18df4bb04dcf9852b3da4bfc7f27c2b093f81513e148a6ca8d5967e7fd1526/68747470733a2f2f696d6167652e6962622e636f2f6855346b39352f776974685f7368616465722e706e67)

I have tested this on both an RPi 4 and PC, however should we need to use a shader that requires even less performance (less than that of even the standard smooth games even), "sharp-bilinear-2x-prescale" does a better job than smooth games but not quite as good as "sharp-bilinear-simple".