### PR TITLE
redo rpi3 workaround, enable threaded video

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -1,3 +1,6 @@
+default:
+  options:
+    video_threaded: true
 nds:
   emulator: drastic
   core:     drastic


### PR DESCRIPTION
The slowdown issue with decorations is back again and no known solution is out there. Considering this has also been an issue in the past and v33 was skipped because of it, it might be best to just leave this option on for the foreseeable future. I'll be testing this from time to time with the option off to see if anything can be done about it.
It also helps with shader slowdown, but that's a separate issue in unto itself.