### PR TITLE
guns on X must use udev

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -156,6 +156,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
 
     # Input configuration
     retroarchConfig['input_joypad_driver'] = 'udev'
+    retroarchConfig['input_driver'] = 'udev'                    # driver for mouse/keyboard. udev required for guns.
     retroarchConfig['input_max_users'] = "16"                   # Allow up to 16 players
 
     retroarchConfig['input_libretro_device_p1'] = '1'           # Default devices choices


### PR DESCRIPTION
on linux, only the udev driver for mouses allows the multiplayer guns.
xorg systems defaults on the x driver.
hope this doesn't break something about the keyboard

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>