### PR TITLE
Condense MAME/LR-MAME

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -27,8 +27,9 @@ def generateMAMEConfigs(playersControllers, system, rom):
     else:
         corePath = system.config['core']
 
-    if system.config['core'] == 'mame':
-        # Set up command line for MAME
+    if system.name in [ 'mame', 'neogeo', 'lcdgames', 'plugnplay' ]:
+        # Set up command line for basic systems
+        # ie. no media, softlists, etc.
         if system.getOptBoolean("customcfg"):
             cfgPath = "/userdata/system/configs/{}/custom/".format(corePath)
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -57,25 +57,16 @@ class MameGenerator(Generator):
                 messRomType.append(row[2])
                 messAutoRun.append(row[3])
         
-        # Identify the current system, select MAME or MESS as needed.
+        # Identify the current system
         try:
             messMode = messSystems.index(system.name)
         except ValueError:
             messMode = -1
-        if messMode == -1:
-            commandArray =  [ "/usr/bin/mame/mame" ]
-        elif system.name == "vgmplay":
-            commandArray =  [ "/usr/bin/mame/vgmplay" ]
-            if system.isOptSet("softList") and system.config["softList"] != "none":
-                softList = system.config["softList"]
-            else:
-                softList = ""
+
+        if system.isOptSet("softList") and system.config["softList"] != "none":
+            softList = system.config["softList"]
         else:
-            commandArray =  [ "/usr/bin/mame/mess" ]
-            if system.isOptSet("softList") and system.config["softList"] != "none":
-                softList = system.config["softList"]
-            else:
-                softList = ""
+            softList = ""
 
         # Auto softlist for FM Towns if there is a zip that matches the folder name
         # Used for games that require a CD and floppy to both be inserted
@@ -84,6 +75,7 @@ class MameGenerator(Generator):
             if os.path.exists('/userdata/roms/fmtowns/{}.zip'.format(romParentPath)):
                 softList = 'fmtowns_cd'
 
+        commandArray =  [ "/usr/bin/mame/mame" ]
         # MAME options used here are explained as it's not always straightforward
         # A lot more options can be configured, just run mame -showusage and have a look
         commandArray += [ "-skip_gameinfo" ]

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-odroidxu4.yml
@@ -19,7 +19,7 @@ psx:
     retroarch.video_hard_sync: 1
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame
 n64:
   options:
     # hud breaking mupen64

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rg552.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rg552.yml
@@ -1,6 +1,6 @@
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame
 psp:
   options:
     # make crash ppsspp

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3288.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3288.yml
@@ -12,4 +12,4 @@ dos:
   core:     dosbox
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rk3399.yml
@@ -1,3 +1,3 @@
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi3.yml
@@ -23,7 +23,7 @@ flash:
   core:     lightspark
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame
 psx:
   options:
     gfxbackend: vulkan

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -10,7 +10,7 @@ flash:
   core:     lightspark
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame
 psx:
   options:
     gfxbackend: vulkan

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-s922x.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-s922x.yml
@@ -9,7 +9,7 @@ wii:
   core:     dolphin
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame
 psx:
   options:
     hud_support: false # duckstation doesn't like it on n2+

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-tritium-h5.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-tritium-h5.yml
@@ -42,4 +42,4 @@ dos:
   core:     dosbox
 fmtowns:
   emulator: libretro
-  core:     mess
+  core:     mame

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -25,10 +25,10 @@ abuse:
   core:     abuse
 adam:
   emulator: libretro
-  core:     mess
+  core:     mame
 advision:
   emulator: libretro
-  core:     mess
+  core:     mame
 amiga500:
   emulator: libretro
   core:     puae
@@ -46,7 +46,7 @@ amstradcpc:
   core:     cap32
 apfm1000:
   emulator: libretro
-  core:     mess
+  core:     mame
 apple2:
   emulator: gsplus
   core:     gsplus
@@ -55,13 +55,13 @@ apple2gs:
   core:     gsplus
 arcadia:
   emulator: libretro
