### PR TITLE
prevent triforce log spam

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
@@ -80,6 +80,7 @@ dolphinTriforceConfig  = CONF + "/dolphin-triforce"
 dolphinTriforceData    = SAVES + "/dolphin-triforce"
 dolphinTriforceIni     = dolphinTriforceConfig + '/Config/Dolphin.ini'
 dolphinTriforceGfxIni  = dolphinTriforceConfig + '/Config/gfx_opengl.ini'
+dolphinTriforceLoggerIni    = dolphinTriforceConfig + '/Config/Logger.ini'
 dolphinTriforceGameSettings = dolphinTriforceConfig + "/GameSettings"
 
 dosboxCustom = CONF + '/dosbox'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -228,11 +228,6 @@ class DolphinTriforceGenerator(Generator):
 
         ## logger settings ##
 
-        dolphinTriforceGFXSettings = configparser.ConfigParser(interpolation=None)
-        # To prevent ConfigParser from converting to lower case
-        dolphinTriforceGFXSettings.optionxform = str
-        dolphinTriforceGFXSettings.read(batoceraFiles.dolphinTriforceGfxIni)
-
         dolphinTriforceLogSettings = configparser.ConfigParser(interpolation=None)
         # To prevent ConfigParser from converting to lower case
         dolphinTriforceLogSettings.optionxform = str

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -226,6 +226,29 @@ class DolphinTriforceGenerator(Generator):
         with open(batoceraFiles.dolphinTriforceGfxIni, 'w') as configfile:
             dolphinTriforceGFXSettings.write(configfile)
 
+        ## logger settings ##
+
+        dolphinTriforceGFXSettings = configparser.ConfigParser(interpolation=None)
+        # To prevent ConfigParser from converting to lower case
+        dolphinTriforceGFXSettings.optionxform = str
+        dolphinTriforceGFXSettings.read(batoceraFiles.dolphinTriforceGfxIni)
+
+        dolphinTriforceLogSettings = configparser.ConfigParser(interpolation=None)
+        # To prevent ConfigParser from converting to lower case
+        dolphinTriforceLogSettings.optionxform = str
+        dolphinTriforceLogSettings.read(batoceraFiles.dolphinTriforceLoggerIni)
+
+        # Sections
+        if not dolphinTriforceLogSettings.has_section("Logs"):
+            dolphinTriforceLogSettings.add_section("Logs")
+
+        # Prevent the constant log spam.
+        dolphinTriforceLogSettings.set("Logs", "DVD", "False")
+
+        # Save Logger.ini
+        with open(batoceraFiles.dolphinTriforceLoggerIni, 'w') as configfile:
+            dolphinTriforceLogSettings.write(configfile)
+
         ## game settings ##
 
         # These cheat files are required to launch Triforce games, and thus should always be present and enabled.


### PR DESCRIPTION
It was making constant writes to the log about every single DVD drive access, which is a lot. A ten minute session would make a 5MB text log. This disables just the DVD access logging in dolphin_triforce, everything else is still logged.