### PR TITLE
Add Squash on Ports

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -2,12 +2,20 @@
 
 from generators.Generator import Generator
 import Command
+import glob
 
 class ShGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, guns, gameResolution):
 
-        commandArray = ["/bin/sh", rom]
+        # in case of squashfs, the root directory is passed
+        shInDir = glob.glob(rom + "/run.sh")
+        if len(shInDir) == 1:
+            shrom = shInDir[0]
+        else:
+            shrom = rom
+
+        commandArray = ["/bin/bash", shrom]
         return Command.Command(array=commandArray)
 
     def getMouseMode(self, config):

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1845,7 +1845,7 @@ ports:
   manufacturer: Ports
   release:
   hardware: port
-  extensions: [sh]
+  extensions: [sh, squashfs]
   group: ports
   path:       /userdata/roms/ports
   emulators:


### PR DESCRIPTION
No use sh is linked to dash
Use bash for improve compatibility
Add Squashfs
Use run.sh for squashfs in some because you can have several "sh" files in the same game folder.
This allows you to launch the desired sh.

Have adding information in wiki : https://wiki.batocera.org/disk_image_compression#squashfs