### PR TITLE
Better fix for wifi enable/disable

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -11,6 +11,9 @@ if ! [ -f "$BATOCONF" ]; then
 fi
 ### #### ###
 
+# WLAN enabled?
+settingsWlan="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.enabled)"
+
 # configure wifi files, always
 batocera_wifi_configure() {
     X=$1
@@ -23,7 +26,7 @@ batocera_wifi_configure() {
     settings_key="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.key)"
     settings_file="/var/lib/connman/batocera_wifi${X}.config"
 
-    if [ -n "$settings_ssid" ];then
+    if [ -n "$settings_ssid" -a "$settingsWlan" = "1" ];then
         mkdir -p "/var/lib/connman"
         cat > "${settings_file}" <<-_EOF_
 		[global]
@@ -34,6 +37,8 @@ batocera_wifi_configure() {
 		Hidden=${settings_hide}
 		Passphrase=${settings_key}
 	_EOF_
+    else
+        rm "${settings_file}" 2>/dev/null
     fi
 }
 
@@ -46,8 +51,6 @@ wifi_configure_all() {
 }
 
 wifi_enable() {
-    # WLAN enabled?
-    settingsWlan="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.enabled)"
     settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
     if [ "$settingsWlan" != "1" ];then
@@ -74,6 +77,7 @@ case "$1" in
 		    sleep 1
 		    connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
 		done
+		sleep 0.5
 
 		# can be done detached
 		wifi_enable &
@@ -85,12 +89,12 @@ case "$1" in
 		start-stop-daemon -K -q -p /var/run/connmand.pid
 		echo "done."
 		;;
-	restart)
+	restart | reload)
 		$0 stop
 		sleep 1
 		$0 start
 		;;
 	*)
-		echo "usage: $0 {start|stop|restart}"
+		echo "usage: $0 {start|stop|restart|reload}"
 		;;
 esac

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -14,72 +14,6 @@ do_scanlist() {
     do_list
 }
 
-do_enable() {
-    SSID=$1
-    PSK=$2
-
-    mkdir -p "/var/lib/connman" || return 1
-    cat > "/var/lib/connman/batocera_wifi.config" <<EOF
-[global]
-Name=batocera
-
-[service_batocera_default]
-Type=wifi
-Name=${SSID}
-EOF
-    if test "${PSK}" != ""
-    then
-	echo "Passphrase=${PSK}" >> "/var/lib/connman/batocera_wifi.config"
-    fi
-
-    connmanctl disable wifi
-    sleep 1
-
-    N=0
-    connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    while test $? -ne 0 -a $N -lt 5 # 5 tries
-    do
-        N=$((N+1))
-        sleep 1
-        connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    done
-
-    connmanctl enable wifi || return 1
-    connmanctl scan   wifi || return 1
-    return 0
-}
-
-do_disable() {
-    N=0
-    connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    while test $? -ne 0 -a $N -lt 5 # 5 tries
-    do
-        N=$((N+1))
-        sleep 1
-        connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    done
-    connmanctl disable wifi
-}
-
-do_start() {
-    settingsWlan="$(/usr/bin/batocera-settings-get wifi.enabled)"
-    if [ "$settingsWlan" != "1" ];then
-        return 0
-    fi
-
-    N=0
-    connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    while test $? -ne 0 -a $N -lt 5 # 5 tries
-    do
-        N=$((N+1))
-        sleep 1
-        connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-    done
-
-    connmanctl enable wifi || return 1
-    connmanctl scan   wifi || return 1
-}
-
 
 if [ $# -eq 0 ]; then
 	do_help
@@ -97,15 +31,30 @@ case "${ACTION}" in
 	do_scanlist
 	;;
     "start")
-	do_start
+	/etc/init.d/S08connman restart
 	;;
     "enable")
-	SSID=$1
-	PSK=$2
-	do_enable "${SSID}" "${PSK}" || exit 1
+	batocera-settings-set wifi.enabled 1
+	if [ "$#" -eq 2 ]; then
+		batocera-settings-set wifi.ssid "$1"
+		batocera-settings-set wifi.key "$2"
+	fi
+	/etc/init.d/S08connman reload
+
+	# wait up to 5 sec for an IP address
+	N=0
+	ifconfig | grep "inet addr" | grep -qv "127\.0\.0\.1"
+	while test $? -ne 0 -a $N -lt 10 # 10 tries
+	do
+		N=$((N+1))
+		sleep 0.5
+		ifconfig | grep "inet addr" | grep -qv "127\.0\.0\.1"
+	done
+
 	;;
     "disable")
-	do_disable || exit 1
+	batocera-settings-set wifi.enabled 0
+	/etc/init.d/S08connman reload
 	;;
 	*)
 		do_help


### PR DESCRIPTION
Odroid Go Advance still has wifi enable/disable issue.
1. Sometimes wifi is still connected when wifi disabled and device rebooted.
2. Enabling and disabling wifi is not stable on Odroid Go Advance. Sometimes wifi actually works when disabled and not work when enabled.

This PR should always fix 1. issue and mostly fix 2. issue.