-  core:     mess
+  core:     mame
 archimedes:
   emulator: libretro
-  core:     mess
+  core:     mame
 astrocde:
   emulator: libretro
-  core:     mess
+  core:     mame
 atari2600:
   emulator: libretro
   core:     stella
@@ -79,13 +79,13 @@ atarist:
   core:     hatari
 atom:
   emulator: libretro
-  core:     mess
+  core:     mame
 atomiswave:
   emulator: libretro
   core:     flycast
 bbc:
   emulator: libretro
-  core:     mess
+  core:     mame
 c64:
   emulator: libretro
   core:     vice_x64
@@ -100,7 +100,7 @@ c20:
   core:     xvic
 camplynx:
   emulator: libretro
-  core:     mess
+  core:     mame
 cannonball:
   emulator: cannonball
   core:     cannonball
@@ -124,13 +124,13 @@ channelf:
   core:     freechaf
 coco:
   emulator: libretro
-  core:     mess
+  core:     mame
 colecovision:
   emulator: libretro
   core:     bluemsx
 crvision:
   emulator: libretro
-  core:     mess
+  core:     mame
 
 # D-L
 
@@ -156,7 +156,7 @@ ecwolf:
   core:     ecwolf
 electron:
   emulator: libretro
-  core:     mess
+  core:     mame
 fbneo:
   emulator: libretro
   core:     fbneo
@@ -177,7 +177,7 @@ flatpak:
     hud_support: false
 fm7:
   emulator: libretro
-  core:     mess
+  core:     mame
 fmtowns:
   emulator: tsugaru
   core:     tsugaru
@@ -186,7 +186,7 @@ gaelco:
   core:     demul
 gamate:
   emulator: libretro
-  core:     mess
+  core:     mame
 gameandwatch:
   emulator: libretro
   core:     gw
@@ -194,7 +194,7 @@ gameandwatch:
     forceNoBezel: true
 gamecom:
   emulator: libretro
-  core:     mess
+  core:     mame
 gamecube:
   emulator: dolphin
   core:     dolphin
@@ -203,7 +203,7 @@ gamegear:
   core:     genesisplusgx
 gamepock:
   emulator: libretro
-  core:     mess
+  core:     mame
 gb:
   emulator: libretro
   core:     gambatte
@@ -221,13 +221,13 @@ gbc2players:
   core:     tgbdual
 gmaster:
   emulator: libretro
-  core:     mess
+  core:     mame
 gong:
   emulator: libretro
   core:     gong
 gp32:
   emulator: libretro
-  core:     mess
+  core:     mame
 gx4000:
   emulator: libretro
   core:     cap32
@@ -275,7 +275,7 @@ megadrive:
   core:     genesisplusgx
 megaduck:
   emulator: libretro
-  core:     mess
+  core:     mame
 model2:
   emulator: model2emu
   core:     model2emu
@@ -376,7 +376,7 @@ pcfx:
   core:     pcfx
 pdp1:
   emulator: libretro
-  core:     mess
+  core:     mame
 pet:
   emulator: vice
   core:     xpet
@@ -385,7 +385,7 @@ pico8:
   core:     retro8
 plugnplay:
   emulator: libretro
-  core:     mess
+  core:     mame
 pokemini:
   emulator: libretro
   core:     pokemini
@@ -413,7 +413,7 @@ psx:
   core:     pcsx_rearmed
 pv1000:
   emulator: libretro
-  core:     mess
+  core:     mame
 pygame:
   emulator: pygame
   core:     pygame
@@ -454,7 +454,7 @@ sgb:
   core:     mgba
 socrates:
   emulator: libretro
-  core:     mess
+  core:     mame
 solarus:
   emulator: solarus
   core:     solarus
@@ -472,7 +472,7 @@ sufami:
   core:     snes9x
 supracan:
   emulator: libretro
-  core:     mess
+  core:     mame
 snes:
   emulator: libretro
   core:     snes9x
@@ -499,7 +499,7 @@ thomson:
   core:     theodore
 ti99:
   emulator: libretro
