### PR TITLE
Add cheevos to kronos in es_features.yml

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1537,6 +1537,7 @@ libretro:
       features: [netplay]
       shared: [rewind, autosave]
     kronos:
+      features: [cheevos]
       shared: [autosave]
     #lutro:
     mame:


### PR DESCRIPTION
Fixes #6074 

Core already referenced in:https://github.com/wholee/batocera.linux/blob/6468c11086f418d7f1e86348217efc1adbff3b9e/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py#L36

and system in:
https://github.com/wholee/batocera.linux/blob/6468c11086f418d7f1e86348217efc1adbff3b9e/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py#L32