### PR TITLE
Add lr-arduous (Arduboy)

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -248,6 +248,7 @@ menu "Emulators"
       source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/retroarch/libretro/libretro-smsplus-gx/Config.in"
       source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/retroarch/libretro/libretro-dolphin/Config.in"
       source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/retroarch/libretro/libretro-lowresnx/Config.in"
+      source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/retroarch/libretro/libretro-arduous/Config.in"
      endmenu
   endmenu
 

--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -33,6 +33,7 @@
         * add: xemu netplay support now enabled and auto-configured by default
         * add: Adding libretro-a5200 for Atari 5200
         * add: libretro-lowresnx for the Lowres NX fantasy console
+        * add: libretro-arduous for Arduboy (open source Aruduino-based handheld) emulation
         * add: expanded Nintendo controller support
         * add: joycond support - joycons can now be paired as one 'virtual' controller
         * add: libretro-bsnes as a SNES emulator option to the RPi4 & S922x devices

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -59,6 +59,9 @@ arcadia:
 archimedes:
   emulator: libretro
   core:     mame
+arduboy:
+  emulator: libretro
+  core:     arduous
 astrocde:
   emulator: libretro
   core:     mame

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -777,6 +777,9 @@ config BR2_PACKAGE_BATOCERA_HANDHELD_SYSTEMS
 	# SAM Coupe
 	select BR2_PACKAGE_SIMCOUPE	                if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
 
+	# Arduboy
+	select BR2_PACKAGE_LIBRETRO_ARDUOUS          # ALL
+
 	help
 		Handheld cores/emulators
 

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3258,7 +3258,7 @@ gp32:
   name:       GP32
   manufacturer: GamePark
   release: 2001
-  hardware: handheld
+  hardware: portable
   extensions: [smc, zip, 7z]
   emulators:
     libretro:
@@ -3267,6 +3267,16 @@ gp32:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
           Requires MAME BIOS file gp32.zip
+
+arduboy:
+  name:       Arduboy
+  manufacturer: Kevin Bates
+  release: 2015
+  hardware: portable
+  extensions: [hex, zip, 7z]
+  emulators:
+    libretro:
+      arduous: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_ARDUOUS] }
 
 gzdoom:
   name:         GZDoom

--- a/package/batocera/emulators/retroarch/libretro/libretro-arduous/Config.in
+++ b/package/batocera/emulators/retroarch/libretro/libretro-arduous/Config.in
@@ -1,0 +1,7 @@
+config BR2_PACKAGE_LIBRETRO_ARDUOUS
+    bool "libretro-arduous"
+    depends on BR2_PACKAGE_RETROARCH
+      help
+        A libretro Arduboy core
+
+        http://www.libretro.com

--- a/package/batocera/emulators/retroarch/libretro/libretro-arduous/libretro-arduous.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-arduous/libretro-arduous.mk
@@ -1,0 +1,18 @@
+################################################################################
+#
+# libretro-arduous
+#
+################################################################################
+
+LIBRETRO_ARDUOUS_VERSION = aed5050
+LIBRETRO_ARDUOUS_SITE = https://github.com/libretro/arduous.git
+LIBRETRO_ARDUOUS_SITE_METHOD=git
+LIBRETRO_ARDUOUS_GIT_SUBMODULES=YES
+LIBRETRO_ARDUOUS_LICENSE = GPLv2
+
+define LIBRETRO_ARDUOUS_INSTALL_TARGET_CMDS
+    $(INSTALL) -D $(@D)/arduous_libretro.so \
+		$(TARGET_DIR)/usr/lib/libretro/arduous_libretro.so
+endef
+
+$(eval $(cmake-package))


### PR DESCRIPTION
Adds the Arduous core, which emulates the Arduboy - an open source, Arduino-based handheld. Currently enabled on all boards.

There are a lot of decent free games available, though currently none of the scrapers have data for the system. There is a repo of games at https://github.com/eried/ArduboyCollection - it includes screenshots and additional info, so it may be possible to write a script (internal or external) to parse that into a gamelist.xml.

Also fixes a minor issue with GP32 in es_systems (listed as Handheld instead of Portable).