### PR TITLE
Add cheevos Encore mode

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -497,6 +497,7 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
     retroarchConfig['cheevos_verbose_enable'] = 'false'
     retroarchConfig['cheevos_auto_screenshot'] = 'false'
     retroarchConfig['cheevos_challenge_indicators'] = 'false'
+    retroarchConfig['cheevos_start_active'] = 'false'
 
     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
         if(system.name in systemToRetroachievements) or (system.config['core'] in coreToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
@@ -529,6 +530,11 @@ def createLibretroConfig(system, controllers, rom, bezel, gameResolution, gfxBac
                 retroarchConfig['cheevos_challenge_indicators'] = 'true'
             else:
                 retroarchConfig['cheevos_challenge_indicators'] = 'false'
+            # retroarchievements_encore_mode
+            if system.isOptSet('retroachievements.encore') and system.getOptBoolean('retroachievements.encore') == True:
+                retroarchConfig['cheevos_start_active'] = 'true'
+            else:
+                retroarchConfig['cheevos_start_active'] = 'false'
     else:
         retroarchConfig['cheevos_enable'] = 'false'
 


### PR DESCRIPTION
This adds an option to `batocera.conf` to enable players to start a gaming session with all achievements active (even the ones they already have registered as unlocked on RetroAchievements.org).

#https://github.com/libretro/RetroArch/pull/10637
#https://github.com/libretro/RetroArch/pull/12472

The option for Retroarch is `cheevos_start_active` but to avoid some confusions it was renamed to _Encore mode_ in #https://github.com/libretro/RetroArch/pull/12472
I've also created a PR for EmulationStation #https://github.com/batocera-linux/batocera-emulationstation/pull/1179 to go along with this setting.
Changes in this PR can also be used regardless if the #https://github.com/batocera-linux/batocera-emulationstation/pull/1179 PR is approved or not.

And to note, this setting can also be used without this PR just by adding `global.retroarch.cheevos_start_active=true` to `batocera.conf`.