### PR TITLE
Fix Retroarch OpenGLES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -286,7 +286,7 @@ def getGFXBackend(system):
             core = system.config['core']
             if backend == "gl" and core in [ 'kronos', 'citra', 'mupen64plus-next', 'melonds', 'beetle-psx-hw' ]:
                 backend = "glcore"
-            if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3', 'flycast' ]:
+            if backend == "glcore" and core in [ 'parallel_n64', 'yabasanshiro', 'openlara', 'boom3' ]:
                 backend = "gl"
 
         return backend

--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -74,7 +74,7 @@ else
 endif
 
 ifeq ($(BR2_PACKAGE_BATOCERA_GLES3),y)
-	RETROARCH_CONF_OPTS += --enable-opengles3 --enable-opengles3_1
+	RETROARCH_CONF_OPTS += --enable-opengles3 --enable-opengles3_1 --enable-opengles3_2
 	RETROARCH_DEPENDENCIES += libgles
 endif
 

--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -73,6 +73,11 @@ else
 	RETROARCH_CONF_OPTS += --disable-pulse
 endif
 
+ifeq ($(BR2_PACKAGE_BATOCERA_GLES3),y)
+	RETROARCH_CONF_OPTS += --enable-opengles3 --enable-opengles3_1
+	RETROARCH_DEPENDENCIES += libgles
+endif
+
 ifeq ($(BR2_PACKAGE_HAS_LIBGLES),y)
 	RETROARCH_CONF_OPTS += --enable-opengles
 	RETROARCH_DEPENDENCIES += libgles


### PR DESCRIPTION
Finally found the true source of the lr-flycast OpenGL/GLCore issues.

Retroarch was compiling without proper OpenGLES support, which was causing Flycast (which was compiled with OpenGLES) to fail.

Added in a conditional to compile Retroarch with OpenGLES3 support if available, which fixes the issue on x86_64. My other test device, an Odroid Go Super never experienced this issue, so I can't test for it there.

There was a report lr-flycast would not load in OpenGL/GLCore on RPI4, so that would be a good test board for it.

Also removed lr-flycast from the GLCore exception list, since it works in GLCore after this fix.