### PR TITLE
allow sony controller triggers to be configured as analog (not buttons)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -19,7 +19,12 @@ class DolphinGenerator(Generator):
         if not os.path.exists(batoceraFiles.dolphinData + "/StateSaves"):
             os.makedirs(batoceraFiles.dolphinData + "/StateSaves")
 
-        dolphinControllers.generateControllerConfig(system, playersControllers, rom)
+        if system.isOptSet('sonyWorkaround'):
+            sonyWorkaround = system.getOptBoolean('sonyWorkaround')
+        else:
+            sonyWorkaround = False
+
+        dolphinControllers.generateControllerConfig(system, playersControllers, rom, sonyWorkaround)
 
         ## dolphin.ini ##
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
@@ -66,7 +66,7 @@ flycastArcadeMapping = { # Directions
 sections = { 'analog', 'digital', 'emulator' }
 
 # Create the controller configuration file
-def generateControllerConfig(controller, type):
+def generateControllerConfig(controller, type, sonyWorkaround):
     # Set config file name
     if type == 'dreamcast':
         configFileName = "{}/SDL_{}.cfg".format(batoceraFiles.flycastMapping, controller.realName)
@@ -85,6 +85,7 @@ def generateControllerConfig(controller, type):
     # Parse controller inputs
     analogbind = 0
     digitalbind = 0
+
     for index in controller.inputs:
         input = controller.inputs[index]
         if type == 'dreamcast':
@@ -118,7 +119,19 @@ def generateControllerConfig(controller, type):
             digitalbind = digitalbind +1
             val = "{}:{}".format(code, var)
             Config.set(section, option, val)
-        
+
+        # Special handling for Sony triggers (l2 / r2)
+        if input.name in ['l2', 'r2'] and sonyWorkaround:
+            section = 'analog'
+            if input.name == 'l2':
+                code = '2+'
+            else:
+                code = '5+'
+            option = "bind{}".format(analogbind)
+            analogbind = analogbind +1
+            val = "{}:{}".format(code, var)
+            Config.set(section, option, val)
+
         if input.type == 'button':
             section = 'digital'
             option = "bind{}".format(digitalbind)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
@@ -29,13 +29,20 @@ class FlycastGenerator(Generator):
         
         if not Config.has_section("input"):
             Config.add_section("input")
+
+        # Load Sony trigger workaround
+        if system.isOptSet('sonyWorkaround'):
+            sonyWorkaround = system.getOptBoolean('sonyWorkaround')
+        else:
+            sonyWorkaround = False
+
         # For each pad detected       
         for index in playersControllers:
             controller = playersControllers[index]
             # Write the mapping files for Dreamcast
-            flycastControllers.generateControllerConfig(controller, "dreamcast")
+            flycastControllers.generateControllerConfig(controller, "dreamcast", sonyWorkaround)
             # Write the Arcade variant (Atomiswave & Naomi/2)
-            flycastControllers.generateControllerConfig(controller, "arcade")
+            flycastControllers.generateControllerConfig(controller, "arcade", sonyWorkaround)
 
             # Set the controller type per Port
             Config.set("input", 'device' + str(controller.player), "0") # Sega Controller

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/redream/redreamGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/redream/redreamGenerator.py
@@ -65,6 +65,11 @@ class RedreamGenerator(Generator):
             "r2":            3
         }
 
+        if system.isOptSet('sonyWorkaround'):
+            sonyWorkaround = system.getOptBoolean('sonyWorkaround')
+        else:
+            sonyWorkaround = False
+
         nplayer = 1
         for index in playersControllers:
             controller = playersControllers[index]
@@ -88,9 +93,15 @@ class RedreamGenerator(Generator):
                         fullprofile = fullprofile + "{}:joy{},".format(buttonname, input.id)
                     #on rare occassions when triggers are buttons
                     if input.type == "button" and input.name == "l2":
-                        fullprofile = fullprofile + "ltrig:joy{},".format(input.id)
+                        if sonyWorkaround:
+                            fullprofile = fullprofile + "ltrig:+axis2,"
+                        else:
+                            fullprofile = fullprofile + "ltrig:joy{},".format(input.id)
                     if input.type == "button" and input.name == "r2":
-                        fullprofile = fullprofile + "rtrig:joy{},".format(input.id)
+                        if sonyWorkaround:
+                            fullprofile = fullprofile + "rtrig:+axis5,"
+                        else:
+                            fullprofile = fullprofile + "rtrig:joy{},".format(input.id)
                     #on occassions when dpad directions are buttons
                     if input.type == "button":
                         if input.name == "up" or input.name == "down" or input.name == "left" or input.name == "right":

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5444,6 +5444,13 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
+        sonyWorkaround:
+            group: ADVANCED OPTIONS
+            prompt:      USE TRIGGERS AS ANALOG
+            description: Enables controllers to use triggers as analog rather than digital. Like Sony Playstation controllers.
+            choices:
+                "Digital (Button)": 0
+                "Analog (Axis)":    1
 
   systems:
     gamecube:
@@ -5818,6 +5825,13 @@ flycast:
       choices:
         "Normal": no
         "Rotate": yes
+    sonyWorkaround:
+      group: ADVANCED OPTIONS
+      prompt:      USE TRIGGERS AS ANALOG
+      description: Enables controllers to use triggers as analog rather than digital. Like Sony Playstation controllers.
+      choices:
+        "Digital (Button)": 0
+        "Analog (Axis)":    1
   systems:
     dreamcast:
       cfeatures:
@@ -6654,6 +6668,13 @@ redream:
               "VGA (Default)": vga
               "RGB":           rgb
               "Composite":     composite
+      sonyWorkaround:
+          group: ADVANCED OPTIONS
+          prompt:      USE TRIGGERS AS ANALOG
+          description: Enables controllers to use triggers as analog rather than digital. Like Sony Playstation controllers.
+          choices:
+            "Digital (Button)": 0
+            "Analog (Axis)":    1
 
 sdlpop:
   features: [padtokeyboard]


### PR DESCRIPTION
this 'fixes' the triggers where sensitive actions were not previously available with the default button identification