### PR TITLE
Sonic Retro Bump & Fix

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -8,6 +8,8 @@
         * bump: dolphin to 5.0-15993
         * bump: flycast & libretro-flycast to 1.2
         * bump: duckstation for final build?
+        * bump: Sonic Retro Egine ports to latest builds
+        * change: Restored Sonic Retro Engine to non-x86 boards (using 1.1.2.1 for sonic2013 & 1.1.2 for soniccd)
         * change: MAME/MESS: speech module and 32k RAM option for TI-99, image reader enabled for Mac IIx model (x86_64)
         * change: MAME: High score plugin enabled by default (can be disabled in game/system options) (x86_64)
         * change: enabled MAME as an alternate emulator for Vectrex (x86_64)

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -1003,8 +1003,8 @@ config BR2_PACKAGE_BATOCERA_CONSOLE_SYSTEMS
 	select BR2_PACKAGE_ECWOLF                       if BR2_PACKAGE_BATOCERA_TARGET_X86_64
 
 	# Sonic Retro Engine
-	select BR2_PACKAGE_SONIC2013                    if BR2_PACKAGE_BATOCERA_TARGET_X86_ANY
-	select BR2_PACKAGE_SONICCD                      if BR2_PACKAGE_BATOCERA_TARGET_X86_ANY
+	select BR2_PACKAGE_SONIC2013                    # ALL
+	select BR2_PACKAGE_SONICCD                      # ALL
 
 	# Super Cassette Vision
 	select BR2_PACKAGE_LIBRETRO_EMUSCV              # ALL

--- a/package/batocera/ports/sonic2013/sonic2013.mk
+++ b/package/batocera/ports/sonic2013/sonic2013.mk
@@ -1,25 +1,17 @@
+SONIC2013_SITE = https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation.git
+SONIC2013_SITE_METHOD = git
+SONIC2013_GIT_SUBMODULES == YES
 
-SONIC2013_VERSION = 759d8459638a4fa97fb7c8729029369b90dcbe87
-SONIC2013_SITE = $(call github,Rubberduckycooly,Sonic-1-2-2013-Decompilation,$(SONIC2013_VERSION))
 SONIC2013_DEPENDENCIES = sdl2 libogg libvorbis
 SONIC2013_LICENSE = Custom
 
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_X86_ANY),y)
+	SONIC2013_VERSION = 290cd5f
+else
+	SONIC2013_VERSION = f9718af
+endif
+
 define SONIC2013_BUILD_CMDS
-	rm -rf $(@D)/tmp
-	rm -rf $(@D)/dependencies/all/asio/
-	git clone https://github.com/chriskohlhoff/asio.git $(@D)/tmp
-	git -C $(@D)/tmp pull --all
-	git -C $(@D)/tmp checkout -b sonic2013 51d5bb3d493f82446e525f68d5b79002e1d797d2
-	mv $(@D)/tmp/* $(@D)/dependencies/all/
-	rm -rf $(@D)/tmp
-	rm -rf $(@D)/dependencies/all/tinyxml2
-	git clone https://github.com/leethomason/tinyxml2.git $(@D)/dependencies/all/tinyxml2
-	git -C $(@D)/dependencies/all/tinyxml2 pull --all
-	git -C $(@D)/dependencies/all/tinyxml2 checkout -b sonic2013 a9773976845b19e89020c1215781e71116477ef1
-	rm -rf $(@D)/dependencies/all/stb-image
-	git clone https://github.com/nothings/stb.git $(@D)/dependencies/all/stb-image
-	git -C $(@D)/dependencies/all/stb-image pull --all
-	git -C $(@D)/dependencies/all/stb-image checkout -b sonic2013 af1a5bc352164740c1cc1354942b1c6b72eacb8a
 	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) -f Makefile VERBOSE=1
 endef
 

--- a/package/batocera/ports/soniccd/soniccd.mk
+++ b/package/batocera/ports/soniccd/soniccd.mk
@@ -1,19 +1,24 @@
+SONICCD_SITE = https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation.git
+SONICCD_SITE_METHOD = git
+SONICCD_GIT_SUBMODULES = YES
 
-SONICCD_VERSION = b99fed54b22821a3512cf5b09de9e826935668bd
-SONICCD_SITE = $(call github,Rubberduckycooly,Sonic-CD-11-Decompilation,$(SONICCD_VERSION))
-SONICCD_DEPENDENCIES = sdl2 libvorbis libogg libtheora
+SONICCD_DEPENDENCIES = sdl2 libogg libvorbis libtheora
 SONICCD_LICENSE = Custom
 
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_X86_ANY),y)
+	SONICCD_VERSION = cb01e5a
+	SONICCD_BINNAME = RSDKv3
+else
+	SONICCD_VERSION = 222caf6
+	SONICCD_BINNAME = soniccd
+endif
+
 define SONICCD_BUILD_CMDS
-	rm -rf $(@D)/dependencies/all/tinyxml2
-	git clone https://github.com/leethomason/tinyxml2.git $(@D)/dependencies/all/tinyxml2
-	git -C $(@D)/dependencies/all/tinyxml2 pull --all
-	git -C $(@D)/dependencies/all/tinyxml2 checkout -b soniccd a9773976845b19e89020c1215781e71116477ef1
 	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D) -f Makefile VERBOSE=1
 endef
 
 define SONICCD_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/bin/RSDKv3 $(TARGET_DIR)/usr/bin/soniccd
+	$(INSTALL) -D -m 0755 $(@D)/bin/$(SONICCD_BINNAME) $(TARGET_DIR)/usr/bin/soniccd
 endef
 
 define SONICCD_POST_PROCESS


### PR DESCRIPTION
* Bumps Sonic Retro on x86
* Cleans up build process (author made dependencies submodules instead of separate downloads)
* Restores Sonic Retro to other boards using an older, pre-unmet dependencies version (commits are v1.1.2.1 on sonic2013 and v1.1.2 on soniccd)

Tested on x86_64 & rk3326 (Odroid Go Super)