### PR TITLE
add default res of 720p to rpizero2 as well

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpizero2.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpizero2.yml
@@ -2,6 +2,7 @@ default:
   options:
     hud_support: false
     video_threaded: true
+    videomode: max-1280x720
     ratio: "4/3"
     smooth:         false
     audio_latency:  96


### PR DESCRIPTION
Fixes the slowdown issue reported by Vininess on the forum: https://forum.batocera.org/d/7679-raspberry-pi-zero-2w-ui-low-frame-lag

Considering the RPi Zero 2 is even weaker than the Rpi 3 which itself has 720p as its max default resolution, this seems like a no-brainer.

I am curious as to why the ratio is set to 4/3, and the "smooth" is set to off. Seems odd. No comment explaining?