### PR TITLE
add mupen64 audio buffer settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
@@ -31,6 +31,30 @@ def setMupenConfig(iniConfig, system, controllers, gameResolution):
         iniConfig.add_section("Audio-SDL")
     iniConfig.set("Audio-SDL", "AUDIO_SYNC", "False")
 
+    # Audio buffer settings
+    # In the future, add for Audio-OMX too?
+    if system.isOptSet("mupen64plus_AudioBuffer"):
+        # Very High
+        if system.config["mupen64plus_AudioBuffer"] == "Very High":
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_SIZE", "16384")
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_TARGET", "4096")
+            iniConfig.set("Audio-SDL", "SECONDARY_BUFFER_SIZE", "2048")
+        # High (defaults provided by mupen64plus)
+        if system.config["mupen64plus_AudioBuffer"] == "High":
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_SIZE", "16384")
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_TARGET", "2048")
+            iniConfig.set("Audio-SDL", "SECONDARY_BUFFER_SIZE", "1024")
+        # Low
+        if system.config["mupen64plus_AudioBuffer"] == "Low":
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_SIZE", "4096")
+            iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_TARGET", "1024")
+            iniConfig.set("Audio-SDL", "SECONDARY_BUFFER_SIZE", "512")
+    else:
+        # Medium
+        iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_SIZE", "8192")
+        iniConfig.set("Audio-SDL", "PRIMARY_BUFFER_TARGET", "2048")
+        iniConfig.set("Audio-SDL", "SECONDARY_BUFFER_SIZE", "1024")
+
     # Invert required when screen is rotated
     if gameResolution["width"] < gameResolution["height"]:
         width = gameResolution["height"]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5865,6 +5865,15 @@ mupen64plus:
                 "3":                    3
                 "4":                    4
                 "5":                    5
+        mupen64plus_AudioBuffer:
+            group: ADVANCED OPTIONS
+            prompt:      AUDIO BUFFER (SAMPLES)
+            description: Lower values reduce audio latency and improve performance, but can cause audio issues.
+            choices:
+                "Very High":     Very High 
+                "High":          High
+                "Medium":        Medium
+                "Low":           Low
         mupen64plus_Mipmapping:
             group: ADVANCED OPTIONS
             prompt:      TEXTURE MIP-MAPPING (BLUR)


### PR DESCRIPTION
In testing across RPi3, regular x86_64 and Intel J4125 x86_64 (thanks xMoJo12) lowering the PRIMARY_BUFFER_SIZE to 8192 from 16384 seems to have a net increase in performance with no audio issues over what mupen itself provides as default.
I'm open to changing this of course if anyone has issues but I've yet to find a case, and the RPi3 is already on the lowest-end of what is considered "weak for N64". In fact, it seems to still be running fine even on the Low preset I made (but I don't need to push boundaries here).