### PR TITLE
Prevent eternal "---- batocera-config ----" log spam

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-config
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-config
@@ -39,7 +39,7 @@ bato_config_set_value () {
 
 log=/userdata/system/logs/batocera.log
 
-echo "---- batocera-config ----" >> $log
+#echo "---- batocera-config ----" >> $log
 
 if [ "$command" = "getRootPassword" ]; then
     # security disabled, force the default one without changing boot configuration


### PR DESCRIPTION
To stop the `system/logs/batocera.log` file from filling up infinitely.

ie. this: 
![image](https://user-images.githubusercontent.com/67527064/160561132-d6b1fd44-a99f-4406-9d6e-9a9c7c842a9a.png)
