### PR TITLE
we want to use the 8821ce driver in the kernel now

### DIFF
--- a/board/batocera/fsoverlay/etc/modprobe.d/8821ce.conf
+++ b/board/batocera/fsoverlay/etc/modprobe.d/8821ce.conf
@@ -1,2 +1,1 @@
-blacklist rtw88_8821ce
-
+#blacklist rtw88_8821ce


### PR DESCRIPTION
the rtw88 drivers have been good since kernel 5.9
- therefore we now want to test using the 8821ce driver from the kernel rather than external sources
- thus disabling this blacklist for now
- if ok, i will remove the legacy driver etc.