### PR TITLE
make standalone scummvm the default

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -408,7 +408,7 @@ saturn:
   emulator: libretro
   core:     yabasanshiro
 scummvm:
-  emulator: libretro
+  emulator: scummvm
   core:     scummvm
 scv:
   emulator: libretro


### PR DESCRIPTION
From user feedback...

Cause the libreto 2.1.1 version does not support all the game engines supported on standalone 2.5.1, and cant play properly some supported games.
- Broker Sword 1 will play it cutscenes only at 2.5.1
- Grin Fradango and some Monkey Island games, will only works at 2.5.1 too.
- And many other engines are supported on 2.5.1: AGS (Adventure Game Studio), Glk (Text Adventures), SCI (Sierra's Creative Interpreter), ...