### PR TITLE
Triforce fixes

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
@@ -19,9 +19,10 @@ def generateControllerConfig(system, playersControllers, rom):
     generateControllerConfig_gamecube(system, playersControllers,rom)               # Pass ROM name to allow for per ROM configuration
 
 def generateControllerConfig_gamecube(system, playersControllers,rom):
+    # Exclude Buttons/Y from mapping as that just resets the system.
     gamecubeMapping = {
         'y':            'Buttons/B',     'b':             'Buttons/A',
-        'x':            'Buttons/Y',     'a':             'Buttons/X',
+        'a':            'Buttons/X',
         'pagedown':     'Buttons/Z',     'start':         'Buttons/Start',
         'l2':           'Triggers/L',    'r2':            'Triggers/R',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',
@@ -66,7 +67,7 @@ def removeControllerConfig_gamecube():
 
 def generateHotkeys(playersControllers):
     configFileName = "{}/{}".format(batoceraFiles.dolphinTriforceConfig, "Config/Hotkeys.ini")
-    f = codecs.open(configFileName, "w", encoding="utf_8_sig")
+    f = codecs.open(configFileName, "w", encoding="utf_8")
 
     hotkeysMapping = {
         'a':           'Keys/Reset',                    'b': 'Keys/Toggle Pause',
@@ -114,7 +115,7 @@ def generateHotkeys(playersControllers):
 
 def generateControllerConfig_any(system, playersControllers, filename, anyDefKey, anyMapping, anyReverseAxes, anyReplacements, extraOptions = {}):
     configFileName = "{}/{}".format(batoceraFiles.dolphinTriforceConfig, filename)
-    f = codecs.open(configFileName, "w", encoding="utf_8_sig")
+    f = codecs.open(configFileName, "w", encoding="utf_8")
     nplayer = 1
     nsamepad = 0
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -196,23 +196,6 @@ D-Pad/Right = `Hat 0 E`
         else:
             dolphinTriforceGFXSettings.set("Settings", "wideScreenHack", "False")
 
-        # Ubershaders (synchronous_ubershader by default)
-        if system.isOptSet('ubershaders') and system.config["ubershaders"] != "no_ubershader":
-            if system.config["ubershaders"] == "exclusive_ubershader":
-                dolphinTriforceGFXSettings.set("Settings", "ShaderCompilationMode", "1")
-            elif system.config["ubershaders"] == "hybrid_ubershader":
-                dolphinTriforceGFXSettings.set("Settings", "ShaderCompilationMode", "2")
-            elif system.config["ubershaders"] == "skip_draw":
-                dolphinTriforceGFXSettings.set("Settings", "ShaderCompilationMode", "3")
-        else:
-            dolphinTriforceGFXSettings.set("Settings", "ShaderCompilationMode", "0")
-
-        # Shader pre-caching
-        if system.isOptSet('wait_for_shaders') and system.getOptBoolean('wait_for_shaders'):
-            dolphinTriforceGFXSettings.set("Settings", "WaitForShadersBeforeStarting", "True")
-        else:
-            dolphinTriforceGFXSettings.set("Settings", "WaitForShadersBeforeStarting", "False")
-
         # Various performance hacks - Default Off
         if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
             dolphinTriforceGFXSettings.set("Hacks", "BBoxEnable", "False")
@@ -243,9 +226,9 @@ D-Pad/Right = `Hat 0 E`
 
         # Internal resolution settings
         if system.isOptSet('internal_resolution'):
-            dolphinTriforceGFXSettings.set("Settings", "InternalResolution", system.config["internal_resolution"])
+            dolphinTriforceGFXSettings.set("Settings", "EFBScale", system.config["internal_resolution"])
         else:
-            dolphinTriforceGFXSettings.set("Settings", "InternalResolution", "2")
+            dolphinTriforceGFXSettings.set("Settings", "EFBScale", "2")
 
         # VSync
         if system.isOptSet('vsync'):
@@ -264,12 +247,6 @@ D-Pad/Right = `Hat 0 E`
             dolphinTriforceGFXSettings.set("Settings", "MSAA", system.config["antialiasing"])
         else:
             dolphinTriforceGFXSettings.set("Settings", "MSAA", "0")
-
-        # Anti aliasing mode
-        if system.isOptSet('use_ssaa') and system.getOptBoolean('use_ssaa'):
-            dolphinTriforceGFXSettings.set("Settings", "SSAA", "True")
-        else:
-            dolphinTriforceGFXSettings.set("Settings", "SSAA", "False")
 
         # Save gfx.ini
         with open(batoceraFiles.dolphinTriforceGfxIni, 'w') as configfile:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -18,33 +18,7 @@ class DolphinTriforceGenerator(Generator):
         if not os.path.exists(batoceraFiles.dolphinTriforceData + "/StateSaves"):
             os.makedirs(batoceraFiles.dolphinTriforceData + "/StateSaves")
 
-        #dolphinTriforceControllers.generateControllerConfig(system, playersControllers, rom)
-        # Workaround to at least have X-input controllers working by default
-        if not os.path.exists(batoceraFiles.dolphinTriforceConfig + "/Config/GCPadNew.ini"):
-            dolphinTriforceGCPad = open(batoceraFiles.dolphinTriforceConfig + "/Config/GCPadNew.ini", "w")
-            dolphinTriforceGCPad.write("""[GCPad1]
-Device = SDL/0/Microsoft X-Box 360 pad
-Buttons/A = `Button 0`
-Buttons/B = `Button 2`
-Buttons/X = `Button 3`
-Buttons/Z = `Button 5`
-Buttons/Start = `Button 7`
-Main Stick/Up = `Axis 1-`
-Main Stick/Down = `Axis 1+`
-Main Stick/Left = `Axis 0-`
-Main Stick/Right = `Axis 0+`
-C-Stick/Up = `Axis 4-`
-C-Stick/Down = `Axis 4+`
-C-Stick/Left = `Axis 3-`
-C-Stick/Right = `Axis 3+`
-Triggers/L-Analog = `Axis 2+`
-Triggers/R-Analog = `Axis 5-+`
-D-Pad/Up = `Hat 0 N`
-D-Pad/Down = `Hat 0 S`
-D-Pad/Left = `Hat 0 W`
-D-Pad/Right = `Hat 0 E`
-""")
-            dolphinTriforceGCPad.close()
+        dolphinTriforceControllers.generateControllerConfig(system, playersControllers, rom)
 
         ## dolphin.ini ##
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -245,7 +245,7 @@ D-Pad/Right = `Hat 0 E`
         if system.isOptSet('internal_resolution'):
             dolphinTriforceGFXSettings.set("Settings", "InternalResolution", system.config["internal_resolution"])
         else:
-            dolphinTriforceGFXSettings.set("Settings", "InternalResolution", "1")
+            dolphinTriforceGFXSettings.set("Settings", "InternalResolution", "2")
 
         # VSync
         if system.isOptSet('vsync'):
@@ -502,9 +502,9 @@ $99 credits
         # with open(batoceraFiles.dolphinTriforceGameSettings + "/GGPE01.ini", 'w') as configfile:
             # dolphinTriforceGameSettingsGGPE01.write(configfile)
 
-        commandArray = ["dolphin-triforce.AppImage", "-b", "-U", "/userdata/system/configs/dolphin-triforce", "-e", rom]
+        commandArray = ["dolphin-triforce", "-b", "-U", "/userdata/system/configs/dolphin-triforce", "-e", rom]
         if system.isOptSet('platform'):
-            commandArray = ["dolphin-triforce.AppImage-nogui", "-b", "-U", "/userdata/system/configs/dolphin-triforce", "-p", system.config["platform"], "-e", rom]
+            commandArray = ["dolphin-triforce-nogui", "-b", "-U", "/userdata/system/configs/dolphin-triforce", "-p", system.config["platform"], "-e", rom]
 
         # No environment variables work for now, paths are coded in above.
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})

