### PR TITLE
Bump dosbox pure to 0.26

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # DOSBOX PURE
 #
 ################################################################################
-# Version.: Commits on Jan 11, 2022
-LIBRETRO_DOSBOX_PURE_VERSION = 0.25
+# Version.: Commits on Jan 23, 2022
+LIBRETRO_DOSBOX_PURE_VERSION = 0.26
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
Changes in 0.26:

- Fix IMGMOUNT writable raw disk images 
- Apply fix for Super Street Fighter 2 Turbo Keyboard Mapping 
- Fix restarting core with raw disk images mounted
- Fix wrong frame draw count in performance statistics while on-screen-keyboard is open

Small fixes. This can be mergeable to v33