-  core:     mess
+  core:     mame
 tic80:
   emulator: libretro
   core:     tic80
@@ -508,7 +508,7 @@ triforce:
   core:     dolphin_triforce
 tutor:
   emulator: libretro
-  core:     mess
+  core:     mame
 tyrquake:
   emulator: libretro
   core:     tyrquake
@@ -517,13 +517,13 @@ uzebox:
   core:     uzem
 vc4000:
   emulator: libretro
-  core:     mess
+  core:     mame
 vectrex:
   emulator: libretro
   core:     vecx
 vgmplay:
   emulator: libretro
-  core:     mamevirtual
+  core:     mame
 videopacplus:
   emulator: libretro
   core:     o2em
@@ -535,7 +535,7 @@ vitaquake2:
   core:     vitaquake2
 vsmile:
   emulator: libretro
-  core:     mess
+  core:     mame
 wii:
   emulator: dolphin
   core:     dolphin
@@ -574,7 +574,7 @@ xash3d_fwgs:
     hud_support: false
 xegs:
   emulator: libretro
-  core:     mess
+  core:     mame
 xrick:
   emulator: libretro
   core:     xrick

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1668,6 +1668,68 @@ libretro:
       features: [cheevos]
       shared: [autosave]
     #lutro:
+    same_cdi:
+      features: [netplay]
+      shared: [autosave]
+      cfeatures:
+            mame_cpu_overclock:
+                group: ADVANCED OPTIONS
+                prompt:      OVERCLOCK (UNSTABLE)
+                description: Enhancement. Reduces system slowdown. Causes issues in some games.
+                choices:
+                    "default":        default
+                    "30":             30
+                    "35":             35
+                    "40":             40
+                    "45":             45
+                    "50":             50
+                    "55":             55
+                    "60":             60
+                    "65":             65
+                    "70":             70
+                    "75":             75
+                    "80":             80
+                    "85":             85
+                    "90":             90
+                    "95":             95
+                    "100":            100
+                    "105":            105
+                    "110":            110
+                    "115":            115
+                    "120":            120
+                    "125":            125
+                    "130":            130
+                    "135":            135
+                    "140":            140
+                    "145":            145
+                    "150":            150
+            mame_altres:
+                prompt:      RENDERING RESOLUTION
+                description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
+                choices:
+                    "640x480":        640x480
+                    "800x600":        800x600
+                    "960x720":        960x720
+                    "1024x768":       1024x768
+                    "1280x720":       1280x720
+                    "1600x800":       1600x800
+                    "1920x1080":      1920x1080
+                    "2560x1440":      2560x1440
+                    "3840x2160":      3840x2160
+            customcfg:
+                group: ADVANCED OPTIONS
+                prompt:      CUSTOM CONFIG
+                description: Use a custom MAME config, do not overwrite config on launch.
+                choices:
+                    "On":            1
+                    "Off (Default)": 0
+            customcfg:
+                group: ADVANCED OPTIONS
+                prompt:      CUSTOM MAME CONFIG
+                description: Set system-wide controls via MAME menu
+                choices:
+                    "On":  1
+                    "Off": 0
     mame:
       features: [netplay]
       shared: [autosave]
@@ -1742,144 +1804,6 @@ libretro:
                 choices:
                     "Enabled":            1
                     "Disabled (Default)": 0
