### PR TITLE
Add screen orientation option for drastic

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/drastic/drasticGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/drastic/drasticGenerator.py
@@ -47,6 +47,11 @@ class DrasticGenerator(Generator):
         else:
             esvaluedrasticfix2d = 0 
         
+        if system.isOptSet("drastic_screen_orientation"):
+            esvaluedrasticscreenorientation = system.config["drastic_screen_orientation"]
+        else:
+            esvaluedrasticscreenorientation = 0
+
         textList = [                             # 0,1,2,3 ...
         "enable_sound"                 + " = 1",
         "compress_savestates"          + " = 1",
@@ -60,15 +65,15 @@ class DrasticGenerator(Generator):
         "rtc_system_time"              + " = 1",
         "use_rtc_custom_time"          + " = 0",
         "rtc_custom_time"              + " = 0",
-        "frameskip_type"               + " = 2",                                 #None/Manual/Auto
-        "frameskip_value"              + " = 1",                                 #50%/100%/200%/300%/400%/Unlimited
+        "frameskip_type"               + " = 2",                                        #None/Manual/Auto
+        "frameskip_value"              + " = 1",                                        #50%/100%/200%/300%/400%/Unlimited
         "safe_frameskip"               + " = 1",
-        "disable_edge_marking"         + " = 1",                                 #will prevent edge marking. It draws outlines around some 3D models to give a cel-shaded effect. Since DraStic doesn't emulate anti-aliasing, it'll cause edges to look harsher than they may on a real DS.
-        "fix_main_2d_screen"           + " = " + str(esvaluedrasticfix2d),       #Top Screen will always be the Action Screen (for 2d games like Sonic)
-        "hires_3d"                     + " = " + str(esvaluedrastichires),       #High Resolution 3D Rendering
-        "threaded_3d"                  + " = " + str(esvaluedrasticthreaded),    #MultiThreaded 3D Rendering - Improves perf in 3D - can cause glitch.
-        "screen_orientation"           + " = 0",                                 #Vertical/Horizontal/OneScreen
-        "screen_scaling"               + " = 0",                                 #No Scaling/Stretch Aspect/1x2x/2x1x/TvSplit
+        "disable_edge_marking"         + " = 1",                                        #will prevent edge marking. It draws outlines around some 3D models to give a cel-shaded effect. Since DraStic doesn't emulate anti-aliasing, it'll cause edges to look harsher than they may on a real DS.
+        "fix_main_2d_screen"           + " = " + str(esvaluedrasticfix2d),              #Top Screen will always be the Action Screen (for 2d games like Sonic)
+        "hires_3d"                     + " = " + str(esvaluedrastichires),              #High Resolution 3D Rendering
+        "threaded_3d"                  + " = " + str(esvaluedrasticthreaded),           #MultiThreaded 3D Rendering - Improves perf in 3D - can cause glitch.
+        "screen_orientation"           + " = " + str(esvaluedrasticscreenorientation),  #Vertical/Horizontal/OneScreen
+        "screen_scaling"               + " = 0",                                        #No Scaling/Stretch Aspect/1x2x/2x1x/TvSplit
         "screen_swap "                 + " = 0"
         ]
         

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6239,6 +6239,13 @@ drastic:
             choices:
                 "Off": 0
                 "On":  1
+        drastic_screen_orientation:
+            prompt:      SCREEN LAYOUT
+            description: Arrange the dual screen layout.
+            choices:
+                "Vertical": 0
+                "Horizontal": 1
+                "Single": 3
 
 xemu:
   shared: [videomode, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]


### PR DESCRIPTION
Adding a screen orientation option to the drastic emu. Same as what is available with the `libretro: DeSmuME`