### PR TITLE
Bump Libretro Dosbox-Pure to 0.24

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on Jan 5, 2022
-LIBRETRO_DOSBOX_PURE_VERSION = 0.22
+# Version.: Commits on Jan 9, 2022
+LIBRETRO_DOSBOX_PURE_VERSION = 0.24
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
This is the twenty-fourth release of DOSBox Pure intended for public testing.

Changes in 0.24:

- Fix CPU cycles in menu and command line (https://github.com/schellingb/dosbox-pure/issues/223)
- Fix "Force 60 FPS" mode when emulating display modes less than 60 Hz (https://github.com/schellingb/dosbox-pure/issues/222)