### PR TITLE
Small PUAE mapping fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -431,7 +431,7 @@ def generateCoreSettings(coreSettings, system, rom):
                 'zoom_mode_toggle': "RETROK_F12",
                 'a': "---",
                 'b': "---",
-                'x': "RETROK_LCTRL",
+                'x': "RETROK_LALT",
                 'y': "RETROK_SPACE",
                 'l': "RETROK_ESCAPE",
                 'l2': "MOUSE_LEFT_BUTTON",


### PR DESCRIPTION
- Added X=Left Alt instead of Left CTRL. Much used with games like Turrican.