### PR TITLE
Bind North and West to = and - respectively on the keyboard by default

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -11,6 +11,8 @@
 		<input name="pageup" type="key" id="33" value="1" />
 		<input name="select" type="key" id="8" value="1" />
 		<input name="start" type="key" id="32" value="1" />
+		<input name="x" type="key" id="61" value="1" />
+		<input name="y" type="key" id="45" value="1" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="GPIO Controller 1" deviceGUID="15000000010000000100000000010000">
 		<input name="a" type="button" id="1" value="1" code="305" />


### PR DESCRIPTION
This allows the user to access the functions behind the North and West button using only the keyboard with the default configuration. Lengthy explanation follows:

The = and - buttons are language agnostic symbols (ie. they appear in the same spots irrelevant of the language layout used) although of course there are still a few exceptions such as for specialised keyboard layouts (such as Dvorak). Still, users of such layouts would know where such keys would lie, and this binding uses the keycode not the label code, so it is positional not label-based. And at the end of the day, having these buttons bound to _something_ by default is better than the current situation of them being bound to _nothing_, being able to access these menus _sometimes_ is better than _never_ in my opinion.

An alternative to this I considered was to use \ and /, but I don't believe those would be as intuitive.