### PR TITLE
Add a bunch of RPCS3 options to ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -90,9 +90,9 @@ class Rpcs3Generator(Generator):
 
         # System aspect ratio (the setting in the PS3 system itself, not the displayed ratio) a.k.a. TV mode.
         if system.isOptSet("tv_mode"):
-            if system.config['tvmode'] == '4/3':
+            if system.config['tv_mode'] == '4/3':
                 rpcs3ymlconfig["Video"]['Aspect ratio'] = '4:3'
-            elif system.config['tvmode'] == '16/9':
+            elif system.config['tv_mode'] == '16/9':
                 rpcs3ymlconfig["Video"]['Aspect ratio'] = '16:9'
         else:
             # This is where the code that automatically works out the ratio of your screen and applies the respective aspect ratio would go.
@@ -154,13 +154,13 @@ class Rpcs3Generator(Generator):
 
     def getInGameRatio(self, config, gameResolution, rom):
         # If stretchy-boy mode has been set, just assume the display resolution is the aspect ratio.
-        if config.isOptSet("stretchtodisplayarea") and config.getOptBoolean("stretchtodisplayarea"):
-            return gameResolution["width"] / gameResolution["height"]
+        #if config.isOptSet("stretchtodisplayarea") and config.getOptBoolean("stretchtodisplayarea"):
+            #return gameResolution["width"] / gameResolution["height"]
 
         # Check if the aspect ratio key exists.
-        if config.isOptSet("tv_mode"):
-            return config['tvmode']
-        else:
+        #if config.isOptSet("tv_mode"):
+            #return config['tv_mode']
+        #else:
             return 16/9
 
     def getFirmwareVersion():

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -153,24 +153,14 @@ class Rpcs3Generator(Generator):
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_CACHE_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
 
     def getInGameRatio(self, config, gameResolution, rom):
-        # Open the configuration file and see what aspect ratio has been set.
-        with open(batoceraFiles.rpcs3config, 'r') as stream:
-            rpcs3ymlconfig = yaml.safe_load(stream)
-
         # If stretchy-boy mode has been set, just assume the display resolution is the aspect ratio.
-        # String version required as rpcs3 stores settings without quotes like an animal.
-        if str(rpcs3ymlconfig["Video"]['Stretch To Display Area']) == "True":
+        if config.isOptSet("stretchtodisplayarea") and config.getOptBoolean("stretchtodisplayarea"):
             return gameResolution["width"] / gameResolution["height"]
 
-        # Check if the aspect ratio key exists first.
-        if 'Aspect ratio' in rpcs3ymlconfig["Video"]:
-            if str(rpcs3ymlconfig["Video"]['Aspect ratio']) == "16:9":
-                return 16/9
-
-            if str(rpcs3ymlconfig["Video"]['Aspect ratio']) == "4:3":
-                return 4/3
+        # Check if the aspect ratio key exists.
+        if config.isOptSet("tv_mode"):
+            return config['tvmode']
         else:
-            # There can be instances where the aspect ratio isn't set (such as on auto). Here would be the same code/passed on value from system.isOptSet("tv_mode") but for now we will simply assume 16/9.
             return 16/9
 
     def getFirmwareVersion():

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -49,7 +49,7 @@ class Rpcs3Generator(Generator):
         rpcs3ymlconfig = {}
         if os.path.isfile(batoceraFiles.rpcs3config):
             with open(batoceraFiles.rpcs3config, 'r') as stream:
-                rpcs3ymlconfig = yaml.load(stream)
+                rpcs3ymlconfig = yaml.safe_load(stream)
 
         if rpcs3ymlconfig is None: # in case the file is empty
             rpcs3ymlconfig = {}
@@ -79,16 +79,50 @@ class Rpcs3Generator(Generator):
 
         # Set the Default Core Values we need
         rpcs3ymlconfig["Core"]['Lower SPU thread priority'] = False