-            sharemameart:
-                group: ADVANCED OPTIONS
-                prompt:      SHARE MAME ARTWORK
-                description: Use the same art paths as standalone MAME - not recommended if using decorations or shaders.
-                choices:
-                    "On (Default)": 1
-                    "Off":          0
-            artworkcrop:
-                group: ADVANCED OPTIONS
-                prompt:      CROP ARTWORK
-                description: Crop MAME artwork to maximize the game screen and only fill unused space.
-                choices:
-                    "On (Default)": 1
-                    "Off":          0
-            customcfg:
-                group: ADVANCED OPTIONS
-                prompt:      CUSTOM CONFIG
-                description: Use a custom MAME config, do not overwrite config on launch.
-                choices:
-                    "On":            1
-                    "Off (Default)": 0
-            customcfg:
-                group: ADVANCED OPTIONS
-                prompt:      CUSTOM MAME CONFIG
-                description: Set system-wide controls via MAME menu
-                choices:
-                    "On":  1
-                    "Off": 0
-    same_cdi:
-      features: [netplay]
-      shared: [autosave]
-      cfeatures:
-            mame_cpu_overclock:
-                group: ADVANCED OPTIONS
-                prompt:      OVERCLOCK (UNSTABLE)
-                description: Enhancement. Reduces system slowdown. Causes issues in some games.
-                choices:
-                    "default":        default
-                    "30":             30
-                    "35":             35
-                    "40":             40
-                    "45":             45
-                    "50":             50
-                    "55":             55
-                    "60":             60
-                    "65":             65
-                    "70":             70
-                    "75":             75
-                    "80":             80
-                    "85":             85
-                    "90":             90
-                    "95":             95
-                    "100":            100
-                    "105":            105
-                    "110":            110
-                    "115":            115
-                    "120":            120
-                    "125":            125
-                    "130":            130
-                    "135":            135
-                    "140":            140
-                    "145":            145
-                    "150":            150
-            mame_altres:
-                prompt:      RENDERING RESOLUTION
-                description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
-                choices:
-                    "640x480":        640x480
-                    "800x600":        800x600
-                    "960x720":        960x720
-                    "1024x768":       1024x768
-                    "1280x720":       1280x720
-                    "1600x800":       1600x800
-                    "1920x1080":      1920x1080
-                    "2560x1440":      2560x1440
-                    "3840x2160":      3840x2160
-            customcfg:
-                group: ADVANCED OPTIONS
-                prompt:      CUSTOM CONFIG
-                description: Use a custom MAME config, do not overwrite config on launch.
-                choices:
-                    "On":            1
-                    "Off (Default)": 0
-            customcfg:
-                group: ADVANCED OPTIONS
-                prompt:      CUSTOM MAME CONFIG
-                description: Set system-wide controls via MAME menu
-                choices:
-                    "On":  1
-                    "Off": 0
-    mess:
-      features: [netplay, padtokeyboard]
-      shared: [autosave]
-      cfeatures:
-            mame_cpu_overclock:
-                group: ADVANCED OPTIONS
-                prompt:      OVERCLOCK (UNSTABLE)
-                description: Enhancement. Reduces system slowdown. Causes issues in some games.
-                choices:
-                    "default":        default
-                    "30":             30
-                    "35":             35
-                    "40":             40
-                    "45":             45
-                    "50":             50
-                    "55":             55
-                    "60":             60
-                    "65":             65
-                    "70":             70
-                    "75":             75
-                    "80":             80
-                    "85":             85
-                    "90":             90
-                    "95":             95
-                    "100":            100
-                    "105":            105
-                    "110":            110
-                    "115":            115
-                    "120":            120
-                    "125":            125
-                    "130":            130
-                    "135":            135
-                    "140":            140
-                    "145":            145
-                    "150":            150
-            mame_altres:
-                prompt:      RENDERING RESOLUTION
-                description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
-                choices:
-                    "640x480":        640x480
-                    "800x600":        800x600
-                    "960x720":        960x720
-                    "1024x768":       1024x768
-                    "1280x720":       1280x720
-                    "1600x800":       1600x800
-                    "1920x1080":      1920x1080
-                    "2560x1440":      2560x1440
-                    "3840x2160":      3840x2160
             sharemameart:
                 group: ADVANCED OPTIONS
                 prompt:      SHARE MAME ARTWORK

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -375,7 +375,7 @@ lcdgames:
   emulators:
     libretro:
       gw:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GW]                                   }
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME], incompatible_extensions: [mgw]          }
 
@@ -389,7 +389,7 @@ gameandwatch:
   emulators:
     libretro:
       gw:   { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GW]                                   }
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME], incompatible_extensions: [mgw]          }
 
