### PR TITLE
rpi-config: Removing gpu_mem and adding cma

### DIFF
--- a/board/batocera/raspberrypi/rpi2/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi2/boot/config.txt
@@ -15,16 +15,14 @@ fixup_file=fixup.dat
 kernel=boot/linux
 initramfs boot/initrd.gz
 
-# GPU memory
-gpu_mem_256=128
-gpu_mem_512=160
-gpu_mem_1024=384
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
 
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
+dtoverlay=vc4-kms-v3d,cma-128
 
 [all]
 include userconfig.txt

--- a/board/batocera/raspberrypi/rpi3/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi3/boot/config.txt
@@ -15,16 +15,14 @@ fixup_file=fixup.dat
 kernel=boot/linux
 initramfs boot/initrd.gz
 
-# GPU memory
-gpu_mem_256=128
-gpu_mem_512=160
-gpu_mem_1024=384
-
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
+dtoverlay=vc4-kms-v3d,cma-512
 
 # Model 3B, Model 3B+, Model 3A+, Compute Module 3, Compute Module 3+
 [pi3]

--- a/board/batocera/raspberrypi/rpi4/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi4/boot/config.txt
@@ -18,8 +18,11 @@ initramfs boot/initrd.gz
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
 # Enable DRM VC4 V3D driver
-dtoverlay=vc4-kms-v3d
+dtoverlay=vc4-kms-v3d,cma-512
 
 # Model 4B, Pi 400, Compute Module 4
 [pi4]


### PR DESCRIPTION
```
cma-512                 CMA is 512MB (needs 1GB)
cma-448                 CMA is 448MB (needs 1GB)
cma-384                 CMA is 384MB (needs 1GB)
cma-320                 CMA is 320MB (needs 1GB)
cma-256                 CMA is 256MB (needs 1GB)
cma-192                 CMA is 192MB (needs 1GB)
cma-128                 CMA is 128MB
cma-96                  CMA is 96MB
cma-64                  CMA is 64MB
```