### PR TITLE
Retroarch OpenGL Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -264,19 +264,29 @@ class LibretroGenerator(Generator):
         return Command.Command(array=commandArray)
 
 def getGFXBackend(system):
-        core = system.config['core']
         # Start with the selected option
         # Pick glcore or gl based on drivers if not selected
         if system.isOptSet("gfxbackend"):
             backend = system.config["gfxbackend"]
+            setManually = True
         else:
-            if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:  
+            setManually = False
+            if videoMode.getGLVersion() >= 3.1 and videoMode.getGLVendor() in ["nvidia", "amd"]:
                 backend = "glcore"
             else:
                 backend = "gl"
-        # If set to glcore or gl, override setting for certain cores that require one or the other
-        if backend == "gl" and core in [ 'kronos', 'citra', 'mupen64plus-next', 'melonds', 'beetle-psx-hw' ]:
-            backend = "glcore"
-        if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3' ]:
+
+        # Retroarch has flipped between using opengl or gl, correct the setting here if needed.
+        if backend == "opengl":
             backend = "gl"
+
+        # Don't change based on core if manually selected.
+        if not setManually:
+            # If set to glcore or gl, override setting for certain cores that require one or the other
+            core = system.config['core']
+            if backend == "gl" and core in [ 'kronos', 'citra', 'mupen64plus-next', 'melonds', 'beetle-psx-hw' ]:
+                backend = "glcore"
+            if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3', 'flycast' ]:
+                backend = "gl"
+
         return backend

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -187,7 +187,7 @@ libretro:
       prompt:      GRAPHICS API
       description: Choose which graphics API library to use. Vulkan may not work for every core.
       choices:
-        "OpenGL": opengl
+        "OpenGL": gl
         "GLCore": glcore
         "Vulkan": vulkan
     audio_latency:


### PR DESCRIPTION
It looks like Retroarch has reverted back to using gl for the OpenGL driver, it was opengl in a previous build when the now-reverted Flycast fix was added.

This PR:
* Changes the option in ES to use gl instead of opengl
* Auto corrects the setting while generating, in case anyone still has opengl from selecting it manually
* Re-adds flycast to the list of non-GLCore cores
* Re-adds the "don't override a manually selected backend by core" function that was reverted with the lr-flycast change.