### PR TITLE
Triforce Tweaks

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
@@ -23,7 +23,7 @@ def generateControllerConfig_gamecube(system, playersControllers,rom):
     gamecubeMapping = {
         'y':            'Buttons/B',     'b':             'Buttons/A',
         'a':            'Buttons/X',
-        'pagedown':     'Buttons/Z',     'start':         'Buttons/Start',
+        'select':     'Buttons/Z',     'start':         'Buttons/Start',
         'l2':           'Triggers/L',    'r2':            'Triggers/R',
         'up': 'D-Pad/Up', 'down': 'D-Pad/Down', 'left': 'D-Pad/Left', 'right': 'D-Pad/Right',
         'joystick1up':  'Main Stick/Up', 'joystick1left': 'Main Stick/Left',

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
@@ -19,7 +19,7 @@ def generateControllerConfig(system, playersControllers, rom):
     generateControllerConfig_gamecube(system, playersControllers,rom)               # Pass ROM name to allow for per ROM configuration
 
 def generateControllerConfig_gamecube(system, playersControllers,rom):
-    # Exclude Buttons/Y from mapping as that just resets the system.
+    # Exclude Buttons/Y from mapping as that just resets the system. Buttons/Z is used to insert credit. Therefore it is set to Select.
     gamecubeMapping = {
         'y':            'Buttons/B',     'b':             'Buttons/A',
         'a':            'Buttons/X',

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -66,7 +66,7 @@ class DolphinTriforceGenerator(Generator):
 
         # PanicHandlers displaymessages
         dolphinTriforceSettings.set("Interface", "UsePanicHandlers",        "False")
-        dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "True")
+        dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "False")
 
         # Don't confirm at stop
         dolphinTriforceSettings.set("Interface", "ConfirmStop", "False")
@@ -440,7 +440,7 @@ $Stuck loop patch
 $60times Loop patch
 $GameTestMode Patch
 $SeatLoopPatch
-$99 credits
+99 credits
 """)
             dolphinTriforceGameSettingsGGPE02.close()
         

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -68,7 +68,7 @@ class DolphinTriforceGenerator(Generator):
         dolphinTriforceSettings.set("Interface", "UsePanicHandlers",        "False")
 	
         # Disable OSD Messages
-        if system.isOptSet("osd_messages") and system.getOptBoolean("osd_messages"):
+        if system.isOptSet("disable_osd_messages") and system.getOptBoolean("disable_osd_messages"):
             dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "False")
         else:
             dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "True")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceGenerator.py
@@ -66,7 +66,12 @@ class DolphinTriforceGenerator(Generator):
 
         # PanicHandlers displaymessages
         dolphinTriforceSettings.set("Interface", "UsePanicHandlers",        "False")
-        dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "False")
+	
+        # Disable OSD Messages
+        if system.isOptSet("osd_messages") and system.getOptBoolean("osd_messages"):
+            dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "False")
+        else:
+            dolphinTriforceSettings.set("Interface", "OnScreenDisplayMessages", "True")
 
         # Don't confirm at stop
         dolphinTriforceSettings.set("Interface", "ConfirmStop", "False")

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5358,6 +5358,13 @@ dolphin_triforce:
             choices:
                 "Off": 0
                 "On":  1
+        osd_messages:
+            group: ADVANCED OPTIONS
+            prompt:      DISABLE OSD MESSAGES
+            description: Disable status messages displayed by the emulator.
+            choices:
+                "Off": 0
+                "On":  1
         rumble:
             prompt:      RUMBLE
             choices:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5358,7 +5358,7 @@ dolphin_triforce:
             choices:
                 "Off": 0
                 "On":  1
-        osd_messages:
+        disable_osd_messages:
             group: ADVANCED OPTIONS
             prompt:      DISABLE OSD MESSAGES
             description: Disable status messages displayed by the emulator.


### PR DESCRIPTION
1 - Remap the Insert Coin button to the 'Select' button to be consistent with other Arcade emulators.

2 - Disable the 99 Credits cheat by default on MKAGP2 to allow user to insert coin as per other Arcade games and emulators. The cheat can still be enabled from dolphin-triforce-config inside Applications.

3 - Added an ES option to Disable On-Screen Display Messages.

All changes have been tested OK