### PR TITLE
Remove FBNeo for NeoGeo CD

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -797,7 +797,6 @@ neogeocd:
   emulators:
     libretro:
       neocd:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_NEOCD] }
-      fbneo:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_FBNEO] }
 
 colecovision:
   name:       ColecoVision
@@ -3196,4 +3195,3 @@ odcommander:
     A two-pane file manager in the style of Norton/Midnight Commander.
   comment_fr: |
     Un gestionnaire de fichiers a deux volets, dans le style Norton/Midnight Commander.
-


### PR DESCRIPTION
Is not work for NeoGeo CD
Is only for old true rip support by NeoCD.
And LR have been remove the rom support from FBNeo : 
https://github.com/libretro/libretro-database/blob/master/metadat/redump/SNK%20-%20Neo%20Geo%20CD.dat
That make confusion for users this core not work anymore for Neo Geo CD now.