### PR TITLE
Fix SDLPoP not saving settings

### DIFF
--- a/package/batocera/ports/sdlpop/sdlpop.mk
+++ b/package/batocera/ports/sdlpop/sdlpop.mk
@@ -13,6 +13,7 @@ SDLPOP_DEPENDENCIES = sdl2 sdl2_image
 define SDLPOP_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/sdlpop
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
+	mkdir -p /userdata/system/configs/sdlpop
 	$(INSTALL) -m 0755 $(@D)/prince -D $(TARGET_DIR)/usr/bin/SDLPoP
 	cp -pr $(@D)/data $(TARGET_DIR)/usr/share/sdlpop/
 	ln -sf /userdata/system/configs/sdlpop/SDLPoP.ini $(TARGET_DIR)/usr/share/sdlpop/SDLPoP.ini


### PR DESCRIPTION
`SDLPoP` writes (many, not all) configuration changes done from within the in-game settings menu
to `SDLPoP.cfg` (which has precedence over the main, read-only, user-supplied configuration `SDLPoP.ini`).
Both `SDLPoP.{cfg,ini}` are currently symlinked from `/usr/share/sdlpop/SDLPoP.{cfg,ini}` to
`/userdata/system/configs/sdlpop/SDLPoP.{cfg,ini}`, however, because the directory
`/userdata/system/configs/sdlpop` doesn't exist the engine cannot create `SDLPoP.cfg` and setting changes
made during runtime are discarded when exiting the game.

This ensures `/userdata/system/configs/sdlpop` gets created so `SDLPoP.cfg` can be created and written to.