### PR TITLE
Revert "Libretro Flycast Fix"

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -25,7 +25,6 @@
         * change: decoration sets can now include MAME-compatible ZIP files with full layouts and multiple images
         * add: game options by folder (manual edits to batocera.conf only)
         * add: adafruit-circuitpython-ws2801 for rpi builds
-        * fix: Disabled GLCore for Libretro Flycast
 
 2022/02/xx - batocera.linux 33
         * add: Support for Beelink GT-KING "https://www.bee-link.com/products/beelink-gt-king-wifi6"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -269,17 +269,14 @@ def getGFXBackend(system):
         # Pick glcore or gl based on drivers if not selected
         if system.isOptSet("gfxbackend"):
             backend = system.config["gfxbackend"]
-            setManually = True
         else:
-            setManually = False
             if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:  
                 backend = "glcore"
             else:
-                backend = "opengl"
+                backend = "gl"
         # If set to glcore or gl, override setting for certain cores that require one or the other
-        if not setManually:
-            if backend == "opengl" and core in [ 'kronos', 'citra', 'mupen64plus-next', 'melonds', 'beetle-psx-hw' ]:
-                backend = "glcore"
-            if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3', 'flycast' ]:
-                backend = "opengl"
+        if backend == "gl" and core in [ 'kronos', 'citra', 'mupen64plus-next', 'melonds', 'beetle-psx-hw' ]:
+            backend = "glcore"
+        if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3' ]:
+            backend = "gl"
         return backend


### PR DESCRIPTION
the commit breaks libretro on sbc.
by the way, options should be set in .yml files, not in python code (except if logic is usefull)

This reverts commit 0be74046ace340e91e4982e3a80d229253d10876.