### PR TITLE
bump linux firmware to 9th May 22

### DIFF
--- a/package/batocera/alllinuxfirmwares/alllinuxfirmwares.mk
+++ b/package/batocera/alllinuxfirmwares/alllinuxfirmwares.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ALLLINUXFIRMWARES_VERSION = 20220411
+ALLLINUXFIRMWARES_VERSION = 20220509
 ALLLINUXFIRMWARES_SITE = http://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git
 ALLLINUXFIRMWARES_SITE_METHOD = git
 


### PR DESCRIPTION
- fixes stability with the MediaTek MT7922 chipset
- adds firmware for RTL8852C devices
- general firmware updates aligning with the 5.17 kernel