### PR TITLE
Merge Sameduck & Megaduck systems/Disable Zip for N64 Standalones

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -401,9 +401,6 @@ reminiscence:
 samcoupe:
   emulator: samcoupe
   core:     samcoupe
-sameduck:
-  emulator: libretro
-  core:     sameduck
 satellaview:
   emulator: libretro
   core:     snes9x

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -200,9 +200,9 @@ n64:
   extensions: [z64, n64, v64, zip, 7z]
   emulators:
     mupen64plus:
-      gliden64:   { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_GLIDEN64] }
-      glide64mk2: { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_VIDEO_GLIDE64MK2]  }
-      rice:       { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_VIDEO_RICE]        }
+      gliden64:   { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_GLIDEN64], incompatible_extensions: [zip, 7z] }
+      glide64mk2: { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_VIDEO_GLIDE64MK2], incompatible_extensions: [zip, 7z] }
+      rice:       { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_VIDEO_RICE], incompatible_extensions: [zip, 7z] }
     libretro:
       mupen64plus-next: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MUPEN64PLUS_NEXT] }
       parallel_n64:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_PARALLEL_N64] }
@@ -2349,7 +2349,7 @@ plugnplay:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
 
 megaduck:
-  name:       Mega Duck
+  name:       Mega Duck / Cougar Boy
   manufacturer: Welback Holdings
   release: 1993
   hardware: portable
@@ -2357,8 +2357,11 @@ megaduck:
   emulators:
     libretro:
       mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      sameduck:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SAMEDUCK], incompatible_extensions: [zip, 7z] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Use unzipped ROMs (BIN format) if using Sameduck.
 
 pv1000:
   name:       PV-1000
@@ -2765,16 +2768,6 @@ vemulator:
   emulators:
     libretro:
       vemulator:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_VEMULATOR] }
-
-sameduck:
-  name:       Mega Duck / Cougar Boy
-  manufacturer: Welback Holdings
-  release: 1993
-  hardware: portable
-  extensions: [bin]
-  emulators:
-    libretro:
-      sameduck:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SAMEDUCK] }
 
 openjazz:
   name:       Jazz Jackrabbit


### PR DESCRIPTION
Two fixes for es_systems.yml:

When sameduck (mega duck emulator) was added, it was added as a new system even though we already had megaduck via mame/mess. Possibly because the emulator doesn't support zip files, but the bin files are the same for both.

Removed the sameduck system, added sameduck as an alternate emulator for megaduck with zip/7z listed as incompatible. I also updated the system name to "Mega Duck / Cougar Boy" as that's what the sameduck system had. I did not change the default emulator, as changing it to sameduck from lr-mess caused errors with missing defaults on some platforms.

In addition, we have common support issues with people trying to use zipped n64 roms on the standalone emulator. They're supposed to work, but don't, and it just returns to ES.

For the time being, I've added zip and 7z to the incompatible extensions on the standalone, so they'll get an ES error that explains the problem rather than just going back to ES with no error.