### PR TITLE
fix pcsx-rearmed multitap setting

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3800,9 +3800,9 @@ libretro:
                 description: Allows up to 5 or 8 controllers in supported games.
                 choices:
                     "Off":              disabled
-                    "Port1":            port 1 only
-                    "Port2":            port 2 only
-                    "Port1+2":          both
+                    "Port1":            port 1
+                    "Port2":            port 2
+                    "Port1+2":          ports 1 and 2
             game_fixes_pcsx:
                 group: ADVANCED OPTIONS
                 prompt:      SPECIFIC GAME FIXES


### PR DESCRIPTION
Config line as saved by RetroArch: `pcsx_rearmed_multitap = "ports 1 and 2"` and `pcsx_rearmed_multitap = "port 2"`

Config line as saved by Batocera ES: `pcsx_rearmed_multitap=both` and `pcsx_rearmed_multitap=port 2 only`

"Thus; we have our culprit. The values were changed by the core, but not updated in Batocera."

How it looks when multitap is set as port 1 in Batocera (it has invalid settings so it gets changed back to "OFF"):
![screenshot-2022 08 03-17h05 17](https://user-images.githubusercontent.com/67527064/182551752-596bb1e4-e173-4064-a094-a6f122220b5d.png)

The currently available options in that setting:
![screenshot-2022 08 03-17h05 36](https://user-images.githubusercontent.com/67527064/182551894-f77abb7e-5543-4302-840d-599cf7b12e82.png)
