### PR TITLE
allow shift+f1 to open RA quick menu on keyboard-only

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -38,7 +38,8 @@ def generateRetroarchCustom():
     retroarchSettings.save('input_player3_analog_dpad_mode',    '"1"')
     retroarchSettings.save('input_player4_analog_dpad_mode',    '"1"')
     retroarchSettings.save('input_enable_hotkey_btn',           '"16"')
-    retroarchSettings.save('input_enable_hotkey',               '"escape"')
+    retroarchSettings.save('input_enable_hotkey',               '"shift"')
+    retroarchSettings.save('input_menu_toggle',                 '"f1"')
     retroarchSettings.save('input_exit_emulator',               '"escape"')
 
     # Video


### PR DESCRIPTION
Fixes the chicken-and-egg issue of opening up the RetroArch menu to allow the user to rebind their keyboard controls when only a keyboard is available.

Existing users will not have their config changed, they will still have Esc be their "immediately close RetroArch" button. But, new users or users who erase their RetroArch custom config will have to press Shift+Esc to exit. Considering the keyboard is not mapped consistently between emulators anyway, I don't see this as an issue. If it is, though, we could easily add in an evmapy keys profile to re-enable the exiting immediately upon pressing Esc functionality (in my opinion, having a single button exit the emulator is not a good practice in the first place, especially when saves are at stake).