-        rpcs3ymlconfig["Core"]['SPU Cache'] = False
-        rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True     
- 
-        rpcs3ymlconfig["Video"]['Frame limit'] = 60
+        rpcs3ymlconfig["Core"]['SPU Cache'] = False # When SPU Cache is True, game performance decreases signficantly. Force it to off.
+        rpcs3ymlconfig["Core"]['PPU LLVM Accurate Vector NaN values'] = True
 
         # gfx backend
         if system.isOptSet("gfxbackend"):
             rpcs3ymlconfig["Video"]['Renderer'] = system.config["gfxbackend"]
         else:
             rpcs3ymlconfig["Video"]['Renderer'] = 'OpenGL' # Vulkan
+
+        # System aspect ratio (the setting in the PS3 system itself, not the displayed ratio) a.k.a. TV mode.
+        if system.isOptSet("tv_mode"):
+            if system.config['tvmode'] == '4/3':
+                rpcs3ymlconfig["Video"]['Aspect ratio'] = '4:3'
+            elif system.config['tvmode'] == '16/9':
+                rpcs3ymlconfig["Video"]['Aspect ratio'] = '16:9'
+        else:
+            # This is where the code that automatically works out the ratio of your screen and applies the respective aspect ratio would go.
+            # For now, we will simply remove the key if it exists, thus using RPCS3's default setting.
+            if 'Aspect ratio' in rpcs3ymlconfig["Video"]:
+                del rpcs3ymlconfig["Video"]['Aspect ratio']
+
+        # Shader compilation
+        if system.isOptSet("shadermode"):
+            rpcs3ymlconfig["Video"]['Shader Mode'] = system.config['shadermode']
+        else:
+            # RPCS3's default "Async Shader Recompiler" has visual glitches, however it's the only setting which doesn't cause the screen to freeze whenever new graphics are on screen. If RPCS3 ever fixes the "Async with Shader Interpreter" option, it would be the preferred option for this setting.
+            rpcs3ymlconfig["Video"]['Shader Mode'] = str("Async Shader Recompiler")
+
+        # Vsync defaults to off because ??? it's faster? Not sure why, but not changing it.
+        if system.isOptSet("vsync") and system.getOptBoolean("vsync"):
+            rpcs3ymlconfig["Video"]['VSync'] = True
+        else:
+            rpcs3ymlconfig["Video"]['VSync'] = False
+
+        # Stretch to display area
+        if system.isOptSet("stretchtodisplayarea") and system.getOptBoolean("stretchtodisplayarea"):
+            rpcs3ymlconfig["Video"]['Stretch To Display Area'] = True
+        else:
+            rpcs3ymlconfig["Video"]['Stretch To Display Area'] = False
+
+        if system.isOptSet("framelimit"):
+            rpcs3ymlconfig["Video"]['Frame limit'] = system.config['framelimit']
+        else:
+            rpcs3ymlconfig["Video"]['Frame limit'] = 60
 
         rpcs3ymlconfig["Audio"]['Renderer'] = 'OpenAL' # ALSA does not support buffering so we have sound cuts ex: Rayman Origin
         rpcs3ymlconfig["Audio"]['Audio Channels'] = 'Downmix to Stereo'
@@ -107,6 +141,7 @@ class Rpcs3Generator(Generator):
             romBasename = path.basename(rom)
             romName = rom + '/PS3_GAME/USRDIR/EBOOT.BIN'
         commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], romName]
+
         if system.isOptSet("gui") and system.getOptBoolean("gui") == False:
             commandArray.append("--no-gui")
 
@@ -118,7 +153,25 @@ class Rpcs3Generator(Generator):
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_CACHE_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
 
     def getInGameRatio(self, config, gameResolution, rom):
