### PR TITLE
brightness persistence when called from batocera-brightness

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-brightness
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-brightness
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 D=$(find /sys/class/backlight/* 2>/dev/null | grep backlight | head -n1)
-CYCLESTEP=20 # % additional brightbess at each step
+CYCLESTEP=20 # % additional brightness at each step
 
 if test ! -e "${D}"/brightness
 then
@@ -20,6 +20,7 @@ setValue() {
     test "${NEWVAL}" -gt "${XMAX}" && NEWVAL="${XMAX}"
     
     echo "${NEWVAL}" > "${B}"
+    batocera-settings-set display.brightness "${NEWVAL}"
 }
 
 cycle() {
@@ -31,6 +32,7 @@ cycle() {
     echo "Brightness cycling to ${NEWVAL}%"
     NEWVAL=$(expr "${NEWVAL}" "*" "${XMAX}" / 100)
     setValue "${NEWVAL}" "${XMAX}"
+    batocera-settings-set display.brightness "${NEWVAL}"
     exit 0
 }
 


### PR DESCRIPTION
This way using the command line tool or the hotkey command will also save the current brightness value.

Drafting until further testing is done.