### PR TITLE
Removing potential problematic link

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -676,9 +676,6 @@ dos:
 
     To quit a game, press CTRL + F9.
 
-    Games files are available on myabandonware:
-    http://www.myabandonware.com/browse/platform/dos/
-
     For more info: https://wiki.batocera.org/systems:dos
   comment_fr: |
     Chaque jeu (fichiers) doit être contenu dans un dossier ayant l'extension ".pc .dos".
@@ -695,9 +692,6 @@ dos:
     Avec pure-dosbox vous pouvez aussi utiliser des fichiers zip.
 
     Pour quitter un jeu, appuyer sur CTRL + F9.
-
-    Les jeux DOS sont disponibles sur myabandonware:
-    http://www.myabandonware.com/browse/platform/dos/
 
     La doc dos pour Batocera se trouve à cet endroit : https://wiki.batocera.org/systems:dos
 


### PR DESCRIPTION
the website linked into the _info.txt file of the dos system doesn't seem legit

> "Is it free? Is it legal?
> 
> We allow you to download old games for free, but we do not take any responsibility for downloads considered illegal in your country. Please try to buy the game first: GOG.com, Steam, Amazon or eBay may be selling your game. We never ask for credit card number, PayPal or anything. "

Also has traces of having games like mario is missing, pretty sure that's nukable material.

If I'm wrong, feel free to dismiss this PR **after** explaining how I was wrong