### PR TITLE
bump: Amiberry to v5.3

### DIFF
--- a/package/batocera/emulators/amiberry/amiberry.mk
+++ b/package/batocera/emulators/amiberry/amiberry.mk
@@ -3,8 +3,8 @@
 # AMIBERRY
 #
 ################################################################################
-# Version.: Release on May 22, 2022
-AMIBERRY_VERSION = v5.2
+# Version.: Release on Jul 01, 2022
+AMIBERRY_VERSION = v5.3
 AMIBERRY_SITE = $(call github,midwan,amiberry,$(AMIBERRY_VERSION))
 AMIBERRY_LICENSE = GPLv3
 AMIBERRY_DEPENDENCIES = sdl2 sdl2_image sdl2_ttf mpg123 libxml2 libmpeg2 flac


### PR DESCRIPTION
https://github.com/BlitterStudio/amiberry/releases/tag/v5.3