### PR TITLE
Commit 3 changes to es_systems.yml to fix theme display

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2539,6 +2539,7 @@ zc210:
   manufacturer: Ports
   release: 1999
   hardware: console
+  theme:	zeldac
   extensions: [qst]
   emulators:
     libretro:

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2342,7 +2342,7 @@ crvision:
   manufacturer: VTech
   release: 1982
   hardware: console
-  theme:	  creativision-w
+  theme:	  creativision
   extensions: [bin, rom, zip, 7z]
   emulators:
     mame:


### PR DESCRIPTION
es_systems.cfg contains errors in the <theme> items for a few systems. This commit fixes theme display issues for BBCMicro, Astrocade, and Creativision