### PR TITLE
Bump lr-mame

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -26,6 +26,7 @@
         * bump: linux device firmware to march 2022
         * bump: mesa to v22
         * bump: retroarch to 1.10
+        * bump: libretro mame/mess to 0.241
         * bump: RPi kernel & associate firmware to 5.15.30
         * bump: vulkan support to 1.3.206
         * bump: flatpak to 1.12.6

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -3,8 +3,8 @@
 # MAME
 #
 ################################################################################
-# Version: Commits on Dec 29, 2021 (0.238)
-LIBRETRO_MAME_VERSION = 2f9c793a77222ae46266c71f64d491cf7870dc1e
+# Version: Commits on March 3, 2022 (0.241)
+LIBRETRO_MAME_VERSION = 1f6e607
 LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))
 LIBRETRO_MAME_LICENSE = MAME
 LIBRETRO_MAME_DEPENDENCIES = retroarch


### PR DESCRIPTION
Bumps to .241. Tested on x86_64, I don't have any of the other boards it runs on to test with.