### PR TITLE
Samcoupe: fix missing advanced options, support for zip.

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8862,9 +8862,9 @@ ryujinx:
   features: [padtokeyboard]
   shared: [videomode]
 
-simcoupe:
+samcoupe:
   features: [padtokeyboard]
-  shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared: [videomode, hud, hud_corner]
 
 hcl:
   features: [padtokeyboard]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2899,7 +2899,7 @@ samcoupe:
   manufacturer: Miles Gordon Technology
   release: 1989
   hardware: computer
-  extensions: [cpm, dsk, sad, mgt, sdf, td0, sbt]
+  extensions: [cpm, dsk, sad, mgt, sdf, td0, sbt, zip]
   emulators:
     samcoupe:
       samcoupe:  { requireAnyOf: [BR2_PACKAGE_SIMCOUPE] }


### PR DESCRIPTION
Fix #6681 (except no bezel, this requires to be added in configgen)