### PR TITLE
rk3399: linux 4.4.296: remove marvell 9215 quirk

### DIFF
--- a/board/batocera/rockchip/rk3399/linux_patches/marvell-9215-no-pci-dma-func1-alias-quirk.patch
+++ b/board/batocera/rockchip/rk3399/linux_patches/marvell-9215-no-pci-dma-func1-alias-quirk.patch
@@ -1,0 +1,14 @@
+diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
+index 41f2066c5..8d3a6eab3 100644
+--- a/drivers/pci/quirks.c
++++ b/drivers/pci/quirks.c
+@@ -3679,9 +3679,6 @@ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_MARVELL_EXT, 0x9183,
+ /* https://bugzilla.kernel.org/show_bug.cgi?id=42679#c46 */
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_MARVELL_EXT, 0x91a0,
+ 			 quirk_dma_func1_alias);
+-/* https://bugzilla.kernel.org/show_bug.cgi?id=42679#c135 */
+-DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_MARVELL_EXT, 0x9215,
+-			 quirk_dma_func1_alias);
+ /* https://bugzilla.kernel.org/show_bug.cgi?id=42679#c127 */
+ DECLARE_PCI_FIXUP_HEADER(PCI_VENDOR_ID_MARVELL_EXT, 0x9220,
+ 			 quirk_dma_func1_alias);


### PR DESCRIPTION
If I've understood correctly the quirk is backported from mainline.
But for some some reason it causes 9215 NOT to work on my Rockpro
(it works fine with mainline kernel).

Added patch removed the quirk in question and, at least for me, it
make 9215 to work again.

Before (sda not found in lsblk, with build
batocera-rk3399-rockpro64-33-20220131.img.gz):

  [root@BATOCERA /userdata/system]# uname -a
  Linux BATOCERA 4.4.296 #1 SMP Thu Jan 27 19:26:46 CET 2022 aarch64 GNU/Linux
  [root@BATOCERA /userdata/system]# lspci -nn
  00:00.0 PCI bridge [0604]: Fuzhou Rockchip Electronics Co., Ltd RK3399 PCI Express Root Port [1d87:0100]
  01:00.0 SATA controller [0106]: Marvell Technology Group Ltd. Device [1b4b:9215] (rev 11)
  [root@BATOCERA /userdata/system]# lsblk
  NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
  loop0          7:0    0  1.2G  1 loop /var/batocerafs
  mmcblk1      179:0    0 14.5G  0 disk
  |-mmcblk1p1  179:1    0    3G  0 part /boot
  `-mmcblk1p2  179:2    0 11.3G  0 part /media/SHARE
  mmcblk1boot0 179:32   0    4M  1 disk
  mmcblk1boot1 179:64   0    4M  1 disk
  mmcblk1rpmb  179:96   0    4M  0 disk

After (sda is found in lsblk, with patch applied):

  [root@BATOCERA /userdata/system]# uname -a
  Linux BATOCERA 4.4.296 #1 SMP Tue Feb 1 15:32:37 CET 2022 aarch64 GNU/Linux
  [root@BATOCERA /userdata/system]# lspci -nn
  00:00.0 PCI bridge [0604]: Fuzhou Rockchip Electronics Co., Ltd RK3399 PCI Express Root Port [1d87:0100]
  01:00.0 SATA controller [0106]: Marvell Technology Group Ltd. Device [1b4b:9215] (rev 11)
  [root@BATOCERA /userdata/system]# lsblk
  NAME         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
  loop0          7:0    0   1.2G  1 loop /overlay/base
  sda            8:0    1 465.8G  0 disk
  `-sda1         8:1    1 465.8G  0 part /media/Retrodisk
  mmcblk1      179:0    0  14.5G  0 disk
  |-mmcblk1p1  179:1    0     3G  0 part /boot
  `-mmcblk1p2  179:2    0  11.3G  0 part /media/SHARE
  mmcblk1boot0 179:32   0     4M  1 disk
  mmcblk1boot1 179:64   0     4M  1 disk
  mmcblk1rpmb  179:96   0     4M  0 disk

Tested by building and copying kernel image + modules to target over
batocera-rk3399-rockpro64-33-20220131.img.gz image.