### PR TITLE
Enable SPU caching for pcs3

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -79,7 +79,7 @@ class Rpcs3Generator(Generator):
 
         # Set the Default Core Values we need
         rpcs3ymlconfig["Core"]['Lower SPU thread priority'] = False
-        rpcs3ymlconfig["Core"]['SPU Cache'] = False
+        rpcs3ymlconfig["Core"]['SPU Cache'] = True
         rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True     
  
         rpcs3ymlconfig["Video"]['Frame limit'] = 60


### PR DESCRIPTION
RPCS3's suggestion is to leave this enabled.

I could understand if this was disabled in an attempt to save disk space usage, however even when this is set to false there's still a massive cache that's made for games anyway:

![unknown](https://user-images.githubusercontent.com/67527064/149242715-c3c612e1-bb59-4769-84fd-ddfecdd463ba.png)

Testing turning on SPU caching shows basically no difference in disk space usage compared to this, and the benefit is increased performance.

Kind of unrelated to this, but why are caches being saved to the system folder? Shouldn't they go into the save folder? Otherwise when someone creates a support file, it will end up trying to compress all of these caches.