### PR TITLE
update explanations + add power button behaviour

### DIFF
--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -1,13 +1,29 @@
 # ------------ A - System Options ----------- #
-## batocera.linux security
-# enforce security
-# samba password required
+
+## Security
+## Enable this to enforce security, requiring a password to access the network share.
 #system.security.enabled=0
 
-## file system compression (btrfs only)
+## Display rotation
+## Leave commented out -> Auto.
+## 0 -> No rotation.
+## 1 -> Rotate 90 degrees clockwise.
+## 2 -> Rotate 160 degrees clockwise.
+## 3 -> Rotate 270 degrees clockwise.
+#display.rotate=0
+
+## Power button behavior
+## Change what the power button does when pressed.
+## shutdown -> Immediately shutdown the system.
+## suspend -> Enter low-power standby mode.
+## hybrid -> Enter an even lower-power standy mode, only available on supported devices.
+#system.suspendmode=suspend
+
+## File system compression (btrfs only)
+## Natively compresses files as they are stored, reduces disk write speed but increases space available.
 #system.fscompression.enabled=0
 
-## Send cec standby command to your first tv/monitor device during shutdown
+## Send the CEC standby command to your first tv/monitor device during shutdown.
 #system.cec.standby=1
 
 ## EmulationStation menu style
@@ -16,106 +32,95 @@
 ## bartop -> less menu, only needed for bartops
 #system.es.menu=default
 
-## Show or hide kodi in emulationstation (0,1)
+## Show or hide Kodi in the EmulationStation menu.
 kodi.enabled=1
-## Start kodi at launch (0,1)
+## Start Kodi at launch.
 kodi.atstartup=0
-## set x button shortcut (0,1)
+## Enable the North button Kodi shortcut.
 kodi.xbutton=1
 
-## Kodi can wait for a network component before starting
-## waithost is the ip or hostname that must answer to a ping to validate the availability
-## waittime is the maximum time waited when kodi boots
-## if waitmode is required, kodi will not start if the component is not available
-## if waitmode is wish, kodi will start if the component is not available
-## if waitmode is not set or has another value, kodi will start immediately
+## Kodi can be instructed to wait for a network component before starting.
+## waithost is the IP or hostname that must answer to a ping to validate the availability.
+## waittime is the maximum wait time when Kodi boots.
+## If waitmode is required, Kodi will not start if the component is not available.
+## If waitmode is wish, Kodi will start if the component is not available.
+## If waitmode is not set or has another value, Kodi will start immediately.
 #kodi.network.waitmode=required
 #kodi.network.waittime=10
 #kodi.network.waithost=192.168.0.50
 
-## Splashscreen is enabled per default set to 0 to disable
+## Splash screen
 ## Set sound option to 0 to silence the video splash
 #splash.screen.enabled=1
 #splash.screen.sound=1
 
-## Extend visible time of video/pictures
-## Possible values are:
-## auto:      All the video will be played but not longer than 90s
-## [0-90]:    Time after the video will be terminated, after this ES starts (recommended)
-## fastboot:  Stop video as soon as ES is ready to start
-#splash.screen.length=auto
-
-## Enable video rotation (if supported) values 0,1,2,3 rotate to 0,90,180 and 270 clockwise
-#display.rotate=0
-
 # ------------ A1 - Platform Specific Options ----------- #
