### PR TITLE
Libretro duckstation/swanstation software renderer fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -262,6 +262,8 @@ def getGFXBackend(system):
         # Pick glcore or gl based on drivers if not selected
         if system.isOptSet("gfxbackend"):
             backend = system.config["gfxbackend"]
+        elif system.core == 'duckstation' and system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software"):
+            return "software"
         else:
             if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:  
                 backend = "glcore"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -262,7 +262,7 @@ def getGFXBackend(system):
         # Pick glcore or gl based on drivers if not selected
         if system.isOptSet("gfxbackend"):
             backend = system.config["gfxbackend"]
-        elif system.core == 'duckstation' and system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software"):
+        elif core == 'duckstation' and system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software"):
             return "software"
         else:
             if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:  

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -262,8 +262,6 @@ def getGFXBackend(system):
         # Pick glcore or gl based on drivers if not selected
         if system.isOptSet("gfxbackend"):
             backend = system.config["gfxbackend"]
-        elif core == 'duckstation' and system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software"):
-            return "software"
         else:
             if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:  
                 backend = "glcore"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1835,18 +1835,18 @@ def generateCoreSettings(coreSettings, system, rom):
 
     if (system.config['core'] == 'swanstation' or system.config['core'] == 'duckstation'):
         # renderer
-        if system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software") == True:
-            coreSettings.save('duckstation_GPU.Renderer', "Software")
+        if system.isOptSet("gpu_software") and system.getOptBoolean("gpu_software"):
+            coreSettings.save('duckstation_GPU.Renderer', '"Software"')
         else:
             if system.isOptSet("gfxbackend"):
                 if system.config["gfxbackend"] == "vulkan":
-                    coreSettings.save('duckstation_GPU.Renderer', "Vulkan")
+                    coreSettings.save('duckstation_GPU.Renderer', '"Vulkan"')
                 elif system.config["gfxbackend"] == "opengl" or system.config["gfxbackend"] == "glcore":
                     coreSettings.save('duckstation_GPU.Renderer', "OpenGL")
                 else:
-                    coreSettings.save('duckstation_GPU.Renderer', "Auto")
+                    coreSettings.save('duckstation_GPU.Renderer', '"Auto"')
             else:
-                coreSettings.save('duckstation_GPU.Renderer', "Auto")
+                coreSettings.save('duckstation_GPU.Renderer', '"Auto"')
 
         # Show official Bootlogo
         if system.isOptSet('duckstation_PatchFastBoot'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -560,8 +560,8 @@ libretro:
                 prompt:      USE SOFTWARE RENDERING
                 description: More accurate emulation, but slower.
                 choices:
-                    "Off":        False
-                    "On":         True
+                    "Off":        "false"
+                    "On":         "true"
             duckstation_resolution_scale:
                 prompt:      RENDERING RESOLUTION
                 description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
@@ -644,8 +644,8 @@ libretro:
                 prompt:      USE SOFTWARE RENDERING
                 description: More accurate emulation, but slower.
                 choices:
-                    "Off":        False
-                    "On":         True
+                    "Off":        "false"
+                    "On":         "true"
             duckstation_resolution_scale:
                 prompt:      RENDERING RESOLUTION
                 description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.


### PR DESCRIPTION
The software renderer option for Duckstation wasn't working, because the settings.yml was using True and False instead of "true" and "false", and that was throwing off the getOptBoolean function, causing it to default to Auto.

The double quotes were also missing from that section of the config writer, so they were added as well.

This should be safe for v33, but can wait until v34, with the note that the software renderer option will not work in v33 unless set manually, or set to lowercase true in batocera.conf.