### PR TITLE
Advanced N64 Options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -979,6 +979,21 @@ def generateCoreSettings(coreSettings, system, rom):
             coreSettings.save('mupen64plus-pak4', system.config['mupen64plus-pak4'])
         else:
             coreSettings.save('mupen64plus-pak4', '"none"')
+        # RDP Plugin
+        if system.isOptSet('mupen64plus-rdpPlugin'):
+            coreSettings.save('mupen64plus-rdp-plugin', '"' + system.config['mupen64plus-rdpPlugin'] + '"')
+        else:
+            coreSettings.save('mupen64plus-rdp-plugin', '"gliden64"')
+        # RSP Plugin
+        if system.isOptSet('mupen64plus-rspPlugin'):
+            coreSettings.save('mupen64plus-rsp-plugin', '"' + system.config['mupen64plus-rspPlugin'] + '"')
+        else:
+            coreSettings.save('mupen64plus-rsp-plugin', '"hle"')
+        # CPU Core
+        if system.isOptSet('mupen64plus-cpuCore'):
+            coreSettings.save('mupen64plus-cpucore', '"' + system.config['mupen64plus-cpuCore'] + '"')
+        else:
+            coreSettings.save('mupen64plus-cpucore', '"dynamic_recompiler"')
 
     if (system.config['core'] == 'parallel_n64'):
         coreSettings.save('parallel-n64-64dd-hardware', '"disabled"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3106,7 +3106,6 @@ libretro:
             mupen64plus-rdpPlugin:
                 group: ADVANCED OPTIONS
                 prompt:      RDP PLUGIN
-                description: Select RDP Plugin
                 choices:
                     "GLideN64 (Fastest)":          gliden64
                     "ParaLLEl-RDP":                parallel
@@ -3114,7 +3113,6 @@ libretro:
             mupen64plus-rspPlugin:
                 group: ADVANCED OPTIONS
                 prompt:      RSP PLUGIN
-                description: Select RSP Plugin
                 choices:
                     "HLE (Fastest)":       hle
                     "ParaLLEl (Best LLE)": parallel
@@ -3122,7 +3120,6 @@ libretro:
             mupen64plus-cpuCore:
                 group: ADVANCED OPTIONS
                 prompt:      CPU CORE
-                description: Select CPU Core
                 choices:
                     "Dynarec (Fastest)":                dynamic_recompiler
                     "Cached Interpreter":               cached_interpreter

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3103,6 +3103,30 @@ libretro:
                     "4xBRZ":      4xBRZ
                     "5xBRZ":      5xBRZ
                     "6xBRZ":      6xBRZ
+            mupen64plus-rdpPlugin:
+                group: ADVANCED OPTIONS
+                prompt:      RDP PLUGIN
+                description: Select RDP Plugin
+                choices:
+                    "GLideN64 (Fastest)":          gliden64
+                    "ParaLLEl-RDP":                parallel
+                    "Angrylion (Most Compatible)": angrylion
+            mupen64plus-rspPlugin:
+                group: ADVANCED OPTIONS
+                prompt:      RSP PLUGIN
+                description: Select RSP Plugin
+                choices:
+                    "HLE (Fastest)":       hle
+                    "ParaLLEl (Best LLE)": parallel
+                    "CXD4 (LLE Fallback)": cxd4
+            mupen64plus-cpuCore:
+                group: ADVANCED OPTIONS
+                prompt:      CPU CORE
+                description: Select CPU Core
+                choices:
+                    "Dynarec (Fastest)":                dynamic_recompiler
+                    "Cached Interpreter":               cached_interpreter
+                    "Pure Interpreter (Most Accurate)": pure_interpreter
             mupen64plus-pak1:
                 prompt:      CONTROLLER PAK 1
                 description: Emulate a pak in the controller expansion port.


### PR DESCRIPTION
* Adds options to select RDP Plugin, RSP Plugin, and CPU Core to lr-mupen64plus-next.
* Defaults are still the current/fastest - GLideN64 RDP, HLE RSP, Dynarec CPU.