-## ODROID-C2
-## CEC only works on your 1st tv HDMI port (EXYNOS driver limitation)
+
+## Raspberry Pi 1/2/3/4 system power switch/utility
+## Select one option.
+## ARGONONE ->           Activate fan control for Argon One case (RPi4)
+## ATX_RASPI_R2_6 ->     http://lowpowerlab.com/atxraspi/#installation
+## MAUSBERRY ->          http://mausberry-circuits.myshopify.com/pages/setup
+## ONOFFSHIM ->          https://shop.pimoroni.com/products/onoff-shim
+## POWERHAT ->           https://www.raspberrypiplastics.com/power-hat-board
+## REMOTEPIBOARD_2003 -> http://www.msldigital.com/pages/support-for-remotepi-board-2013
+## REMOTEPIBOARD_2005 -> http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
+## KINTARO ->            http://www.kintaro.co SNES style case aka Roshambo/Super Kintaro Kuma System
+## RETROFLAG ->          http://www.retroflag.com  -- note: enable UART in config.txt for LED action
+## RETROFLAG_ADV ->      Activate on RESET button more commands to quit emulators or restart ES
+## RETROFLAG_GPI ->      Activate GPi CASE SAFE SHUTDOWN functions.
+## PIBOY ->              Activate PIBOY.
+## DESKPIPRO ->          Fan & power control for RPi4 DeskPi Pro case.
+## PISTATION_LCD ->      Config.txt tweaks to get the display to work.
+## Simple Switches without active devices
+## See https://batocera.org/wiki/doku.php?id=en:add_powerdevices_rpi_only
+## PIN56ONOFF ->         For latching switches
+## PIN56PUSH ->          For momentary buttons
+## PIN356ONOFFRESET ->   Restart and shutdown board. Needs 2 switches.
+#system.power.switch=RETROFLAG
 
 ## Rockpro64
 ## Roshambo/Kintaro case
 #roshambo.enabled=1
 
-## Raspberry Pi 1/2/3/4
-## System power switch
-## Overview of switches and description how to install on your device
-##
-## ARGONONE:           Activate fan control for Argon One case (RPi4)
-## ATX_RASPI_R2_6:     http://lowpowerlab.com/atxraspi/#installation
-## MAUSBERRY:          http://mausberry-circuits.myshopify.com/pages/setup
-## ONOFFSHIM:          https://shop.pimoroni.com/products/onoff-shim
-## POWERHAT:           https://www.raspberrypiplastics.com/power-hat-board
-## REMOTEPIBOARD_2003: http://www.msldigital.com/pages/support-for-remotepi-board-2013
-## REMOTEPIBOARD_2005: http://www.msldigital.com/pages/support-for-remotepi-board-plus-2015
-## KINTARO:            http://www.kintaro.co SNES style case aka Roshambo/Super Kintaro Kuma System
-## RETROFLAG           http://www.retroflag.com  -- note: enable UART in config.txt for LED action
-## RETROFLAG_ADV:      Activate on RESET button more commands to quit emulators or restart ES
-## RETROFLAG_GPI:      Activate GPi CASE SAFE SHUTDOWN functions.
-## PIBOY:              Activate PIBOY.
-## DESKPIPRO:          Fan & power control for RPi4 DeskPi Pro case.
-## PISTATION_LCD:      Config.txt tweaks to get the display to work.
-##
-## Simple Switches without active devices
-## See https://batocera.org/wiki/doku.php?id=en:add_powerdevices_rpi_only
-## PIN56ONOFF:         For latching switches
-## PIN56PUSH:          For momentary buttons
-## PIN356ONOFFRESET:   Restart and shutdown board. Needs 2 switches.
-##
-#system.power.switch=RETROFLAG
 
 # ------------ B - Network ------------ #
-## Set system hostname
+
+## Set system hostname, accessible via network share
 system.hostname=BATOCERA
-## Country code (00 for World)
+## Wi-Fi country code (00 for World), see https://wiki.batocera.org/wifi_ssid#i_can_t_see_my_ssid_in_the_list_but_i_can_see_my_neighbor_s
 #wifi.country=FR
-## Activate wifi (0,1)
+## Activate Wi-Fi (0,1)
 wifi.enabled=0
-## Wifi SSID (string)
+## Wi-Fi SSID (string)
 #wifi.ssid=new ssid
-## Wifi KEY (string)
-## Escape your special chars (# ; $) with a backslash : $ => \$
+## Wi-Fi KEY (string)
+## Escape your special chars (# ; $) with a backslash. eg. $ becomes \$
 #wifi.key=new key
 
-# secondary wifi (not configurable via the user interface)
+## Secondary Wi-Fi (not configurable via the user interface)
 #wifi2.ssid=new ssid
 #wifi2.key=new key
 
