### PR TITLE
amend 8bitdo M30 gamepad input.cfg (please read desc!)

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -1409,19 +1409,21 @@
 		<input name="y" type="button" id="3" value="1" code="307" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="8Bitdo  8BitDo M30 gamepad" deviceGUID="03000000c82d00000650000011010000">
-		<input name="a" type="button" id="0" value="1" code="304" />
-		<input name="b" type="button" id="1" value="1" code="305" />
-		<input name="down" type="axis" id="1" value="1" code="1" />
-		<input name="hotkey" type="button" id="10" value="1" code="314" />
-		<input name="left" type="axis" id="0" value="-1" code="0" />
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="2" value="1" code="306" />
+		<input name="l2" type="button" id="6" value="1" code="310" />
+		<input name="left" type="hat" id="0" value="8" />
 		<input name="pagedown" type="button" id="9" value="1" code="313" />
 		<input name="pageup" type="button" id="8" value="1" code="312" />
-		<input name="right" type="axis" id="0" value="1" code="0" />
+		<input name="r2" type="button" id="7" value="1" code="311" />
+		<input name="right" type="hat" id="0" value="2" />
 		<input name="select" type="button" id="10" value="1" code="314" />
 		<input name="start" type="button" id="11" value="1" code="315" />
-		<input name="up" type="axis" id="1" value="-1" code="1" />
-		<input name="x" type="button" id="3" value="1" code="307" />
-		<input name="y" type="button" id="4" value="1" code="308" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="4" value="1" code="308" />
+		<input name="y" type="button" id="3" value="1" code="307" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="05000000c82d00005106000000010000">
 		<input name="a" type="button" id="7" value="1" code="311" />


### PR DESCRIPTION
It's concerning that it's overwriting an already existing config, but that one was just plain wrong. Has something happened to cause Batocera to start interpreting controls from controllers in a different order? I've noticed other controllers also acting like they have different mappings (like the Xbox 360 controller config for the 8bitdo BT adapter).
If it were just a case of "controller is in a different input mode", then why wouldn't its GUID change? Was it just a coincidence that other controllers started playing up around the same time too?

The old config didn't have Z and C bound (in this case, I just bound them to L2 and R2) so maybe it's just a case of an old config that's been forgotten.