### PR TITLE
Batocera 34 - additional fixes & updates

### DIFF
--- a/package/batocera/core/batocera-controller-overlays/batocera-controller-overlays.hash
+++ b/package/batocera/core/batocera-controller-overlays/batocera-controller-overlays.hash
@@ -1,1 +1,1 @@
-sha256 138d0e33ed2cfbb94841ffe55e4465901777ea74c1fb84e0603d732f1a1e2cd8  batocera-controller-overlays-ff04f89e34e621c51a8716a942fec0f1ef301454.tar.gz
+sha256 940578ee11ab9a903361a6e6a8cc8c95bf06800a78a47a792460029dfbd799b0  batocera-controller-overlays-0dfa15a0ae1e32835ba280ff4bf76a73870bc532.tar.gz

--- a/package/batocera/core/batocera-controller-overlays/batocera-controller-overlays.mk
+++ b/package/batocera/core/batocera-controller-overlays/batocera-controller-overlays.mk
@@ -3,8 +3,8 @@
 # Batocera controller overlays
 #
 ################################################################################
-# Last commit: Nov 24, 2021
-BATOCERA_CONTROLLER_OVERLAYS_VERSION = ff04f89e34e621c51a8716a942fec0f1ef301454
+# Last commit: May 18, 2022
+BATOCERA_CONTROLLER_OVERLAYS_VERSION = 0dfa15a0ae1e32835ba280ff4bf76a73870bc532
 BATOCERA_CONTROLLER_OVERLAYS_SITE = $(call github,batocera-linux,batocera-controller-overlays,$(BATOCERA_CONTROLLER_OVERLAYS_VERSION))
 
 define BATOCERA_CONTROLLER_OVERLAYS_INSTALL_TARGET_CMDS

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -646,9 +646,10 @@ systems = {
                                                 { "md5": "e95415b161121bef35ade12367138c63", "file": "bios/mie.zip"} ] },
 
     # ---------- GCE Vectrex ---------- #
-    "vectrex":   { "name": "GCE Vectrex", "biosFiles":  [ { "md5": "", "file": "bios/vectrex.zip"  },
-                                                { "md5": "ab082fa8c8e632dd68589a8c7741388f", "zippedFile": "exec_rom.bin", "file": "bios/vectrex.zip"},
-                                                { "md5": "a9c238473229912eb757ff3dfe6f4631", "zippedFile": "exec_rom_intl_284001-1.bin", "file": "bios/vectrex.zip"} ] },
+    # Not required for libretro-vecx, the default emulator
+    # "vectrex":   { "name": "GCE Vectrex", "biosFiles":  [ { "md5": "", "file": "bios/vectrex.zip"  },
+    #                                            { "md5": "ab082fa8c8e632dd68589a8c7741388f", "zippedFile": "exec_rom.bin", "file": "bios/vectrex.zip"},
+    #                                            { "md5": "a9c238473229912eb757ff3dfe6f4631", "zippedFile": "exec_rom_intl_284001-1.bin", "file": "bios/vectrex.zip"} ] },
 }
 
 class BiosStatus:

--- a/package/batocera/emulators/retroarch/libretro/libretro-cap32/amstradcpc.keys
+++ b/package/batocera/emulators/retroarch/libretro/libretro-cap32/amstradcpc.keys
@@ -1,0 +1,19 @@
+{
+    "actions_player1": [
+        {
+            "trigger": "y",
+            "type": "key",
+            "target": "KEY_Y"
+        },
+        {
+            "trigger": "x",
+            "type": "key",
+            "target": "KEY_N"
+        },
+        {
+            "trigger": "pageup",
+            "type": "key",
+            "target": "KEY_P"
+        }
+    ]
+}

--- a/package/batocera/emulators/retroarch/libretro/libretro-cap32/libretro-cap32.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-cap32/libretro-cap32.mk
@@ -38,6 +38,7 @@ endef
 define LIBRETRO_CAP32_INSTALL_TARGET_CMDS
 	$(INSTALL) -D $(@D)/cap32_libretro.so \
 		$(TARGET_DIR)/usr/lib/libretro/cap32_libretro.so
+	cp -f $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/retroarch/libretro/libretro-cap32/amstradcpc.keys $(TARGET_DIR)/usr/share/evmapy/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
- Fix Vectrex BIOS requirement (not required by default emulator)
- Add controller overlays/tattoos for Amstrad CPC, Amiga, Atari ST, ZX81
- Better pad2key for Amstrad CPC