### PR TITLE
OD commander patch a/b controls

### DIFF
--- a/package/batocera/utils/od-commander/001-swap-ab-controls.patch
+++ b/package/batocera/utils/od-commander/001-swap-ab-controls.patch
@@ -1,0 +1,28 @@
+diff --git a/controller_buttons.cpp b/controller_buttons.cpp
+index f10c7c9..8fa0286 100644
+--- a/controller_buttons.cpp
++++ b/controller_buttons.cpp
+@@ -36,8 +36,8 @@ ControllerButton ControllerButtonFromSdlEvent(const SDL_Event &event)
+         case SDL_CONTROLLERBUTTONDOWN:
+         case SDL_CONTROLLERBUTTONUP:
+             switch (event.cbutton.button) {
+-                case SDL_CONTROLLER_BUTTON_A: return ControllerButton::A;
+-                case SDL_CONTROLLER_BUTTON_B: return ControllerButton::B;
++                case SDL_CONTROLLER_BUTTON_A: return ControllerButton::B;
++                case SDL_CONTROLLER_BUTTON_B: return ControllerButton::A;
+                 case SDL_CONTROLLER_BUTTON_X: return ControllerButton::X;
+                 case SDL_CONTROLLER_BUTTON_Y: return ControllerButton::Y;
+                 case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+@@ -84,10 +84,10 @@ bool IsControllerButtonDown(
+                 controller, SDL_CONTROLLER_BUTTON_DPAD_RIGHT);
+         case ControllerButton::A:
+             return SDL_GameControllerGetButton(
+-                controller, SDL_CONTROLLER_BUTTON_A);
++                controller, SDL_CONTROLLER_BUTTON_B);
+         case ControllerButton::B:
+             return SDL_GameControllerGetButton(
+-                controller, SDL_CONTROLLER_BUTTON_B);
++                controller, SDL_CONTROLLER_BUTTON_A);
+         case ControllerButton::X:
+             return SDL_GameControllerGetButton(
+                 controller, SDL_CONTROLLER_BUTTON_X);


### PR DESCRIPTION
OD commander has A and B switched by default, this patch makes it so it uses the same layout as the rest of Batocera does.