### PR TITLE
Add support for showing unmatched roms in batocera-es-thebezelproject

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject
@@ -14,9 +14,10 @@
 # 20200709 Add : Progress count (started from Terminal/SSH vs ES)
 # 20210130 Add : Take bezels by systems from TheBezelProjet Github (Batocera 30+)
 # 20211010 Fix : recursive search in roms directory
+# 20220524 Add : output unmatched ROMs when requested
 #
 
-readonly VERSION="20211010"
+readonly VERSION="20220524"
 readonly TITLE="the BezelProject for BATOCERA"
 readonly LOGS_DIR="/userdata/system/logs"
 readonly DECORATION_DIR="/userdata/decorations"
@@ -59,7 +60,7 @@ function usage() {
 		record "It accepts three modes: 'list', 'install' and 'remove' <system>'" "2"
 		record "- 'list' to list systems installed locally, which are available within TheBezelProject:" "2"
 		record "   [A]vailable to install, [I]nstalled or [?]unknown." "2"
-		record "- 'install <system>' to install the bezels for this <system>." "2"
+		record "- 'install <system> [--show-unmatched]' to install the bezels for this <system>." "2"
 		record "- 'remove <system>' to remove the bezels for this <system>." "2"
 		record "- 'remove all' to remove all the bezels from TheBezelProject." "2"
 		record " " "2"
@@ -238,6 +239,10 @@ function install() {
 		local path
 		local git_path
 		local file
+
+		local show_unmatched="$2"
+		local unmatched=()
+		local unmatched_count
 
 		record "* Install"
 		record "Path to games bezels $DECORATION_DIR/$BEZELPROJECT_GAMES_DIR"
@@ -448,6 +453,7 @@ function install() {
 				# NOT MATCHING
 				if [ "$matching_rom" -eq 0 ]; then
 						record "NOT MATCHING : $rom_name"
+						[[ -n "$show_unmatched" ]] && unmatched+=("$rom_name")
 				fi
 
 				# is there too many warning ?
@@ -506,6 +512,15 @@ function install() {
 				else
 						record "Warning : file $(basename $url2) could not be downloaded from $(dirname $url2)"
 				fi
+		fi
+
+		# If requested (and any roms couldn't be matched), the output the list for easy lookup (only show on stdout if started from Terminal/SSH)
+		unmatched_count=${#unmatched[@]} 
+		if [[ $unmatched_count != 0 ]]; then
+			record "[$system_to_install] $unmatched_count unmatched ROM(s) (check $url$git_path to see if the bezel exists)" "$TERMINAL"
+			for (( i=0; i< "$unmatched_count"; i++ )); do
+				record "$(($i + 1)). ${unmatched[$i]}" "$TERMINAL"
+			done
 		fi
 
 		# sync disk
@@ -574,7 +589,13 @@ fi
 if [[ "$command" = "list" ]]; then
 		list
 elif [[ "$command" = "install" && -n "$system" ]]; then
-		install "$system"
+		if [[ -n "$3" && "$3" != "--show-unmatched" ]]; then
+			record "Error : unknown argument for install: $3" "1"
+			record "" "1"
+			usage
+		else
+			install "$system" "$3"
+		fi
 elif [[ "$command" = "remove" && -n "$system" ]]; then
 		remove "$system"
 else

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-thebezelproject
@@ -517,9 +517,11 @@ function install() {
 		# If requested (and any roms couldn't be matched), the output the list for easy lookup (only show on stdout if started from Terminal/SSH)
 		unmatched_count=${#unmatched[@]} 
 		if [[ $unmatched_count != 0 ]]; then
+			local sorted=()
 			record "[$system_to_install] $unmatched_count unmatched ROM(s) (check $url$git_path to see if the bezel exists)" "$TERMINAL"
+			readarray -t sorted < <(for a in "${unmatched[@]}"; do echo "$a"; done | sort)
 			for (( i=0; i< "$unmatched_count"; i++ )); do
-				record "$(($i + 1)). ${unmatched[$i]}" "$TERMINAL"
+				record "$(($i + 1)). ${sorted[$i]}" "$TERMINAL"
 			done
 		fi
 


### PR DESCRIPTION
`batocera-es-thebezelproject install <system>` performs an almost exact text match on ROMs vs bezel filenames to determine a match. Unmatched ROMs often differ in trivial ways and without playing the game, it is otherwise hard to know when something hasn't matched. (NB: the information is in the log, but you have to dig to find it versus all the other log messages.)

This PR adds an option to `install` which is `--show-unmatched`. With this option enabled, the script will gather all the unmatched ROMs and dump them at the end of the script.

The output looks like this:

```
batocera-es-thebezelproject install psx --show-unmatched
[psx] 75 ROMs found
[psx] 72 bezels (75 ROMs) were installed/modified
[psx] Installing system bezel
[psx] Installing default bezel
[psx] Unmatched ROMS (check https://github.com/thebezelproject/bezelproject-PSX/raw/master/retroarch/overlay/GameBezels/PSX/ to see if the bezel exists)
1. Colony Wars - Red Sun (USA).chd
2. Ridge Racer Type 4 (USA) [SLUS-00797].chd
3. Spyro 2 - Ripto's Rage (USA).chd
```

Without adding the switch, the output is exactly the same as before, so existing scripts or usage of `batocera-es-thebezelproject` won't fail.

I have found this addition _incredibly_ useful to canonicalize my ROM names. This has also helped with scraping after the fact.