### PR TITLE
Add missing Apple II MESS BIOS Files to Script

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -554,7 +554,13 @@ systems = {
                                                 { "md5": "4431aea380185e3f509285540d7cb418", "zippedFile": "342-0132-c.e12", "file": "bios/apple2e.zip"},
                                                 { "md5": "e6d453d8738e6df4f73df8c8051df3e8", "zippedFile": "342-0133-a.chr", "file": "bios/apple2e.zip"},
                                                 { "md5": "72924019cf1719765e4fde35e59c1c7d", "zippedFile": "342-0134-a.64", "file": "bios/apple2e.zip"},
-                                                { "md5": "0b150f4bfa090770a866cc5d214703f4", "zippedFile": "342-0135-b.64", "file": "bios/apple2e.zip"} ] },
+                                                { "md5": "0b150f4bfa090770a866cc5d214703f4", "zippedFile": "342-0135-b.64", "file": "bios/apple2e.zip"},
+                                                { "md5": "", "file": "bios/a2diskiing.zip" },
+                                                { "md5": "2020aa1413ff77fe29353f3ee72dc295", "zippedFile": "341-0027-a.p5", "file": "bios/a2diskiing.zip"},
+                                                { "md5": "", "file": "bios/votrax.zip" },
+                                                { "md5": "95b91e4a2fe7d6f13d353ba1827d37f9", "zippedFile": "sc01a.bin", "file": "bios/votrax.zip"},
+                                                { "md5": "", "file": "bios/d2fdc.zip" },
+                                                { "md5": "5f1be0c1cdff26f5956eef9643911886", "zippedFile": "341-0028-a.rom", "file": "bios/d2fdc.zip"} ] },
 
     # ---------- Apple IIgs ---------- #
     "apple2gs":   { "name": "Apple IIgs", "biosFiles":  [ { "md5": "", "file": "bios/apple2gs.zip"  },


### PR DESCRIPTION
Missing a couple of files - 2 prevent Apple II from launching in MESS, the 3rd (votrax.zip) is listed as required but doesn't throw an error if missing.