### PR TITLE
rpiZero2: Adding bcm2710-rpi-zero-2 to rpi3 image

### DIFF
--- a/board/batocera/raspberrypi/rpi3/boot/config.txt
+++ b/board/batocera/raspberrypi/rpi3/boot/config.txt
@@ -138,8 +138,13 @@ gpu_mem=32
 # Enable audio (loads snd_bcm2835)
 dtparam=audio=on
 
+[pi3]
 # Enable DRM VC4 V3D driver
 dtoverlay=vc4-kms-v3d,cma-512
+
+[pi02]
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d,cma-256
 
 [DPI]
 # Put any DPI required display code here

--- a/configs/batocera-rpi3_defconfig
+++ b/configs/batocera-rpi3_defconfig
@@ -53,7 +53,7 @@ BR2_LINUX_KERNEL_IMAGE_TARGET_NAME="Image"
 
 # Build the DTB from the kernel sources
 BR2_LINUX_KERNEL_DTS_SUPPORT=y
-BR2_LINUX_KERNEL_INTREE_DTS_NAME="broadcom/bcm2710-rpi-3-b broadcom/bcm2710-rpi-3-b-plus broadcom/bcm2837-rpi-3-b"
+BR2_LINUX_KERNEL_INTREE_DTS_NAME="broadcom/bcm2710-rpi-zero-2 broadcom/bcm2710-rpi-3-b broadcom/bcm2710-rpi-3-b-plus broadcom/bcm2837-rpi-3-b"
 
 BR2_PACKAGE_ESPEAK=y
 BR2_PACKAGE_ESPEAK_AUDIO_BACKEND_ALSA=y

--- a/package/batocera/core/batocera-scripts/scripts/batocera-overclock
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-overclock
@@ -14,6 +14,9 @@ then
     if grep -q "^Raspberry Pi 3 Model [A-Z] Plus" "/proc/device-tree/model"
     then
 	ARCH="rpi3+"
+    elif grep -q "^Raspberry Pi Zero 2" "/proc/device-tree/model"
+    then
+    ARCH="rpizero2"
     fi
 fi
 


### PR DESCRIPTION
It will be possible to use the image of rpi3 in rpiZero2.