### PR TITLE
remove a few options from advanced

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -921,7 +921,6 @@ libretro:
                     "3":           3
                     "4":           4
             fbneo-lightgun-hide-crosshair:
-                group: ADVANCED OPTIONS
                 prompt:      SHOW LIGHTGUN CROSSHAIRS
                 description: Lightgun device must be selected on at least one port.
                 choices:
@@ -2111,7 +2110,6 @@ libretro:
                     "NTSC":                        NTSC
                     "PAL":                         PAL
             o2em_swap_gamepads:
-                group: ADVANCED OPTIONS
                 prompt:      SWAP GAMEPADS
                 description: Some games accept input from port 2 instead of port 1.
                 choices:
@@ -2320,7 +2318,6 @@ libretro:
                     "2":                2
                     "3":                3
             neon_enhancement:
-                group: ADVANCED OPTIONS
                 prompt:      ENHANCED RENDERING RESOLUTION (32-BIT ONLY)
                 description: Double the rendering resolution. No effect on 64-bit machines.
                 choices:
@@ -5128,7 +5125,6 @@ supermodel:
                 "Off":      0
                 "On":       1
         crosshairs:
-            group: ADVANCED OPTIONS
             prompt:      SHOW LIGHTGUN CROSSHAIRS
             description: Enable crosshairs in shooting games for the selected players.
             choices:


### PR DESCRIPTION
  * `o2em_swap_gamepads`: This one probably shouldn't be an advanced option, it's pretty easy to understand what it does and why you might need to change it. There are also a lot of games that do require you to change it, so hiding it away could make things more complicated. And it's not consistent either, other platforms with similar options don't have this as an advanced option.
  * `neon_enhancement`: This is the only option regarding rendering resolution that's been tagged as "advanced". Removing for consistency.
  * `crosshairs`: This is pretty necessary for lightgun games, and isn't too hard to understand what it does. Also, these are the only two platforms where this was tagged as advanced, the rest don't have this. Removing for consistency, but could also go the other way just as easily.