### PR TITLE
change libretro vulkan messaging to avoid confusion

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -60,7 +60,7 @@ libretro:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4, rk3326]
       prompt:      GRAPHICS API
-      description: Choose which graphics API library to use. Vulkan is better, when supported.
+      description: Choose which graphics API library to use. Vulkan may not work for every core.
       choices:
         "OpenGL": opengl
         "GLCore": glcore


### PR DESCRIPTION
we need to change the messaging for libretro
not every core supports vulkan but we provide the option regardless
some cores will drop back to opengl, but not all
therefore we should outline this to the user