### PR TITLE
Game Options by Folder

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -1,6 +1,7 @@
 2022/xx/xx - batocera.linux 34
         * add: demul emulator for running Sega - Naomi 2, Hikaru, Gaelco & Cave CV1000 games - requires Wine - (x86_64)
 		* add: add more flycast options including vulkan support
+                * add: game options by folder (manual edits to batocera.conf only)
 		* bump: dolphin to 5.0-15993
 		* bump: flycast & libretro-flycast to 1.2
 		* bump: duckstation for final build?

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -27,6 +27,7 @@ class Emulator():
         recalSettings = UnixSettings(batoceraFiles.batoceraConf)
         globalSettings = recalSettings.loadAll('global')
         systemSettings = recalSettings.loadAll(self.name)
+        folderSettings = recalSettings.loadAll(self.name + ".folder[\"" + os.path.dirname(rom) + "\"]")
         gameSettings = recalSettings.loadAll(self.name + "[\"" + os.path.basename(rom) + "\"]")
 
         # add some other options
@@ -37,6 +38,7 @@ class Emulator():
         # update config
         Emulator.updateConfiguration(self.config, globalSettings)
         Emulator.updateConfiguration(self.config, systemSettings)
+        Emulator.updateConfiguration(self.config, folderSettings)
         Emulator.updateConfiguration(self.config, gameSettings)
         self.updateFromESSettings()
         eslog.debug("uimode: {}".format(self.config['uimode']))


### PR DESCRIPTION
This is currently only for manual batocera.conf editing, though ES could be modified to allow settings there. There is no saving/changing/removing these options via Batocera directly.

To use, add a line in batocera.conf in the format:
system.folder["/full/path/"].option=value

For example, to change the shader set for a folder of Japanese NES games, I used:
nes.folder["/userdata/roms/nes/Japan/"].shaderset=Mega-Bezel-Community-JP-Night

This should work for any option - software list settings, decorations, shaders set, or emulator (ie have MAME subfolders for different versions of MAME) would be common uses.

Folder options are loaded after system options but before game options, so individual game settings will still override them.