### PR TITLE
add: ethtool

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -71,6 +71,7 @@ menu "System"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/network/rtl8821ce/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/network/rtl8723ds/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/network/rtl8192eu/Config.in"
+    source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/network/ethtool/Config.in"
   endmenu
 
   menu "Device trees"

--- a/package/batocera/network/ethtool/Config.in
+++ b/package/batocera/network/ethtool/Config.in
@@ -1,0 +1,9 @@
+config BR2_PACKAGE_ETHTOOL
+        bool "ethtool"
+        default y
+        help
+          ethtool is a small utility for examining and tuning your
+          ethernet-based network interface
+
+          https://www.kernel.org/pub/software/network/ethtool/
+


### PR DESCRIPTION
This is a pull request for adding "ethtool" into Batocera.
It basically is a small network configuration tool.
The idea behind this pull request is to add WOL (Wake-On-Lan) functionality into Batocera, which will be a huge improvement for home automation possibilities.
This pull request simply adds "ethtool" to the command line of Batocera and does not change any configuration.
If this pull request is being accepted, I will create a Batocera Wiki page with all the instructions on how to enable Wake-On-Lan by using "ethtool" (I did a lot of tests in the last few weeks and it works flawlessly). Also I am preparing a specific Batocera Wiki page on how to include WOL-enabled Batocera systems into home automation systems (e.g. HomeAssistant) by using smart remote controls (e.g. Logitech Harmony).
According to those Wiki pages I will create and maintain, every user can decide on its own if he wants to enable Wake-On-Lan for his specific device or not.

Sidenote: "ethtool" is already part of Batocera's buildroot system and its make file is already pre-configured here (so actually we don't need to add an additional "ethtool.mk" file):
https://github.com/batocera-linux/buildroot/blob/0092c4811ab958a4cbc8f17b93d310e84d8a9b75/package/ethtool/ethtool.mk
I did not make this pull request based on buildroot, as I have seen there have been some pull requests being rejected in the past because the main developers of Batocera seem to want to keep buildroot as untouched as possible.