### PR TITLE
change VRR auto setting from true to false

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -33,7 +33,7 @@
         * add: Mega Bezel shaders by HyperspaceMadness
         * add: libretro-vice x64sc, xplus4 (for Commodore Plus4), x128 (Commodore 128), xvic (VIC-20), xpet (PET)
         * add: batocera-resolution can now adjust refresh rate on xorg (PC x86_64)
-        * add: variable refresh rate enabled and on by default for libretro, turn off with global.retroarch.vrr_run_loop = 0
+        * add: variable refresh rate for libretro, turn on with global.retroarch.vrr_runloop_enable = 1
         * add: miniVMac emulator for 68k-based Macintosh computers
         * fix: borders are now shown on Vice C64, also fixed default aspect ratio
         * fix: duckstation quick menu can now actually be accessed with hotkey+south

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -125,10 +125,10 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
         retroarchConfig['video_allow_rotate'] = 'true'    
 
     # variable refresh rate
-    if system.isOptSet("vrr_runloop_enable") and system.getOptBoolean("vrr_runloop_enable") == False:
-        retroarchConfig['vrr_runloop_enable'] = 'false'
-    else:
+    if system.isOptSet("vrr_runloop_enable") and system.getOptBoolean("vrr_runloop_enable") == True:
         retroarchConfig['vrr_runloop_enable'] = 'true'
+    else:
+        retroarchConfig['vrr_runloop_enable'] = 'false'
 
     # required at least for vulkan (to get the correct resolution)
     retroarchConfig['video_fullscreen_x'] = gameResolution["width"]


### PR DESCRIPTION
I have tested this option on a non-VRR display and did not notice any increased judder from usual. However, this old issue report has been brought to my attention: libretro/RetroArch#10304
It's nearly a year old, and the issue is fundamentally with RetroArch, but if even one person is reporting that having this on by default has worsened the experience I would rather have this default to off than on.

I will leave this PR as a draft for a bit to see if there are any candid reports of increased judder/stutter in the next beta.