### PR TITLE
Fix Retro-Bit Sega Saturn 2.4Ghz X-Input

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -2770,21 +2770,25 @@
 		<input name="y" type="button" id="9" value="1" code="308" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="Microsoft X-Box 360 pad" deviceGUID="030000005e0400008e02000072050000">
+        <input name="up" type="hat" id="0" value="1" />
+		<input name="down" type="hat" id="0" value="4" />
+        <input name="left" type="hat" id="0" value="8" />
+		<input name="right" type="hat" id="0" value="2" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
-		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-		<input name="joystick1left" type="axis" id="3" value="-1" code="3" />
-		<input name="joystick1up" type="axis" id="4" value="-1" code="4" />
-		<input name="a" type="axis" id="5" value="1" code="5" />
-		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />		
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="hotkey" type="button" id="8" value="1" code="316" />
-		<input name="l2" type="button" id="4" value="1" code="310" />
-		<input name="pagedown" type="axis" id="2" value="1" code="2" />
-		<input name="pageup" type="button" id="2" value="1" code="307" />
-		<input name="r2" type="button" id="5" value="1" code="311" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
 		<input name="select" type="button" id="6" value="1" code="314" />
 		<input name="start" type="button" id="7" value="1" code="315" />
 		<input name="x" type="button" id="3" value="1" code="308" />
-		<input name="y" type="button" id="0" value="1" code="304" />
+		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="Xarcade-to-Gamepad Device 1" deviceGUID="03000000010000000100000004000000">
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />


### PR DESCRIPTION
fix retro-bit saturn wireless es_config mapping

Remapped Retro-Bit Sega Saturn 2.4Ghz Controller to default X-Input from Retro-Bit.
It was setup as a Xbox Fight-stick before.
Removed and fixed the D-pad that was  setup twice as the left analog. This could cause issue in Wine with controller scrolling the menus by itself.

Added
DPad to normal, press and hold Up + Start for 3 seconds
DPad to Left Analog mode, press and hold Left + Start for 3 seconds
DPad to Right Analog mode, press and hold Right + Start for 3 second

/Rion