### PR TITLE
handledrmconnectors

### DIFF
--- a/board/batocera/patches/sdl2/002-drm-conn.patch
+++ b/board/batocera/patches/sdl2/002-drm-conn.patch
@@ -1,0 +1,79 @@
+diff --git a/src/video/kmsdrm/SDL_kmsdrmvideo.c b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+index f0deeb9..8595c96 100644
+--- a/src/video/kmsdrm/SDL_kmsdrmvideo.c
++++ b/src/video/kmsdrm/SDL_kmsdrmvideo.c
+@@ -84,6 +84,7 @@ check_modestting(int devindex)
+     char device[512];
+     int drm_fd;
+     int i;
++    int drmConn = 0;
+ 
+     SDL_snprintf(device, sizeof (device), KMSDRM_DRI_DEVFMT, KMSDRM_DRI_PATH, devindex);
+ 
+@@ -103,9 +104,27 @@ check_modestting(int devindex)
+                  && resources->count_encoders > 0
+                  && resources->count_crtcs > 0)
+                 {
++		  // batocera
++		  {
++		    FILE* fdDrmConn;
++		    int drmConnRead;
++		    if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++		      if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++			if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++			  drmConn = drmConnRead;
++			}
++		      }
++		    }
++		  }
++		  //
++
+                     available = SDL_FALSE;
+                     for (i = 0; i < resources->count_connectors; i++) {
+-                        drmModeConnector *conn = KMSDRM_drmModeGetConnector(drm_fd,
++		      drmModeConnector *conn;
++
++		      if(i != drmConn) continue;
++
++		      conn = KMSDRM_drmModeGetConnector(drm_fd,
+                             resources->connectors[i]);
+ 
+                         if (!conn) {
+@@ -804,6 +823,7 @@ int KMSDRM_InitDisplays (_THIS) {
+     uint64_t async_pageflip = 0;
+     int ret = 0;
+     int i;
++    int drmConn = 0;
+ 
+     /* Open /dev/dri/cardNN (/dev/drmN if on OpenBSD) */
+     SDL_snprintf(viddata->devpath, sizeof(viddata->devpath), KMSDRM_DRI_CARDPATHFMT, viddata->devindex);
+@@ -825,10 +845,28 @@ int KMSDRM_InitDisplays (_THIS) {
+         goto cleanup;
+     }
+ 
++    // batocera
++    {
++      FILE* fdDrmConn;
++      int drmConnRead;
++      if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++	if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	  if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++	    drmConn = drmConnRead;
++	  }
++	}
++      }
++    }
++    //
++
+     /* Iterate on the available connectors. For every connected connector,
+        we create an SDL_Display and add it to the list of SDL Displays. */
+     for (i = 0; i < resources->count_connectors; i++) {
+-        drmModeConnector *connector = KMSDRM_drmModeGetConnector(viddata->drm_fd,
++      drmModeConnector *connector;
++
++      if(i != drmConn) continue;
++
++      connector = KMSDRM_drmModeGetConnector(viddata->drm_fd,
+             resources->connectors[i]);
+ 
+         if (!connector) {

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resolution.drm
@@ -22,7 +22,15 @@ then
     exit 1
 fi
 
+f_checkVals() {
+    test ! -e /var/run/drmConn && echo 0 > /var/run/drmConn
+    test ! -e /var/run/drmMode && echo 0 > /var/run/drmMode
+}
+
 f_listModes() {
+    f_checkVals
+    DRMCONN=$(cat /var/run/drmConn)
+
     if test "${1}" = "all"
     then
 	echo "max-1920x1080:maximum 1920x1080"
@@ -30,13 +38,15 @@ f_listModes() {
     fi
     for GPU in /dev/dri/card*
     do
-	batocera-drminfo "${GPU}" "${1}" 2>/dev/null | sed -e s+"^\([0-9]*\):\([0-9]*\)x\([0-9]*\) \([0-9]*\)\(Hz .*\)$"+"\1.\2x\3.\4:\2x\3 \4\5"+
+	batocera-drminfo "${GPU}" "${1}" 2>/dev/null | grep -E "^${DRMCONN}\." |  sed -e s+"^\([0-9]*\)\.\([0-9]*\):\([^ ]*\) \([0-9]*\)x\([0-9]*\) \([0-9]*\)\(Hz .*\)$"+"\1.\2.\4x\5.\6:\3 \4x\5 \6\7"+
     done
 }
 
 f_currentResolution() {
+    f_checkVals
+    DRMCONN=$(cat /var/run/drmConn)
     DRMMODE=$(cat /var/run/drmMode)
-    f_listModes "all" | grep -E "^${DRMMODE}\." | head -1 | sed -e s+"^[^:]*:\([0-9]*x[0-9]*\) .*$"+"\1"+
+    f_listModes "all" | grep -E "^${DRMCONN}\.${DRMMODE}\." | head -1 | sed -e s+"^[^:]*:[^ ]* \([0-9]*x[0-9]*\) .*$"+"\1"+
 }
 
 f_minTomaxResolution() {
@@ -52,8 +62,8 @@ f_minTomaxResolution() {
 		MAXHEIGHT=1080
 	fi
 	# if current resolution is ok, keep it
-	read CURRENTWIDTH CURRENTHEIGHT <<< $(f_listModes "current" | sed -e s+"^\([^:]*\):\([0-9]*\)x\([0-9]*\) \([0-9]*\)\(.*\)$"+"\2 \3"+)
-
+	read CURRENTWIDTH CURRENTHEIGHT <<< $(f_listModes "current" | sed -e s+"^\([^:]*\):[^ ]* \([0-9]*\)x\([0-9]*\) \([0-9]*\)\(.*\)$"+"\2 \3"+)
+	
 	if test "${CURRENTWIDTH}" -le "${MAXWIDTH}" -a "${CURRENTHEIGHT}" -le "${MAXHEIGHT}"
 	then
 	    exit 0
@@ -63,7 +73,7 @@ f_minTomaxResolution() {
 	# select the first one valid
 	# is it the best ? or should we loop to search the first with the same ratio ?
 	# Highest resolution first, but list [p]rogressive before [i]nterlaced (p is omitted by default)
-	f_listModes | sed -e "/i)$/!"s+")$"+"p)"+ -e s+"^\([^:]*\):\([0-9]*x[0-9]*\) \([0-9]*\)Hz (\(.*\))$"+"\2_\3_\4:\1:\2"+ | sort -nr | sed -e "s/_[0-9]*x[0-9]*[pi]//" |
+	f_listModes | sed -e "/i)$/!"s+")$"+"p)"+ -e s+"^\([^:]*\):[^ ]* \([0-9]*x[0-9]*\) \([0-9]*\)Hz (\(.*\))$"+"\2_\3_\4:\1:\2"+ | sort -nr | sed -e "s/_[0-9]*x[0-9]*[pi]//" |
             while IFS=':\n' read SORTSTR SUGGMODE SUGGRESOLUTION
             do
 		SUGGWIDTH=$(echo "${SUGGRESOLUTION}" | cut -d x -f 1)
@@ -99,15 +109,25 @@ case "${ACTION}" in
 	fi
 	;;
     "currentMode")
+	f_checkVals
+	DRMCONN=$(cat /var/run/drmConn)
 	DRMMODE=$(cat /var/run/drmMode)
-	f_listModes "all" | grep -E "^${DRMMODE}\." | cut -d ":" -f 1
+	f_listModes "all" | grep -E "^${DRMCONN}\.${DRMMODE}\." | cut -d ":" -f 1
 	;;
     "currentResolution")
 	f_currentResolution
 	;;
     "listOutputs")
+	for GPU in /dev/dri/card*
+	do
+	    batocera-drminfo "${GPU}" "${1}" 2>/dev/null | sed -e s+"^\([0-9]*\)\.\([0-9]*\):\([^ ]*\) \([0-9]*\)x\([0-9]*\) \([0-9]*\)\(Hz .*\)$"+"\1 - \3"+ | sort -u
+	done
 	;;
     "setOutput")
+	MODE=$1
+	echo "${MODE}" | sed -e s+"^\([0-9]*\) .*"+"\1"+ > /var/run/drmConn
+	echo 0 > /var/run/drmMode # reset the drmMode
+	f_minTomaxResolution
 	;;
     "minTomaxResolution" | "minTomaxResolution-secure")
 	# first, give the current resolution as the default in case it is not reduced.

--- a/package/batocera/emulators/dolphin-emu/007-drm-conn.patch
+++ b/package/batocera/emulators/dolphin-emu/007-drm-conn.patch
@@ -1,0 +1,48 @@
+diff --git a/Source/Core/Common/GL/GLInterface/EGLDRM.cpp b/Source/Core/Common/GL/GLInterface/EGLDRM.cpp
+index 55efc47..b96768f 100644
+--- a/Source/Core/Common/GL/GLInterface/EGLDRM.cpp
++++ b/Source/Core/Common/GL/GLInterface/EGLDRM.cpp
+@@ -371,14 +371,33 @@ static bool drm_get_connector(GFXContextDRMData* drm, int fd)
+   unsigned i;
+   unsigned monitor_index_count = 0;
+   unsigned monitor = 1;
++  int drmConn = 0;
+ 
+   /* Enumerate all connectors. */
+ 
+   INFO_LOG(VIDEO, "[DRM]: Found %d connectors.\n", drm->drm_resources->count_connectors);
+ 
++  // batocera
++  {
++    FILE* fdDrmConn;
++    int drmConnRead;
++    if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++      if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++	  drmConn = drmConnRead;
++	}
++      }
++    }
++  }
++  //
++
+   for (i = 0; (int)i < drm->drm_resources->count_connectors; i++)
+   {
+-    drmModeConnectorPtr conn = drmModeGetConnector(fd, drm->drm_resources->connectors[i]);
++    drmModeConnectorPtr conn;
++
++    if(i != drmConn) continue;
++
++    conn = drmModeGetConnector(fd, drm->drm_resources->connectors[i]);
+ 
+     if (conn)
+     {
+@@ -399,6 +418,8 @@ static bool drm_get_connector(GFXContextDRMData* drm, int fd)
+ 
+   for (i = 0; (int)i < drm->drm_resources->count_connectors; i++)
+   {
++    if(i != drmConn) continue;
++
+     drm->drm_connector = drmModeGetConnector(fd, drm->drm_resources->connectors[i]);
+ 
+     if (!drm->drm_connector)

--- a/package/batocera/emulators/duckstation/007-drm-conn.patch
+++ b/package/batocera/emulators/duckstation/007-drm-conn.patch
@@ -1,0 +1,86 @@
+diff --git a/src/common/drm_display.cpp b/src/common/drm_display.cpp
+index 0064d85..a4289f3 100644
+--- a/src/common/drm_display.cpp
++++ b/src/common/drm_display.cpp
+@@ -108,6 +108,8 @@ void DRMDisplay::RestoreBuffer()
+ 
+ bool DRMDisplay::TryOpeningCard(int card, u32 width, u32 height, float refresh_rate)
+ {
++  int drmConn = 0;
++
+   if (m_card_fd >= 0)
+     close(m_card_fd);
+ 
+@@ -127,9 +129,27 @@ bool DRMDisplay::TryOpeningCard(int card, u32 width, u32 height, float refresh_r
+ 
+   Assert(!m_connector);
+ 
++  // batocera
++  {
++    FILE* fdDrmConn;
++    int drmConnRead;
++    if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++      if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++	  drmConn = drmConnRead;
++	}
++      }
++    }
++  }
++  //
++
+   for (int i = 0; i < resources->count_connectors; i++)
+   {
+-    drmModeConnector* next_connector = drmModeGetConnector(m_card_fd, resources->connectors[i]);
++    drmModeConnector* next_connector;
++
++    if(i != drmConn) continue;
++
++    next_connector = drmModeGetConnector(m_card_fd, resources->connectors[i]);
+     if (next_connector->connection == DRM_MODE_CONNECTED)
+     {
+       m_connector = next_connector;
+@@ -275,6 +295,8 @@ void DRMDisplay::PresentBuffer(u32 fb_id, bool wait_for_vsync)
+ bool DRMDisplay::GetCurrentMode(u32* width, u32* height, float* refresh_rate, int card, int connector)
+ {
+   int card_fd = -1;
++  int drmConn = 0;
++
+   if (card < 0)
+   {
+     for (int try_card = 0; try_card < MAX_CARDS_TO_TRY; try_card++)
+@@ -304,12 +326,27 @@ bool DRMDisplay::GetCurrentMode(u32* width, u32* height, float* refresh_rate, in
+     return false;
+   }
+ 
++  // batocera
++  {
++    FILE* fdDrmConn;
++    int drmConnRead;
++    if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++      if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++	  drmConn = drmConnRead;
++	}
++      }
++    }
++  }
++  //
++
+   Common::ScopeGuard resources_guard([resources]() { drmModeFreeResources(resources); });
+   drmModeConnector* connector_ptr = nullptr;
+   if (connector < 0)
+   {
+     for (int i = 0; i < resources->count_connectors; i++)
+     {
++      if(i != drmConn) continue;
+       connector_ptr = drmModeGetConnector(card_fd, resources->connectors[i]);
+       if (connector_ptr->connection == DRM_MODE_CONNECTED)
+         break;
+@@ -368,4 +405,4 @@ bool DRMDisplay::GetCurrentMode(u32* width, u32* height, float* refresh_rate, in
+     *refresh_rate = current_refresh_rate;
+ 
+   return true;
+-}
+\ No newline at end of file
++}

--- a/package/batocera/emulators/retroarch/retroarch/008-drm-conn.patch
+++ b/package/batocera/emulators/retroarch/retroarch/008-drm-conn.patch
@@ -1,0 +1,228 @@
+diff --git a/deps/libgo2/src/display.c b/deps/libgo2/src/display.c
+index b91cf06..cedf3c4 100644
+--- a/deps/libgo2/src/display.c
++++ b/deps/libgo2/src/display.c
+@@ -99,6 +99,7 @@ typedef struct go2_presenter
+ go2_display_t* go2_display_create()
+ {
+     int i;
++    int drmConn = 0;
+ 
+     go2_display_t* result = malloc(sizeof(*result));
+     if (!result)
+@@ -126,11 +127,26 @@ go2_display_t* go2_display_create()
+         goto err_01;
+     }
+ 
++    // batocera
++    {
++     FILE* fdDrmConn;
++     int drmConnRead;
++     if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++       if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	 if(drmConnRead>=0 && drmConn<resources->count_connectors) {
++	   drmConn = drmConnRead;
++	 }
++       }
++     }
++   }
++   //
+ 
+     // Find connector
+     drmModeConnector* connector;
+     for (i = 0; i < resources->count_connectors; i++)
+     {
++        if(i != drmConn) continue;
++
+         connector = drmModeGetConnector(result->fd, resources->connectors[i]);
+         if (connector->connection == DRM_MODE_CONNECTED) {
+             break;
+diff --git a/deps/switchres/custom_video_drmkms.cpp b/deps/switchres/custom_video_drmkms.cpp
+index 3706f2e..876179c 100644
+--- a/deps/switchres/custom_video_drmkms.cpp
++++ b/deps/switchres/custom_video_drmkms.cpp
+@@ -342,6 +342,21 @@ bool drmkms_timing::init()
+ 	char drm_name[15] = "/dev/dri/card_";
+ 	drmModeRes *p_res;
+ 	drmModeConnector *p_connector;
++	int drmConn = 0;
++
++	// batocera
++	{
++	  FILE* fdDrmConn;
++	  int drmConnRead;
++	  if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++	    if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	      if(drmConnRead>=0 && drmConn<g_drm_resources->count_connectors) {
++		drmConn = drmConnRead;
++	      }
++	    }
++	  }
++	}
++	//
+ 
+ 	int output_position = 0;
+ 	for (int num = 0; !m_desktop_output && num < 10; num++)
+@@ -366,6 +381,8 @@ bool drmkms_timing::init()
+ 
+ 			for (int i = 0; i < p_res->count_connectors; i++)
+ 			{
++			        if(i != drmConn) continue;
++
+ 				p_connector = drmModeGetConnector(m_drm_fd, p_res->connectors[i]);
+ 				if (p_connector)
+ 				{
+@@ -730,10 +747,29 @@ bool drmkms_timing::get_timing(modeline *mode)
+ 
+ 	// INFO: not used vrefresh, hskew, vscan
+ 	drmModeRes *p_res = drmModeGetResources(m_drm_fd);
++	int drmConn = 0;
++
++	// batocera
++	{
++	  FILE* fdDrmConn;
++	  int drmConnRead;
++	  if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++	    if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	      if(drmConnRead>=0 && drmConn<g_drm_resources->count_connectors) {
++		drmConn = drmConnRead;
++	      }
++	    }
++	  }
++	}
++	//
+ 
+ 	for (int i = 0; i < p_res->count_connectors; i++)
+ 	{
+-		drmModeConnector *p_connector = drmModeGetConnector(m_drm_fd, p_res->connectors[i]);
++	  drmModeConnector *p_connector;
++
++	  if(i != drmConn) continue;
++
++	  p_connector = drmModeGetConnector(m_drm_fd, p_res->connectors[i]);
+ 
+ 		// Cycle through the modelines and report them back to the display manager
+ 		if (p_connector && m_desktop_output == p_connector->connector_id)
+diff --git a/gfx/common/drm_common.c b/gfx/common/drm_common.c
+index 5759d82..e352b1d 100644
+--- a/gfx/common/drm_common.c
++++ b/gfx/common/drm_common.c
+@@ -68,6 +68,21 @@ bool drm_get_connector(int fd, unsigned monitor_index)
+    unsigned i;
+    unsigned monitor_index_count = 0;
+    unsigned monitor       = MAX(monitor_index, 1);
++   int drmConn = 0;
++
++   // batocera
++   {
++     FILE* fdDrmConn;
++     int drmConnRead;
++     if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++       if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	 if(drmConnRead>=0 && drmConn<g_drm_resources->count_connectors) {
++	   drmConn = drmConnRead;
++	 }
++       }
++     }
++   }
++   //
+ 
+    /* Enumerate all connectors. */
+ 
+@@ -75,7 +90,11 @@ bool drm_get_connector(int fd, unsigned monitor_index)
+ 
+    for (i = 0; (int)i < g_drm_resources->count_connectors; i++)
+    {
+-      drmModeConnectorPtr conn = drmModeGetConnector(
++     drmModeConnectorPtr conn;
++
++     if(i != drmConn) continue;
++
++     conn = drmModeGetConnector(
+             fd, g_drm_resources->connectors[i]);
+ 
+       if (conn)
+@@ -96,6 +115,8 @@ bool drm_get_connector(int fd, unsigned monitor_index)
+ 
+    for (i = 0; (int)i < g_drm_resources->count_connectors; i++)
+    {
++      if(i != drmConn) continue;
++
+       g_drm_connector = drmModeGetConnector(fd,
+             g_drm_resources->connectors[i]);
+ 
+diff --git a/gfx/drivers/drm_gfx.c b/gfx/drivers/drm_gfx.c
+index b0b380c..ff85e60 100644
+--- a/gfx/drivers/drm_gfx.c
++++ b/gfx/drivers/drm_gfx.c
+@@ -607,6 +607,7 @@ static bool init_drm(void)
+    int ret;
+    drmModeConnector *connector;
+    uint i;
++   int drmConn = 0;
+ 
+    drm.fd = open("/dev/dri/card0", O_RDWR);
+ 
+@@ -642,9 +643,25 @@ static bool init_drm(void)
+       return false;
+    }
+ 
++   // batocera
++   {
++     FILE* fdDrmConn;
++     int drmConnRead;
++     if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++       if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	 if(drmConnRead>=0 && drmConn<g_drm_resources->count_connectors) {
++	   drmConn = drmConnRead;
++	 }
++       }
++     }
++   }
++   //
++
+    /* Find a connected connector. */
+    for (i = 0; i < (uint)drm.resources->count_connectors; i++)
+    {
++     if(i != drmConn) continue;
++
+       connector = drmModeGetConnector(drm.fd, drm.resources->connectors[i]);
+       /* It's connected, let's use it. */
+       if (connector->connection == DRM_MODE_CONNECTED)
+diff --git a/gfx/drivers/oga_gfx.c b/gfx/drivers/oga_gfx.c
+index 0e7a321..ff11fac 100644
+--- a/gfx/drivers/oga_gfx.c
++++ b/gfx/drivers/oga_gfx.c
+@@ -111,6 +111,7 @@ static bool oga_create_display(oga_video_t* vid)
+    drmModeModeInfo *mode;
+    drmModeEncoder *encoder;
+    drmModeRes *resources;
++   int drmConn = 0;
+ 
+    vid->fd = open("/dev/dri/card0", O_RDWR);
+    if (vid->fd < 0)
+@@ -126,8 +127,24 @@ static bool oga_create_display(oga_video_t* vid)
+       goto err_01;
+    }
+ 
++   // batocera
++   {
++     FILE* fdDrmConn;
++     int drmConnRead;
++     if((fdDrmConn = fopen("/var/run/drmConn", "r")) != NULL) {
++       if(fscanf(fdDrmConn, "%i", &drmConnRead) == 1) {
++	 if(drmConnRead>=0 && drmConn<g_drm_resources->count_connectors) {
++	   drmConn = drmConnRead;
++	 }
++       }
++     }
++   }
++   //
++
+    for (i = 0; i < resources->count_connectors; i++)
+    {
++      if(i != drmConn) continue;
++
+       connector = drmModeGetConnector(vid->fd, resources->connectors[i]);
+       if (connector->connection == DRM_MODE_CONNECTED)
+          break;


### PR DESCRIPTION
this fixes an issue on drm having multiple output (bad variable usage in drm-info)
and this allow to switch between multiple drm output (this is not the case of the rpi4 which has 2 cards of 1 entry).
but this fixes for rg552.

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>