### PR TITLE
Update pcsx2Generator.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -269,9 +269,9 @@ def configureGFX(config_directory, system):
 
     # Skipdraw Hack
     if system.isOptSet('skipdraw'):
-        pcsx2GFXSettings.save('UserHacks_SkipDraw', system.config['skipdraw'])
+        pcsx2GFXSettings.save('UserHacks_SkipDraw_Start', system.config['skipdraw'])
     else:
-        pcsx2GFXSettings.save('UserHacks_SkipDraw', '0')
+        pcsx2GFXSettings.save('UserHacks_SkipDraw_Start', '0')
 
     # Align sprite Hack
     if system.isOptSet('align_sprite'):


### PR DESCRIPTION
correction SkipDraw qui ne fonctionner plus en V34