### PR TITLE
MAME Re-bump & Shader Fix (v34?)

### DIFF
--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -3,8 +3,8 @@
 # MAME
 #
 ################################################################################
-# Version.: Release 0.241
-MAME_VERSION = gm0241sr002g
+# Version.: Release 0.242
+MAME_VERSION = gm0242sr002h
 MAME_SITE = $(call github,antonioginer,GroovyMAME,$(MAME_VERSION))
 MAME_DEPENDENCIES = sdl2 sdl2_ttf zlib libpng fontconfig sqlite jpeg flac rapidjson expat glm
 MAME_LICENSE = MAME
@@ -229,7 +229,6 @@ define MAME_INSTALL_TARGET_CMDS
 	# Delete bgfx shaders for DX9/DX11/Metal
 	rm -Rf $(TARGET_DIR)/usr/bin/mame/bgfx/shaders/metal/
 	rm -Rf $(TARGET_DIR)/usr/bin/mame/bgfx/shaders/dx11/
-	rm -Rf $(TARGET_DIR)/usr/bin/mame/bgfx/shaders/dx9/
 
 	# Copy extra bgfx shaders
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/crt-geom-deluxe-rgb.json $(TARGET_DIR)/usr/bin/mame/bgfx/chains


### PR DESCRIPTION
The issue that was preventing shaders from working in standalone MAME was that in v242, the DX9 shaders were set to the default, and if the files were missing (even on Linux), BGFX would fail. We've been removing the DX9 shaders since they don't work on Linux anyway. Rion found the issue reported on MAME's github.

This re-bumps to v242, and will leave the DX9 shaders in place. We went through a good part of v34 beta using v242 and the only issue was the shaders, so it should be safe if it's not too late.