### PR TITLE
Revert "Add SDL env variable for controller" - v33

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -7,7 +7,6 @@ import configparser
 import os.path
 import httplib2
 import json
-import controllersConfig
 from utils.logger import get_logger
 from os import environ
 
@@ -280,8 +279,7 @@ class DuckstationGenerator(Generator):
             os.makedirs(os.path.dirname(settings_path))
         with open(settings_path, 'w') as configfile:
             settings.write(configfile)
-        env = {"XDG_DATA_HOME":batoceraFiles.CONF, "QT_QPA_PLATFORM":"xcb",
-               "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)}
+        env = {"XDG_DATA_HOME":batoceraFiles.CONF, "QT_QPA_PLATFORM":"xcb"}
         return Command.Command(array=commandArray, env=env)
 
 


### PR DESCRIPTION
Reverts batocera-linux/batocera.linux#5509 as it didn't fix anything and seemingly broke other controllers