### PR TITLE
move threaded video option

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -175,12 +175,19 @@ shared:
       choices:
         "On": 1
         "Off": 0
+    video_threaded:
+      submenu:     LATENCY REDUCTION
+      prompt:      THREADED VIDEO
+      description: Improves performance at the cost of latency and more video stuttering.
+      choices:
+        "On": 1
+        "Off": 0
 
 global:
-  shared: [videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable]
+  shared: [videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded]
 
 libretro:
-  shared: [videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, integerscale, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable]
+  shared: [videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, integerscale, runahead, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, rpi4, rk3326]
@@ -202,13 +209,6 @@ libretro:
         "32":     32
         "16":     16
         "8":      8
-    video_threaded:
-        group: ADVANCED OPTIONS
-        prompt:      THREADED VIDEO
-        description: Improves performance at the cost of latency and more video stuttering.
-        choices:
-            "On":   "true"
-            "Off":  "false"
     video_allow_rotate:
         group: ADVANCED OPTIONS
         prompt:      ALLOW ROTATION


### PR DESCRIPTION
Moves the threaded video option from being an advanced setting only for libretro into the latency reduction settings for all emulators.

There are other emulators with similar settings that this may benefit from in the future. Plus, it makes more sense, as it's directly tied to input latency.

Also made its logic consistent with the other similar options.