### PR TITLE
relabel + fix gamecube options/bezel

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -269,23 +269,32 @@ class DolphinGenerator(Generator):
         dolphinGFXSettings.read(batoceraFiles.dolphinGfxIni)
 
         dolphin_aspect_ratio = dolphinGFXSettings.get("Settings", "AspectRatio")
-        wii_tv_mode = 0 #gamecube workaround
+        # What if we're playing a GameCube game with the widescreen patch or not?
+        if 'widescreen_hack' in config and config["widescreen_hack"] == "1":
+            wii_tv_mode = 1
+        else:
+            wii_tv_mode = 0
+
         try:
             wii_tv_mode = dolphinSYSCONF.getRatioFromConfig(config, gameResolution)
         except:
             pass
-                
+
+        # Auto
         if dolphin_aspect_ratio == "0":
             if wii_tv_mode == 1:
                 return 16/9
             return 4/3
-            
+
+        # Forced 16:9
         if dolphin_aspect_ratio == "1":
             return 16/9
-        
+
+        # Forced 4:3
         if dolphin_aspect_ratio == "2":
             return 4/3
-            
+
+        # Stretched (thus depends on physical screen geometry)
         if dolphin_aspect_ratio == "3":
             return gameResolution["width"] / gameResolution["height"]
                 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -10,7 +10,7 @@ shared:
       choices:
         "None": none
         "Game info/art": game
-        "Performance": perf
+        "Performance (MangoHUD)": perf
         "Custom": custom
     runahead:
       submenu:     LATENCY REDUCTION
@@ -3655,7 +3655,7 @@ dolphin:
                 "7x (4480x3696)":       7
                 "8x 5K (5120x4224)":    8
         dolphin_aspect_ratio:
-            prompt:      ASPECT RATIO
+            prompt:      GAME ASPECT RATIO
             description: The final output image, unrelated to the Wii's emulated NAND setting.
             choices:
                 "Force 16:9": 1
@@ -3727,12 +3727,6 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
-        widescreen_hack:
-            prompt:      WIDESCREEN HACK (GLITCHY)
-            description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
-            choices:
-                "Off": 0
-                "On":  1
         enable_cheats:
             prompt:      ENABLE CHEATS
             description: To use game cheats or 16/9 Aspect Ratio Fix codes.
@@ -3776,6 +3770,14 @@ dolphin:
                 "On":  1
 
   systems:
+    gamecube:
+        cfeatures:
+            widescreen_hack:
+                prompt:      WIDESCREEN HACK (GLITCHY)
+                description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
+                choices:
+                    "Off": 0
+                    "On":  1
     wii:
         cfeatures:
             tv_mode:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -10,7 +10,7 @@ shared:
       choices:
         "None": none
         "Game info/art": game
-        "Performance (MangoHUD)": perf
+        "Performance": perf
         "Custom": custom
     runahead:
       submenu:     LATENCY REDUCTION


### PR DESCRIPTION
As prolific as MangoHUD is, it should probably be mentioned by name here so people can realise what it actually is.

Also fixes the bezel issue with GameCube games with the widescreen hack. For instance, if the user had widescreen mode enabled while playing a GameCube game, then they *would* have gotten bezels. However, bezels were disabled in v33, so nobody even noticed this. It's satisfying squishing a bug before it could even affect anyone.

Actually I've tested this and it seems like bezels are working perfectly fine for Dolphin (on x86_64 at least). Maybe we can re-enable it?

Moved the widescreen hack to be gamecube-specific. Wii already has the ability to natively play widescreen games, the widescreen hack is only required for gamecube afaik. Let me know if that's not the case, though.