### PR TITLE
fixes speed hacks like MTVU not applying if enabled (v33)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -335,6 +335,8 @@ def configureUI(config_directory, bios_directory, system_config, gameResolution)
             iniConfig.add_section(section)
     
     iniConfig.set("NO_SECTION","EnablePresets","disabled")
+    # manually allow speed hacks
+    iniConfig.set("NO_SECTION","EnableSpeedHacks","enabled")
     iniConfig.set("ProgramLog", "Visible",     "disabled")
     iniConfig.set("Filenames",  "BIOS",        biosFile)
     iniConfig.set("GSWindow",   "AspectRatio", resolution)


### PR DESCRIPTION
as reported in the forum for v33 rc1 & rc2

For Pcsx2, MicroVuSpeedHack doesn’t works until enable speedhack is enabled inside the emulator itself (via F1 - Applications). 