### PR TITLE
virtual dolphin bar (called virtual-wii-mouse-bar)

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -108,6 +108,7 @@ menu "Controllers"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/controllers/aimtrak-guns/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/controllers/dolphinbar-guns/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/controllers/sinden-guns/Config.in"
+  source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/controllers/wiimotes-rules/Config.in"
 endmenu
 
 menu "Emulators"

--- a/board/batocera/fsoverlay/etc/udev/rules.d/99-wiimote.rules
+++ b/board/batocera/fsoverlay/etc/udev/rules.d/99-wiimote.rules
@@ -1,2 +1,0 @@
-SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"
-SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_KEY}="0"

--- a/package/batocera/controllers/wiimotes-rules/99-wiimote.rules
+++ b/package/batocera/controllers/wiimotes-rules/99-wiimote.rules
@@ -1,0 +1,7 @@
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_KEY}="0"
+
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", RUN+="/usr/bin/virtual-wii-mouse-bar-add"
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote IR", MODE="0666", RUN+="/usr/bin/virtual-wii-mouse-bar-add"
+SUBSYSTEM=="input", ATTRS{name}=="Nintendo Wii Remote Accelerometer", ENV{ID_INPUT_JOYSTICK}="0"
+
+SUBSYSTEM=="input", ATTRS{name}=="virtual wii mouse bar", MODE="0666", ENV{ID_INPUT_GUN}="1", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="1"

--- a/package/batocera/controllers/wiimotes-rules/Config.in
+++ b/package/batocera/controllers/wiimotes-rules/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_WIIMOTES_RULES
+	bool "wiimotes-rules"
+	select BR2_PACKAGE_EVSIEVE
+
+	help
+	  wiimote support

--- a/package/batocera/controllers/wiimotes-rules/virtual-wii-mouse-bar-add
+++ b/package/batocera/controllers/wiimotes-rules/virtual-wii-mouse-bar-add
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+test "${ACTION}" = "add" || exit 0
+echo "${DEVNAME}" | grep -E "^/dev/input/event[0-9]+$" || exit 0
+
+WIIMOTEMODE=$(batocera-settings-get controllers.wiimote.mode)
+test "${WIIMOTEMODE}" == 'gun' || exit 0 # gun mode not enabled
+
+USBPATHHASH=$(echo "${ID_PATH}" | sed -e s+"\.[0-9]*$"++ | md5sum | cut -c 0-8)
+NDEVS=$(cat "/var/run/virtual-wii-mouse-devices.${USBPATHHASH}" | wc -l)
+
+echo "${DEVNAME} ${USBPATHHASH} ${ID_PATH}" >> /var/run/virtual-wii-mouse-devices.seen || exit 1
+
+if test "${NDEVS}" = 1
+then
+    DEV1=$(head -1 "/var/run/virtual-wii-mouse-devices.${USBPATHHASH}")
+    rm "/var/run/virtual-wii-mouse-devices.${USBPATHHASH}" || exit 1
+
+    nohup evsieve --input "${DEV1}" "${DEVNAME}" grab persist=exit --map abs:hat0x abs:x --map abs:hat0y abs:y --map btn:mode btn:middle --map btn:east btn:left --map btn:south btn:right --output name="virtual wii mouse bar" 2>"/var/log/virtual-wii-mouse-devices.${USBPATHHASH}.log" &
+else
+    echo "${DEVNAME}" >> "/var/run/virtual-wii-mouse-devices.${USBPATHHASH}" || exit 1
+fi

--- a/package/batocera/controllers/wiimotes-rules/wiimotes-rules.mk
+++ b/package/batocera/controllers/wiimotes-rules/wiimotes-rules.mk
@@ -1,0 +1,15 @@
+################################################################################
+#
+# wiimotes-rules
+#
+################################################################################
+WIIMOTES_RULES_VERSION = 1
+WIIMOTES_RULES_LICENSE = GPL
+WIIMOTES_RULES_SOURCE=
+
+define WIIMOTES_RULES_INSTALL_TARGET_CMDS
+	$(INSTALL) -m 0644 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/wiimotes-rules/99-wiimote.rules $(TARGET_DIR)/etc/udev/rules.d/99-wiimote.rules
+	$(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/wiimotes-rules/virtual-wii-mouse-bar-add $(TARGET_DIR)/usr/bin/virtual-wii-mouse-bar-add
+endef
+
+$(eval $(generic-package))

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -193,6 +193,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_XPAD_NOONE                           if !BR2_PACKAGE_BATOCERA_TARGET_RK3326 && !BR2_PACKAGE_BATOCERA_TARGET_RK3128 && !BR2_PACKAGE_BATOCERA_TARGET_RG552 # xbox receiver (require linux >= 4.15)
 	select BR2_PACKAGE_XOW                                  if BR2_PACKAGE_BATOCERA_TARGET_RK3326 && BR2_PACKAGE_BATOCERA_TARGET_RK3128 # xbox receiver (require linux >= 4.5)
 	select BR2_PACKAGE_WII_U_GC_ADAPTER                     # wii-u-gc-adapter
+	select BR2_PACKAGE_WIIMOTES_RULES                       # wiimotes
 	select BR2_PACKAGE_BATOCERA_GUNS
 	select BR2_SYSTEM_ENABLE_NLS                            # locales
 	select BR2_PACKAGE_ACPID                                if BR2_PACKAGE_BATOCERA_TARGET_X86_ANY


### PR DESCRIPTION
no more dolphin bar required, only a ir, so only one dolphinbar plugged
on tv for example for all wii, or a standard wiibar or a candle

=>>>>>> needs controllers.wiimote.mode=gun in batocera.conf

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>