### PR TITLE
grammar correct light gun label

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -183,9 +183,9 @@ shared:
         "On": 1
         "Off": 0
     use_guns:
-      group: LIGHTGUN
-      prompt: Use guns
-      description: Use guns instead of pads if guns are detected on the system
+      group: LIGHT GUN
+      prompt: USE LIGHT GUNS
+      description: Use light guns instead of pads if light guns are connected.
       choices:
         "On":  1
         "Off": 0


### PR DESCRIPTION
"lightgun" is a product by Sinden, "light gun" is the generic term.
Also adjusted description to be less Engrish.
(why does this option even exist? shouldn't it be automatic?)