--- a/package/batocera/core/batocera-desktopapps/scripts/batocera-config-dolphin-triforce
+++ b/package/batocera/core/batocera-desktopapps/scripts/batocera-config-dolphin-triforce
@@ -8,4 +8,4 @@ then
     export DISPLAY=:0.0
 fi
 
-XDG_CONFIG_HOME=/userdata/system/configs XDG_DATA_HOME=/userdata/saves QT_QPA_PLATFORM=xcb /usr/bin/dolphin-triforce.AppImage -U "/userdata/system/configs/dolphin-triforce"
+XDG_CONFIG_HOME=/userdata/system/configs XDG_DATA_HOME=/userdata/saves QT_QPA_PLATFORM=xcb /usr/bin/dolphin-triforce -U "/userdata/system/configs/dolphin-triforce"

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5239,7 +5239,7 @@ dolphin_triforce:
                 "On":  1
         use_pad_profiles:
             group: ADVANCED OPTIONS
-            prompt:      USE PAD PROFILES (KO'D, DO NOT USE YET)
+            prompt:      USE PAD PROFILES
             description: Search for custom configured joystick profiles.
             choices:
                 "Off": 0
@@ -5310,7 +5310,7 @@ dolphin_triforce:
                 "Off": 0
                 "On":  1
         rumble:
-            prompt:      RUMBLE (KO'D, DO NOT USE YET)
+            prompt:      RUMBLE
             choices:
                 "Off": 0
                 "On":  1

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5210,21 +5210,19 @@ dolphin:
                     "Wiimote Sideway + Nunchuk": in
 
 dolphin_triforce:
-  features: [decoration, padtokeyboard]
+  features: [decoration]
   shared: [hud]
   cfeatures:
         internal_resolution:
             prompt:      RENDERING RESOLUTION
             description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
             choices:
-                "1x native (640x528)":  1
-                "2x 720p (1280x1056)":  2
-                "3x 1080p (1920x1584)": 3
-                "4x 1440p (2560x2112)": 4
-                "5x (3200x2640)":       5
-                "6x 4K (3840x3168)":    6
-                "7x (4480x3696)":       7
-                "8x 5K (5120x4224)":    8
+                "1x native (640x528)":    2
+                "1.5x 720p (960x792)":    3
+                "2x (1280x1056)":         4
+                "2.5x 1080p (1600x1320)": 5
+                "3x (1920x1584)":         6
+                "4x 1440p (2560x2112)":   7
         dolphin_aspect_ratio:
             prompt:      ASPECT RATIO
             description: The final output image, unrelated to the Wii's emulated NAND setting.

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5230,33 +5230,22 @@ dolphin_triforce:
                 "Force 16:9": 1
                 "Force 4:3": 2
                 "Stretch to window": 3
-        ubershaders:
-            prompt:      UBERSHADERS (needs review)
-            description: May not work well on all hardware. Hybrid is preferred, where supported.
-            choices:
-                "No Ubershaders":                          no_ubershader
-                "Exclusive Ubershaders":                   exclusive_ubershader
-                "Hybrid Ubershaders":                      hybrid_ubershader
-                "Skip Drawing":                            skip_draw
-        wait_for_shaders:
-            prompt:      PRE-CACHE SHADERS
-            description: Compile shaders on next launch of game (one time). Reduces micro-freezes.
-            choices:
-                "Off (default)": 0
-                "On":            1
         perf_hacks:
+            group: ADVANCED OPTIONS
             prompt:      PERFORMANCE HACKS (needs review)
             description: Increase emulator performance, at the cost of accuracy/stability.
             choices:
                 "Off": 0
                 "On":  1
         use_pad_profiles:
-            prompt:      USE PAD PROFILES
+            group: ADVANCED OPTIONS
+            prompt:      USE PAD PROFILES (KO'D, DO NOT USE YET)
             description: Search for custom configured joystick profiles.
             choices:
                 "Off": 0
                 "On":  1
         anisotropic_filtering:
+            group: ADVANCED OPTIONS
             prompt:      ANISOTROPIC FILTERING
             description: Improves clarity of distant textures.
             choices:
@@ -5266,56 +5255,62 @@ dolphin_triforce:
                 "8x":  3
                 "16x": 4
         dual_core:
-            prompt:      DUAL CORE MODE (needs review)
+            group: ADVANCED OPTIONS
+            prompt:      DUAL CORE MODE
             description: Usually not much faster than single core mode.
             choices:
                 "Off": 0
                 "On":  1
         gpu_sync:
-            prompt:      GPU SYNC (needs review)
+            group: ADVANCED OPTIONS
+            prompt:      GPU SYNC
             description: Speed hack for dual core mode to fix some glitches.
             choices:
                 "Off": 0
                 "On":  1
         antialiasing:
+            group: ADVANCED OPTIONS
             prompt:      ANTI-ALIASING
             description: Enhancement. Smooth out jagged edges on 3D object polygons.
             choices:
-                "Off": 0
-                "2x":  2
-                "4x":  4
-                "8x":  8
-        use_ssaa:
-            prompt:      ANTI-ALIASING MODE
-            description: Toggle MSAA/SSAA. Depends on anti-aliasing being enabled.
-            choices:
-                "MSAA (default)": 0
-                "SSAA":           1
+                "Off":         0
+                "2x":          1
+                "4x":          2
+                "8x":          3
+                "8x (CSAA)":   4
+                "8xQ (CSAA)":  5
+                "16x (CSAA)":  6
+                "16xQ (CSAA)": 7
+                "4x (SSAA)":   8
         hires_textures:
+            group: ADVANCED OPTIONS
             prompt:      LOAD CUSTOM TEXTURES
             choices:
                 "Off": 0
                 "On":  1
         widescreen_hack:
+            group: ADVANCED OPTIONS
             prompt:      WIDESCREEN HACK (GLITCHY)
             description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
             choices:
                 "Off": 0
                 "On":  1
         enable_mmu:
+            group: ADVANCED OPTIONS
             prompt:      MEMORY MANAGEMENT UNIT
             description: Required by some games.
             choices:
                 "Off": 0
                 "On":  1
         vsync:
+            group: ADVANCED OPTIONS
             prompt:      VSYNC
             description: Fix screen tearing. CPU heavy.
             choices:
                 "Off": 0
                 "On":  1
         rumble:
-            prompt:      RUMBLE (needs review)
+            prompt:      RUMBLE (KO'D, DO NOT USE YET)
             choices:
                 "Off": 0
                 "On":  1

--- a/package/batocera/emulators/dolphin-triforce/dolphin-triforce.mk
+++ b/package/batocera/emulators/dolphin-triforce/dolphin-triforce.mk
@@ -18,14 +18,14 @@ endif
 # Includes custom game configs required to successfully launch and play them.
 define DOLPHIN_TRIFORCE_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin
-	$(INSTALL) -D -m 0555 "$(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-triforce/dolphin-triforce.AppImage" "${TARGET_DIR}/usr/bin/dolphin-triforce.AppImage"
+	$(INSTALL) -D -m 0555 "$(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-triforce/dolphin-triforce.AppImage" "${TARGET_DIR}/usr/bin/dolphin-triforce"
 endef
 
 # Hotkeys (non-functional at the moment)
 define DOLPHIN_TRIFORCE_EVMAP
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 
-	cp -prn $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-triforce/triforce.dolphin_triforce.keys \
+	cp -prn $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-triforce/triforce.dolphin-triforce.keys \
 		$(TARGET_DIR)/usr/share/evmapy
 endef
 

--- a/package/batocera/emulators/dolphin-triforce/triforce.dolphin-triforce.keys
+++ b/package/batocera/emulators/dolphin-triforce/triforce.dolphin-triforce.keys
@@ -9,8 +9,20 @@
         {
             "trigger": ["hotkey", "b"],
             "type": "key",
-            "target": ["KEY_LEFTALT", "KEY_ENTER"],
+            "target": ["KEY_LEFTALT", "KEY_RETURN"],
             "description": "Open Dolphin-triforce's menu"
+        },
+        {
+            "trigger": ["hotkey", "x"],
+            "type": "key",
+            "target": ["KEY_F1"],
+            "description": "Load State Slot 1"
+        },
+        {
+            "trigger": ["hotkey", "y"],
+            "type": "key",
+            "target": ["KEY_LEFTSHIFT", "KEY_F1"],
+            "description": "Save State Slot 1"
         },
         {
             "trigger": ["hotkey", "pageup"],


### PR DESCRIPTION
- Rename binary to exclude ".AppImage" extension and adjusted appropriate commandArrays; fixes evmapy, now actually works (addresses one point in https://github.com/batocera-linux/batocera.linux/pull/5621#issuecomment-1039702230 )
- Adjust internal resolution scaling to only go up to 4x (this branch did not support higher resolutions) and fix the numerical values for configgen.
- Removes features that aren't actually in the triforce branch
- Categorise the appropriate features as "ADVANCED OPTIONS"