### PR TITLE
Auto Standalone Decorations

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -395,7 +395,10 @@ def getHudBezel(system, rom, gameResolution):
         return None
 
     bezel = system.config['bezel']
-    bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name)
+    if system.config['emulator'] == 'libretro':
+        bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name, True)
+    else:
+        bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name)
     if bz_infos is None:
         eslog.debug("no bezel info file found")
         return None

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -363,7 +363,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
         # If set manually, proritize that.
         # Otherwise, set to portrait for games listed as 90 degrees, manual (default) if not.
         if not system.isOptSet('wswan_rotate_display'):
-            wswanGameRotation = videoMode.getGameSpecial(system.name, rom)
+            wswanGameRotation = videoMode.getGameSpecial(system.name, rom, True)
             if wswanGameRotation == "90":
                 wswanOrientation = "portrait"
             else:
@@ -673,7 +673,7 @@ def writeBezelConfig(bezel, retroarchConfig, rom, gameResolution, system):
     if bezel is None:
         return
 
-    bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name)
+    bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name, True)
     if bz_infos is None:
         return
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -210,7 +210,7 @@ class LibretroGenerator(Generator):
 
         # RetroArch 1.7.8 (Batocera 5.24) now requires the shaders to be passed as command line argument
         renderConfig = system.renderconfig
-        gameSpecial = videoMode.getGameSpecial(system.name, rom)
+        gameSpecial = videoMode.getGameSpecial(system.name, rom, True)
         gameShader = None
         if gameSpecial == "0":
             if 'shader' in renderConfig:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -7,7 +7,7 @@ from .videoMode import getGameSpecial
 
 eslog = get_logger(__name__)
 
-def getBezelInfos(rom, bezel, systemName):
+def getBezelInfos(rom, bezel, systemName, retroarch = False):
     # by order choose :
     # rom name in the system subfolder of the user directory (gb/mario.png)
     # rom name in the system subfolder of the system directory (gb/mario.png)
@@ -20,7 +20,7 @@ def getBezelInfos(rom, bezel, systemName):
     # default name (default.png)
     # else return
     # mamezip files are for MAME-specific advanced artwork (bezels with overlays and backdrops, animated LEDs, etc)
-    gameSpecial = getGameSpecial(systemName, rom)
+    gameSpecial = getGameSpecial(systemName, rom, retroarch)
     romBase = os.path.splitext(os.path.basename(rom))[0] # filename without extension
     overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".info"
     overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".png"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -74,11 +74,14 @@ def getGLVendor():
     except:
         return "unknown"
 
-def getGameSpecial(systemName, rom):
+def getGameSpecial(systemName, rom, retroarch):
     # Returns an ID for games that need rotated bezels/shaders or have special art
     # Vectrex will actually return an abbreviated game name for overlays, all others will return 0, 90, or 270 for rotation angle
     # 0 will be ignored.
     # Currently in use with bezels & libretro shaders
+    if not retroarch:
+        return "standalone"
+
     if not systemName in [ 'lynx', 'wswan', 'wswanc', 'mame', 'fbneo', 'naomi', 'atomiswave', 'nds', '3ds', 'vectrex' ]:
         return "0"
 


### PR DESCRIPTION
This adds an additional auto-decoration parameter, -standalone. Most standalone emulators can't resize the viewport, so the standard decoration images cut off the edges. While an alternate set can be used, that complicates switching emulators or using different emulators for different games in the same system.

This change will let decoration packs have a [decoration name]-standalone.png/.info alongside the standard Retroarch decoration that will be used if a non-Libretro emulator is in use. If it is not available, it will fall back to the standard decoration like the existing rotated decoration selection.

To minimize disruption to existing code, the Retroarch flag is optional and set to False by default, so any calls to bezel.py will look for the standalone. It's set to True if called from the Libretro generator, or if Libretro is the selected emulator in emulatorlauncher.py. If it needs to be called from any other generators (currently MAME is the only other one), the flag can be safely ignored.