### PR TITLE
change default no sprite limit to disabled in genesisplusgx

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1743,7 +1743,7 @@ def generateCoreSettings(coreSettings, system, rom, guns):
         if system.isOptSet('gpgx_no_sprite_limit'):
             coreSettings.save('genesis_plus_gx_no_sprite_limit', system.config['gpgx_no_sprite_limit'])
         else:
-            coreSettings.save('genesis_plus_gx_no_sprite_limit', '"enabled"')
+            coreSettings.save('genesis_plus_gx_no_sprite_limit', '"disabled"')
         # Blargg NTSC filter
         if system.isOptSet('gpgx_blargg_filter_md') and system.name == 'megadrive':
             coreSettings.save('genesis_plus_gx_blargg_ntsc_filter', system.config['gpgx_blargg_filter_md'])


### PR DESCRIPTION
The default setting for this core is not to have this setting enabled.

Having this setting enabled by default causes visual glitches in certain games. Most notably, Sonic the Hedgehog's title screen and underwater sections.

Glitched title screen (when this setting is enabled):
![q0TeJWk](https://user-images.githubusercontent.com/67527064/172615256-d94f7db6-8efa-4a2e-afe0-434515e82b24.png)

How it's meant to look (when this setting is disabled):
![sonic-title-screen-550x385](https://user-images.githubusercontent.com/67527064/172615294-90e68424-e63f-4e41-996f-93a63db3a475.png)