### PR TITLE
Add system.timezone in batocera-boot.conf

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -8,7 +8,7 @@
 [ "$1" = "stop" ] || exit 0
 
 set --
-for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled
+for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled system.timezone
 do
     value="$(/usr/bin/batocera-settings-get "$key")" || continue
     if [ "$value" != "$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf "$key")" ]


### PR DESCRIPTION
Add system.timezone in batocera-boot.conf needed for wiki script.

And wiki script https://wiki.batocera.org/troubleshooting#changing_batocera_to_use_windows_local_time_instead needs fix

    #!/bin/bash

    TZ=$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf system.timezone) hwclock --systz --localtime