### PR TITLE
fix "none" shader set behaviour

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -429,7 +429,7 @@ def createLibretroConfig(system, controllers, guns, rom, bezel, shaderBezel, gam
         retroarchConfig['video_smooth'] = 'false'
 
     # Shader option
-    if 'shader' in renderConfig and (renderConfig['shader'] != None and renderConfig['shader'] != "none"):
+    if 'shader' in renderConfig and (renderConfig['shader'] != None or renderConfig['shader'] != "none"):
         retroarchConfig['video_shader_enable'] = 'true'
         retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs
     else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -429,9 +429,10 @@ def createLibretroConfig(system, controllers, guns, rom, bezel, shaderBezel, gam
         retroarchConfig['video_smooth'] = 'false'
 
     # Shader option
-    if 'shader' in renderConfig and (renderConfig['shader'] != None or renderConfig['shader'] != "none"):
-        retroarchConfig['video_shader_enable'] = 'true'
-        retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs
+    if 'shader' in renderConfig:
+        if renderConfig['shader'] != None and renderConfig['shader'] != "none":
+            retroarchConfig['video_shader_enable'] = 'true'
+            retroarchConfig['video_smooth']        = 'false'     # seems to be necessary for weaker SBCs
     else:
         retroarchConfig['video_shader_enable'] = 'false'
 


### PR DESCRIPTION
It seems that there are situations where only one of these conditions are true. We should veer on the side of allowing the user to manually use RetroArch if they only set the shader set to none.