### PR TITLE
Added features from Hypseus Singe v2.8.2, scanlines, excluded -js_range from Daphne games

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
@@ -35,7 +35,7 @@ class DaphneGenerator(Generator):
         # Default -fullscreen behaviour respects game aspect ratio
         if system.isOptSet('daphne_ratio') and system.config['daphne_ratio'] == "stretch":
             commandArray.extend(["-x", str(gameResolution["width"]), "-y", str(gameResolution["height"])])
-        elif system.isOptSet('daphne_ratio') and system.config['daphne_ratio'] == "force43":
+        elif system.isOptSet('daphne_ratio') and system.config['daphne_ratio'] == "force_ratio":
             commandArray.extend(["-force_aspect_ratio"])
 
         # Backend - Default OpenGL
@@ -59,20 +59,32 @@ class DaphneGenerator(Generator):
         # Invert Axis
         if system.isOptSet('invert_axis') and system.getOptBoolean("invert_axis"):
             commandArray.append("-tiphat")
-            
+
         # Game rotation options for vertical screens, default is 0.
         if system.isOptSet('daphne_rotate') and system.config['daphne_rotate'] == "90":
             commandArray.extend(["-rotate", "90"])
         elif system.isOptSet('daphne_rotate') and system.config['daphne_rotate'] == "270":
-            commandArray.extend(["-rotate", "270"])			
+            commandArray.extend(["-rotate", "270"])
 
         # Singe joystick sensitivity, default is 5.
-        if system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "10":
+        if os.path.isfile(singeFile) and system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "10":
             commandArray.extend(["-js_range", "10"])
-        elif system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "15":
+        elif os.path.isfile(singeFile) and system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "15":
             commandArray.extend(["-js_range", "15"])
-        elif system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "20":
-            commandArray.extend(["-js_range", "20"]) 
+        elif os.path.isfile(singeFile) and system.isOptSet('singe_joystick_range') and system.config['singe_joystick_range'] == "20":
+            commandArray.extend(["-js_range", "20"])
+
+        # Scanlines
+        if system.isOptSet('daphne_scanlines') and system.getOptBoolean("daphne_scanlines"):
+            commandArray.append("-scanlines")
+
+        # Hide crosshair in supported games (e.g. ActionMax)
+        if system.isOptSet('singe_crosshair') and system.getOptBoolean("singe_crosshair"):
+            commandArray.append("-nocrosshair")
+
+        # Enable SDL_TEXTUREACCESS_STREAMING, can aid SBC's with SDL2 => 2.0.16
+        if system.isOptSet('daphne_texturestream') and system.getOptBoolean("daphne_texturestream"):
+            commandArray.append("-texturestream") 
             
         # The folder may have a file with the game name and .commands with extra arguments to run the game.
         if os.path.isfile(commandsFile):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5185,10 +5185,10 @@ daphne:
             prompt:      ASPECT RATIO
             description: Not all games support Stretch, depending on the video files.
             choices:
-                "Original":  original
-                "Stretch":   stretch
-                "Force 4:3": force43
-            daphne_rotate:
+                "Original":   original
+                "Stretch":    stretch
+                "Force 4:3":  force_ratio
+        daphne_rotate:
             prompt:      SCREEN ROTATION
             description: Rotate the screen with the emulator.
             choices:
@@ -5202,6 +5202,14 @@ daphne:
             choices:
                 "On":  0
                 "Off": 1
+        daphne_scanlines:
+            archs_include: [x86, x86_64]
+            group: ADVANCED OPTIONS
+            prompt:      SCANLINES
+            description: Use with Stretch aspect ratio and adjust joystick sensitivity as required.
+            choices:
+                "Off":                          0
+                "On":                           1
         blend_sprites:
             group: ADVANCED OPTIONS
             prompt:      BLEND SPRITES (SINGE)
@@ -5232,6 +5240,20 @@ daphne:
                 "10": 10
                 "15": 15
                 "20": 20
+        singe_crosshair:
+            group: ADVANCED OPTIONS
+            prompt:      HIDE LIGHTGUN CROSSHAIRS
+            description: Hide crosshairs in supported games e.g. ActionMax.
+            choices:
+                "Off":                          0
+                "On":                           1
+        daphne_texturestream:
+            group: ADVANCED OPTIONS
+            prompt:      SDL TEXTUREACCESS STREAMING
+            description: Can improve video performance. Do not use with ActionMax games or scanlines.
+            choices:
+                "Off":                          0
+                "On":                           1
 
 devilutionx:
   features: [padtokeyboard]


### PR DESCRIPTION
New features from Hypseus Singe v2.8.2:
- Enable SDL_TEXTUREACCESS_STREAMING, can improve video performance on SBC's with SDL2 => 2.0.16 on higher resolution Singe games.
- Hide crosshair in supported games (e.g. ActionMax)

Added parameter:
- Enable scanlines. Use with Stretch aspect ratio and adjust joystick sensitivity as required.
NOTE: made -scanlines PC only as it negates the performance improvements of -texturestream on SBCs

Fixes:
- Daphne games crashed when -js_range is set for all games, now applied to Singe and ActionMax games only