### PR TITLE
Fix lr-mame custom config

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -408,8 +408,8 @@ def generateMAMEPadConfig(cfgPath, playersControllers, system, messSysName, romB
         except:
             pass # reinit the file
 
-    if system.isOptSet('customCfg'):
-        customCfg = system.getOptBoolean('customCfg')
+    if system.isOptSet('customcfg'):
+        customCfg = system.getOptBoolean('customcfg')
     else:
         customCfg = False
     # Don't overwrite if using custom configs


### PR DESCRIPTION
There was a typo loading the custom config setting, causing it to be overwritten on launch. This fixes it.