### PR TITLE
Update PC88 *.cmt

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1786,7 +1786,7 @@ pc88:
   manufacturer: NEC
   release: 1981
   hardware: computer
-  extensions: [d88, u88, m3u]
+  extensions: [cmt, d88, u88, m3u]
   platform:   pc88
   emulators:
     libretro:


### PR DESCRIPTION
Even if the official docs don't have the _cmt_ extension as supported https://docs.libretro.com/library/quasi88/#extensions

the emulator itself does: https://github.com/libretro/quasi88-libretro/blob/dccf881719d793aac56944e3e6c3d5358ac2c87a/src/help.h#L38

And Retropie also has it listed as supported: https://retropie.org.uk/docs/PC-8800/