### PR TITLE
Add VTech Laser 310 (MAME)

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -6,7 +6,7 @@
         * add: wiimote calibration (the wiimote is now precise and can be used as a gun without drawing the target on screen)
         * add: MediaTek MT7921U & MT7986 wifi, RealTek RTL8852A wifi & better AMD sound SOC support. (Kernel 5.18)
         * add: Additional RPCS3 options & auto aspect ratio
-        * add: GamePark GP32 using MAME/MESS
+        * add: GamePark GP32 & VTech Laser 310 using MAME/MESS
         * add: fallback config option to use the Nvidia legacy drivers 'nvidia-driver=legacy' or legacy390
         * add: Nvidia 'legacy' linux driver 470.129.06 & 390.151
         * add: RTL8189es SDIO drivers for the Amlogic S905x devices

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -25,6 +25,10 @@ class LibretroGenerator(Generator):
     # Main entry of the module
     # Configure retroarch and return a command
     def generate(self, system, rom, playersControllers, guns, gameResolution):
+        # Fix for the removed MESS/MAMEVirtual cores
+        if system.config['core'] in [ 'mess', 'mamevirtual' ]:
+            system.config['core'] = 'mame'
+
         # Get the graphics backend first
         gfxBackend = getGFXBackend(system)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -107,6 +107,15 @@ def generateMAMEConfigs(playersControllers, system, rom):
                 if not system.isOptSet("ti99_speech") or (system.isOptSet("ti99_speech") and system.getOptBoolean("ti99_speech")):
                     commandLine += ["-ioport:peb:slot3", "speech"]
 
+            #Laser 310 Memory Expansion & joystick
+            if system.name == "laser310":
+                commandLine += ['-io', 'joystick']
+                if not system.isOptSet('memslot'):
+                    laser310mem = 'laser_64k'
+                else:
+                    laser310mem = system.config['memslot']
+                commandLine += ["-mem", laser310mem]
+
             # BBC Joystick
             if system.name == "bbc":
                 if system.isOptSet('sticktype') and system.config['sticktype'] != 'none':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -249,6 +249,15 @@ class MameGenerator(Generator):
                 if not system.isOptSet("ti99_speech") or (system.isOptSet("ti99_speech") and system.getOptBoolean("ti99_speech")):
                     commandArray += ["-ioport:peb:slot3", "speech"]
 
+            #Laser 310 Memory Expansion & Joystick
+            if system.name == "laser310":
+                commandArray += ['-io', 'joystick']
+                if not system.isOptSet('memslot'):
+                    laser310mem = 'laser_64k'
+                else:
+                    laser310mem = system.config['memslot']
+                commandArray += ["-mem", laser310mem]
+
             # BBC Joystick
             if system.name == "bbc":
                 if system.isOptSet('sticktype') and system.config['sticktype'] != 'none':

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-x86_64.yml
@@ -135,6 +135,9 @@ vc4000:
 gp32:
   emulator: mame
   core:     mame
+laser310:
+  emulator: mame
+  core:     mame
 gaelco:
   options:
     videomode: max-640x480

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -250,6 +250,9 @@ kodi:
   emulator: kodi
   options:
     videomode: default
+laser310:
+  emulator: libretro
+  core:     mame
 lcdgames:
   emulator: libretro
   core:     gw

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -21,6 +21,7 @@ gamecom;gamecom;cart1;
 gamepock;gamepock;cart;
 gmaster;gmaster;cart;
 gp32;gp32;memc;
+laser310;laser310;dump;
 lcdgames;;;
 macintosh;maclc3;flop1;
 megaduck;megaduck;cart;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -296,6 +296,12 @@ systems = {
                                   { "md5": "cac4b56c0db80922cae75403faef40af", "zippedFile": "gp32100k.bin", "file": "bios/gp32.zip"},
                                   { "md5": "d4af2bc352bdaf4972ea40902feda114", "zippedFile": "gp32mfv2.bin", "file": "bios/gp32.zip"} ] },
 
+    # ---------- VTech Laser 310 ---------- #
+    "laser310":  { "name": "VTech Laser 310", "biosFiles": [  { "md5": "", "file": "bios/laser310.zip" },
+                                  { "md5": "42c8f9e6c2133ae0e953b89ccbbdb7e2", "zippedFile": "vtechv20.u12", "file": "bios/laser310.zip"},
+                                  { "md5": "f7e5d9a3eb2b57bf5f4e2a4565318a8f", "zippedFile": "vtechv21.u12", "file": "bios/laser310.zip"} ] },
+
+
     # ---------- Future Pinball ---------- #
     "fpinball":   { "name": "Future Pinball", "biosFiles":  [ { "md5": "65a8ebf870420316a939ac44fd4c731d", "file": "bios/wsh57/scripten.exe"  } ] },
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2458,6 +2458,44 @@ libretro:
                       choices:
                           "On":  1
                           "Off": 0
