### PR TITLE
Fix integer scaling french batocera-es-system.po

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/locales/fr/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/fr/batocera-es-system.po
@@ -105,7 +105,7 @@ msgstr "FILTRAGE BILINEAIRE"
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid "INTEGER SCALING (PIXEL PERFECT)"
-msgstr "MISE À L'ÉCHELLE (PIXEL PERFECT)"
+msgstr "ÉCHELLE ENTIÈRE (PIXEL PERFECT)"
 
 #. TRANSLATION: shared, shared, shared, shared, shared, ...
 msgctxt "game_options"


### PR DESCRIPTION
The Integer Scaling option was translated as "Mise à l'échelle (pixel perfect)", leaving the most important word, aka Integer, out of the translation.

This fixes it, while also not being too long.