### PR TITLE
fix f-zero game detection for triforce

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -106,14 +106,14 @@ class DolphinTriforceGenerator(Generator):
         # Serial Port 1 to AM-Baseband
         # F-Zero GX exception, it needs to not be using the AM-Baseband to function.
         # This cannot be set in the game's INI for some reason.
-        if rom == "F-Zero GX (USA).iso":
+        if rom == "/userdata/roms/triforce/F-Zero GX (USA).iso":
             dolphinTriforceSettings.set("Core", "SerialPort1", "255")
         else:
             dolphinTriforceSettings.set("Core", "SerialPort1", "6")
 
         # Gamecube pads forced as AM-Baseband
         # F-Zero GX exception, it needs it to be a regular pad instead.
-        if rom == "F-Zero GX (USA).iso":
+        if rom == "/userdata/roms/triforce/F-Zero GX (USA).iso":
             dolphinTriforceSettings.set("Core", "SIDevice0", "6")
         else:
             dolphinTriforceSettings.set("Core", "SIDevice0", "11")


### PR DESCRIPTION
The game itself is pretty unstable, not recommended in this version of Dolphin.