### PR TITLE
Shorten RA's fps update interval for the fps counter

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -29,6 +29,7 @@ def generateRetroarchCustom():
     retroarchSettings.save('menu_show_load_content',            '"false"')
     retroarchSettings.save('menu_show_online_updater',          '"false"')
     retroarchSettings.save('menu_show_core_updater',            '"false"')
+    retroarchSettings.save('fps_update_interval',               '"10"')
 
     # Input
     retroarchSettings.save('input_autodetect_enable',           '"false"')


### PR DESCRIPTION
the current default is 255, which means it takes two seconds for the FPS counter in the top right to update. This shortens that so it can actually be useful.