### PR TITLE
Update default moonlight framerate to 30 fps

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/moonlight/moonlightConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/moonlight/moonlightConfig.py
@@ -48,9 +48,9 @@ def generateMoonlightConfig(system):
             elif system.config["moonlight_framerate"] == "2":
                 moonlightConfig.save('fps', '120')
             else:
-                moonlightConfig.save('fps', '60')
+                moonlightConfig.save('fps', '30')
         else:
-            moonlightConfig.save('fps', '60')
+            moonlightConfig.save('fps', '30')
 
         # bitrate
         if system.isOptSet('moonlight_bitrate'):


### PR DESCRIPTION
Changes moonlight default framerate to 30fps. This prevents issue with graphical glitches for 30 fps games when moonlight is set to 60 fps. 