### PR TITLE
enable threaded video by default on rpi3

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,3 +1,6 @@
+default:
+  options:
+    video_threaded: true
 nds:
   emulator: drastic
   core:     drastic

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,6 +1,7 @@
 default:
   options:
     video_threaded: true
+    audio_latency: 96
 nds:
   emulator: drastic
   core:     drastic


### PR DESCRIPTION
Fixes --- [poor performance](https://github.com/batocera-linux/batocera.linux/issues/5518) (is a workaround, should be disabled for the v34 beta) for emulators in RPi3.

Also increased the audio latency by 32ms to avoid audio crackling in most systems.

Alternative workaround: disable bezels. They seem to be directly causing the slowdown. Not sure why, but that would obviously be a much more intrusive and noticeable workaround.