### PR TITLE
Bump lr_dosbox-pure 0.25

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on Jan 9, 2022
-LIBRETRO_DOSBOX_PURE_VERSION = 0.24
+# Version.: Commits on Jan 11, 2022
+LIBRETRO_DOSBOX_PURE_VERSION = 0.25
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
Changes in 0.25:

- Fix running core without content
- Add core option to limit emulation CPU usage
- Support config changes via commandline