### PR TITLE
Amiberry pad2key conf

### DIFF
--- a/package/batocera/emulators/amiberry/controllers/amiga1200.amiberry.keys
+++ b/package/batocera/emulators/amiberry/controllers/amiga1200.amiberry.keys
@@ -1,28 +1,50 @@
 {
     "actions_player1": [
         {
-            "trigger": "joystick2",
+            "trigger": ["joystick2"],
             "type": "mouse"
         },
         {
-            "trigger": "x",
+            "trigger": ["x"],
             "type": "key",
-            "target": "KEY_SPACE"
+            "target": [ "KEY_LEFTCTRL" ],
+            "description": "CTRL Key"
         },
         {
-            "trigger": "y",
+            "trigger": ["y"],
             "type": "key",
-            "target": "KEY_ENTER"
+            "target": [ "KEY_SPACE" ],
+            "description": "SPACE Key"
         },
         {
-            "trigger": "l2",
+            "trigger": ["start"],
             "type": "key",
-            "target": "BTN_LEFT"
+            "target": [ "KEY_ENTER" ],
+            "description": "ENTER Key"
         },
         {
-            "trigger": "r2",
+            "trigger": ["pageup"],
             "type": "key",
-            "target": "BTN_RIGHT"
+            "target": [ "KEY_ESC" ],
+            "description": "ESC Key"
+        },
+        {
+            "trigger": ["pagedown"],
+            "type": "key",
+            "target": [ "KEY_F1" ],
+            "description": "F1 Key"
+        },
+        {
+            "trigger": ["l2"],
+            "type": "key",
+            "target": [ "BTN_LEFT" ],
+            "description": "Mouse Left Button"
+        },
+        {
+            "trigger": ["r2"],
+            "type": "key",
+            "target": [ "BTN_RIGHT" ],
+            "description": "Mouse Right Button"
         }
     ]
 }

--- a/package/batocera/emulators/amiberry/controllers/amiga500.amiberry.keys
+++ b/package/batocera/emulators/amiberry/controllers/amiga500.amiberry.keys
@@ -1,28 +1,50 @@
 {
     "actions_player1": [
         {
-            "trigger": "joystick2",
+            "trigger": ["joystick2"],
             "type": "mouse"
         },
         {
-            "trigger": "x",
+            "trigger": ["x"],
             "type": "key",
-            "target": "KEY_SPACE"
+            "target": [ "KEY_LEFTCTRL" ],
+            "description": "CTRL Key"
         },
         {
-            "trigger": "y",
+            "trigger": ["y"],
             "type": "key",
-            "target": "KEY_ENTER"
+            "target": [ "KEY_SPACE" ],
+            "description": "SPACE Key"
         },
         {
-            "trigger": "l2",
+            "trigger": ["start"],
             "type": "key",
-            "target": "BTN_LEFT"
+            "target": [ "KEY_ENTER" ],
+            "description": "ENTER Key"
         },
         {
-            "trigger": "r2",
+            "trigger": ["pageup"],
             "type": "key",
-            "target": "BTN_RIGHT"
+            "target": [ "KEY_ESC" ],
+            "description": "ESC Key"
+        },
+        {
+            "trigger": ["pagedown"],
+            "type": "key",
+            "target": [ "KEY_F1" ],
+            "description": "F1 Key"
+        },
+        {
+            "trigger": ["l2"],
+            "type": "key",
+            "target": [ "BTN_LEFT" ],
+            "description": "Mouse Left Button"
+        },
+        {
+            "trigger": ["r2"],
+            "type": "key",
+            "target": [ "BTN_RIGHT" ],
+            "description": "Mouse Right Button"
         }
     ]
 }

--- a/package/batocera/emulators/amiberry/controllers/amigacd32.amiberry.keys
+++ b/package/batocera/emulators/amiberry/controllers/amigacd32.amiberry.keys
@@ -1,18 +1,20 @@
 {
     "actions_player1": [
         {
-            "trigger": "joystick2",
+            "trigger": ["joystick2"],
             "type": "mouse"
         },
         {
-            "trigger": "l2",
+            "trigger": ["l2"],
             "type": "key",
-            "target": "BTN_LEFT"
+            "target": [ "BTN_LEFT" ],
+            "description": "Mouse Left Button"
         },
         {
-            "trigger": "r2",
+            "trigger": ["r2"],
             "type": "key",
-            "target": "BTN_RIGHT"
+            "target": [ "BTN_RIGHT" ],
+            "description": "Mouse Right Button"
         }
     ]
 }

--- a/package/batocera/emulators/amiberry/controllers/amigacdtv.amiberry.keys
+++ b/package/batocera/emulators/amiberry/controllers/amigacdtv.amiberry.keys
@@ -1,0 +1,50 @@
+{
+    "actions_player1": [
+        {
+            "trigger": ["joystick2"],
+            "type": "mouse"
+        },
+        {
+            "trigger": ["x"],
+            "type": "key",
+            "target": [ "KEY_LEFTCTRL" ],
+            "description": "CTRL Key"
+        },
+        {
+            "trigger": ["y"],
+            "type": "key",
+            "target": [ "KEY_SPACE" ],
+            "description": "SPACE Key"
+        },
+        {
+            "trigger": ["start"],
+            "type": "key",
+            "target": [ "KEY_ENTER" ],
+            "description": "ENTER Key"
+        },
+        {
+            "trigger": ["pageup"],
+            "type": "key",
+            "target": [ "KEY_ESC" ],
+            "description": "ESC Key"
+        },
+        {
+            "trigger": ["pagedown"],
+            "type": "key",
+            "target": [ "KEY_F1" ],
+            "description": "F1 Key"
+        },
+        {
+            "trigger": ["l2"],
+            "type": "key",
+            "target": [ "BTN_LEFT" ],
+            "description": "Mouse Left Button"
+        },
+        {
+            "trigger": ["r2"],
+            "type": "key",
+            "target": [ "BTN_RIGHT" ],
+            "description": "Mouse Right Button"
+        }
+    ]
+}


### PR DESCRIPTION
- Updated Amiberry default pad2key configurations for Amiga 500, Amiga 1200 and Amiga CD32.
- Added CDTV

Edit: I've found a strange issue. For an unknown reason, the L2 and R2 don't works correctly. It just press only one time Mouse Left or Right Button and the same Amiberry has this issue, because they weren't implemented. 
Anyway, There is a question: Pad2Key can make conflicts with Amiberry custom input settings. So the solution can be removing the pad2key conf and hardcoding joystick and mouse buttons to gamepad in AmiberryGenerator.py. With this method, you can save an Amiberry game config files by using the menu without make any conflict.