### PR TITLE
Add Shared Storage Option to 3DO (Safe for v34)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1542,6 +1542,14 @@ def generateCoreSettings(coreSettings, system, rom):
                 coreSettings.save('opera_hack_timing_5',        '"enabled"')
             elif system.config['game_fixes_opera'] == 'timing_hack6':
                 coreSettings.save('opera_hack_timing_6',        '"enabled"')
+        # Shared nvram
+        # If ROM includes the word Disc, assume it's a multi disc game, and enable shared nvram if the option isn't set.
+        if system.isOptSet('opera_nvram_storage'):
+            coreSettings.save('opera_nvram_storage', '"' + system.config['opera_nvram_storage'] + '"')
+        elif 'disc' in rom.casefold():
+            coreSettings.save('opera_nvram_storage', '"shared"')
+        else:
+            coreSettings.save('opera_nvram_storage', '"per game"')
 
     # ScummVM CORE Options
     if (system.config['core'] == 'scummvm'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3299,6 +3299,13 @@ libretro:
                     "Crash-n Burn":      timing_hack1
                     "Dinopark Tycoon":   timing_hack3
                     "Microcosm":         timing_hack5
+            opera_nvram_storage:
+                group: ADVANCED OPTIONS
+                prompt:      NVRAM STORAGE
+                description: Enable shared saves for multi-disc games
+                choices:
+                    "Shared":   shared
+                    "Per Game": per game
     parallel_n64:
       features: [cheevos]
       shared: [autosave]


### PR DESCRIPTION
3DO doesn't support m3u files as the system didn't have a change disk option (ejecting resets the console). Opera's default for saved games is to use separate files per game, which makes multi-disc games not work without manually changing the option in Retroarch. This PR:

* Adds an NVRAM Storage option to 3DO for per system or game settings in ES
* Will normally default to Per Game if left on auto, but if the ROM name contains the word "Disc" it will assume it's a multi-disc game and enable it.