### PR TITLE
hide bezel on duckstation quick menu open

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -68,6 +68,7 @@
         * fix: user-created shaders in retroarch's menu being ignored
     	* fix: moonlight custom config getting overwritten
 		* fix: redream controllers, hotkey now quits redream
+		* fix: duckstation quick menu now hides decoration
 
 2022/02/xx - batocera.linux 33
         * add: Support for Beelink GT-KING "https://www.bee-link.com/products/beelink-gt-king-wifi6"

--- a/package/batocera/emulators/duckstation/psx.duckstation.keys
+++ b/package/batocera/emulators/duckstation/psx.duckstation.keys
@@ -25,6 +25,12 @@
 	    "description": "Open DuckStation Quick Menu"
 	},
 	{
+            "trigger": ["hotkey", "b"],
+            "type": "key",
+            "target": [ "KEY_RIGHTSHIFT", "KEY_F12" ],
+	    "description": "Hide the bezel"
+	},
+	{
             "trigger": ["hotkey", "a"],
             "type": "key",
             "target": [ "KEY_F6" ],
@@ -66,6 +72,12 @@
             "target": [ "KEY_TAB" ],
 	    "description": "Fast Forward"
 	},
+	{
+            "trigger": ["hotkey", "right"],
+            "type": "key",
+            "target": [ "KEY_LEFTCTRL", "KEY_TAB" ],
+	    "description": "Switch menu focus in quick menu"
+	},
     {
             "trigger": "up",
             "type": "key",
@@ -91,7 +103,7 @@
         "description": "Navigate menu right"
     },
     {
-            "trigger": "a",
+            "trigger": "b",
             "type": "key",
             "target": [ "KEY_SPACE" ],
         "description": "Navigate menu confirm"


### PR DESCRIPTION
and a few other minor fixes.
For instance, quick menu tabs can now be switched by pressing the fast forward toggle (hotkey + right), rendering the quick menu 100% controller navigatable.

Before:
![screenshot-2022 04 08-21h50 19](https://user-images.githubusercontent.com/67527064/162430080-9846dc72-f20b-481c-8e6d-2f25819cb05e.png)

After:
![screenshot-2022 04 08-21h50 43](https://user-images.githubusercontent.com/67527064/162430134-5bfa4343-8d02-4c4d-8e75-d875c802327c.png)

Of course, this isn't perfect, as the user could say open the quick menu with the shortcut, but then simply press the "Resume Game" option and the bezel won't be returned. However, they could open the quick menu again, have the bezel return, and press "Resume Game" again to retrieve the bezel. This is still better than the current situation where the quick menu is simply unusable.