### PR TITLE
bump syncthing + fix permissions issue with cache

### DIFF
--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -36,7 +36,6 @@ define SYNCTHING_BUILD_CMDS
 endef
 
 define SYNCTHING_INSTALL_TARGET_CMDS
-	mkdir -p $(TARGET_DIR)/usr/bin
 	mkdir -p $(TARGET_DIR)/etc/init.d
 	$(INSTALL) -D $(@D)/syncthing $(TARGET_DIR)/usr/bin/syncthing
 	$(INSTALL) -Dm755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/syncthing/S27syncthing $(TARGET_DIR)/etc/init.d/

--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SYNCTHING_VERSION = v1.18.6
+SYNCTHING_VERSION = v1.19.1
 SYNCTHING_SITE = $(call github,syncthing,syncthing,$(SYNCTHING_VERSION))
 SYNCTHING_LICENSE = MPLv2
 SYNCTHING_LICENSE_FILES = LICENSE
@@ -29,6 +29,9 @@ SYNCTHING_TARGET_ENV = \
 
 define SYNCTHING_BUILD_CMDS
 	cd $(@D) && $(SYNCTHING_TARGET_ENV) $(GO_BIN) run build.go -goos linux -goarch $(GOARCH) build
+	# Fix directory permissions to make sure cleanbuild works.
+	# For details see: https://github.com/golang/go/issues/27161 https://github.com/golang/go/issues/27455
+	cd $(@D) && find . -type d -exec chmod +w '{}' \;
 endef
 
 define SYNCTHING_INSTALL_TARGET_CMDS

--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -19,26 +19,27 @@ ifeq ($(BR2_x86_64),y)
 GOARCH=amd64
 endif
 
+# GOFLAGS="-modcacherw" used to fix directory permissions to make sure cleanbuild works.
+# For details see: https://github.com/golang/go/issues/27161 https://github.com/golang/go/issues/27455
+
 SYNCTHING_TARGET_ENV = \
 	PATH=$(BR_PATH) \
 	CGO_ENABLED=1 \
 	GOCACHE="$(HOST_GO_TARGET_CACHE)" \
 	GOMODCACHE="$(@D)" \
+	GOFLAGS="-modcacherw" \
 	CC_FOR_TARGET="$(TARGET_CC)" \
 	CXX_FOR_TARGET="$(TARGET_CXX)"
 
 define SYNCTHING_BUILD_CMDS
 	cd $(@D) && $(SYNCTHING_TARGET_ENV) $(GO_BIN) run build.go -goos linux -goarch $(GOARCH) build
-	# Fix directory permissions to make sure cleanbuild works.
-	# For details see: https://github.com/golang/go/issues/27161 https://github.com/golang/go/issues/27455
-	cd $(@D) && find . -type d -exec chmod +w '{}' \;
 endef
 
 define SYNCTHING_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin
 	mkdir -p $(TARGET_DIR)/etc/init.d
 	$(INSTALL) -D $(@D)/syncthing $(TARGET_DIR)/usr/bin/syncthing
-	$(INSTALL) -Dm755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/syncthing/S27syncthing       $(TARGET_DIR)/etc/init.d/
+	$(INSTALL) -Dm755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/syncthing/S27syncthing $(TARGET_DIR)/etc/init.d/
 endef
 
 $(eval $(golang-package))


### PR DESCRIPTION
builds OK, fixes issue with cleanbuild not being able to remove the syncthing folder from `output/<arch>/build/syncthing-v###`. Credit to nuumio for the code/suggestion.