+         laser310:
+              cfeatures:
+                  softList:
+                      group: ADVANCED OPTIONS
+                      prompt:      SOFTWARE LIST
+                      description: Use MAME software lists to identify ROM
+                      choices:
+                          "Don't Use (Default)":                         none
+                          "Dick Smith Electronics VZ-200/300 cassettes": vz_cass
+                          "Dick Smith Electronics VZ-200/300 snapshots": vz_snap
+                  memslot:
+                      group: ADVANCED OPTIONS
+                      prompt:      MEMORY SLOT
+                      description: Choose hardware for the memory expansion slot
+                      choices:
+                          "Laser 310/VZ-300 16k Memory":   laser310_16k
+                          "Laser/VZ 64k Memory (Default)": laser_64k
+                  altromtype:
+                      group: ADVANCED OPTIONS
+                      prompt:      MEDIA TYPE
+                      description: Type of ROM file to load.
+                      choices:
+                          "Cassette": cass
+                          "Snapshot": snap
+                  enableui:
+                      group: ADVANCED OPTIONS
+                      prompt:      UI KEYS
+                      description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+                      choices:
+                          "Off at Start": 0
+                          "On at Start":  1
+                  pergamecfg:
+                      group: ADVANCED OPTIONS
+                      prompt:      CUSTOM CONFIG
+                      description: Enable per-game custom configuration via MAME menu.
+                      choices:
+                          "On":  1
+                          "Off": 0
          macintosh:
               cfeatures:
                   softList:
@@ -7661,6 +7699,44 @@ mame:
                 pergamecfg:
                     group: ADVANCED OPTIONS
                     prompt:      CUSTOM GAME CONFIG
+                    description: Enable per-game custom configuration via MAME menu.
+                    choices:
+                        "On":  1
+                        "Off": 0
+       laser310:
+            cfeatures:
+                softList:
+                    group: ADVANCED OPTIONS
+                    prompt:      SOFTWARE LIST
+                    description: Use MAME software lists to identify ROM
+                    choices:
+                        "Don't Use (Default)":                         none
+                        "Dick Smith Electronics VZ-200/300 cassettes": vz_cass
+                        "Dick Smith Electronics VZ-200/300 snapshots": vz_snap
+                memslot:
+                    group: ADVANCED OPTIONS
+                    prompt:      MEMORY SLOT
+                    description: Choose hardware for the memory expansion slot
+                    choices:
+                        "Laser 310/VZ-300 16k Memory":   laser310_16k
+                        "Laser/VZ 64k Memory (Default)": laser_64k
+                altromtype:
+                    group: ADVANCED OPTIONS
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file to load.
+                    choices:
+                        "Cassette": cass
+                        "Snapshot": snap
+                enableui:
+                    group: ADVANCED OPTIONS
+                    prompt:      UI KEYS
+                    description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+                    choices:
+                        "Off at Start": 0
+                        "On at Start":  1
+                pergamecfg:
+                    group: ADVANCED OPTIONS
+                    prompt:      CUSTOM CONFIG
                     description: Enable per-game custom configuration via MAME menu.
                     choices:
                         "On":  1

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2456,6 +2456,21 @@ crvision:
   comment_en: |
           Requires MAME BIOS file crvision.zip
 
+laser310:
+  name:       Laser 310
+  manufacturer: VTech
+  release: 1984
+  hardware: computer
+  extensions: [vz, wav, cas, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file laser310.zip
+          Using snapshot (.vz) files is recommended.
+
 socrates:
   name:       Socrates
   manufacturer: VTech

--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -200,6 +200,7 @@ define MAME_EVMAPY
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gmaster.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/gp32.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/lcdgames.mame.keys
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/laser310.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/macintosh.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/megaduck.mame.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/mame.mame.keys $(TARGET_DIR)/usr/share/evmapy/pdp1.mame.keys


### PR DESCRIPTION
Another 8-bit computer system added by request. Seems to be a bit flaky in lr-mame at the moment, if that doesn't resolve itself in lr-mame updates it can be restricted to standalone-only.

Also a small fix due to the removed/merged lr-mess & lr-mamevirtual cores - if either of those are set in batocera.conf, the generator will load the correct lr-mame instead.