### PR TITLE
Handheld PC: brightness and suspend mode

### DIFF
--- a/board/batocera/x86/fsoverlay/etc/acpi/events/powerbtn
+++ b/board/batocera/x86/fsoverlay/etc/acpi/events/powerbtn
@@ -1,0 +1,3 @@
+event=button[ /]power
+action=/usr/bin/batocera-shutdown
+

--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -63,6 +63,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/batocera-screenshot.$(BATOCERA_SCRIPT_SCREENSHOT_TYPE) $(TARGET_DIR)/usr/bin/batocera-screenshot
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/batocera-timezone               $(TARGET_DIR)/usr/bin/
 	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/batocera-gameforce              $(TARGET_DIR)/usr/bin/
+	install -m 0755 $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-scripts/scripts/batocera-shutdown               $(TARGET_DIR)/usr/bin/
 endef
 
 define BATOCERA_SCRIPTS_INSTALL_RG552

--- a/package/batocera/core/batocera-scripts/scripts/batocera-brightness
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-brightness
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 D=$(find /sys/class/backlight/* 2>/dev/null | grep backlight | head -n1)
+CYCLESTEP=20 # % additional brightbess at each step
 
 if test ! -e "${D}"/brightness
 then
@@ -8,6 +9,7 @@ then
     exit 1
 else
     B="${D}"/brightness
+    XMAX=$(cat "${D}"/max_brightness)
 fi
 
 setValue() {
@@ -20,11 +22,22 @@ setValue() {
     echo "${NEWVAL}" > "${B}"
 }
 
+cycle() {
+    X=$(cat "${B}")
+    FVALUE=$(echo "scale=3;${X}" "*" "100" / "${XMAX}" | bc)
+    LC_ALL=C FVALUE=$(printf '%.*f\n' 0 "${FVALUE}") # round
+    NEWVAL=$(echo "${FVALUE} + ${CYCLESTEP}" | bc)
+    [ "${NEWVAL}" -gt 100 ] && NEWVAL=0
+    echo "Brightness cycling to ${NEWVAL}%"
+    NEWVAL=$(expr "${NEWVAL}" "*" "${XMAX}" / 100)
+    setValue "${NEWVAL}" "${XMAX}"
+    exit 0
+}
+
 # get
 if test $# = 0
 then
     X=$(cat "${B}")
-    XMAX=$(cat "${D}"/max_brightness)
     FVALUE=$(echo "scale=3;${X}" "*" "100" / "${XMAX}" | bc)
     LC_ALL=C printf '%.*f\n' 0 "${FVALUE}" # round
     exit 0
@@ -33,17 +46,19 @@ fi
 # set
 if test $# = 1
 then
-    XMAX=$(cat "${D}"/max_brightness)
-    NEWVAL=$(expr "${1}" "*" "${XMAX}" / 100)
-    setValue "${NEWVAL}" "${XMAX}"
-    exit 0
+    if [ "${1}" = "cycle" ]; then
+       cycle
+    else
+       NEWVAL=$(expr "${1}" "*" "${XMAX}" / 100)
+       setValue "${NEWVAL}" "${XMAX}"
+       exit 0
+    fi
 fi
 
 # set +
 if test $# = 2
 then
     X=$(cat "${B}")
-    XMAX=$(cat "${D}"/max_brightness)
     DELTA=$(expr "${2}" '*' ${XMAX} / 100)
     NEWVAL=$(expr "${X}" "${1}" "${DELTA}")
     setValue "${NEWVAL}" "${XMAX}"
@@ -54,4 +69,5 @@ fi
 echo "${0}"      >&2
 echo "${0} + 10" >&2
 echo "${0} - 20" >&2
+echo "${0} cycle" >&2
 exit 1

--- a/package/batocera/core/batocera-scripts/scripts/batocera-shutdown
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-shutdown
@@ -1,0 +1,18 @@
+#!/bin/bash 
+#
+# Suspend or shutdown
+#
+
+SUSPEND_MODE="$(/usr/bin/batocera-settings-get system.suspendmode)"
+
+###############################
+command="$1"
+tz="$2"
+if [ "${SUSPEND_MODE}" = "suspend" ]; then
+	pm-is-supported --suspend && pm-suspend
+elif [ "${SUSPEND_MODE}" = "hybrid" ]; then
+	# pm-hibernate is not supported on the Win600 at the moment
+	pm-is-supported --suspend-hybrid && pm-suspend-hybrid
+else
+	/sbin/shutdown -h now
+fi

--- a/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
+++ b/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
@@ -3,8 +3,9 @@ KEY_VOLUMEUP 2                  batocera-audio setSystemVolume +5
 KEY_VOLUMEDOWN 1                batocera-audio setSystemVolume -5
 KEY_VOLUMEDOWN 2                batocera-audio setSystemVolume -5
 KEY_MUTE        1               batocera-audio setSystemVolume mute-toggle
-KEY_POWER       1               /sbin/shutdown -h now
+KEY_POWER       1               batocera-shutdown
 # display some information on X displays
 KEY_F2          1               /usr/bin/batocera-info --short | HOME=/userdata/system XAUTHORITY=/var/lib/.Xauthority DISPLAY=:0.0 osd_cat -f -*-*-bold-*-*-*-38-120-*-*-*-*-*-* -cred -s 3 -d 4
 KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
 KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
+KEY_LEFTMETA    1               batocera-brightness cycle


### PR DESCRIPTION
Tested on Anbernic Win600 but should work on Aya Neo and OneXPlayer as well.
- the "Windows" button (i.e. the "Windows" keyboard key) will cycle through brightness as there's no dedicated hardware button
- you can select a power suspend mode adding `system.suspendmode=suspend` or `system.suspendmode=hybrid` in `batocera.conf`. Hybrid saves a little more energy than suspend (but takes longer). Full "hibernate" mode doesn't work right now. As these options are only working on x86_64 handheld PC, not on ARM-based OGA/OGS/RG552 yet, I think it's better not to add an entry in ES menus at this point. 

This PR addresses a part of #6679 