-# third wifi (not configurable via the user interface)
+## Third Wi-Fi (not configurable via the user interface)
 #wifi3.ssid=new ssid
 #wifi3.key=new key
 
-# Add values here to connect to a hidden AP
+## Add values here to connect to a hidden AP.
 #wifi.hidden.ssid=hidden SSID
 #wifi.hidden.key=new key
 
-## Samba share
-#system.samba.enabled=1
-### SSH
-#system.ssh.enabled=1
+## Disable Samba share, see https://wiki.batocera.org/add_games_bios#while_batocera_is_running
+#system.samba.enabled=0
+
+## Disable SSH, see https://wiki.batocera.org/access_the_batocera_via_ssh
+#system.ssh.enabled=0
+
 
 # ------------ C - Audio ------------ #
+
 ## Set the audio device
-## use "batocera-audio list" to see available devices
+## Use "batocera-audio list" to see available devices.
 audio.device=auto
 ## Set system volume (0..100)
 audio.volume=90
@@ -124,116 +129,149 @@ audio.volume.boost=100
 ## Enable or disable system sounds in ES (0,1)
 audio.bgmusic=1
 
+
 # -------------- D - Controllers ----------------- #
-# Enable support for standard bluetooth controllers
+
+## Enable Bluetooth
 controllers.bluetooth.enabled=1
 
-## Please enable only one of these
-
 # -------------- D1 - PS3 Controllers ------------ #
-##Enable PS3 controllers support
+
+## Enable PS3 controller support
 controllers.ps3.enabled=1
-## Choose a driver between bluez, official and shanwan
-## bluez -> bluez 5 + kernel drivers, support official and shanwan sisaxis
-## official -> sixad drivers, support official and gasia sisaxis
-## shanwan -> shanwan drivers, support official and shanwan sisaxis
+## Choose a driver
+## bluez -> bluez 5 + kernel drivers, supports official and shanwan sisaxis
+## official -> sixad drivers, supports official and gasia sisaxis
+## shanwan -> shanwan drivers, supports official and shanwan sisaxis
 controllers.ps3.driver=bluez
 
-# ------------ D2 - XBOX Controllers ------------ #
-## Xbox controllers are already supported, but xboxdrv can solve some compatibility issues
-## Enable xboxdrv driver, disable this if you enabled ps3 controllers (0,1)
+# ------------ D2 - Xbox Controllers ------------ #
+
+## Xbox controllers are already supported, but xboxdrv can solve some compatibility issues.
+## Enable the xboxdrv driver, disable this if you enabled PS3 controllers.
 controllers.xboxdrv.enabled=0
 ## Set the amount of controllers to use with xboxdrv (0..4)
 controllers.xboxdrv.nbcontrols=2
 
-# ------------ D3 - Others Controllers ------------ #
+# ------------ D3 - Other Controllers ------------ #
+
 ## XGaming's XArcade Tankstik and other compatible devices
 controllers.xarcade.enabled=1
 
 # ------------ D4 - GPIO Controllers (RPi only) ------------ #
+
 ## GPIO Controllers
-## enable controllers on GPIO with mk_arcarde_joystick_rpi (0,1)
+## Enable controllers on GPIO with mk_arcarde_joystick_rpi.
 controllers.gpio.enabled=0
-## mk_gpio arguments, map=1 for one controller, map=1,2 for 2 (map=1,map=1,2)
+## GPIO arguments
+## map=1 -> for one controller
+## map=1,2 -> for two controllers
 controllers.gpio.args=map=1,2
 
 ## DB9 Controllers
-## Enable DB9 drivers for atari, megadrive, amiga controllers (0,1)
+## Enable DB9 drivers for Atari, Megadrive and Amiga controllers.
 controllers.db9.enabled=0
-## db9 arguments
+## DB9 arguments
 controllers.db9.args=map=1
 
 ## Gamecon controllers
-## Enable gamecon controllers, for nes, snes psx (0,1)
+## Enable Gamecon controllers, for NES, SNES and PSX controllers.
 controllers.gamecon.enabled=0
