### PR TITLE
name savestate file as rom file name. prerequisite to savestates

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_EMULATIONSTATION_VERSION = 303f34ec0fe7379777b4867e1e397060fb2825bd
+BATOCERA_EMULATIONSTATION_VERSION = 60a1292966460f3f8db03e15398e8e698e0f5be6
 BATOCERA_EMULATIONSTATION_SITE = https://github.com/batocera-linux/batocera-emulationstation
 BATOCERA_EMULATIONSTATION_SITE_METHOD = git
 BATOCERA_EMULATIONSTATION_LICENSE = MIT

--- a/package/batocera/emulators/mupen64plus/mupen64plus-core/003-statenameasromfilename.patch
+++ b/package/batocera/emulators/mupen64plus/mupen64plus-core/003-statenameasromfilename.patch
@@ -1,0 +1,149 @@
+diff --git a/src/api/frontend.c b/src/api/frontend.c
+index 069d8ff..d24cbe1 100644
+--- a/src/api/frontend.c
++++ b/src/api/frontend.c
+@@ -176,6 +176,9 @@ EXPORT m64p_error CALL CoreDoCommand(m64p_command Command, int ParamInt, void *P
+     {
+         case M64CMD_NOP:
+             return M64ERR_SUCCESS;
++         case M64CMD_ROM_FILENAME:
++	  strncpy(g_rom_filename, (const unsigned char *) ParamPtr, ParamInt);
++	  return M64ERR_SUCCESS;
+         case M64CMD_ROM_OPEN:
+             if (g_EmulatorRunning || l_ROMOpen)
+                 return M64ERR_INVALID_STATE;
+diff --git a/src/api/m64p_types.h b/src/api/m64p_types.h
+index c3a1fc2..4cb8ca6 100644
+--- a/src/api/m64p_types.h
++++ b/src/api/m64p_types.h
+@@ -168,7 +168,8 @@ typedef enum {
+   M64CMD_NETPLAY_GET_VERSION,
+   M64CMD_NETPLAY_CLOSE,
+   M64CMD_PIF_OPEN,
+-  M64CMD_ROM_SET_SETTINGS
++  M64CMD_ROM_SET_SETTINGS,
++  M64CMD_ROM_FILENAME
+ } m64p_command;
+ 
+ typedef struct {
+diff --git a/src/main/main.c b/src/main/main.c
+index 64bb53f..88b9bab 100644
+--- a/src/main/main.c
++++ b/src/main/main.c
+@@ -113,6 +113,7 @@ uint32_t g_start_address = UINT32_C(0xa4000040);
+ struct device g_dev;
+ 
+ m64p_media_loader g_media_loader;
++char g_rom_filename[1024] = "";
+ 
+ int g_gs_vi_counter = 0;
+ 
+diff --git a/src/main/main.h b/src/main/main.h
+index 68efd5e..f1e6d1d 100644
+--- a/src/main/main.h
++++ b/src/main/main.h
+@@ -50,6 +50,7 @@ extern void* g_mem_base;
+ extern struct device g_dev;
+ 
+ extern m64p_media_loader g_media_loader;
++extern char g_rom_filename[1024];
+ 
+ extern m64p_frame_callback g_FrameCallback;
+ 
+diff --git a/src/main/savestates.c b/src/main/savestates.c
+index cec408b..537b307 100644
+--- a/src/main/savestates.c
++++ b/src/main/savestates.c
+@@ -86,17 +86,23 @@ static char *savestates_generate_path(savestates_type type)
+     }
+     else /* Use the selected savestate slot */
+     {
++        char* prefix = ROM_SETTINGS.goodname;
++	if(g_rom_filename[0] != '\0') {
++	  char *x = strrchr(g_rom_filename, '/');
++	  if(x != NULL) prefix = x;
++	}
++
+         char *filename;
+         switch (type)
+         {
+             case savestates_type_m64p:
+-                filename = formatstr("%s.st%d", ROM_SETTINGS.goodname, slot);
++	        filename = formatstr("%s.st%d", prefix, slot);
+                 break;
+             case savestates_type_pj64_zip:
+-                filename = formatstr("%s.pj%d.zip", ROM_PARAMS.headername, slot);
++                filename = formatstr("%s.pj%d.zip", prefix, slot);
+                 break;
+             case savestates_type_pj64_unc:
+-                filename = formatstr("%s.pj%d", ROM_PARAMS.headername, slot);
++                filename = formatstr("%s.pj%d", prefix, slot);
+                 break;
+             default:
+                 filename = NULL;
+@@ -2143,6 +2149,7 @@ int savestates_save(void)
+     char *filepath;
+     int ret = 0;
+     const struct device* dev = &g_dev;
++    char ScreenshotFileName[256];
+ 
+     /* Can only save PJ64 savestates on VI / COMPARE interrupt.
+        Otherwise try again in a little while. */
+@@ -2166,9 +2173,14 @@ int savestates_save(void)
+             case savestates_type_pj64_unc: ret = savestates_save_pj64_unc(dev, filepath); break;
+             default: ret = 0; break;
+         }
++
++	strncpy(ScreenshotFileName, filepath, 251);
++	strncat(ScreenshotFileName, ".png", 4);
+         free(filepath);
+     }
+ 
++    TakeScreenshotToFile(ScreenshotFileName, 0);
++
+     // deliver callback to indicate completion of state saving operation
+     StateChanged(M64CORE_STATE_SAVECOMPLETE, ret);
+ 
+diff --git a/src/main/screenshot.c b/src/main/screenshot.c
+index 7f2260e..9180fec 100644
+--- a/src/main/screenshot.c
++++ b/src/main/screenshot.c
+@@ -224,6 +224,11 @@ void TakeScreenshot(int iFrameNumber)
+     if (filename == NULL)
+         return;
+ 
++    TakeScreenshotToFile(filename, iFrameNumber);
++    free(filename);
++}
++void TakeScreenshotToFile(char* filename, int iFrameNumber)
++{
+     // get the width and height
+     int width = 640;
+     int height = 480;
+@@ -233,7 +238,6 @@ void TakeScreenshot(int iFrameNumber)
+     unsigned char *pucFrame = (unsigned char *) malloc(width * height * 3);
+     if (pucFrame == NULL)
+     {
+-        free(filename);
+         return;
+     }
+ 
+@@ -244,7 +248,6 @@ void TakeScreenshot(int iFrameNumber)
+     SaveRGBBufferToFile(filename, pucFrame, width, height, width * 3);
+     // free the memory
+     free(pucFrame);
+-    free(filename);
+     // print message -- this allows developers to capture frames and use them in the regression test
+     main_message(M64MSG_INFO, OSD_BOTTOM_LEFT, "Captured screenshot for frame %i.", iFrameNumber);
+ }
+diff --git a/src/main/screenshot.h b/src/main/screenshot.h
+index c7f6bad..fdc3e36 100644
+--- a/src/main/screenshot.h
++++ b/src/main/screenshot.h
+@@ -24,5 +24,6 @@
+ 
+ void ScreenshotRomOpen(void);
+ void TakeScreenshot(int iFrameNumber);
++void TakeScreenshotToFile(char *filename, int iFrameNumber);
+ 
+ #endif

--- a/package/batocera/emulators/mupen64plus/mupen64plus-ui-console/001-statenameasromfilename.patch
+++ b/package/batocera/emulators/mupen64plus/mupen64plus-ui-console/001-statenameasromfilename.patch
@@ -1,0 +1,19 @@
+diff --git a/src/main.c b/src/main.c
+index 04a46f0..313527e 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -1025,6 +1025,14 @@ int main(int argc, char *argv[])
+     }
+     fclose(fPtr);
+ 
++    if ((*CoreDoCommand)(M64CMD_ROM_FILENAME, strlen(l_ROMFilepath), l_ROMFilepath) != M64ERR_SUCCESS) {
++      DebugMessage(M64MSG_ERROR, "core failed to ROM_FILENAME image file '%s'.", l_ROMFilepath);
++      free(ROM_buffer);
++      (*CoreShutdown)();
++      DetachCoreLib();
++      return 10;
++    }
++
+     /* Try to load the ROM image into the core */
+     if ((*CoreDoCommand)(M64CMD_ROM_OPEN, (int) romlength, ROM_buffer) != M64ERR_SUCCESS)
+     {

--- a/package/batocera/emulators/ppsspp/004-statenameasromfilename.patch
+++ b/package/batocera/emulators/ppsspp/004-statenameasromfilename.patch
@@ -1,0 +1,13 @@
+diff --git a/Core/SaveState.cpp b/Core/SaveState.cpp
+index 95074f8..ae2ad78 100644
+--- a/Core/SaveState.cpp
++++ b/Core/SaveState.cpp
+@@ -445,7 +445,7 @@ namespace SaveState
+ 
+ 	Path GenerateSaveSlotFilename(const Path &gameFilename, int slot, const char *extension)
+ 	{
+-		std::string filename = StringFromFormat("%s_%d.%s", GenerateFullDiscId(gameFilename).c_str(), slot, extension);
++	  std::string filename = StringFromFormat("%s_%d.%s", gameFilename.WithReplacedExtension("").GetFilename().c_str(), slot, extension);
+ 		return GetSysDirectory(DIRECTORY_SAVESTATE) / filename;
+ 	}
+ 


### PR DESCRIPTION
due to this pr, some people may want to rename their psp and n64 saves ;-(

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>