### PR TITLE
group atari800 + xegs as atari8bit

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -850,6 +850,7 @@ atari800:
   release: 1979
   hardware: computer
   extensions: [rom, xfd, atr, atx, cdm, cas, car, bin, a52, xex, zip, 7z]
+  group:      atari8bit
   emulators:
     libretro:
       atari800: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_ATARI800] }
@@ -860,6 +861,7 @@ xegs:
   release: 1987
   hardware: computer
   extensions: [atr, dsk, xfd, bin, rom, car, zip, 7z]
+  group:      atari8bit
   emulators:
     libretro:
       mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }


### PR DESCRIPTION
proposal by DarkNior. Would be preferable to leave as a group not checked by default.