-## gamecon_args
+## Gamecon arguments
 controllers.gamecon.args=map=1
 
-# ------------ F - Language and keyboard ------------ #
-## Set the language of the system (fr_FR,en_US,en_GB,de_DE,pt_BR,es_ES,it_IT,eu_ES,tr_TR,zh_CN)
+
+# ------------ F - Language and Keyboard ------------ #
+
+## System language
+## Some common examples:
+## en_US -> English
+## en_GB -> English (UK)
+## fr_FR -> French
+## de_DE -> German
+## pt_BR -> Brazillian Portuguese
+## it_IT -> Italian
+## tr_TR -> Turkish
+## zh_CN -> Chinese
+## Check the menu in ES for more.
 #system.language=en_US
-## Set the keyboard layout (fr,de,us,es). See /usr/share/keymaps/.
+
+## Set the keyboard layout (fr,de,us,es). Run ls /usr/share/keymaps/.
 #system.kblayout=us
 ## Set you local time
-## Select your timezone from : ls /usr/share/zoneinfo/ (string)
+## Run ls /usr/share/zoneinfo/
 #system.timezone=Europe/Paris
 
-# ------------ G - UPDATES ------------ #
-## Automatically check for updates at start (0,1)
+
+# ------------ G - Updates ------------ #
+
+## Automatically check for updates after booting.
 updates.enabled=1
-# default : stable ; set to beta to get the next version currently being tested. set to unstable at your own risk to get the development version.
+## Set the update type.
+## stable -> Current stable version
+## beta -> Current development verion, use at your own risk
 updates.type=stable
 
-# ------------ H - GLOBAL EMULATOR CONFIGURATION ------------ #
-## The global value will be used for all emulators, except if the value
-## is redefined in the emulator
 
-## Set game resolution for emulators
-## select your mode from the command : tvservice -m [MODE]
-## CEA 5 HDMI : 1920x1080 @ 60Hz 16:9, clock:74MHz interlaced
-## CEA 4 HDMI : 1280x720 @ 60Hz 16:9, clock:74MHz progressive
-## use 'default' for using the default resolution
-## (string)
+# ------------ H - Global Emulator Configuration ------------ #
+
+## The global value will be used for all emulators, except if the value is redefined in the emulator
+
+## Video mode
+## Force the emulator to run at this resolution. Run batocera-resolution. See https://wiki.batocera.org/display_issues
 #global.videomode=CEA 4 HDMI
 
-## set the prefered output
-## use "batocera-config lsoutputs" to get your available outputs
+## Set the preferred output
+## Run batocera-resolution listOutputs
 #global.videooutput=""
 
 ## DPI
-## Workaround when correct DPI setting is not detected
-## if fonts are too small, uncomment next line
+## If the text is too small, adjust this value.
 #global.dpi=96
 
 ## Shader set
-## Automatically select shaders for all systems
-## (none, default, retro, scanlines, curvature, enhanced, zfast, flatten-glow)
+## Automatically select shaders for all systems, see https://wiki.batocera.org/emulationstation:shaders_set
+## default -> Default shader
+## none -> No shader
+## curvature -> Realistic CRT curve with scanlines, CPU expensive
+## enhanced -> Upscale pixel graphics
+## flatten-glow -> Make the image glow
+## mega-bezel -> Add reflections to shader bezel, CPU expensive
+## retro -> Pixelated shader
+## scanlines -> Add scanlines to the image
+## zfast -> Cheaper version for scanlines
 #global.shaderset=none
 
-## Once enabled, your screen will be cropped, and you will have a pixel perfect image (0,1)
+## Integer scaling (pixel perfect)
+## Only scale the image in integers, maintaining pixel ratio.
 #global.integerscale=0
 
-## Set gpslp shader for all emulators (prefer shadersets above). Absolute path (string)
-#global.shaders=
-
-# bezel
+## Decoration set
+## See https://wiki.batocera.org/decoration
 #global.bezel=default
 
-## Set ratio for all emulators (auto,4/3,16/9,16/10,custom)
+## Game aspect ratio
+## Set the ratio for emulators
 #global.ratio=auto
 
