### PR TITLE
update "GAME ASPECT RATIO" description

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -9,7 +9,7 @@ shared:
       preset: videomodes
     ratio:
       prompt: GAME ASPECT RATIO
-      description: Force the game to render in this aspect ratio. Decorations override this setting.
+      description: Force the game to render in this aspect ratio. Not all systems support all ratios.
       choices:
         "4/3":           "4/3"
         "16/9":          "16/9"


### PR DESCRIPTION
The functionality was altered by https://github.com/batocera-linux/batocera.linux/pull/6689, this adjusts the description accordingly.

In the future, it is intended for this setting to apply globally to all applicable emulators, but since not all emulators support all ratios, the description now mentions this.