### PR TITLE
iNNEXT SNES Retro USB Controller - es_input.cfg

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -2809,5 +2809,20 @@
 		<input name="up" type="hat" id="0" value="1" />
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="0" value="1" code="304" />
+	</inputConfig>	
+	<inputConfig type="joystick" deviceName="iNNEXT SNES Retro USB Controller" deviceGUID="03000000790000001100000010010000">
+		<input name="a" type="button" id="1" value="1" code="289" />
+		<input name="b" type="button" id="2" value="1" code="290" />
+		<input name="down" type="axis" id="1" value="1" code="1" />
+		<input name="hotkey" type="button" id="8" value="1" code="296" />
+		<input name="left" type="axis" id="0" value="-1" code="0" />
+		<input name="pagedown" type="button" id="5" value="1" code="293" />
+		<input name="pageup" type="button" id="4" value="1" code="292" />
+		<input name="right" type="axis" id="0" value="1" code="0" />
+		<input name="select" type="button" id="8" value="1" code="296" />
+		<input name="start" type="button" id="9" value="1" code="297" />
+		<input name="up" type="axis" id="1" value="-1" code="1" />
+		<input name="x" type="button" id="0" value="1" code="288" />
+		<input name="y" type="button" id="3" value="1" code="291" />
 	</inputConfig>
 </inputList>


### PR DESCRIPTION
Hi.

Adding the iNNEXT SNES-Alike USB controller(https://www.youtube.com/watch?v=v7KYR5HAQBc)

![image](https://user-images.githubusercontent.com/11742211/157369536-625508f0-d320-4dc9-a7c7-e67cf1129d97.png)
