### PR TITLE
fixes: wrong upgrade msg badge, set new config.txt per default

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
@@ -45,6 +45,8 @@ do_badgeines() {
 
 # ---- MAIN ----
 echo "Starting the upgrade..."
+echo "Cleaning up files..."
+test -f "/userdata/system/upgrade/upgrade_message.txt" && rm -f "/userdata/system/upgrade/upgrade_message.txt"
 
 # --- Prepare update URLs ---
 
@@ -141,7 +143,7 @@ fi
 # all these files doesn't exist on non rpi platform, so, we have to test them
 # don't put the boot.ini file while it's not really to be customized
 do_upgmsg "Backing up config files ..." 0.5
-BOOTFILES="config.txt batocera-boot.conf"
+BOOTFILES="batocera-boot.conf"
 for BOOTFILE in ${BOOTFILES}
 do
     if test -e "/boot/${BOOTFILE}"


### PR DESCRIPTION
msg badge could show permanent wrong info if `upgrade_message` is still present.
This happens if you switch off the device during upgrade process (very rare!)

More important:
Do not save config.txt for Pie installs anymore
Usually everything is setted per automatic in BATOCERA - so I think it's more usefull to overwrite default config and get rid of "repair init.d scripts"
We should therefore burn old bridges and build new ones