### PR TITLE
Make RetroArch produce better achievement screenshot filenames

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/013-cheevos-screenshot-filename.patch
+++ b/package/batocera/emulators/retroarch/retroarch/013-cheevos-screenshot-filename.patch
@@ -1,0 +1,15 @@
+diff --git a/cheevos/cheevos.c b/cheevos/cheevos.c
+index 6cd3a06320..6845517e06 100644
+--- a/cheevos/cheevos.c
++++ b/cheevos/cheevos.c
+@@ -361,9 +361,10 @@ void rcheevos_award_achievement(rcheevos_locals_t* locals,
+ 
+       if (shotname)
+       {
+-         snprintf(shotname, shotname_len, "%s/%s-cheevo-%u",
++         snprintf(shotname, shotname_len, "%s/%s - %s (%u)",
+                settings->paths.directory_screenshot,
+                path_basename(path_get(RARCH_PATH_BASENAME)),
++               cheevo->title,
+                cheevo->id);
+          shotname[shotname_len - 1] = '\0';


### PR DESCRIPTION
This patches retroarch to add the achievement title to achievement screenshot filenames.

Right now they get output as (rom name)-cheevo-(cheevo id) without any context. It's pretty meaningless to an end user, you go through the screenshots in your library and nothing has any context. You can't even look an id up on retroachievements without making your own url.

I think ideally the achievement notification should be in the screenshot itself, but for now I think this change goes a long way to jog your memory about an old screenshot and neatens up the library view.