### PR TITLE
fix video frame delay auto setting in x86_64 defaults

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -3,7 +3,7 @@ default:
   core:
   options:
     hud_support: true
-    retroarch.video_frame_delay_auto: true
+    video_frame_delay_auto: true
 
 pcengine:
   emulator: libretro


### PR DESCRIPTION
A change in batocera's configgen caused this setting to no longer apply, this fixes it.