### PR TITLE
rollback cemu to 1.26.2

### DIFF
--- a/package/batocera/emulators/cemu/cemu/cemu.hash
+++ b/package/batocera/emulators/cemu/cemu/cemu.hash
@@ -1,2 +1,2 @@
 # Locally calculated after checking pgp signature
-sha256 d8e72e47f012f6cead4382409f44c3071c20342f9e18ec89235fa5d190404638  cemu_1.27.1.zip
+sha256 b0e3abf5048f78e352b42c3e1660a2c6e85d6905cd9f60d06ca2f2318fa3152c  cemu_1.26.2.zip

--- a/package/batocera/emulators/cemu/cemu/cemu.mk
+++ b/package/batocera/emulators/cemu/cemu/cemu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-CEMU_VERSION = 1.27.1
+CEMU_VERSION = 1.26.2
 CEMU_SOURCE = cemu_$(CEMU_VERSION).zip
 CEMU_SITE = https://cemu.info/releases
 


### PR DESCRIPTION
1.27.1 could not mount games to launch them properly