### PR TITLE
ES Seasonal splash + some customisations

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -113,19 +113,42 @@ do
 
     test -x /userdata/system/custom-es-config && /userdata/system/custom-es-config
 
-    #####################
+    ###################
+    ## ES splash screens ##
+    ## idea: https://github.com/batocera-linux/batocera.linux/pull/5241
+    ES_SPLASH=
+    ES_LOADBAR=$(/usr/bin/batocera-settings-get es.loadbar.enabled)
+    ES_SEASON= $(/usr/bin/batocera-settings-get es.season.enabled)
+    [ "${ES_LOADBAR}" == "0" ] && ES_SPLASH="--no-splash"
 
+    if [ "${ES_LOADBAR}" != "0" ] && [ "${ES_SEASON}" != "0" ]
+    then
+        #[ $(date +%m) -eq 12 -a $(date +%d) -gt 20 ] && ES_SEASON=xmas
+        #[ $(date +%m%d) -eq 401 ]                    && ES_SEASON=aprilfool
+        #[ $(date +%m%d) -eq 621 ]                    && ES_SEASON=anniversary
+        # add more
+        if [ -n "${ES_SEASON}" ]; then
+            ES_SPLASH="--splash-image /usr/share/batocera/splash/season-${ES_SEASON}.png"
+        fi
+    fi
+
+    ## Use Framebuffer as picture overlay, you can see it if you load a ROM or shutdown ES
+    ES_FBPICTURE=$(/usr/bin/batocera-settings-get es.fbpicture.enabled)
+    if [ "${ES_FBPICTURE}" == "1" ]; then    
+        test -e /dev/fb0 && fbv -f -e -i "/usr/share/batocera/splash/boot-logo.png"
+    fi
+    
+    ###################
     # launch automatically a game only the first time
     if test ${GAMELAUNCH} = 1
        then
-	   GAMELAUNCHOPT=
+       GAMELAUNCHOPT=
     else
-	GAMELAUNCHOPT="--no-startup-game"
+        GAMELAUNCHOPT="--no-startup-game"
     fi
 
     cd /userdata # es need a PWD
-    %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation ${GAMELAUNCHOPT} --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
-
+    %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation ${GAMELAUNCHOPT} ${ES_SPLASH} --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
     GAMELAUNCH=0
 done
 exit 0

--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -113,7 +113,7 @@ do
 
     test -x /userdata/system/custom-es-config && /userdata/system/custom-es-config
 
-    ###################
+    #######################
     ## ES splash screens ##
     ## idea: https://github.com/batocera-linux/batocera.linux/pull/5241
     ES_SPLASH=
@@ -123,25 +123,22 @@ do
 
     if [ "${ES_LOADBAR}" != "0" ] && [ "${ES_SEASON}" != "0" ]
     then
-        #[ $(date +%m) -eq 12 -a $(date +%d) -gt 20 ] && ES_SEASON=xmas
-        #[ $(date +%m%d) -eq 401 ]                    && ES_SEASON=aprilfool
-        #[ $(date +%m%d) -eq 621 ]                    && ES_SEASON=anniversary
+        today=$(date +%m%d)
+        [ $today -eq 1031 -o $today -eq 1101 ]        && ES_SEASON=halloween
+        [ $(date +%m) -eq 12 -a $(date +%d) -gt 20 ]  && ES_SEASON=xmas
+        #[ $today -eq 1231 -o $today -eq 101 ]         && ES_SEASON=newyear
+        #[ $today -eq 401 ]                            && ES_SEASON=aprilfool
+        #[ $(date +%m%d) -eq 621 ]                     && ES_SEASON=anniversary
         # add more
         if [ -n "${ES_SEASON}" ]; then
             ES_SPLASH="--splash-image /usr/share/batocera/splash/season-${ES_SEASON}.png"
         fi
     fi
 
-    ## Use Framebuffer as picture overlay, you can see it if you load a ROM or shutdown ES
-    ES_FBPICTURE=$(/usr/bin/batocera-settings-get es.fbpicture.enabled)
-    if [ "${ES_FBPICTURE}" == "1" ]; then    
-        test -e /dev/fb0 && fbv -f -e -i "/usr/share/batocera/splash/boot-logo.png"
-    fi
-    
     ###################
     # launch automatically a game only the first time
     if test ${GAMELAUNCH} = 1
-       then
+    then
        GAMELAUNCHOPT=
     else
         GAMELAUNCHOPT="--no-startup-game"


### PR DESCRIPTION
idea: https://github.com/batocera-linux/batocera.linux/pull/5241
@Hew-ux, also a feature used that was added by @nadenislamarre with https://github.com/batocera-linux/batocera-emulationstation/pull/1077

1) Seasonal splash, therefore some more picture needed to be attached and activated into the script
2) Added possibility to remove loading bar (this also disables the season splash of course)
3) Added frambuffer picture, as default - I liked the idea, but it's lost since Batocera 32
The intention is to make these pictures not changeable for the average user.

Some options need to be added to `batocera.conf`
```
## ES splash screens, also some for special events always visible if ES starts
## The default one displays the loading bar and are enabled per default
## As last option: the fb-option for showing a picture between your rom loads (disabled per default)
#es.season.enabled=1
#es.loadbar.enabled=1
#es.fbpicture.enabled=0
```