### PR TITLE
Update Swanstation config.in link

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-swanstation/Config.in
+++ b/package/batocera/emulators/retroarch/libretro/libretro-swanstation/Config.in
@@ -9,6 +9,6 @@ config BR2_PACKAGE_LIBRETRO_SWANSTATION
       help
         SwanStation - PlayStation 1, aka. PSX Emulator
 
-	    https://github.com/libretro/duckstation
+	    https://github.com/libretro/swanstation
 
 


### PR DESCRIPTION
https://github.com/libretro/duckstation doesn't redirect to https://github.com/libretro/swanstation anymore