-        return 16/9
+        # Open the configuration file and see what aspect ratio has been set.
+        with open(batoceraFiles.rpcs3config, 'r') as stream:
+            rpcs3ymlconfig = yaml.safe_load(stream)
+
+        # If stretchy-boy mode has been set, just assume the display resolution is the aspect ratio.
+        # String version required as rpcs3 stores settings without quotes like an animal.
+        if str(rpcs3ymlconfig["Video"]['Stretch To Display Area']) == "True":
+            return gameResolution["width"] / gameResolution["height"]
+
+        # Check if the aspect ratio key exists first.
+        if 'Aspect ratio' in rpcs3ymlconfig["Video"]:
+            if str(rpcs3ymlconfig["Video"]['Aspect ratio']) == "16:9":
+                return 16/9
+
+            if str(rpcs3ymlconfig["Video"]['Aspect ratio']) == "4:3":
+                return 4/3
+        else:
+            # There can be instances where the aspect ratio isn't set (such as on auto). Here would be the same code/passed on value from system.isOptSet("tv_mode") but for now we will simply assume 16/9.
+            return 16/9
 
     def getFirmwareVersion():
         try:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4351,8 +4351,8 @@ rpcs3:
             prompt:      GRAPHICAL USER INTERFACE
             description: Allows Alt+Tab to RPCS3's menu. Useful for manual disc-swapping.
             choices:
-                "Off":      0
-                "On":       1
+                "Off":   0
+                "On":    1
         gfxbackend:
             prompt:      GRAPHICS API
             description: Choose which graphics API library to use. Vulkan is better, when supported.
@@ -4361,12 +4361,47 @@ rpcs3:
                 "Vulkan":   Vulkan
         spudecoder:
             prompt:      SPU DECODER
-            description: If game crashes, try ASMJIT. If still crashing, try Interpreter (fast).
+            description: If game crashes, try ASMJIT. If still crashing, try Fast Interpreter.
             choices:
-                "Recompiler (LLVM)":      Recompiler (LLVM)
-                "Recompiler (ASMJIT)":    Recompiler (ASMJIT)
-                "Interpreter (fast)":     Interpreter (fast)
-                "Interpreter (precise)":  Interpreter (precise)
+                "LLVM Recompiler":      Recompiler (LLVM)
+                "ASMJIT Recompiler":    Recompiler (ASMJIT)
+                "Fast Interpreter":     Interpreter (fast)
+                "Precise Interpreter":  Interpreter (precise)
+        tv_mode:
+            prompt:      TV MODE
+            description: PS3's internal ratio setting. Some games only support 16/9.
+            choices:
+                "16:9":  16/9
+                "4:3":   4/3
+        framelimit:
+            prompt:      ADDITIONAL FRAMELIMIT
+            description: Most games already have an internal framelimit. Minor performance cost.
+            choices:
+                "Off (faster, unstable)":  Off
+                "59.94":                   59.94
+                "50":                      50
+                "60":                      60
+                "30":                      30
+        shadermode:
+            prompt:      SHADER MODE
+            description: Only Async (skip draw) avoids freezing while compiling shaders.
+            choices:
+                "Legacy (laggy)":                   Shader Recompiler
+                "Async (skip draw, recommended)":   Async Shader Recompiler
+                "Async with interp. (hybrid)":      Async with Shader Interpreter
+                "Interpreter only (experimental)":  Shader Interpreter only
+        vsync:
+            prompt:      VSYNC
+            description: Can fix screen tearing on unorthodox displays (most LCDs don't need this).
+            choices:
+                "Off":         0
+                "On (slower)": 1
+        stretchtodisplayarea:
+            prompt:      STRETCH TO DISPLAY AREA
+            description: Distorts the output to fill the display fully.
+            choices:
+                "Off":   0
+                "On":    1
 
 scummvm:
   features: [ratio, padtokeyboard, decoration]


### PR DESCRIPTION
Unfortunately the 4:3 ratio in RPCS3 seems to be glitched: instead of showing the 4:3 aspect ratio at its intended resolution, it will instead stretch out the 4:3 image to 16:9 when "stretch to display" is not on (with it on, it will simply distort to whatever dimensions your display has, be it 16:9 or 4:3). Still, implementing this is better than not implementing it, as there are some users on genuine 4:3 screens who would appreciate this option.

![screenshot-2022 01 13-19h13 37](https://user-images.githubusercontent.com/67527064/149291681-04bfe6a3-868a-4675-9dc8-eafea9c9cbd3.png)