@@ -888,7 +888,7 @@ xegs:
   group:      atari8bit
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -1542,7 +1542,7 @@ apple2:
   extensions: [nib, do, po, dsk, mfi, dfi, rti, edd, woz, wav, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
     gsplus:
@@ -1847,7 +1847,7 @@ fmtowns:
   platform:   fmtowns
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME], incompatible_extensions: [xdf, m3u] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME], incompatible_extensions: [xdf, m3u] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME], incompatible_extensions: [xdf, m3u] }
     tsugaru:
@@ -2344,7 +2344,7 @@ apple2gs:
   extensions: [2mg, do, nib, po, dsk, mfi, dfi, rti, edd, woz, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqui, ima, img, ufi, 360, ipf, dc42, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
     gsplus:
@@ -2382,7 +2382,7 @@ advision:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2396,7 +2396,7 @@ plugnplay:
   extensions: [zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
 
@@ -2408,7 +2408,7 @@ megaduck:
   extensions:  [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
       sameduck:  { requireAnyOf: [BR2_PACKAGE_LIBRETRO_SAMEDUCK], incompatible_extensions: [zip, 7z] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
@@ -2423,7 +2423,7 @@ pv1000:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
 
@@ -2435,7 +2435,7 @@ gamate:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2450,7 +2450,7 @@ crvision:
   extensions: [bin, rom, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2464,7 +2464,7 @@ socrates:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2479,7 +2479,7 @@ vsmile:
   extensions: [u1, u3, bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2493,7 +2493,7 @@ supracan:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2507,7 +2507,7 @@ gamecom:
   extensions: [bin, tgc, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2521,7 +2521,7 @@ gamepock:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2535,7 +2535,7 @@ fm7:
   extensions: [wav, t77, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2549,7 +2549,7 @@ archimedes:
   extensions: [mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, ima, img, ufi, 360, ipf, adf, apd, jfd, ads, adm, adl, ssd, bbc, dsd, st, msa, chd, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2565,7 +2565,7 @@ atom:
   extensions: [wav, tap, csw, uef, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, 40t, atm, bin, rom, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2581,7 +2581,7 @@ electron:
   extensions: [wav, csw, uef, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, ssd, bbc, img, dsd, adf, ads, adm, adl, rom, bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2597,7 +2597,7 @@ apfm1000:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2612,7 +2612,7 @@ bbc:
   extensions: [mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, ima, img, ufi, 360, ipf, ssd, bbc, dsd, adf, ads, adm, adl, fsd, wav, tap, bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2627,7 +2627,7 @@ camplynx:
   extensions: [wav, tap, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2642,7 +2642,7 @@ adam:
   extensions: [wav, ddp, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, rom, col, bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2657,7 +2657,7 @@ arcadia:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
 
@@ -2669,7 +2669,7 @@ gmaster:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2684,7 +2684,7 @@ astrocde:
   extensions: [bin, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2698,7 +2698,7 @@ ti99:
   extensions: [rpk, wav, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2713,7 +2713,7 @@ tutor:
   extensions: [bin, wav, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2728,7 +2728,7 @@ coco:
   extensions: [wav, cas, ccc, rom, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2742,7 +2742,7 @@ vc4000:
   extensions: [bin, rom, pgm, tvc, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
 
@@ -2754,7 +2754,7 @@ vgmplay:
   extensions: [vgm, vgz, zip, 7z]
   emulators:
     libretro:
-      mamevirtual: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -2938,7 +2938,7 @@ macintosh:
   emulators:
     libretro:
       minivmac: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MINIVMAC], incompatible_extensions: [7z, mfi, dfi, hfe, mfm, td0, imd, d77, d88, 1dd, cqm, cqi, dsk, ima, img, ufi, ipf, dc42, woz, 2mg, 360, chd, cue, toc, nrg, gdi, iso, cdr, hd, hdv, 2mg, hdi] }
-      mess:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -3190,7 +3190,7 @@ pdp1:
   extensions: [zip, 7z, tap, rim, drm]
   emulators:
     libretro:
-      mess:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame:     { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
@@ -3240,7 +3240,7 @@ gp32:
   extensions: [smc, zip, 7z]
   emulators:
     libretro:
-      mess: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |

--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -63,7 +63,7 @@ define MAME_BUILD_CMDS
 	cd $(@D); \
 	PATH="$(HOST_DIR)/bin:$$PATH" \
 	$(MAKE) TARGETOS=linux OSD=sdl genie \
-	TARGET=mame SUBTARGET=tiny \
+	TARGET=mame SUBTARGET=tiny\
 	NO_USE_PORTAUDIO=1 NO_X11=1 USE_SDL=0 \
 	USE_QTDEBUG=0 DEBUG=0 IGNORE_GIT=1 MPARAM=""
 
@@ -77,77 +77,7 @@ define MAME_BUILD_CMDS
 	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig" \
 	$(MAKE) -j$(MAME_JOBS) TARGETOS=linux OSD=sdl \
 	TARGET=mame \
-	SUBTARGET=arcade \
-	OVERRIDE_CC="$(TARGET_CC)" \
-	OVERRIDE_CXX="$(TARGET_CXX)" \
-	OVERRIDE_LD="$(TARGET_LD)" \
-	OVERRIDE_AR="$(TARGET_AR)" \
-	OVERRIDE_STRIP="$(TARGET_STRIP)" \
-	CROSS_BUILD=1 \
-	CROSS_ARCH="$(MAME_CROSS_ARCH)" \
-	$(MAME_CROSS_OPTS) \
-	NO_USE_PORTAUDIO=1 \
-	USE_SYSTEM_LIB_ZLIB=1 \
-	USE_SYSTEM_LIB_JPEG=1 \
-	USE_SYSTEM_LIB_FLAC=1 \
-	USE_SYSTEM_LIB_SQLITE3=1 \
-	USE_SYSTEM_LIB_RAPIDJSON=1 \
-	USE_SYSTEM_LIB_EXPAT=1 \
-	USE_SYSTEM_LIB_GLM=1 \
-	OPENMP=1 \
-	SDL_INSTALL_ROOT="$(STAGING_DIR)/usr" USE_LIBSDL=1 \
-	USE_QTDEBUG=0 DEBUG=0 IGNORE_GIT=1 \
-	REGENIE=1 \
-	LDOPTS="-lasound -lfontconfig" \
-	SYMBOLS=0 \
-	STRIP_SYMBOLS=1 \
-	TOOLS=1
-
-	# Compile emulation target (MESS)
-	cd $(@D); \
-	PATH="$(HOST_DIR)/bin:$$PATH" \
-	SYSROOT="$(STAGING_DIR)" \
-	CFLAGS="--sysroot=$(STAGING_DIR) $(MAME_CFLAGS) -fpch-preprocess"   \
-	PKG_CONFIG="$(HOST_DIR)/usr/bin/pkg-config --define-prefix" \
-	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig" \
-	$(MAKE) -j$(MAME_JOBS) TARGETOS=linux OSD=sdl \
-	TARGET=mame \
-	SUBTARGET=mess \
-	OVERRIDE_CC="$(TARGET_CC)" \
-	OVERRIDE_CXX="$(TARGET_CXX)" \
-	OVERRIDE_LD="$(TARGET_LD)" \
-	OVERRIDE_AR="$(TARGET_AR)" \
-	OVERRIDE_STRIP="$(TARGET_STRIP)" \
-	CROSS_BUILD=1 \
-	CROSS_ARCH="$(MAME_CROSS_ARCH)" \
-	$(MAME_CROSS_OPTS) \
-	NO_USE_PORTAUDIO=1 \
-	USE_SYSTEM_LIB_ZLIB=1 \
-	USE_SYSTEM_LIB_JPEG=1 \
-	USE_SYSTEM_LIB_FLAC=1 \
-	USE_SYSTEM_LIB_SQLITE3=1 \
-	USE_SYSTEM_LIB_RAPIDJSON=1 \
-	USE_SYSTEM_LIB_EXPAT=1 \
-	USE_SYSTEM_LIB_GLM=1 \
-	OPENMP=1 \
-	SDL_INSTALL_ROOT="$(STAGING_DIR)/usr" USE_LIBSDL=1 \
-	USE_QTDEBUG=0 DEBUG=0 IGNORE_GIT=1 \
-	REGENIE=1 \
-	LDOPTS="-lasound -lfontconfig" \
-	SYMBOLS=0 \
-	STRIP_SYMBOLS=1 \
-	TOOLS=1
-
-	# Compile emulation target (Virtual Devices)
-	cd $(@D); \
-	PATH="$(HOST_DIR)/bin:$$PATH" \
-	SYSROOT="$(STAGING_DIR)" \
-	CFLAGS="--sysroot=$(STAGING_DIR) $(MAME_CFLAGS) -fpch-preprocess"   \
-	PKG_CONFIG="$(HOST_DIR)/usr/bin/pkg-config --define-prefix" \
-	PKG_CONFIG_PATH="$(STAGING_DIR)/usr/lib/pkgconfig" \
-	$(MAKE) -j$(MAME_JOBS) TARGETOS=linux OSD=sdl \
-	TARGET=mame \
-	SUBTARGET=virtual \
+	SUBTARGET=mame \
 	OVERRIDE_CC="$(TARGET_CC)" \
 	OVERRIDE_CXX="$(TARGET_CXX)" \
 	OVERRIDE_LD="$(TARGET_LD)" \
@@ -188,9 +118,7 @@ define MAME_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin/mame/roms
 
 	# Install binaries and default distro
-	$(INSTALL) -D $(@D)/mamearcade	$(TARGET_DIR)/usr/bin/mame/mame
-	$(INSTALL) -D $(@D)/mess		$(TARGET_DIR)/usr/bin/mame/mess
-	$(INSTALL) -D $(@D)/mamevirtual	$(TARGET_DIR)/usr/bin/mame/vgmplay
+	$(INSTALL) -D $(@D)/mame	$(TARGET_DIR)/usr/bin/mame/mame
 	cp $(@D)/COPYING			$(TARGET_DIR)/usr/bin/mame/
 	cp $(@D)/README.md			$(TARGET_DIR)/usr/bin/mame/
 	cp $(@D)/uismall.bdf		$(TARGET_DIR)/usr/bin/mame/

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -38,31 +38,13 @@ define LIBRETRO_MAME_BUILD_CMDS
 		CONFIG=libretro LIBRETRO_OS="unix" ARCH="" PROJECT="" ARCHOPTS="$(LIBRETRO_MAME_ARCHOPTS)" \
 		DISTRO="debian-stable" OVERRIDE_CC="$(TARGET_CC)" OVERRIDE_CXX="$(TARGET_CXX)"             \
 		OVERRIDE_LD="$(TARGET_LD)" RANLIB="$(TARGET_RANLIB)" AR="$(TARGET_AR)"                     \
-		$(LIBRETRO_MAME_EXTRA_ARGS) CROSS_BUILD=1 TARGET="mame" SUBTARGET="arcade" RETRO=1         \
-		OSD="retro" DEBUG=0
-
-	$(MAKE) -j$(LIBRETRO_MAME_JOBS) -C $(@D)/ OPENMP=1 REGENIE=1 VERBOSE=1 NOWERROR=1 PYTHON_EXECUTABLE=python3 \
-		CONFIG=libretro LIBRETRO_OS="unix" ARCH="" PROJECT="" ARCHOPTS="$(LIBRETRO_MAME_ARCHOPTS)" \
-		DISTRO="debian-stable" OVERRIDE_CC="$(TARGET_CC)" OVERRIDE_CXX="$(TARGET_CXX)"             \
-		OVERRIDE_LD="$(TARGET_LD)" RANLIB="$(TARGET_RANLIB)" AR="$(TARGET_AR)"                     \
-		$(LIBRETRO_MAME_EXTRA_ARGS) CROSS_BUILD=1 TARGET="mame" SUBTARGET="mess" RETRO=1         \
-		OSD="retro" DEBUG=0
-
-	$(MAKE) -j$(LIBRETRO_MAME_JOBS) -C $(@D)/ OPENMP=1 REGENIE=1 VERBOSE=1 NOWERROR=1 PYTHON_EXECUTABLE=python3 \
-		CONFIG=libretro LIBRETRO_OS="unix" ARCH="" PROJECT="" ARCHOPTS="$(LIBRETRO_MAME_ARCHOPTS)" \
-		DISTRO="debian-stable" OVERRIDE_CC="$(TARGET_CC)" OVERRIDE_CXX="$(TARGET_CXX)"             \
-		OVERRIDE_LD="$(TARGET_LD)" RANLIB="$(TARGET_RANLIB)" AR="$(TARGET_AR)"                     \
-		$(LIBRETRO_MAME_EXTRA_ARGS) CROSS_BUILD=1 TARGET="mame" SUBTARGET="virtual" RETRO=1         \
+		$(LIBRETRO_MAME_EXTRA_ARGS) CROSS_BUILD=1 TARGET="mame" SUBTARGET="mame" RETRO=1         \
 		OSD="retro" DEBUG=0
 endef
 
 define LIBRETRO_MAME_INSTALL_TARGET_CMDS
-	$(INSTALL) -D $(@D)/mamearcade_libretro.so \
+	$(INSTALL) -D $(@D)/mame_libretro.so \
 		$(TARGET_DIR)/usr/lib/libretro/mame_libretro.so
-	$(INSTALL) -D $(@D)/mess_libretro.so \
-		$(TARGET_DIR)/usr/lib/libretro/mess_libretro.so
-	$(INSTALL) -D $(@D)/mamevirtual_libretro.so \
-		$(TARGET_DIR)/usr/lib/libretro/mamevirtual_libretro.so
 	mkdir -p $(TARGET_DIR)/usr/share/lr-mame/hash
 	cp -R $(@D)/hash $(TARGET_DIR)/usr/share/lr-mame
 
@@ -71,17 +53,13 @@ define LIBRETRO_MAME_INSTALL_TARGET_CMDS
 	
 	# Copy coin drop plugin
 	mkdir -p $(TARGET_DIR)/usr/bin/mame/
-  cp -R -u $(@D)/plugins $(TARGET_DIR)/usr/bin/mame/
+	cp -R -u $(@D)/plugins $(TARGET_DIR)/usr/bin/mame/
 	cp -R -u $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/coindrop $(TARGET_DIR)/usr/bin/mame/plugins  
 endef
 
 define LIBRETRO_MAME_INSTALL_STAGING_CMDS
 	$(INSTALL) -D $(@D)/mamearcade_libretro.so \
 		$(STAGING_DIR)/usr/lib/libretro/mame_libretro.so
-	$(INSTALL) -D $(@D)/mess_libretro.so \
-		$(STAGING_DIR)/usr/lib/libretro/mess_libretro.so
-	$(INSTALL) -D $(@D)/mamevirtual_libretro.so \
-		$(STAGING_DIR)/usr/lib/libretro/mamevirtual_libretro.so
 	mkdir -p $(STAGING_DIR)/usr/share/lr-mame/hash
 	cp -R $(@D)/hash $(STAGING_DIR)/usr/share/lr-mame
 	mkdir -p $(TARGET_DIR)/usr/share/mame


### PR DESCRIPTION
This is mostly to speed up compiling - MAME and LR-MAME now only compile once each instead of the previous 3x each. It's a full build that includes all supported MAME machines, so arcade, MESS, and MAMEVirtual are all one binary (just like downloading a precompiled version).

The generators and ES system files have been updated to replace LR-MESS & LR-MAMEVirtual with just LR-MAME. I tested arcade, systemless non-arcade ROMs (plugnplay & lcdgames), and a couple of MESS systems in both emulators, and it appears to all be working fine.