### PR TITLE
Color Computer Alternate Models/Default Change (Safe for v33, not urgent)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -39,7 +39,7 @@ class MameGenerator(Generator):
         # Define systems that will use the MESS executable instead of MAME
         messSystems = [ "lcdgames", "gameandwatch", "cdi", "advision", "plugnplay", "megaduck", "crvision", "gamate", "pv1000", "gamecom" , "fm7", "xegs", "gamepock", "aarch", "atom", "apfm1000", "bbc", "camplynx", "adam", "arcadia", "supracan", "gmaster", "astrocde", "ti99", "tutor", "coco", "socrates", "macintosh" ]
         # If it needs a system name defined, use it here. Add a blank string if it does not (ie non-arcade, non-system ROMs)
-        messSysName = [ "", "", "cdimono1", "advision", "", "megaduck", "crvision", "gamate", "pv1000", "gamecom", "fm7", "xegs", "gamepock", "aa310", "atom", "apfm1000", "bbcb", "lynx48k", "adam", "arcadia", "supracan", "gmaster", "astrocde", "ti99_4a", "tutor", "coco", "socrates", "maclc3" ]
+        messSysName = [ "", "", "cdimono1", "advision", "", "megaduck", "crvision", "gamate", "pv1000", "gamecom", "fm7", "xegs", "gamepock", "aa310", "atom", "apfm1000", "bbcb", "lynx48k", "adam", "arcadia", "supracan", "gmaster", "astrocde", "ti99_4a", "tutor", "coco3", "socrates", "maclc3" ]
         # For systems with a MAME system name, the type of ROM that needs to be passed on the command line (cart, tape, cdrm, etc)
         # If there are multiple ROM types (ie a computer w/disk & tape), select the default or primary type here.
         messRomType = [ "", "", "cdrm", "cart", "", "cart", "cart", "cart", "cart", "cart1", "flop1", "cart", "cart", "flop", "cass", "cart", "flop1", "cass", "cass1", "cart", "cart", "cart", "cart", "cart", "cart", "cart", "cart", "flop1" ]

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -323,7 +323,19 @@ systems = {
 
     # ---------- Tandy Color Conputer ---------- #
     "coco":   { "name": "Tandy Color Computer", "biosFiles":  [ { "md5": "", "file": "bios/coco.zip"  },
-                                                { "md5": "a74f3d95b395dad7cdca19d560eeea74", "zippedFile": "bas10.rom", "file": "bios/coco.zip"} ] },
+                                                { "md5": "a74f3d95b395dad7cdca19d560eeea74", "zippedFile": "bas10.rom", "file": "bios/coco.zip"}
+                                                { "md5": "", "file": "bios/coco2.zip"  },
+                                                { "md5": "c933316c7d939532a13648850c1c2aa6", "zippedFile": "bas12.rom", "file": "bios/coco2.zip"}
+                                                { "md5": "21070aa0496142b886c562bf76d7c113", "zippedFile": "extbas11.rom", "file": "bios/coco2.zip"}
+                                                { "md5": "", "file": "bios/coco2b.zip"  },
+                                                { "md5": "c2fc43556eb6b7b25bdf5955bd9df825", "zippedFile": "bas13.rom", "file": "bios/coco2b.zip"}
+                                                { "md5": "21070aa0496142b886c562bf76d7c113", "zippedFile": "extbas11.rom", "file": "bios/coco2.zip"}
+                                                { "md5": "", "file": "bios/coco3.zip"  },
+                                                { "md5": "7233c6c429f3ce1c7392f28a933e0b6f", "zippedFile": "coco3.rom", "file": "bios/coco3.zip"}
+                                                { "md5": "", "file": "bios/coco3p.zip"  },
+                                                { "md5": "4ae57e5a8e7494e5485446fefedb580b", "zippedFile": "coco3p.rom", "file": "bios/coco3p.zip"}
+                                                { "md5": "", "file": "bios/coco_fdc_v11.zip"  },
+                                                { "md5": "8cab28f4b7311b8df63c07bb3b59bfd5", "zippedFile": "disk11.rom", "file": "bios/coco_fdc_v11.zip"} ] },
 
     # ---------- Tomy Tutor ---------- #
     "tutor":   { "name": "Tomy Tutor", "biosFiles":  [ { "md5": "", "file": "bios/tutor.zip"  },

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4811,6 +4811,15 @@ mame:
                         "Off": 0
        coco:
             cfeatures:
+                altmodel:
+                    prompt:      COLOR COMPUTER MODEL
+                    description: Select the model of Color Computer to emulate
+                    choices:
+                        "Color Computer":                    coco
+                        "Color Computer 2":                  coco2
+                        "Color Computer 2B":                 coco2b
+                        "Color Computer 3 (NTSC) (Default)": coco3
+                        "Color Computer 3 (PAL)":            coco3p
                 altromtype:
                     prompt:      MEDIA TYPE
                     description: Type of ROM file to load.


### PR DESCRIPTION
There were requests to make the default Color Computer model the CoCo3 for compatibility reasons.

The altmodel setting was not implemented in ES, but has been suggested and used as a manual option. All this pull does is change the default to coco3, add the altmodel setting to ES for coco/2/2b/3/3p, and check BIOS files for all models, making it "official."

If it doesn't make it into v33, it will still function as a manual setting.