### PR TITLE
Fixe unclutter

### DIFF
--- a/package/batocera/utils/unclutter/unclutter.mk
+++ b/package/batocera/utils/unclutter/unclutter.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 # Version: 1.5-batocera
-UNCLUTTER_VERSION = v1.5-batocera
+UNCLUTTER_VERSION = a73b7f8f353b8322374720aecf670803af4c8d8e
 UNCLUTTER_LICENSE = MIT
 UNCLUTTER_SITE = $(call github,batocera-linux,unclutter-xfixes,$(UNCLUTTER_VERSION))
 UNCLUTTER_DEPENDENCIES = xserver_xorg-server libev


### PR DESCRIPTION
Fixe github issue : 

```
WARNING: no hash file for unclutter-v1.5-batocera.tar.gz
>>> unclutter v1.5-batocera Extracting
gzip -d -c /build/buildroot/dl/unclutter/unclutter-v1.5-batocera.tar.gz | tar --strip-components=1 -C /x86_wow64/build/unclutter-v1.5-batocera   -xf -

gzip: /build/buildroot/dl/unclutter/unclutter-v1.5-batocera.tar.gz: not in gzip format
tar: This does not look like a tar archive
tar: Exiting with failure status due to previous errors
make: *** [package/pkg-generic.mk:251: /x86_wow64/build/unclutter-v1.5-batocera/.stamp_extracted] Error 2
make: Leaving directory '/build/buildroot'
make: *** [Makefile:105 : x86_wow64-build] Erreur 2
```