### PR TITLE
MAME Offscreen Reload

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -290,6 +290,10 @@ def generateMAMEConfigs(playersControllers, system, rom):
                 else:
                     commandLine += [ '-flop2', '/userdata/saves/lr-mess/{}/{}.dsk'.format(system.name, os.path.splitext(romBasename)[0]) ]
 
+    # Lightgun reload option
+    if system.isOptSet('offscreenreload') and system.getOptBoolean('offscreenreload'):
+        commandArray += [ "-offscreen_reload" ]
+
     # Art paths - lr-mame displays artwork in the game area and not in the bezel area, so using regular MAME artwork + shaders is not recommended.
     # By default, will ignore standalone MAME's art paths.
     if system.config['core'] != 'same_cdi':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -229,6 +229,8 @@ class MameGenerator(Generator):
         else:
             commandArray += [ "-lightgunprovider", "auto" ]
             commandArray += [ "-lightgun_device", "mouse" ]
+        if system.isOptSet('offscreenreload') and system.getOptBoolean('offscreenreload'):
+            commandArray += [ "-offscreen_reload" ]
 
         # Finally we pass game name
         # MESS will use the full filename and pass the system & rom type parameters if needed.

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1842,6 +1842,13 @@ libretro:
                 choices:
                     "On":  1
                     "Off": 0
+            offscreenreload:
+                group: LIGHT GUN
+                prompt:      OFF SCREEN RELOAD
+                description: Set gun button 2 to reload for games that require shooting off screen
+                choices:
+                    "On":            1
+                    "Off (Default)": 0
       systems:
          adam:
               cfeatures:
@@ -7348,6 +7355,13 @@ mame:
             choices:
                 "Enabled":            1
                 "Disabled (Default)": 0
+        offscreenreload:
+            group: LIGHT GUN
+            prompt:      OFF SCREEN RELOAD
+            description: Set gun button 2 to reload for games that require shooting off screen
+            choices:
+                "On":            1
+                "Off (Default)": 0
   systems:
        adam:
             cfeatures:


### PR DESCRIPTION
Adds an option to use Lightgun Button 2 to replicate an off-screen reload. This is a command line option provided by MAME. IT should work for lr-mame as well, but I'm currently having lightgun issues with it.

It's per game/system, intended to be used for game/controller combinations that don't play nice with shooting off-screen (ie Wiimote & Lethal Enforcers).

It may make sense to have Auto enable it based on game/controller, for now it's just off by default.