### PR TITLE
lr-mame Dragonrise Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -1050,8 +1050,16 @@ def input2definition(pad, key, input, joycode, reversed, altButtons):
                     dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1DOWN'
                 if pad.inputs[direction].value == "8":
                     dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1LEFT'
+            # If no specific input defined (controller w/no d-pad), use generic d-pad inputs for Retropad
             else:
-                dpadInputs[direction] = ''
+                if direction == 'up':
+                    dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1UP'
+                elif direction == 'down':
+                    dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1DOWN'
+                elif direction == 'left':
+                    dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1LEFT'
+                elif direction == 'right':
+                    dpadInputs[direction] = f'JOYCODE_{joycode}_HAT1RIGHT'
         buttonDirections = {}
         for direction in ['a', 'b', 'x', 'y']:
             if pad.inputs[direction].type == 'button':


### PR DESCRIPTION
There was a report of directional controls not working in lr-mame on a Dragonrise encoder. It appears there are two issues:

1) The Dragonrise uses the analog stick axis for directions, and the MAME/LR-MAME controller handler wasn't built to handle controllers with analog but no d-pad.

Which wouldn't have been a problem, except:

2) lr-mame got changed to use a strange version of the virtual Retropad in config files instead of the actual button IDs like it used to. This would explain the recent button flip issues.

The end result was that lr-mame was looking for analog stick inputs (the real controller), but being passed d-pad inputs (the Retropad).

This fix will map the d-pad if there's no secondary input. There is a chance that other controllers may have other issues. If so, I can do a partial rewrite and replace all inputs with Retropad ones, once I figure out what controls are being passed to the core.