### PR TITLE
Bump to latest official umtool release

### DIFF
--- a/package/batocera/controllers/umtool/umtool.mk
+++ b/package/batocera/controllers/umtool/umtool.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UMTOOL_VERSION = 1665ad16a8fc4ca22181c54765fcc66650e299c3
+UMTOOL_VERSION = 1.2.0
 UMTOOL_SITE = $(call github,katie-snow,Ultimarc-linux,$(UMTOOL_VERSION))
 UMTOOL_LICENSE = GPLv2
 UMTOOL_DEPENDENCIES = json-c libusb libtool udev


### PR DESCRIPTION
Initial commit was a snapshot of master.  This updates `umtool` to the latest official release, which was released shortly thereafter.