### PR TITLE
FPinball: add L2/R2 for flippers

### DIFF
--- a/package/batocera/emulators/fpinball/fpinball.keys
+++ b/package/batocera/emulators/fpinball/fpinball.keys
@@ -4,6 +4,16 @@
             "trigger": ["hotkey", "start"],
             "type": "key",
             "target": [ "KEY_ESC" ]
+	},
+	{
+            "trigger": ["l2"],
+            "type": "key",
+            "target": [ "KEY_LEFTSHIFT" ]
+	},
+	{
+            "trigger": ["r2"],
+            "type": "key",
+            "target": [ "KEY_RIGHTSHIFT" ]
 	}
     ]
 }


### PR DESCRIPTION
If L2 and R2 are triggers (aka `axis` like XBox360 pads) there seems to be no way to use them as flippers in `configgen`: it looks like Future Pinball takes only digital buttons. 
So, with this work around, we should have a solution that works with L2 and R2 as flippers, both when L2/R2 are buttons or triggers.