### PR TITLE
Removed Forced Analog to Digital Type for Flycast

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -258,16 +258,6 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
 
     ## Sega Dreamcast controller
     if system.config['core'] == 'flycast':
-        if system.name != 'dreamcast':
-            retroarchConfig['input_player1_analog_dpad_mode'] = '3'
-            retroarchConfig['input_player2_analog_dpad_mode'] = '3'
-            retroarchConfig['input_player3_analog_dpad_mode'] = '3'
-            retroarchConfig['input_player4_analog_dpad_mode'] = '3'
-        else:
-            retroarchConfig['input_player1_analog_dpad_mode'] = '1'
-            retroarchConfig['input_player2_analog_dpad_mode'] = '1'
-            retroarchConfig['input_player3_analog_dpad_mode'] = '1'
-            retroarchConfig['input_player4_analog_dpad_mode'] = '1'
         if system.isOptSet('controller1_dc'):
             retroarchConfig['input_libretro_device_p1'] = system.config['controller1_dc']
         else:


### PR DESCRIPTION
Removed any kind of forcing Analog to Digital Type modes for Flycast (DC/NAOMI/Atomiswave). Now, the latest core version can recognize correctly the best mode for every system.