### PR TITLE
fix mupen64 aspect ratio settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
@@ -63,20 +63,21 @@ def setMupenConfig(iniConfig, system, controllers, gameResolution):
     iniConfig.set("Video-Glide64mk2", "Version", "1")
 
     # Widescreen Mode -> ONLY for GLIDE64 & MK2
-    if system.config["ratio"] == "16/9":
-        # Glide64mk2.: Adjust screen aspect for wide screen mode: -1=Game default, 0=disable. 1=enable
-        # Glide64mk2.: Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original
-        iniConfig.set("Video-Glide64mk2", "adjust_aspect", "1")
-        iniConfig.set("Video-Glide64mk2", "aspect", "1")
-        # GLideN64.: Screen aspect ratio (0=stretch, 1=force 4:3, 2=force 16:9, 3=adjust)
-        iniConfig.set("Video-GLideN64",   "AspectRatio", "2")
-    elif system.config["ratio"] == "4/3":
-        iniConfig.set("Video-Glide64mk2", "adjust_aspect", "0")
-        iniConfig.set("Video-Glide64mk2", "aspect", "0")
-        iniConfig.set("Video-GLideN64",   "AspectRatio", "1")
+    if system.isOptSet("mupen64plus_ratio"):
+        if system.config["mupen64plus_ratio"] == "16/9":
+            # Glide64mk2.: Adjust screen aspect for wide screen mode: -1=Game default, 0=disable. 1=enable
+            iniConfig.set("Video-Glide64mk2", "adjust_aspect", "1")
+            # Glide64mk2.: Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original
+            iniConfig.set("Video-Glide64mk2", "aspect", "1")
+            # GLideN64.: Screen aspect ratio (0=stretch, 1=force 4:3, 2=force 16:9, 3=adjust)
+            iniConfig.set("Video-GLideN64",   "AspectRatio", "2")
+        else:
+            iniConfig.set("Video-Glide64mk2", "adjust_aspect", "0")
+            iniConfig.set("Video-Glide64mk2", "aspect", "0")
+            iniConfig.set("Video-GLideN64",   "AspectRatio", "1")
     else:
-        iniConfig.set("Video-Glide64mk2", "adjust_aspect", "1")
-        iniConfig.set("Video-Glide64mk2", "aspect", "2")
+        iniConfig.set("Video-Glide64mk2", "adjust_aspect", "-1")
+        iniConfig.set("Video-Glide64mk2", "aspect", "-1")
         iniConfig.set("Video-GLideN64",   "AspectRatio", "3")
 
     # Textures Mip-Mapping (Filtering)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
@@ -17,6 +17,9 @@ class MupenGenerator(Generator):
         iniConfig.optionxform = str
         if os.path.exists(batoceraFiles.mupenCustom):
             iniConfig.read(batoceraFiles.mupenCustom)
+        else:
+            os.makedirs(os.path.dirname(batoceraFiles.mupenCustom))
+            iniConfig.read(batoceraFiles.mupenCustom)
 
         mupenConfig.setMupenConfig(iniConfig, system, playersControllers, gameResolution)
         mupenControllers.setControllersConfig(iniConfig, playersControllers, system.config)

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4050,9 +4050,14 @@ moonlight:
   shared: [hud]
 
 mupen64plus:
-  features: [ratio, decoration]
+  features: [decoration]
   shared: [hud]
   cfeatures:
+        mupen64plus_ratio:
+            prompt:      GAME ASPECT RATIO
+            choices:
+                "4:3":   4/3
+                "16:9":  16/9
         mupen64plus_frameskip:
             prompt:      FRAMESKIP (GL64MK2 ONLY)
             description: Skip frames to improve performance, at the cost of choppy motion.


### PR DESCRIPTION
fixes mupen64 defaulting to 16:9, no longer uses libretro's ratios (it never used them in the first place, it would just ignore them like Dolphin used to).