### PR TITLE
fix shader generator behaviour

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -404,7 +404,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
         retroarchConfig['video_smooth'] = 'false'
 
     # Shader option
-    if 'shader' in renderConfig and renderConfig['shader'] != "none":
+    if 'shader' in renderConfig and (renderConfig['shader'] != None and renderConfig['shader'] != "none"):
         retroarchConfig['video_shader_enable'] = 'true'
         retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs
     else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -404,7 +404,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
         retroarchConfig['video_smooth'] = 'false'
 
     # Shader option
-    if 'shader' in renderConfig and renderConfig['shader'] != None:
+    if 'shader' in renderConfig and renderConfig['shader'] != "none":
         retroarchConfig['video_shader_enable'] = 'true'
         retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs
     else:


### PR DESCRIPTION
This bug caused user-set shaders to be ignored by default. It was impossible to set the shader to "none".

Suggestion: rename "none" to "custom", to imply that the user can indeed use RetroArch to set up their preferred shaders.