-## Set smooth for all emulators (0,1)
+## Smooth games (bilinear filtering)
+## Softens the image. Is overidden if using a shader set.
 #global.smooth=1
 
-## Set rewind for all emulators (0,1)
+## Rewind
+## CPU expensive
 #global.rewind=1
 
-## Set autosave/load savestate for all emulators (0,1)
+## Auto save/load
+## Automatically save state when exiting emulators, automatical load latest save state when launching emulators.
 #global.autosave=0
 
-## Enable retroarchievements (0,1)
-## Set your www.retroachievements.org username/password
-## Escape your special chars (# ; $) with a backslash : $ => \$
+## Incremental savestates
+#global.incrementalsavestates=0
+
+## Retroachievement settings
+## Set up your www.retroachievements.org username/password first
+## Escape your special chars (# ; $) with a backslash. eg. $ becomes \$
 #global.retroachievements=0
 #global.retroachievements.hardcore=0
 #global.retroachievements.leaderboards=0
@@ -243,22 +281,28 @@ updates.type=stable
 #global.retroachievements.username=
 #global.retroachievements.password=
 #global.retroachievements.sound=
+
 ## Enable RetroArch AI game translation service
 #global.ai_service_enabled=0
 #global.ai_service_url=http://ztranslate.net/service?api_key=BATOCERA
 #global.ai_target_lang=
 
 ## HUD (x86 or RPi4 only)
-# game / perf / custom (in that case, configuration is read from hud_custom)
+## game -> Show game's boxart/metadata info
+## perf -> Show current performance statistics
+## custom -> Use hud_custom configuration
 #global.hud=perf
+## Custom HUD configuration
+## Performance eg. position=bottom-left\nbackground_alpha=0.9\nlegacy_layout=false\ncustom_text=%GAMENAME%\ncustom_text=%SYSTEMNAME%\ncustom_text=%EMULATORCORE%\nfps\ngpu_name\nengine_version\nvulkan_driver\nresolution\nram\ngpu_stats\ngpu_temp\ncpu_stats\ncpu_temp\ncore_load
+## Game eg. position=bottom-left\nbackground_alpha=0\nlegacy_layout=false\nfont_size=32\nimage_max_width=200\nimage=%THUMBNAIL%\ncustom_text=%GAMENAME%\ncustom_text=%SYSTEMNAME%\ncustom_text=%EMULATORCORE%
+## More examples at https://github.com/flightlessmango/MangoHud/blob/master/README.md#mangohud_config-and-mangohud_configfile-environment-variables
 #global.hud_custom=position=bottom-left\nbackground_alpha=0\nlegacy_layout=false\nfont_size=64\nimage_max_width=200\nimage=%THUMBNAIL%\ncustom_text=%GAMENAME%\ncustom_text=%SYSTEMNAME%\ncustom_text=%EMULATORCORE%
-# for example, the value for perf is position=bottom-left\nbackground_alpha=0.9\nlegacy_layout=false\ncustom_text=%GAMENAME%\ncustom_text=%SYSTEMNAME%\ncustom_text=%EMULATORCORE%\nfps\ngpu_name\nengine_version\nvulkan_driver\nresolution\nram\ngpu_stats\ngpu_temp\ncpu_stats\ncpu_temp\ncore_load
-# the value for game is position=bottom-left\nbackground_alpha=0\nlegacy_layout=false\nfont_size=32\nimage_max_width=200\nimage=%THUMBNAIL%\ncustom_text=%GAMENAME%\ncustom_text=%SYSTEMNAME%\ncustom_text=%EMULATORCORE%
-# more examples on https://github.com/flightlessmango/MangoHud/blob/master/README.md#mangohud_config-and-mangohud_configfile-environment-variables
 
-# ------------ I - EMULATORS CHOICES ----------- #
-## You can override the global configuration here
-## Here is the snes example
+
+# ------------ I - Per System Advanced Configuration ----------- #
+
+## It's also possible to apply unique settings per system
+## eg. to set unique options for SNES:
 #snes.core=snes9x_next
 #snes.shaders=/userdata/shaders/shaders_glsl/mysnesshader.gplsp
 #snes.ratio=16/9
