### PR TITLE
add dolphin (the file explorer) .directory file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ batocera.mk
 .vscode/*
 make.log
 package/batocera/emulationstation/batocera-emulationstation/keys.txt
+.directory


### PR DESCRIPTION
This allows you to save folder view properties in Dolphin (KDE's default file manager) without fear!