### PR TITLE
[easyrpg-player standalone]Changed the Screenshot key

### DIFF
--- a/package/batocera/emulators/easyrpg/easyrpg-player/easyrpg.easyrpg.keys
+++ b/package/batocera/emulators/easyrpg/easyrpg-player/easyrpg.easyrpg.keys
@@ -43,7 +43,7 @@
 	{
             "trigger": ["hotkey", "pageup"],
             "type": "key",
-            "target": [ "KEY_F10" ]
+            "target": [ "KEY_F7" ]
 	},
 	{
             "trigger": ["hotkey", "right"],


### PR DESCRIPTION
The recent update of EasyRPG Player changed the screenshot key from F10 to F7, this reflects this change.

This change happened because the original test-play mode of RPG Maker 2003 had a "Abort Event" at F10, which the player now has as well, so they had to swap them out to stay faithful.

**_Please note_** that in the current state, it won't save the screenshots to the screenshot folder, but in the save folder, changing this goes beyond my abilities though, as I think this isn't something that can be set up in main branch of easyrpg itself currently (I think there was a patch on batocera's side for that, but it may not be there anymore(?)).