@@ -267,26 +311,33 @@ updates.type=stable
 #snes.autosave=0
 #snes.emulator=libretro
 #snes.integerscale=0
-## You can also configure directly retroarch.cfg via batocera.conf via lines like
+
+## Advanced RetroArch configuration
+## See https://wiki.batocera.org/advanced_retroarch_settings
 #snes.retroarch.menu_driver=rgui
 #global.retroarch.input_max_users=4
 
-## Wiimotes
-## Real wiimotes must not be paired with batocera.linux system so that they can work with the Wii emulator
-## Set emulatedwiimotes to 1 to emulate wiimotes with standard pads
+## Emulate Wiimotes for Dolphin
+## Allows regular pads to act as if though they were Wiimotes when running Dolphin.
+## Real wiimotes must not be paired with Batocera while using this option.
 #wii.emulatedwiimotes=0
 
-## PS2
-# Enables fast booting (skip PS2 BIOS when booting an ISO ; some games relies on BIOS to get start-up parameters and thus may not work correctly)
-# Set fullboot to 0 to disable BIOS when booting an ISO
-#ps2.fullboot=1
+
+# ------------ J - Other ----------- #
 
 ## Scraper
-# Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart
+## Set order scraper prefers, separated by commas.
+## s -> snapshot
+## b -> boxart
+## f -> fanart
+## a -> banner
+## l -> logo
+## 3b -> 3D boxart
 #scrapper.style=s,b,f,a,l,3b
 
 ## Enable DXVK for Wine and FPS HUD.
 #windows.dxvk=0
 #windows.dxvk_hud=0
 
-## Configurations generated by Batocera.linux
+
+# ------------ User-generated Configurations ----------- #

--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -145,20 +145,12 @@ controllers.ps3.enabled=1
 ## shanwan -> shanwan drivers, supports official and shanwan sisaxis
 controllers.ps3.driver=bluez
 
-# ------------ D2 - Xbox Controllers ------------ #
-
-## Xbox controllers are already supported, but xboxdrv can solve some compatibility issues.
-## Enable the xboxdrv driver, disable this if you enabled PS3 controllers.
-controllers.xboxdrv.enabled=0
-## Set the amount of controllers to use with xboxdrv (0..4)
-controllers.xboxdrv.nbcontrols=2
-
-# ------------ D3 - Other Controllers ------------ #
+# ------------ D2 - Other Controllers ------------ #
 
 ## XGaming's XArcade Tankstik and other compatible devices
 controllers.xarcade.enabled=1
 
-# ------------ D4 - GPIO Controllers (RPi only) ------------ #
+# ------------ D3 - GPIO Controllers (RPi only) ------------ #
 
 ## GPIO Controllers
 ## Enable controllers on GPIO with mk_arcarde_joystick_rpi.


### PR DESCRIPTION
  * Add system.suspendmode
  * Correct grammar/spelling in the comments
  * Remove splash.screen.length option as it was removed from Batocera itself
  * Moved display rotation option up (it's important)
  * Remove (0,1) notation on boolean options, it's implied by the examples and not consistent anyway
  * Remove unnecessary note about limitation with Odroid CEC (this should only be on the wiki, and this device has since been discontinued/is barely supported by Batocera anymore)
  * Reverse polarity of SSH/Samba (they're enabled by default)
  * Remove ## Please enable only one of the following: as it is contradictory to the default settings
  * Add language code descriptions
  * Made new lines consistent
  * Camelcase all headers for consistency
  * Add Other section
  * Redid options for scraper preferences
  * Add descriptions for shaders
  * Remove shaders (not shaderset) line, no longer applicable to Batocera
  * Add incremental savestates
  * Rename EMULATORS CHOICES to Per System Advanced Configuration
  * Update info about Wiimotes
  * Removed PS2-specific options (why is this like the only system here with its own option from ES like that?)
  * Rename to user-generated configurations