### PR TITLE
Update es_input.cfg

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -2749,8 +2749,8 @@
 	<inputConfig type="joystick" deviceName="Microsoft X-Box 360 pad" deviceGUID="030000005e0400008e02000072050000">
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
-		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="joystick1left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick1up" type="axis" id="4" value="-1" code="4" />
 		<input name="a" type="axis" id="5" value="1" code="5" />
 		<input name="b" type="button" id="1" value="1" code="305" />
 		<input name="hotkey" type="button" id="8" value="1" code="316" />


### PR DESCRIPTION
I have been informed that "joystick2" for the negative axis values was a typo, this changes it to "joystick1".