### PR TITLE
Add MAME VSync

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -18,6 +18,7 @@
         * bump: amiberry to v5.2
         * change: enabled more flycast standalone options (DSP & anisotropic)
         * change: enabled more duckstation options (PGXP & OSD)
+        * change: enabled VSync option for standalone MAME
         * fix: lr-swanstation not working on some SBC's with OpenGLES
 
 2022/05/24 - batocera.linux 34 - blue morpho

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -193,6 +193,14 @@ class MameGenerator(Generator):
             commandArray += [ "-nochangeres" ]
             commandArray += [ "-noswitchres" ]
 
+        # Refresh rate options to help with screen tearing
+        # syncrefresh is unlisted, it requires specific display timings and 99.9% of users will get unplayable games.
+        # Leaving it so it can be set manually, for CRT or other arcade-specific display users.
+        if system.isOptSet("vsync") and system.getOptBoolean("vsync"):
+            commandArray += [ "-waitvsync" ]
+        if system.isOptSet("syncrefresh") and system.getOptBoolean("syncrefresh"):
+            commandArray += [ "-syncrefresh" ]
+
         # Rotation / TATE options
         if system.isOptSet("rotation") and system.config["rotation"] == "autoror":
             commandArray += [ "-autoror" ]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6882,6 +6882,12 @@ mame:
                 "BGFX":            bgfx
                 "Accel":           accel
                 "OpenGL":          opengl
+        vsync:
+            prompt:      VSYNC
+            description: Fix screen tearing, but may drop frames.
+            choices:
+                "Off (Default)": 0
+                "On":            1
         bgfxbackend:
             archs_include: [x86, x86_64, rpi4, rk3326]
             prompt:      BGFX GRAPHICS API


### PR DESCRIPTION
* Adds a VSync option to standalone MAME. Due to the way MAME works, this may result in dropped frames, but fixes screen tearing.
* There is a second option, "synctorefresh," that runs the game at the screen's exact refresh rate. This is designed for screens with custom or arcade-specific refresh rates. It is currently not listed in the options as in most cases turning it on will result in the game running at nearly unthrottled speeds and being unplayable. I did leave the code in place to enable it if added to batocera.conf manually (mame.syncrefresh=1) for the edge cases where it may be useful, like CRT users. We don't have an easy way to enable this otherwise.

I can re-enable that option in es_settings.yml, but it would very likely result in support requests when it doesn't behave as expected. Documenting the "hidden" option for advanced users on the Wiki seems safer. It could also be removed, but would be trickier to enable if needed.