### PR TITLE
include all extra glibc iconv modules

### DIFF
--- a/board/batocera/patches/glibc/002-glibc-iconv-modules-extra.patch
+++ b/board/batocera/patches/glibc/002-glibc-iconv-modules-extra.patch
@@ -1,0 +1,3791 @@
+diff --git a/iconvdata/gconv-modules b/iconvdata/gconv-modules
+index 7ee0757..f04dbb3 100644
+--- a/iconvdata/gconv-modules
++++ b/iconvdata/gconv-modules
+@@ -113,3 +113,1892 @@ module	INTERNAL		UTF-32BE//		UTF-32		1
+ alias	UTF7//			UTF-7//
+ module	UTF-7//			INTERNAL		UTF-7		1
+ module	INTERNAL		UTF-7//			UTF-7		1
++# GNU libc iconv configuration.
++# Copyright (C) 1997-2022 Free Software Foundation, Inc.
++# This file is part of the GNU C Library.
++
++# The GNU C Library is free software; you can redistribute it and/or
++# modify it under the terms of the GNU Lesser General Public
++# License as published by the Free Software Foundation; either
++# version 2.1 of the License, or (at your option) any later version.
++
++# The GNU C Library is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++# Lesser General Public License for more details.
++
++# You should have received a copy of the GNU Lesser General Public
++# License along with the GNU C Library; if not, see
++# <https://www.gnu.org/licenses/>.
++
++# All lines contain the following information:
++
++# If the lines start with `module'
++#  fromset:	either a name triple or a regular expression triple.
++#  toset:	a name triple or an expression with \N to get regular
++#		expression matching results.
++#  filename:	filename of the module implementing the transformation.
++#		If it is not absolute the path is made absolute by prepending
++#		the directory the configuration file is found in.
++#  cost:	optional cost of the transformation.  Default is 1.
++
++# If the lines start with `alias'
++#  alias:	alias name which is not really recognized.
++#  name:	the real name of the character set
++
++alias	ISO-IR-4//		BS_4730//
++alias	ISO646-GB//		BS_4730//
++alias	GB//			BS_4730//
++alias	UK//			BS_4730//
++alias	CSISO4UNITEDKINGDOM//	BS_4730//
++module	BS_4730//		INTERNAL		ISO646		2
++module	INTERNAL		BS_4730//		ISO646		2
++
++alias	ISO-IR-121//		CSA_Z243.4-1985-1//
++alias	ISO646-CA//		CSA_Z243.4-1985-1//
++alias	CSA7-1//		CSA_Z243.4-1985-1//
++alias	CA//			CSA_Z243.4-1985-1//
++alias	CSISO121CANADIAN1//	CSA_Z243.4-1985-1//
++alias	CSA_Z243.419851//	CSA_Z243.4-1985-1//
++module	CSA_Z243.4-1985-1//	INTERNAL		ISO646		2
++module	INTERNAL		CSA_Z243.4-1985-1//	ISO646		2
++
++alias	ISO-IR-122//		CSA_Z243.4-1985-2//
++alias	ISO646-CA2//		CSA_Z243.4-1985-2//
++alias	CSA7-2//		CSA_Z243.4-1985-2//
++alias	CSISO122CANADIAN2//	CSA_Z243.4-1985-2//
++alias	CSA_Z243.419852//	CSA_Z243.4-1985-2//
++module	CSA_Z243.4-1985-2//	INTERNAL		ISO646		2
++module	INTERNAL		CSA_Z243.4-1985-2//	ISO646		2
++
++alias	ISO-IR-21//		DIN_66003//
++alias	DE//			DIN_66003//
++alias	ISO646-DE//		DIN_66003//
++alias	CSISO21GERMAN//		DIN_66003//
++module	DIN_66003//		INTERNAL		ISO646		2
++module	INTERNAL		DIN_66003//		ISO646		2
++
++alias	DS2089//		DS_2089//
++alias	ISO646-DK//		DS_2089//
++alias	DK//			DS_2089//
++alias	CSISO646DANISH//	DS_2089//
++module	DS_2089//		INTERNAL		ISO646		2
++module	INTERNAL		DS_2089//		ISO646		2
++
++alias	ISO-IR-17//		ES//
++alias	ISO646-ES//		ES//
++alias	CSISO17SPANISH//	ES//
++module	ES//			INTERNAL		ISO646		2
++module	INTERNAL		ES//			ISO646		2
++
++alias	ISO-IR-85//		ES2//
++alias	ISO646-ES2//		ES2//
++alias	CSISO85SPANISH2//	ES2//
++module	ES2//			INTERNAL		ISO646		2
++module	INTERNAL		ES2//			ISO646		2
++
++alias	ISO-IR-57//		GB_1988-80//
++alias	CN//			GB_1988-80//
++alias	ISO646-CN//		GB_1988-80//
++alias	CSISO58GB1988//		GB_1988-80//
++alias	GB_198880//		GB_1988-80//
++module	GB_1988-80//		INTERNAL		ISO646		2
++module	INTERNAL		GB_1988-80//		ISO646		2
++
++alias	ISO-IR-15//		IT//
++alias	ISO646-IT//		IT//
++alias	CSISO15ITALIAN//	IT//
++module	IT//			INTERNAL		ISO646		2
++module	INTERNAL		IT//			ISO646		2
++
++alias	ISO-IR-14//		JIS_C6220-1969-RO//
++alias	JP//			JIS_C6220-1969-RO//
++alias	ISO646-JP//		JIS_C6220-1969-RO//
++alias	CSISO14JISC6220RO//	JIS_C6220-1969-RO//
++alias	JIS_C62201969RO//	JIS_C6220-1969-RO//
++module	JIS_C6220-1969-RO//	INTERNAL		ISO646		2
++module	INTERNAL		JIS_C6220-1969-RO//	ISO646		2
++
++alias	ISO-IR-92//		JIS_C6229-1984-B//
++alias	ISO646-JP-OCR-B//	JIS_C6229-1984-B//
++alias	JP-OCR-B//		JIS_C6229-1984-B//
++alias	CSISO92JISC62991984B//	JIS_C6229-1984-B//
++alias	JIS_C62291984B//	JIS_C6229-1984-B//
++module	JIS_C6229-1984-B//	INTERNAL		ISO646		2
++module	INTERNAL		JIS_C6229-1984-B//	ISO646		2
++
++alias	ISO-IR-141//		JUS_I.B1.002//
++alias	ISO646-YU//		JUS_I.B1.002//
++alias	JS//			JUS_I.B1.002//
++alias	YU//			JUS_I.B1.002//
++alias	CSISO141JUSIB1002//	JUS_I.B1.002//
++module	JUS_I.B1.002//		INTERNAL		ISO646		2
++module	INTERNAL		JUS_I.B1.002//		ISO646		2
++
++alias	ISO646-KR//		KSC5636//
++alias	CSKSC5636//		KSC5636//
++module	KSC5636//		INTERNAL		ISO646		2
++module	INTERNAL		KSC5636//		ISO646		2
++
++alias	ISO-IR-86//		MSZ_7795.3//
++alias	ISO646-HU//		MSZ_7795.3//
++alias	HU//			MSZ_7795.3//
++alias	CSISO86HUNGARIAN//	MSZ_7795.3//
++module	MSZ_7795.3//		INTERNAL		ISO646		2
++module	INTERNAL		MSZ_7795.3//		ISO646		2
++
++alias	CUBA//			NC_NC00-10//
++alias	NC_NC00-10:81//		NC_NC00-10//
++alias	ISO-IR-151//		NC_NC00-10//
++alias	ISO646-CU//		NC_NC00-10//
++alias	CSISO151CUBA//		NC_NC00-10//
++alias	NC_NC0010//		NC_NC00-10//
++module	NC_NC00-10//		INTERNAL		ISO646		2
++module	INTERNAL		NC_NC00-10//		ISO646		2
++
++alias	ISO-IR-69//		NF_Z_62-010//
++alias	ISO646-FR//		NF_Z_62-010//
++alias	FR//			NF_Z_62-010//
++alias	CSISO69FRENCH//		NF_Z_62-010//
++alias	NF_Z_62010//		NF_Z_62-010//
++module	NF_Z_62-010//		INTERNAL		ISO646		2
++module	INTERNAL		NF_Z_62-010//		ISO646		2
++
++alias	ISO-IR-25//		NF_Z_62-010_1973//
++alias	ISO646-FR1//		NF_Z_62-010_1973//
++alias	NF_Z_62-010_(1973)//	NF_Z_62-010_1973//
++alias	CSISO25FRENCH//		NF_Z_62-010_1973//
++alias	NF_Z_62010_1973//	NF_Z_62-010_1973//
++module	NF_Z_62-010_1973//	INTERNAL		ISO646		2
++module	INTERNAL		NF_Z_62-010_1973//	ISO646		2
++
++alias	ISO-IR-60//		NS_4551-1//
++alias	ISO646-NO//		NS_4551-1//
++alias	NO//			NS_4551-1//
++alias	CSISO60DANISHNORWEGIAN// NS_4551-1//
++alias	CSISO60NORWEGIAN1//	NS_4551-1//
++alias	NS_45511//		NS_4551-1//
++module	NS_4551-1//		INTERNAL		ISO646		2
++module	INTERNAL		NS_4551-1//		ISO646		2
++
++alias	ISO646-NO2//		NS_4551-2//
++alias	ISO-IR-61//		NS_4551-2//
++alias	NO2//			NS_4551-2//
++alias	CSISO61NORWEGIAN2//	NS_4551-2//
++alias	NS_45512//		NS_4551-2//
++module	NS_4551-2//		INTERNAL		ISO646		2
++module	INTERNAL		NS_4551-2//		ISO646		2
++
++alias	ISO-IR-16//		PT//
++alias	ISO646-PT//		PT//
++alias	CSISO16PORTUGESE//	PT//
++module	PT//			INTERNAL		ISO646		2
++module	INTERNAL		PT//			ISO646		2
++
++alias	ISO-IR-84//		PT2//
++alias	ISO646-PT2//		PT2//
++alias	CSISO84PORTUGUESE2//	PT2//
++module	PT2//			INTERNAL		ISO646		2
++module	INTERNAL		PT2//			ISO646		2
++
++alias	ISO-IR-10//		SEN_850200_B//
++alias	FI//			SEN_850200_B//
++alias	ISO646-FI//		SEN_850200_B//
++alias	ISO646-SE//		SEN_850200_B//
++alias	SE//			SEN_850200_B//
++alias	CSISO10SWEDISH//	SEN_850200_B//
++alias	SS636127//		SEN_850200_B//
++module	SEN_850200_B//		INTERNAL		ISO646		2
++module	INTERNAL		SEN_850200_B//		ISO646		2
++
++alias	ISO-IR-11//		SEN_850200_C//
++alias	ISO646-SE2//		SEN_850200_C//
++alias	SE2//			SEN_850200_C//
++alias	CSISO11SWEDISHFORNAMES// SEN_850200_C//
++module	SEN_850200_C//		INTERNAL		ISO646		2
++module	INTERNAL		SEN_850200_C//		ISO646		2
++
++#	from			to			module		cost
++alias	ISO-IR-101//		ISO-8859-2//
++alias	ISO_8859-2:1987//	ISO-8859-2//
++alias	ISO_8859-2//		ISO-8859-2//
++alias	ISO8859-2//		ISO-8859-2//
++alias	ISO88592//		ISO-8859-2//
++alias	LATIN2//		ISO-8859-2//
++alias	L2//			ISO-8859-2//
++alias	CSISOLATIN2//		ISO-8859-2//
++alias	8859_2//		ISO-8859-2//
++alias	OSF00010002//		ISO-8859-2//
++alias	IBM912//		ISO-8859-2//
++alias	CP912//			ISO-8859-2//
++module	ISO-8859-2//		INTERNAL		ISO8859-2	1
++module	INTERNAL		ISO-8859-2//		ISO8859-2	1
++
++#	from			to			 module		cost
++alias	ISO-IR-109//		ISO-8859-3//
++alias	ISO_8859-3:1988//	ISO-8859-3//
++alias	ISO_8859-3//		ISO-8859-3//
++alias	ISO8859-3//		ISO-8859-3//
++alias	ISO88593//		ISO-8859-3//
++alias	LATIN3//		ISO-8859-3//
++alias	L3//			ISO-8859-3//
++alias	CSISOLATIN3//		ISO-8859-3//
++alias	8859_3//		ISO-8859-3//
++alias	OSF00010003//		ISO-8859-3//
++module	ISO-8859-3//		INTERNAL		ISO8859-3	1
++module	INTERNAL		ISO-8859-3//		ISO8859-3	1
++
++#	from			to			module		cost
++alias	ISO-IR-110//		ISO-8859-4//
++alias	ISO_8859-4:1988//	ISO-8859-4//
++alias	ISO_8859-4//		ISO-8859-4//
++alias	ISO8859-4//		ISO-8859-4//
++alias	ISO88594//		ISO-8859-4//
++alias	LATIN4//		ISO-8859-4//
++alias	L4//			ISO-8859-4//
++alias	CSISOLATIN4//		ISO-8859-4//
++alias	8859_4//		ISO-8859-4//
++alias	OSF00010004//		ISO-8859-4//
++module	ISO-8859-4//		INTERNAL		ISO8859-4	1
++module	INTERNAL		ISO-8859-4//		ISO8859-4	1
++
++#	from			to			module		cost
++alias	ISO-IR-144//		ISO-8859-5//
++alias	ISO_8859-5:1988//	ISO-8859-5//
++alias	ISO_8859-5//		ISO-8859-5//
++alias	ISO8859-5//		ISO-8859-5//
++alias	ISO88595//		ISO-8859-5//
++alias	CYRILLIC//		ISO-8859-5//
++alias	CSISOLATINCYRILLIC//	ISO-8859-5//
++alias	8859_5//		ISO-8859-5//
++alias	OSF00010005//		ISO-8859-5//
++alias	IBM915//		ISO-8859-5//
++alias	CP915//			ISO-8859-5//
++module	ISO-8859-5//		INTERNAL		ISO8859-5	1
++module	INTERNAL		ISO-8859-5//		ISO8859-5	1
++
++#	from			to			module		cost
++alias	ISO-IR-127//		ISO-8859-6//
++alias	ISO_8859-6:1987//	ISO-8859-6//
++alias	ISO_8859-6//		ISO-8859-6//
++alias	ISO8859-6//		ISO-8859-6//
++alias	ISO88596//		ISO-8859-6//
++alias	ECMA-114//		ISO-8859-6//
++alias	ASMO-708//		ISO-8859-6//
++alias	ARABIC//		ISO-8859-6//
++alias	CSISOLATINARABIC//	ISO-8859-6//
++alias	8859_6//		ISO-8859-6//
++alias	OSF00010006//		ISO-8859-6//
++alias	IBM1089//		ISO-8859-6//
++alias	CP1089//		ISO-8859-6//
++module	ISO-8859-6//		INTERNAL		ISO8859-6	1
++module	INTERNAL		ISO-8859-6//		ISO8859-6	1
++
++#	from			to			module		cost
++alias	ISO-IR-126//		ISO-8859-7//
++alias	ISO_8859-7:2003//	ISO-8859-7//
++alias	ISO_8859-7:1987//	ISO-8859-7//
++alias	ISO_8859-7//		ISO-8859-7//
++alias	ISO8859-7//		ISO-8859-7//
++alias	ISO88597//		ISO-8859-7//
++alias	ELOT_928//		ISO-8859-7//
++alias	ECMA-118//		ISO-8859-7//
++alias	GREEK//			ISO-8859-7//
++alias	GREEK8//		ISO-8859-7//
++alias	CSISOLATINGREEK//	ISO-8859-7//
++alias	8859_7//		ISO-8859-7//
++alias	OSF00010007//		ISO-8859-7//
++alias	IBM813//		ISO-8859-7//
++alias	CP813//			ISO-8859-7//
++module	ISO-8859-7//		INTERNAL		ISO8859-7	1
++module	INTERNAL		ISO-8859-7//		ISO8859-7	1
++
++#	from			to			module		cost
++alias	ISO-IR-138//		ISO-8859-8//
++alias	ISO_8859-8:1988//	ISO-8859-8//
++alias	ISO_8859-8//		ISO-8859-8//
++alias	ISO8859-8//		ISO-8859-8//
++alias	ISO88598//		ISO-8859-8//
++alias	HEBREW//		ISO-8859-8//
++alias	CSISOLATINHEBREW//	ISO-8859-8//
++alias	8859_8//		ISO-8859-8//
++alias	OSF00010008//		ISO-8859-8//
++alias	IBM916//		ISO-8859-8//
++alias	CP916//			ISO-8859-8//
++module	ISO-8859-8//		INTERNAL		ISO8859-8	1
++module	INTERNAL		ISO-8859-8//		ISO8859-8	1
++
++#	from			to			module		cost
++alias	ISO-IR-148//		ISO-8859-9//
++alias	ISO_8859-9:1989//	ISO-8859-9//
++alias	ISO_8859-9//		ISO-8859-9//
++alias	ISO8859-9//		ISO-8859-9//
++alias	ISO88599//		ISO-8859-9//
++alias	LATIN5//		ISO-8859-9//
++alias	L5//			ISO-8859-9//
++alias	CSISOLATIN5//		ISO-8859-9//
++alias	8859_9//		ISO-8859-9//
++alias	OSF00010009//		ISO-8859-9//
++alias	IBM920//		ISO-8859-9//
++alias	CP920//			ISO-8859-9//
++alias	TS-5881//		ISO-8859-9//
++alias	ECMA-128//		ISO-8859-9//
++module	ISO-8859-9//		INTERNAL		ISO8859-9	1
++module	INTERNAL		ISO-8859-9//		ISO8859-9	1
++
++#	from			to			module		cost
++alias	ISO-IR-157//		ISO-8859-10//
++alias	ISO_8859-10:1992//	ISO-8859-10//
++alias	ISO_8859-10//		ISO-8859-10//
++alias	ISO8859-10//		ISO-8859-10//
++alias	ISO885910//		ISO-8859-10//
++alias	LATIN6//		ISO-8859-10//
++alias	L6//			ISO-8859-10//
++alias	CSISOLATIN6//		ISO-8859-10//
++alias	OSF0001000A//		ISO-8859-10//
++module	ISO-8859-10//		INTERNAL		ISO8859-10	1
++module	INTERNAL		ISO-8859-10//		ISO8859-10	1
++
++#	from			to			module		cost
++alias	ISO8859-11//		ISO-8859-11//
++alias	ISO885911//		ISO-8859-11//
++module	ISO-8859-11//		INTERNAL		ISO8859-11	1
++module	INTERNAL		ISO-8859-11//		ISO8859-11	1
++
++#	from			to			module		cost
++alias	ISO8859-13//		ISO-8859-13//
++alias	ISO885913//		ISO-8859-13//
++alias	ISO-IR-179//		ISO-8859-13//
++alias	LATIN7//		ISO-8859-13//
++alias	L7//			ISO-8859-13//
++alias	BALTIC//		ISO-8859-13//
++module	ISO-8859-13//		INTERNAL		ISO8859-13	1
++module	INTERNAL		ISO-8859-13//		ISO8859-13	1
++
++#	from			to			module		cost
++alias	ISO8859-14//		ISO-8859-14//
++alias	ISO885914//		ISO-8859-14//
++alias	ISO-IR-199//		ISO-8859-14//
++alias	LATIN8//		ISO-8859-14//
++alias	L8//			ISO-8859-14//
++alias	ISO_8859-14:1998//	ISO-8859-14//
++alias	ISO_8859-14//		ISO-8859-14//
++alias	ISO-CELTIC//		ISO-8859-14//
++module	ISO-8859-14//		INTERNAL		ISO8859-14	1
++module	INTERNAL		ISO-8859-14//		ISO8859-14	1
++
++#	from			to			module		cost
++alias	ISO8859-16//		ISO-8859-16//
++alias	ISO885916//		ISO-8859-16//
++alias	ISO-IR-226//		ISO-8859-16//
++alias	LATIN10//		ISO-8859-16//
++alias	L10//			ISO-8859-16//
++alias	ISO_8859-16:2001//	ISO-8859-16//
++alias	ISO_8859-16//		ISO-8859-16//
++module	ISO-8859-16//		INTERNAL		ISO8859-16	1
++module	INTERNAL		ISO-8859-16//		ISO8859-16	1
++
++#	from			to			module		cost
++alias	T.61//			T.61-8BIT//
++alias	ISO-IR-103//		T.61-8BIT//
++alias	CSISO103T618BIT//	T.61-8BIT//
++alias	T.618BIT//		T.61-8BIT//
++module	T.61-8BIT//		INTERNAL		T.61		1
++module	INTERNAL		T.61-8BIT//		T.61		1
++
++#	from			to			module		cost
++alias	ISO-IR-156//		ISO_6937//
++alias	ISO_6937:1992//		ISO_6937//
++alias	ISO6937//		ISO_6937//
++module	ISO_6937//		INTERNAL		ISO_6937	1
++module	INTERNAL		ISO_6937//		ISO_6937	1
++
++
++#	from			to			module		cost
++alias	ISO-IR-90//		ISO_6937-2//
++alias	ISO_6937-2:1983//	ISO_6937-2//
++alias	CSISO90//		ISO_6937-2//
++alias	ISO_69372//		ISO_6937-2//
++module	ISO_6937-2//		INTERNAL		ISO_6937-2	1
++module	INTERNAL		ISO_6937-2//		ISO_6937-2	1
++
++#	from			to			module		cost
++alias	SHIFT-JIS//		SJIS//
++alias	SHIFT_JIS//		SJIS//
++alias	MS_KANJI//		SJIS//
++alias	CSSHIFTJIS//		SJIS//
++module	SJIS//			INTERNAL		SJIS		1
++module	INTERNAL		SJIS//			SJIS		1
++
++#	from			to			module		cost
++alias	WINDOWS-31J//		CP932//
++alias	MS932//			CP932//
++alias	SJIS-OPEN//		CP932//
++alias	SJIS-WIN//		CP932//
++alias	CSWINDOWS31J//		CP932//
++module	CP932//			INTERNAL		CP932		1
++module	INTERNAL		CP932//			CP932		1
++
++#	from			to			module		cost
++alias	KOI8//			KOI-8//
++module	KOI-8//			INTERNAL		KOI-8		1
++module	INTERNAL		KOI-8//			KOI-8		1
++
++#	from			to			module		cost
++alias	CSKOI8R//		KOI8-R//
++alias	KOI8R//			KOI8-R//
++module	KOI8-R//		INTERNAL		KOI8-R		1
++module	INTERNAL		KOI8-R//		KOI8-R		1
++
++#	from			to			module		cost
++alias	ISO-IR-19//		LATIN-GREEK//
++alias	CSISO19LATINGREEK//	LATIN-GREEK//
++alias	LATINGREEK//		LATIN-GREEK//
++module	LATIN-GREEK//		INTERNAL		LATIN-GREEK	1
++module	INTERNAL		LATIN-GREEK//		LATIN-GREEK	1
++
++#	from			to			module		cost
++alias	ISO-IR-27//		LATIN-GREEK-1//
++alias	CSISO27LATINGREEK1//	LATIN-GREEK-1//
++alias	LATINGREEK1//		LATIN-GREEK-1//
++module	LATIN-GREEK-1//		INTERNAL		LATIN-GREEK-1	1
++module	INTERNAL		LATIN-GREEK-1//		LATIN-GREEK-1	1
++
++#	from			to			module		cost
++alias	ROMAN8//		HP-ROMAN8//
++alias	R8//			HP-ROMAN8//
++alias	CSHPROMAN8//		HP-ROMAN8//
++alias	OSF10010001//		HP-ROMAN8//
++alias	HPROMAN8//		HP-ROMAN8//
++module	HP-ROMAN8//		INTERNAL		HP-ROMAN8	1
++module	INTERNAL		HP-ROMAN8//		HP-ROMAN8	1
++
++#	from			to			module		cost
++alias	CSEBCDICATDE//		EBCDIC-AT-DE//
++alias	EBCDICATDE//		EBCDIC-AT-DE//
++module	EBCDIC-AT-DE//		INTERNAL		EBCDIC-AT-DE	1
++module	INTERNAL		EBCDIC-AT-DE//		EBCDIC-AT-DE	1
++
++#	from			to			module		cost
++alias	CSEBCDICATDEA//		EBCDIC-AT-DE-A//
++alias	EBCDICATDEA//		EBCDIC-AT-DE-A//
++module	EBCDIC-AT-DE-A//	INTERNAL		EBCDIC-AT-DE-A	1
++module	INTERNAL		EBCDIC-AT-DE-A//	EBCDIC-AT-DE-A	1
++
++#	from			to			module		cost
++alias	CSEBCDICCAFR//		EBCDIC-CA-FR//
++alias	EBCDICCAFR//		EBCDIC-CA-FR//
++module	EBCDIC-CA-FR//		INTERNAL		EBCDIC-CA-FR	1
++module	INTERNAL		EBCDIC-CA-FR//		EBCDIC-CA-FR	1
++
++#	from			to			module		cost
++alias	CSEBCDICDKNO//		EBCDIC-DK-NO//
++alias	EBCDICDKNO//		EBCDIC-DK-NO//
++module	EBCDIC-DK-NO//		INTERNAL		EBCDIC-DK-NO	1
++module	INTERNAL		EBCDIC-DK-NO//		EBCDIC-DK-NO	1
++
++#	from			to			module		cost
++alias	CSEBCDICDKNOA//		EBCDIC-DK-NO-A//
++alias	EBCDICDKNOA//		EBCDIC-DK-NO-A//
++module	EBCDIC-DK-NO-A//	INTERNAL		EBCDIC-DK-NO-A	1
++module	INTERNAL		EBCDIC-DK-NO-A//	EBCDIC-DK-NO-A	1
++
++#	from			to			module		cost
++alias	CSEBCDICES//		EBCDIC-ES//
++alias	EBCDICES//		EBCDIC-ES//
++module	EBCDIC-ES//		INTERNAL		EBCDIC-ES	1
++module	INTERNAL		EBCDIC-ES//		EBCDIC-ES	1
++
++#	from			to			module		cost
++alias	CSEBCDICESA//		EBCDIC-ES-A//
++alias	EBCDICESA//		EBCDIC-ES-A//
++module	EBCDIC-ES-A//		INTERNAL		EBCDIC-ES-A	1
++module	INTERNAL		EBCDIC-ES-A//		EBCDIC-ES-A	1
++
++#	from			to			module		cost
++alias	CSEBCDICESS//		EBCDIC-ES-S//
++alias	EBCDICESS//		EBCDIC-ES-S//
++module	EBCDIC-ES-S//		INTERNAL		EBCDIC-ES-S	1
++module	INTERNAL		EBCDIC-ES-S//		EBCDIC-ES-S	1
++
++#	from			to			module		cost
++alias	CSEBCDICFISE//		EBCDIC-FI-SE//
++alias	EBCDICFISE//		EBCDIC-FI-SE//
++module	EBCDIC-FI-SE//		INTERNAL		EBCDIC-FI-SE	1
++module	INTERNAL		EBCDIC-FI-SE//		EBCDIC-FI-SE	1
++
++#	from			to			module		cost
++alias	CSEBCDICFISEA//		EBCDIC-FI-SE-A//
++alias	EBCDICFISEA//		EBCDIC-FI-SE-A//
++module	EBCDIC-FI-SE-A//	INTERNAL		EBCDIC-FI-SE-A	1
++module	INTERNAL		EBCDIC-FI-SE-A//	EBCDIC-FI-SE-A	1
++
++#	from			to			module		cost
++alias	CSEBCDICFR//		EBCDIC-FR//
++alias	EBCDICFR//		EBCDIC-FR//
++module	EBCDIC-FR//		INTERNAL		EBCDIC-FR	1
++module	INTERNAL		EBCDIC-FR//		EBCDIC-FR	1
++
++#	from			to			module		cost
++alias	EBCDICISFRISS//		EBCDIC-IS-FRISS//
++module	EBCDIC-IS-FRISS//	INTERNAL		EBCDIC-IS-FRISS	1
++module	INTERNAL		EBCDIC-IS-FRISS//	EBCDIC-IS-FRISS	1
++
++#	from			to			module		cost
++alias	CSEBCDICIT//		EBCDIC-IT//
++alias	EBCDICIT//		EBCDIC-IT//
++module	EBCDIC-IT//		INTERNAL		EBCDIC-IT	1
++module	INTERNAL		EBCDIC-IT//		EBCDIC-IT	1
++
++#	from			to			module		cost
++alias	CSEBCDICPT//		EBCDIC-PT//
++alias	EBCDICPT//		EBCDIC-PT//
++module	EBCDIC-PT//		INTERNAL		EBCDIC-PT	1
++module	INTERNAL		EBCDIC-PT//		EBCDIC-PT	1
++
++#	from			to			module		cost
++alias	CSEBCDICUK//		EBCDIC-UK//
++alias	EBCDICUK//		EBCDIC-UK//
++module	EBCDIC-UK//		INTERNAL		EBCDIC-UK	1
++module	INTERNAL		EBCDIC-UK//		EBCDIC-UK	1
++
++#	from			to			module		cost
++alias	CSEBCDICUS//		EBCDIC-US//
++alias	EBCDICUS//		EBCDIC-US//
++module	EBCDIC-US//		INTERNAL		EBCDIC-US	1
++module	INTERNAL		EBCDIC-US//		EBCDIC-US	1
++
++#	from			to			module		cost
++alias	CP037//			IBM037//
++alias	EBCDIC-CP-US//		IBM037//
++alias	EBCDIC-CP-CA//		IBM037//
++alias	EBCDIC-CP-WT//		IBM037//
++alias	EBCDIC-CP-NL//		IBM037//
++alias	CSIBM037//		IBM037//
++alias	OSF10020025//		IBM037//
++alias	CP1070//		IBM037//
++alias	CP282//			IBM037//
++module	IBM037//		INTERNAL		IBM037		1
++module	INTERNAL		IBM037//		IBM037		1
++
++#	from			to			module		cost
++alias	EBCDIC-INT//		IBM038//
++alias	CP038//			IBM038//
++alias	CSIBM038//		IBM038//
++module	IBM038//		INTERNAL		IBM038		1
++module	INTERNAL		IBM038//		IBM038		1
++
++#	from			to			module		cost
++alias	EBCDIC-INT1//		IBM256//
++module	IBM256//		INTERNAL		IBM256		1
++module	INTERNAL		IBM256//		IBM256		1
++
++#	from			to			module		cost
++alias	CP273//			IBM273//
++alias	CSIBM273//		IBM273//
++alias	OSF10020111//		IBM273//
++module	IBM273//		INTERNAL		IBM273		1
++module	INTERNAL		IBM273//		IBM273		1
++
++#	from			to			module		cost
++alias	EBCDIC-BE//		IBM274//
++alias	CP274//			IBM274//
++alias	CSIBM274//		IBM274//
++module	IBM274//		INTERNAL		IBM274		1
++module	INTERNAL		IBM274//		IBM274		1
++
++#	from			to			module		cost
++alias	EBCDIC-BR//		IBM275//
++alias	CP275//			IBM275//
++alias	CSIBM275//		IBM275//
++module	IBM275//		INTERNAL		IBM275		1
++module	INTERNAL		IBM275//		IBM275		1
++
++#	from			to			module		cost
++alias	EBCDIC-CP-DK//		IBM277//
++alias	EBCDIC-CP-NO//		IBM277//
++alias	CSIBM277//		IBM277//
++alias	OSF10020115//		IBM277//
++module	IBM277//		INTERNAL		IBM277		1
++module	INTERNAL		IBM277//		IBM277		1
++
++#	from			to			module		cost
++alias	CP278//			IBM278//
++alias	EBCDIC-CP-FI//		IBM278//
++alias	EBCDIC-CP-SE//		IBM278//
++alias	CSIBM278//		IBM278//
++alias	OSF10020116//		IBM278//
++module	IBM278//		INTERNAL		IBM278		1
++module	INTERNAL		IBM278//		IBM278		1
++
++#	from			to			module		cost
++alias	CP280//			IBM280//
++alias	EBCDIC-CP-IT//		IBM280//
++alias	CSIBM280//		IBM280//
++alias	OSF10020118//		IBM280//
++module	IBM280//		INTERNAL		IBM280		1
++module	INTERNAL		IBM280//		IBM280		1
++
++#	from			to			module		cost
++alias	EBCDIC-JP-E//		IBM281//
++alias	CP281//			IBM281//
++alias	CSIBM281//		IBM281//
++module	IBM281//		INTERNAL		IBM281		1
++module	INTERNAL		IBM281//		IBM281		1
++
++#	from			to			module		cost
++alias	CP284//			IBM284//
++alias	EBCDIC-CP-ES//		IBM284//
++alias	CSIBM284//		IBM284//
++alias	OSF1002011C//		IBM284//
++alias	CP1079//		IBM284//
++module	IBM284//		INTERNAL		IBM284		1
++module	INTERNAL		IBM284//		IBM284		1
++
++#	from			to			module		cost
++alias	CP285//			IBM285//
++alias	EBCDIC-CP-GB//		IBM285//
++alias	CSIBM285//		IBM285//
++alias	OSF1002011D//		IBM285//
++module	IBM285//		INTERNAL		IBM285		1
++module	INTERNAL		IBM285//		IBM285		1
++
++#	from			to			module		cost
++alias	CP290//			IBM290//
++alias	EBCDIC-JP-KANA//	IBM290//
++alias	CSIBM290//		IBM290//
++alias	OSF10020122//		IBM290//
++module	IBM290//		INTERNAL		IBM290		1
++module	INTERNAL		IBM290//		IBM290		1
++
++#	from			to			module		cost
++alias	CP297//			IBM297//
++alias	EBCDIC-CP-FR//		IBM297//
++alias	CSIBM297//		IBM297//
++alias	OSF10020129//		IBM297//
++alias	CP1081//		IBM297//
++module	IBM297//		INTERNAL		IBM297		1
++module	INTERNAL		IBM297//		IBM297		1
++
++#	from			to			module		cost
++alias	CP420//			IBM420//
++alias	EBCDIC-CP-AR1//		IBM420//
++alias	CSIBM420//		IBM420//
++alias	OSF100201A4//		IBM420//
++module	IBM420//		INTERNAL		IBM420		1
++module	INTERNAL		IBM420//		IBM420		1
++
++#	from			to			module		cost
++alias	CP423//			IBM423//
++alias	EBCDIC-CP-GR//		IBM423//
++alias	CSIBM423//		IBM423//
++module	IBM423//		INTERNAL		IBM423		1
++module	INTERNAL		IBM423//		IBM423		1
++
++#	from			to			module		cost
++alias	CP424//			IBM424//
++alias	EBCDIC-CP-HE//		IBM424//
++alias	CSIBM424//		IBM424//
++alias	OSF100201A8//		IBM424//
++module	IBM424//		INTERNAL		IBM424		1
++module	INTERNAL		IBM424//		IBM424		1
++
++#	from			to			module		cost
++alias	CP437//			IBM437//
++alias	437//			IBM437//
++alias	CSPC8CODEPAGE437//	IBM437//
++alias	OSF100201B5//		IBM437//
++module	IBM437//		INTERNAL		IBM437		1
++module	INTERNAL		IBM437//		IBM437		1
++
++#	from			to			module		cost
++alias	CP500//			IBM500//
++alias	500//			IBM500//
++alias	500V1//			IBM500//
++alias	EBCDIC-CP-BE//		IBM500//
++alias	EBCDIC-CP-CH//		IBM500//
++alias	CSIBM500//		IBM500//
++alias	OSF100201F4//		IBM500//
++alias	CP1084//		IBM500//
++module	IBM500//		INTERNAL		IBM500		1
++module	INTERNAL		IBM500//		IBM500		1
++
++#	from			to			module		cost
++alias	CP850//			IBM850//
++alias	850//			IBM850//
++alias	CSPC850MULTILINGUAL//	IBM850//
++alias	OSF10020352//		IBM850//
++module	IBM850//		INTERNAL		IBM850		1
++module	INTERNAL		IBM850//		IBM850		1
++
++#	from			to			module		cost
++alias	CP858//			IBM858//
++alias	858//			IBM858//
++alias	CSPC858MULTILINGUAL//	IBM858//
++module	IBM858//		INTERNAL		IBM858		1
++module	INTERNAL		IBM858//		IBM858		1
++
++#	from			to			module		cost
++alias	CP851//			IBM851//
++alias	851//			IBM851//
++alias	CSIBM851//		IBM851//
++module	IBM851//		INTERNAL		IBM851		1
++module	INTERNAL		IBM851//		IBM851		1
++
++#	from			to			module		cost
++alias	CP852//			IBM852//
++alias	852//			IBM852//
++alias	CSPCP852//		IBM852//
++alias	OSF10020354//		IBM852//
++module	IBM852//		INTERNAL		IBM852		1
++module	INTERNAL		IBM852//		IBM852		1
++
++#	from			to			module		cost
++alias	CP855//			IBM855//
++alias	855//			IBM855//
++alias	CSIBM855//		IBM855//
++alias	OSF10020357//		IBM855//
++module	IBM855//		INTERNAL		IBM855		1
++module	INTERNAL		IBM855//		IBM855		1
++
++#	from			to			module		cost
++alias	IBM-856//		IBM856//
++alias	CP856//			IBM856//
++alias	856//			IBM856//
++alias	CSIBM856//		IBM856//
++module	IBM856//		INTERNAL		IBM856		1
++module	INTERNAL		IBM856//		IBM856		1
++
++#	from			to			module		cost
++alias	CP857//			IBM857//
++alias	857//			IBM857//
++alias	CSIBM857//		IBM857//
++alias	OSF10020359//		IBM857//
++module	IBM857//		INTERNAL		IBM857		1
++module	INTERNAL		IBM857//		IBM857		1
++
++#	from			to			module		cost
++alias	CP860//			IBM860//
++alias	860//			IBM860//
++alias	CSIBM860//		IBM860//
++module	IBM860//		INTERNAL		IBM860		1
++module	INTERNAL		IBM860//		IBM860		1
++
++#	from			to			module		cost
++alias	CP861//			IBM861//
++alias	861//			IBM861//
++alias	CPIBM861//		IBM861//
++alias	OSF1002035D//		IBM861//
++module	IBM861//		INTERNAL		IBM861		1
++module	INTERNAL		IBM861//		IBM861		1
++
++#	from			to			module		cost
++alias	CP862//			IBM862//
++alias	862//			IBM862//
++alias	CSPC862LATINHEBREW//	IBM862//
++alias	OSF1002035E//		IBM862//
++module	IBM862//		INTERNAL		IBM862		1
++module	INTERNAL		IBM862//		IBM862		1
++
++#	from			to			module		cost
++alias	CP863//			IBM863//
++alias	863//			IBM863//
++alias	CSIBM863//		IBM863//
++alias	OSF1002035F//		IBM863//
++module	IBM863//		INTERNAL		IBM863		1
++module	INTERNAL		IBM863//		IBM863		1
++
++#	from			to			module		cost
++alias	CP864//			IBM864//
++alias	864//			IBM864//
++alias	CSIBM864//		IBM864//
++alias	OSF10020360//		IBM864//
++module	IBM864//		INTERNAL		IBM864		1
++module	INTERNAL		IBM864//		IBM864		1
++
++#	from			to			module		cost
++alias	CP865//			IBM865//
++alias	865//			IBM865//
++alias	CSIBM865//		IBM865//
++module	IBM865//		INTERNAL		IBM865		1
++module	INTERNAL		IBM865//		IBM865		1
++
++#	from			to			module		cost
++alias	CP866//			IBM866//
++alias	866//			IBM866//
++alias	CSIBM866//		IBM866//
++module	IBM866//		INTERNAL		IBM866		1
++module	INTERNAL		IBM866//		IBM866		1
++
++#	from			to			module		cost
++alias	CP866NAV//		IBM866NAV//
++alias	866NAV//		IBM866NAV//
++module	IBM866NAV//		INTERNAL		IBM866NAV	1
++module	INTERNAL		IBM866NAV//		IBM866NAV	1
++
++#	from			to			module		cost
++alias	CP868//			IBM868//
++alias	CP-AR//			IBM868//
++alias	CSIBM868//		IBM868//
++alias	OSF10020364//		IBM868//
++module	IBM868//		INTERNAL		IBM868		1
++module	INTERNAL		IBM868//		IBM868		1
++
++#	from			to			module		cost
++alias	CP869//			IBM869//
++alias	869//			IBM869//
++alias	CP-GR//			IBM869//
++alias	CSIBM869//		IBM869//
++alias	OSF10020365//		IBM869//
++module	IBM869//		INTERNAL		IBM869		1
++module	INTERNAL		IBM869//		IBM869		1
++
++#	from			to			module		cost
++alias	CP870//			IBM870//
++alias	EBCDIC-CP-ROECE//	IBM870//
++alias	EBCDIC-CP-YU//		IBM870//
++alias	CSIBM870//		IBM870//
++alias	OSF10020366//		IBM870//
++module	IBM870//		INTERNAL		IBM870		1
++module	INTERNAL		IBM870//		IBM870		1
++
++#	from			to			module		cost
++alias	CP871//			IBM871//
++alias	EBCDIC-CP-IS//		IBM871//
++alias	CSIBM871//		IBM871//
++alias	OSF10020367//		IBM871//
++module	IBM871//		INTERNAL		IBM871		1
++module	INTERNAL		IBM871//		IBM871		1
++
++#	from			to			module		cost
++alias	CP875//			IBM875//
++alias	EBCDIC-GREEK//		IBM875//
++alias	OSF1002036B//		IBM875//
++module	IBM875//		INTERNAL		IBM875		1
++module	INTERNAL		IBM875//		IBM875		1
++
++#	from			to			module		cost
++alias	CP880//			IBM880//
++alias	EBCDIC-CYRILLIC//	IBM880//
++alias	CSIBM880//		IBM880//
++alias	OSF10020370//		IBM880//
++module	IBM880//		INTERNAL		IBM880		1
++module	INTERNAL		IBM880//		IBM880		1
++
++#	from			to			module		cost
++alias	CP891//			IBM891//
++alias	CSIBM891//		IBM891//
++alias	OSF1002037B//		IBM891//
++module	IBM891//		INTERNAL		IBM891		1
++module	INTERNAL		IBM891//		IBM891		1
++
++#	from			to			module		cost
++alias	CP903//			IBM903//
++alias	CSIBM903//		IBM903//
++alias	OSF10020387//		IBM903//
++module	IBM903//		INTERNAL		IBM903		1
++module	INTERNAL		IBM903//		IBM903		1
++
++#	from			to			module		cost
++alias	CP904//			IBM904//
++alias	904//			IBM904//
++alias	CSIBM904//		IBM904//
++alias	OSF10020388//		IBM904//
++module	IBM904//		INTERNAL		IBM904		1
++module	INTERNAL		IBM904//		IBM904		1
++
++#	from			to			module		cost
++alias	CP905//			IBM905//
++alias	EBCDIC-CP-TR//		IBM905//
++alias	CSIBM905//		IBM905//
++module	IBM905//		INTERNAL		IBM905		1
++module	INTERNAL		IBM905//		IBM905		1
++
++#	from			to			module		cost
++alias	CP918//			IBM918//
++alias	EBCDIC-CP-AR2//		IBM918//
++alias	CSIBM918//		IBM918//
++alias	OSF10020396//		IBM918//
++module	IBM918//		INTERNAL		IBM918		1
++module	INTERNAL		IBM918//		IBM918		1
++
++#	from			to			module		cost
++alias	IBM-922//		IBM922//
++alias	CP922//			IBM922//
++alias	CSIBM922//		IBM922//
++module	IBM922//		INTERNAL		IBM922		1
++module	INTERNAL		IBM922//		IBM922		1
++
++#	from			to			module		cost
++alias	IBM-930//		IBM930//
++alias	CP930//			IBM930//
++alias	CSIBM930//		IBM930//
++module	IBM930//		INTERNAL		IBM930		1
++module	INTERNAL		IBM930//		IBM930		1
++
++#	from			to			module		cost
++alias	IBM-932//		IBM932//
++alias	CSIBM932//		IBM932//
++module	IBM932//		INTERNAL		IBM932		1
++module	INTERNAL		IBM932//		IBM932		1
++
++#	from			to			module		cost
++alias	IBM-933//		IBM933//
++alias	CP933//			IBM933//
++alias	CSIBM933//		IBM933//
++module	IBM933//		INTERNAL		IBM933		1
++module	INTERNAL		IBM933//		IBM933		1
++
++#	from			to			module		cost
++alias	IBM-935//		IBM935//
++alias	CP935//			IBM935//
++alias	CSIBM935//		IBM935//
++module	IBM935//		INTERNAL		IBM935		1
++module	INTERNAL		IBM935//		IBM935		1
++
++#	from			to			module		cost
++alias	IBM-937//		IBM937//
++alias	CP937//			IBM937//
++alias	CSIBM937//		IBM937//
++module	IBM937//		INTERNAL		IBM937		1
++module	INTERNAL		IBM937//		IBM937		1
++
++#	from			to			module		cost
++alias	IBM-939//		IBM939//
++alias	CP939//			IBM939//
++alias	CSIBM939//		IBM939//
++module	IBM939//		INTERNAL		IBM939		1
++module	INTERNAL		IBM939//		IBM939		1
++
++#	from			to			module		cost
++alias	IBM-943//		IBM943//
++alias	CSIBM943//		IBM943//
++module	IBM943//		INTERNAL		IBM943		1
++module	INTERNAL		IBM943//		IBM943		1
++
++#	from			to			module		cost
++alias	CP1004//		IBM1004//
++alias	OS2LATIN1//		IBM1004//
++module	IBM1004//		INTERNAL		IBM1004		1
++module	INTERNAL		IBM1004//		IBM1004		1
++
++#	from			to			module		cost
++alias	CP1026//		IBM1026//
++alias	1026//			IBM1026//
++alias	CSIBM1026//		IBM1026//
++alias	OSF10020402//		IBM1026//
++module	IBM1026//		INTERNAL		IBM1026		1
++module	INTERNAL		IBM1026//		IBM1026		1
++
++#	from			to			module		cost
++alias	IBM-1046//		IBM1046//
++alias	CP1046//		IBM1046//
++alias	1046//			IBM1046//
++module	IBM1046//		INTERNAL		IBM1046		1
++module	INTERNAL		IBM1046//		IBM1046		1
++
++#	from			to			module		cost
++alias	IBM-1047//		IBM1047//
++alias	CP1047//		IBM1047//
++alias	1047//			IBM1047//
++alias	OSF10020417//		IBM1047//
++module	IBM1047//		INTERNAL		IBM1047		1
++module	INTERNAL		IBM1047//		IBM1047		1
++
++#	from			to			module		cost
++alias	IBM-1124//		IBM1124//
++alias	CP1124//		IBM1124//
++alias	CSIBM1124//		IBM1124//
++module	IBM1124//		INTERNAL		IBM1124		1
++module	INTERNAL		IBM1124//		IBM1124		1
++
++#	from			to			module		cost
++alias	IBM-1129//		IBM1129//
++alias	CP1129//		IBM1129//
++alias	CSIBM1129//		IBM1129//
++module	IBM1129//		INTERNAL		IBM1129		1
++module	INTERNAL		IBM1129//		IBM1129		1
++
++#	from			to			module		cost
++alias	IBM-1160//		IBM1160//
++alias	CP1160//		IBM1160//
++alias	CSIBM1160//		IBM1160//
++module	IBM1160//		INTERNAL		IBM1160		1
++module	INTERNAL		IBM1160//		IBM1160		1
++
++#	from			to			module		cost
++alias	IBM-1161//		IBM1161//
++alias	CP1161//		IBM1161//
++alias	CSIBM1161//		IBM1161//
++module	IBM1161//		INTERNAL		IBM1161		1
++module	INTERNAL		IBM1161//		IBM1161		1
++
++#	from			to			module		cost
++alias	IBM-1132//		IBM1132//
++alias	CP1132//		IBM1132//
++alias	CSIBM1132//		IBM1132//
++module	IBM1132//		INTERNAL		IBM1132		1
++module	INTERNAL		IBM1132//		IBM1132		1
++
++#	from			to			module		cost
++alias	IBM-1133//		IBM1133//
++alias	CP1133//		IBM1133//
++alias	CSIBM1133//		IBM1133//
++module	IBM1133//		INTERNAL		IBM1133		1
++module	INTERNAL		IBM1133//		IBM1133		1
++
++#	from			to			module		cost
++alias	IBM-1162//		IBM1162//
++alias	CP1162//		IBM1162//
++alias	CSIBM11621162//		IBM1162//
++module	IBM1162//		INTERNAL		IBM1162		1
++module	INTERNAL		IBM1162//		IBM1162		1
++
++#	from			to			module		cost
++alias	IBM-1163//		IBM1163//
++alias	CP1163//		IBM1163//
++alias	CSIBM1163//		IBM1163//
++module	IBM1163//		INTERNAL		IBM1163		1
++module	INTERNAL		IBM1163//		IBM1163		1
++
++#	from			to			module		cost
++alias	IBM-1164//		IBM1164//
++alias	CP1164//		IBM1164//
++alias	CSIBM1164//		IBM1164//
++module	IBM1164//		INTERNAL		IBM1164		1
++module	INTERNAL		IBM1164//		IBM1164		1
++
++#	from			to			module		cost
++alias	EUCKR//			EUC-KR//
++alias	CSEUCKR//		EUC-KR//
++alias	OSF0004000a//		EUC-KR//
++module	EUC-KR//		INTERNAL		EUC-KR		1
++module	INTERNAL		EUC-KR//		EUC-KR		1
++
++#	from			to			module		cost
++alias	MSCP949//		UHC//
++alias	CP949//			UHC//
++alias	OSF100203B5//		UHC//
++module	UHC//			INTERNAL		UHC		1
++module	INTERNAL		UHC//			UHC		1
++
++#	from			to			module		cost
++alias	MSCP1361//		JOHAB//
++alias	CP1361//		JOHAB//
++module	JOHAB//			INTERNAL		JOHAB		1
++module	INTERNAL		JOHAB//			JOHAB		1
++
++#	from			to			module		cost
++alias	BIG-FIVE//		BIG5//
++alias	BIGFIVE//		BIG5//
++alias	BIG-5//			BIG5//
++alias	CN-BIG5//		BIG5//
++alias	CP950//			BIG5//
++module	BIG5//			INTERNAL		BIG5		1
++module	INTERNAL		BIG5//			BIG5		1
++
++#	from			to			module		cost
++alias	BIG5-HKSCS//		BIG5HKSCS//
++module	BIG5HKSCS//		INTERNAL		BIG5HKSCS	1
++module	INTERNAL		BIG5HKSCS//		BIG5HKSCS	1
++
++#	from			to			module		cost
++alias	EUCJP-MS//		EUC-JP-MS//
++alias	EUCJP-OPEN//		EUC-JP-MS//
++alias	EUCJP-WIN//		EUC-JP-MS//
++module	EUC-JP-MS//		INTERNAL		EUC-JP-MS	1
++module	INTERNAL		EUC-JP-MS//		EUC-JP-MS	1
++
++#	from			to			module		cost
++alias	EUCJP//			EUC-JP//
++alias	CSEUCPKDFMTJAPANESE//	EUC-JP//
++alias	OSF00030010//		EUC-JP//
++alias	UJIS//			EUC-JP//
++module	EUC-JP//		INTERNAL		EUC-JP		1
++module	INTERNAL		EUC-JP//		EUC-JP		1
++
++#	from			to			module		cost
++alias	EUCCN//			EUC-CN//
++alias	GB2312//		EUC-CN//
++alias	csGB2312//		EUC-CN//
++alias	CN-GB//			EUC-CN//
++module	EUC-CN//		INTERNAL		EUC-CN		1
++module	INTERNAL		EUC-CN//		EUC-CN		1
++
++#	from			to			module		cost
++module	EUC-CN//		BIG5//			GBBIG5		1
++module	BIG5//			EUC-CN//		GBBIG5		1
++
++#	from			to			module		cost
++alias	GB13000//		GBK//
++alias	CP936//			GBK//
++alias	MS936//			GBK//
++alias	WINDOWS-936//		GBK//
++module	GBK//			INTERNAL		GBK		1
++module	INTERNAL		GBK//			GBK		1
++
++#	from			to			module		cost
++module	GBK//			EUC-CN//		GBGBK		1
++module	EUC-CN//		GBK//			GBGBK		1
++
++#	from			to			module		cost
++alias	EUCTW//			EUC-TW//
++alias	OSF0005000a//		EUC-TW//
++module	EUC-TW//		INTERNAL		EUC-TW		1
++module	INTERNAL		EUC-TW//		EUC-TW		1
++
++#	from			to			module		cost
++alias	RUSCII//		CP1125//
++alias	IBM848//		CP1125//
++module	CP1125//		INTERNAL		CP1125		1
++module	INTERNAL		CP1125//		CP1125		1
++
++#	from			to			module		cost
++alias	MS-EE//			CP1250//
++alias	WINDOWS-1250//		CP1250//
++module	CP1250//		INTERNAL		CP1250		1
++module	INTERNAL		CP1250//		CP1250		1
++
++#	from			to			module		cost
++alias	MS-CYRL//		CP1251//
++alias	WINDOWS-1251//		CP1251//
++module	CP1251//		INTERNAL		CP1251		1
++module	INTERNAL		CP1251//		CP1251		1
++
++#	from			to			module		cost
++alias	MS-GREEK//		CP1253//
++alias	WINDOWS-1253//		CP1253//
++module	CP1253//		INTERNAL		CP1253		1
++module	INTERNAL		CP1253//		CP1253		1
++
++#	from			to			module		cost
++alias	MS-TURK//		CP1254//
++alias	WINDOWS-1254//		CP1254//
++module	CP1254//		INTERNAL		CP1254		1
++module	INTERNAL		CP1254//		CP1254		1
++
++#	from			to			module		cost
++alias	MS-HEBR//		CP1255//
++alias	WINDOWS-1255//		CP1255//
++module	CP1255//		INTERNAL		CP1255		1
++module	INTERNAL		CP1255//		CP1255		1
++
++#	from			to			module		cost
++alias	MS-ARAB//		CP1256//
++alias	WINDOWS-1256//		CP1256//
++module	CP1256//		INTERNAL		CP1256		1
++module	INTERNAL		CP1256//		CP1256		1
++
++#	from			to			module		cost
++alias	WINBALTRIM//		CP1257//
++alias	WINDOWS-1257//		CP1257//
++module	CP1257//		INTERNAL		CP1257		1
++module	INTERNAL		CP1257//		CP1257		1
++
++#	from			to			module		cost
++alias	WINDOWS-1258//		CP1258//
++module	CP1258//		INTERNAL		CP1258		1
++module	INTERNAL		CP1258//		CP1258		1
++
++#	from			to			module		cost
++alias	874//			IBM874//
++alias	CP874//			IBM874//
++alias	WINDOWS-874//		IBM874//
++module	IBM874//		INTERNAL		IBM874		1
++module	INTERNAL		IBM874//		IBM874		1
++
++#	from			to			module		cost
++module	CP737//			INTERNAL		CP737		1
++module	INTERNAL		CP737//			CP737		1
++
++#	from			to			module		cost
++module	CP770//			INTERNAL		CP770		1
++module	INTERNAL		CP770//			CP770		1
++
++#	from			to			module		cost
++module	CP771//			INTERNAL		CP771		1
++module	INTERNAL		CP771//			CP771		1
++
++#	from			to			module		cost
++module	CP772//			INTERNAL		CP772		1
++module	INTERNAL		CP772//			CP772		1
++
++#	from			to			module		cost
++module	CP773//			INTERNAL		CP773		1
++module	INTERNAL		CP773//			CP773		1
++
++#	from			to			module		cost
++module	CP774//			INTERNAL		CP774		1
++module	INTERNAL		CP774//			CP774		1
++
++#	from			to			module		cost
++alias	IBM775//		CP775//
++alias	CSPC775BALTIC//		CP775//
++module	CP775//			INTERNAL		CP775		1
++module	INTERNAL		CP775//			CP775		1
++
++#	from			to			module		cost
++alias	CSISO2022JP//		ISO-2022-JP//
++alias	ISO2022JP//		ISO-2022-JP//
++module	ISO-2022-JP//		INTERNAL		ISO-2022-JP	1
++module	INTERNAL		ISO-2022-JP//		ISO-2022-JP	1
++
++#	from			to			module		cost
++alias	CSISO2022JP2//		ISO-2022-JP-2//
++alias	ISO2022JP2//		ISO-2022-JP-2//
++module	ISO-2022-JP-2//		INTERNAL		ISO-2022-JP	1
++module	INTERNAL		ISO-2022-JP-2//		ISO-2022-JP	1
++
++#	from			to			module		cost
++module	ISO-2022-JP-3//		INTERNAL		ISO-2022-JP-3	1
++module	INTERNAL		ISO-2022-JP-3//		ISO-2022-JP-3	1
++
++#	from			to			module		cost
++alias	CSISO2022KR//		ISO-2022-KR//
++alias	ISO2022KR//		ISO-2022-KR//
++module	ISO-2022-KR//		INTERNAL		ISO-2022-KR	1
++module	INTERNAL		ISO-2022-KR//		ISO-2022-KR	1
++
++#	from			to			module		cost
++alias	CSISO2022CN//		ISO-2022-CN//
++alias	ISO2022CN//		ISO-2022-CN//
++module	ISO-2022-CN//		INTERNAL		ISO-2022-CN	1
++module	INTERNAL		ISO-2022-CN//		ISO-2022-CN	1
++
++#	from			to			module		cost
++alias	ISO2022CNEXT//		ISO-2022-CN-EXT//
++module	ISO-2022-CN-EXT//	INTERNAL		ISO-2022-CN-EXT	1
++module	INTERNAL		ISO-2022-CN-EXT//	ISO-2022-CN-EXT	1
++
++#	from			to			module		cost
++alias	MAC//			MACINTOSH//
++alias	CSMACINTOSH//		MACINTOSH//
++module	MACINTOSH//		INTERNAL		MACINTOSH	1
++module	INTERNAL		MACINTOSH//		MACINTOSH	1
++
++#	from			to			module		cost
++alias	ISO-IR-143//		IEC_P27-1//
++alias	CSISO143IECP271//	IEC_P27-1//
++alias	IEC_P271//		IEC_P27-1//
++module	IEC_P27-1//		INTERNAL		IEC_P27-1	1
++module	INTERNAL		IEC_P27-1//		IEC_P27-1	1
++
++#	from			to			module		cost
++alias	ISO_9036//		ASMO_449//
++alias	ARABIC7//		ASMO_449//
++alias	ISO-IR-89//		ASMO_449//
++alias	CSISO89ASMO449//	ASMO_449//
++module	ASMO_449//		INTERNAL		ASMO_449	1
++module	INTERNAL		ASMO_449//		ASMO_449	1
++
++#	from			to			module		cost
++alias	ISO-IR-139//		CSN_369103//
++alias	CSISO139CSN369103//	CSN_369103//
++module	CSN_369103//		INTERNAL		CSN_369103	1
++module	INTERNAL		CSN_369103//		CSN_369103	1
++
++#	from			to			module		cost
++alias	CWI-2//			CWI//
++alias	CP-HU//			CWI//
++module	CWI//			INTERNAL		CWI		1
++module	INTERNAL		CWI//			CWI		1
++
++#	from			to			module		cost
++alias	DEC//			DEC-MCS//
++alias	CSDECMCS//		DEC-MCS//
++alias	DECMCS//		DEC-MCS//
++module	DEC-MCS//		INTERNAL		DEC-MCS		1
++module	INTERNAL		DEC-MCS//		DEC-MCS		1
++
++#	from			to			module		cost
++alias	ISO-IR-111//		ECMA-CYRILLIC//
++alias	CSISO111ECMACYRILLIC//	ECMA-CYRILLIC//
++alias	ECMACYRILLIC//		ECMA-CYRILLIC//
++module	ECMA-CYRILLIC//		INTERNAL		ECMA-CYRILLIC	1
++module	INTERNAL		ECMA-CYRILLIC//		ECMA-CYRILLIC	1
++
++#	from			to			module		cost
++alias	ST_SEV_358-88//		GOST_19768-74//
++alias	GOST_19768//		GOST_19768-74//
++alias	ISO-IR-153//		GOST_19768-74//
++alias	CSISO153GOST1976874//	GOST_19768-74//
++alias	GOST_1976874//		GOST_19768-74//
++module	GOST_19768-74//		INTERNAL		GOST_19768-74	1
++module	INTERNAL		GOST_19768-74//		GOST_19768-74	1
++
++#	from			to			module		cost
++alias	ISO-IR-150//		GREEK-CCITT//
++alias	CSISO150//		GREEK-CCITT//
++alias	CSISO150GREEKCCITT//	GREEK-CCITT//
++alias	GREEKCCITT//		GREEK-CCITT//
++module	GREEK-CCITT//		INTERNAL		GREEK-CCITT	1
++module	INTERNAL		GREEK-CCITT//		GREEK-CCITT	1
++
++#	from			to			module		cost
++alias	ISO-IR-88//		GREEK7//
++alias	CSISO88GREEK7//		GREEK7//
++module	GREEK7//		INTERNAL		GREEK7		1
++module	INTERNAL		GREEK7//		GREEK7		1
++
++#	from			to			module		cost
++alias	ISO-IR-18//		GREEK7-OLD//
++alias	CSISO18GREEK7OLD//	GREEK7-OLD//
++alias	GREEK7OLD//		GREEK7-OLD//
++module	GREEK7-OLD//		INTERNAL		GREEK7-OLD	1
++module	INTERNAL		GREEK7-OLD//		GREEK7-OLD	1
++
++#	from			to			module		cost
++alias	ISO-IR-49//		INIS//
++alias	CSISO49INIS//		INIS//
++module	INIS//			INTERNAL		INIS		1
++module	INTERNAL		INIS//			INIS		1
++
++#	from			to			module		cost
++alias	ISO-IR-50//		INIS-8//
++alias	CSISO50INIS8//		INIS-8//
++alias	INIS8//			INIS-8//
++module	INIS-8//		INTERNAL		INIS-8		1
++module	INTERNAL		INIS-8//		INIS-8		1
++
++#	from			to			module		cost
++alias	ISO-IR-51//		INIS-CYRILLIC//
++alias	CSISO51INISCYRILLIC//	INIS-CYRILLIC//
++alias	INISCYRILLIC//		INIS-CYRILLIC//
++module	INIS-CYRILLIC//		INTERNAL		INIS-CYRILLIC	1
++module	INTERNAL		INIS-CYRILLIC//		INIS-CYRILLIC	1
++
++#	from			to			module		cost
++alias	ISO-IR-98//		ISO_2033//
++alias	ISO_2033-1983//		ISO_2033//
++alias	E13B//			ISO_2033//
++alias	CSISO2033//		ISO_2033//
++module	ISO_2033//		INTERNAL		ISO_2033	1
++module	INTERNAL		ISO_2033//		ISO_2033	1
++
++#	from			to			module		cost
++alias	ISO-IR-37//		ISO_5427//
++alias	KOI-7//			ISO_5427//
++alias	CSISO5427CYRILLIC//	ISO_5427//
++module	ISO_5427//		INTERNAL		ISO_5427	1
++module	INTERNAL		ISO_5427//		ISO_5427	1
++
++#	from			to			module		cost
++alias	ISO-IR-54//		ISO_5427-EXT//
++alias	ISO_5427:1981//		ISO_5427-EXT//
++alias	CSISO5427CYRILLIC1981//	ISO_5427-EXT//
++alias	ISO_5427EXT//		ISO_5427-EXT//
++module	ISO_5427-EXT//		INTERNAL		ISO_5427-EXT	1
++module	INTERNAL		ISO_5427-EXT//		ISO_5427-EXT	1
++
++#	from			to			module		cost
++alias	ISO-IR-55//		ISO_5428//
++alias	ISO_5428:1980//		ISO_5428//
++alias	CSISO5428GREEK//	ISO_5428//
++module	ISO_5428//		INTERNAL		ISO_5428	1
++module	INTERNAL		ISO_5428//		ISO_5428	1
++
++#	from			to			module		cost
++alias	ISO-IR-155//		ISO_10367-BOX//
++alias	CSISO10367BOX//		ISO_10367-BOX//
++alias	ISO_10367BOX//		ISO_10367-BOX//
++module	ISO_10367-BOX//		INTERNAL		ISO_10367-BOX	1
++module	INTERNAL		ISO_10367-BOX//		ISO_10367-BOX	1
++
++#	from			to			module		cost
++alias	MACIS//			MAC-IS//
++module	MAC-IS//		INTERNAL		MAC-IS		1
++module	INTERNAL		MAC-IS//		MAC-IS		1
++
++#	from			to			module		cost
++alias	MACUK//			MAC-UK//
++alias	MACUKRAINIAN//		MAC-UK//
++alias	MAC-CYRILLIC//		MAC-UK//
++alias	MACCYRILLIC//		MAC-UK//
++module	MAC-UK//		INTERNAL		MAC-UK		1
++module	INTERNAL		MAC-UK//		MAC-UK		1
++
++#	from			to			module		cost
++alias	MS-MAC-CYRILLIC//	CP10007//
++alias	MSMACCYRILLIC//		CP10007//
++module	CP10007//		INTERNAL		CP10007		1
++module	INTERNAL		CP10007//		CP10007		1
++
++#	from			to			module		cost
++alias	ISO-IR-9-1//		NATS-DANO//
++alias	CSNATSDANO//		NATS-DANO//
++alias	NATSDANO//		NATS-DANO//
++module	NATS-DANO//		INTERNAL		NATS-DANO	1
++module	INTERNAL		NATS-DANO//		NATS-DANO	1
++
++#	from			to			module		cost
++alias	ISO-IR-8-1//		NATS-SEFI//
++alias	CSNATSSEFI//		NATS-SEFI//
++alias	NATSSEFI//		NATS-SEFI//
++module	NATS-SEFI//		INTERNAL		NATS-SEFI	1
++module	INTERNAL		NATS-SEFI//		NATS-SEFI	1
++
++#	from			to			module		cost
++alias	WS2//			WIN-SAMI-2//
++alias	WINSAMI2//		WIN-SAMI-2//
++module	WIN-SAMI-2//		INTERNAL		SAMI-WS2	1
++module	INTERNAL		WIN-SAMI-2//		SAMI-WS2	1
++
++#	from			to			module		cost
++module	ISO-IR-197//		INTERNAL		ISO-IR-197	1
++module	INTERNAL		ISO-IR-197//		ISO-IR-197	1
++
++#	from			to			module		cost
++alias	TIS620//		TIS-620//
++alias	TIS620-0//		TIS-620//
++alias	TIS620.2529-1//		TIS-620//
++alias	TIS620.2533-0//		TIS-620//
++alias	ISO-IR-166//		TIS-620//
++module	TIS-620//		INTERNAL		TIS-620		1
++module	INTERNAL		TIS-620//		TIS-620		1
++
++#	from			to			module		cost
++alias	KOI8U//			KOI8-U//
++module	KOI8-U//		INTERNAL		KOI8-U		1
++module	INTERNAL		KOI8-U//		KOI8-U		1
++
++#	from			to			module		cost
++alias	ISIRI3342//		ISIRI-3342//
++module	ISIRI-3342//		INTERNAL		ISIRI-3342	1
++module	INTERNAL		ISIRI-3342//		ISIRI-3342	1
++
++#	from			to			module		cost
++module	GB18030//		INTERNAL		GB18030		1
++module	INTERNAL		GB18030//		GB18030		1
++
++#	from			to			module		cost
++module	VISCII//		INTERNAL		VISCII		1
++module	INTERNAL		VISCII//		VISCII		1
++
++#	from			to			module		cost
++module	KOI8-T//		INTERNAL		KOI8-T		1
++module	INTERNAL		KOI8-T//		KOI8-T		1
++
++#	from			to			module		cost
++module	GEORGIAN-PS//		INTERNAL		GEORGIAN-PS	1
++module	INTERNAL		GEORGIAN-PS//		GEORGIAN-PS	1
++
++#	from			to			module		cost
++module	GEORGIAN-ACADEMY//	INTERNAL		GEORGIAN-ACADEMY 1
++module	INTERNAL		GEORGIAN-ACADEMY//	GEORGIAN-ACADEMY 1
++
++#	from			to			module		cost
++module	ISO-IR-209//		INTERNAL		ISO-IR-209	1
++module	INTERNAL		ISO-IR-209//		ISO-IR-209	1
++
++#	from			to			module		cost
++module	MAC-SAMI//		INTERNAL		MAC-SAMI	1
++module	INTERNAL		MAC-SAMI//		MAC-SAMI	1
++
++#	from			to			module		cost
++alias	ARMSCII8//		ARMSCII-8//
++module	ARMSCII-8//		INTERNAL		ARMSCII-8	1
++module	INTERNAL		ARMSCII-8//		ARMSCII-8	1
++
++#	from			to			module		cost
++alias	TCVN//			TCVN5712-1//
++alias	TCVN-5712//		TCVN5712-1//
++alias	TCVN5712-1:1993//	TCVN5712-1//
++module	TCVN5712-1//		INTERNAL		TCVN5712-1	1
++module	INTERNAL		TCVN5712-1//		TCVN5712-1	1
++
++#	from			to			module		cost
++module	EUC-JISX0213//		INTERNAL		EUC-JISX0213	1
++module	INTERNAL		EUC-JISX0213//		EUC-JISX0213	1
++
++#	from			to			module		cost
++alias	ShiftJISX0213//		Shift_JISX0213//
++module	Shift_JISX0213//	INTERNAL		SHIFT_JISX0213	1
++module	INTERNAL		Shift_JISX0213//	SHIFT_JISX0213	1
++
++#	from			to			module		cost
++module	TSCII//			INTERNAL		TSCII		1
++module	INTERNAL		TSCII//			TSCII		1
++
++#	from			to			module		cost
++module	PT154//			INTERNAL		PT154		1
++module	INTERNAL		PT154//			PT154		1
++
++#	from			to			module		cost
++alias	STRK1048-2002//		RK1048//
++module	RK1048//		INTERNAL		RK1048		1
++module	INTERNAL		RK1048//		RK1048		1
++
++#	from			to			module		cost
++alias	IBM-1025//		IBM1025//
++alias	CP1025//		IBM1025//
++alias	CSIBM1025//		IBM1025//
++module	IBM1025//		INTERNAL		IBM1025		1
++module	INTERNAL		IBM1025//		IBM1025		1
++
++#	from			to			module		cost
++alias	IBM-1122//		IBM1122//
++alias	CP1122//		IBM1122//
++alias	CSIBM1122//		IBM1122//
++module	IBM1122//		INTERNAL		IBM1122		1
++module	INTERNAL		IBM1122//		IBM1122		1
++
++#	from			to			module		cost
++alias	IBM-1137//		IBM1137//
++alias	CP1137//		IBM1137//
++alias	CSIBM1137//		IBM1137//
++module	IBM1137//		INTERNAL		IBM1137		1
++module	INTERNAL		IBM1137//		IBM1137		1
++
++#	from			to			module		cost
++alias	IBM-1153//		IBM1153//
++alias	CP1153//		IBM1153//
++alias	CSIBM1153//		IBM1153//
++module	IBM1153//		INTERNAL		IBM1153		1
++module	INTERNAL		IBM1153//		IBM1153		1
++
++#	from			to			module		cost
++alias	IBM-1154//		IBM1154//
++alias	CP1154//		IBM1154//
++alias	CSIBM1154//		IBM1154//
++module	IBM1154//		INTERNAL		IBM1154		1
++module	INTERNAL		IBM1154//		IBM1154		1
++
++#	from			to			module		cost
++alias	IBM-1155//		IBM1155//
++alias	CP1155//		IBM1155//
++alias	CSIBM1155//		IBM1155//
++module	IBM1155//		INTERNAL		IBM1155		1
++module	INTERNAL		IBM1155//		IBM1155		1
++
++#	from			to			module		cost
++alias	IBM-1156//		IBM1156//
++alias	CP1156//		IBM1156//
++alias	CSIBM1156//		IBM1156//
++module	IBM1156//		INTERNAL		IBM1156		1
++module	INTERNAL		IBM1156//		IBM1156		1
++
++#	from			to			module		cost
++alias	IBM-1157//		IBM1157//
++alias	CP1157//		IBM1157//
++alias	CSIBM1157//		IBM1157//
++module	IBM1157//		INTERNAL		IBM1157		1
++module	INTERNAL		IBM1157//		IBM1157		1
++
++#	from			to			module		cost
++alias	IBM-1158//		IBM1158//
++alias	CP1158//		IBM1158//
++alias	CSIBM1158//		IBM1158//
++module	IBM1158//		INTERNAL		IBM1158		1
++module	INTERNAL		IBM1158//		IBM1158		1
++
++#	from			to			module		cost
++alias	IBM-803//		IBM803//
++alias	CP803//		IBM803//
++alias	CSIBM803//		IBM803//
++module	IBM803//		INTERNAL		IBM803		1
++module	INTERNAL		IBM803//		IBM803		1
++
++#	from			to			module		cost
++alias	IBM-901//		IBM901//
++alias	CP901//		IBM901//
++alias	CSIBM901//		IBM901//
++module	IBM901//		INTERNAL		IBM901		1
++module	INTERNAL		IBM901//		IBM901		1
++
++#	from			to			module		cost
++alias	IBM-902//		IBM902//
++alias	CP902//		IBM902//
++alias	CSIBM902//		IBM902//
++module	IBM902//		INTERNAL		IBM902		1
++module	INTERNAL		IBM902//		IBM902		1
++
++#	from			to			module		cost
++alias	IBM-921//		IBM921//
++alias	CP921//		IBM921//
++alias	CSIBM921//		IBM921//
++module	IBM921//		INTERNAL		IBM921		1
++module	INTERNAL		IBM921//		IBM921		1
++
++#	from			to			module		cost
++alias	IBM-1008//		IBM1008//
++alias	CP1008//		IBM1008//
++alias	CSIBM1008//		IBM1008//
++module	IBM1008//		INTERNAL		IBM1008		1
++module	INTERNAL		IBM1008//		IBM1008		1
++
++#	from			to			module		cost
++module	IBM1008//		IBM420//		IBM1008_420	1
++module	IBM420//		IBM1008//		IBM1008_420	1
++
++#	from			to			module		cost
++alias	IBM-1097//		IBM1097//
++alias	CP1097//		IBM1097//
++alias	CSIBM1097//		IBM1097//
++module	IBM1097//		INTERNAL		IBM1097		1
++module	INTERNAL		IBM1097//		IBM1097		1
++
++#	from			to			module		cost
++alias	IBM-1112//		IBM1112//
++alias	CP1112//		IBM1112//
++alias	CSIBM1112//		IBM1112//
++module	IBM1112//		INTERNAL		IBM1112		1
++module	INTERNAL		IBM1112//		IBM1112		1
++
++#	from			to			module		cost
++alias	IBM-1123//		IBM1123//
++alias	CP1123//		IBM1123//
++alias	CSIBM1123//		IBM1123//
++module	IBM1123//		INTERNAL		IBM1123		1
++module	INTERNAL		IBM1123//		IBM1123		1
++
++#	from			to			module		cost
++alias	IBM-1130//		IBM1130//
++alias	CP1130//		IBM1130//
++alias	CSIBM1130//		IBM1130//
++module	IBM1130//		INTERNAL		IBM1130		1
++module	INTERNAL		IBM1130//		IBM1130		1
++
++#	from			to			module		cost
++alias	IBM-1140//		IBM1140//
++alias	CP1140//		IBM1140//
++alias	CSIBM1140//		IBM1140//
++module	IBM1140//		INTERNAL		IBM1140		1
++module	INTERNAL		IBM1140//		IBM1140		1
++
++#	from			to			module		cost
++alias	IBM-1141//		IBM1141//
++alias	CP1141//		IBM1141//
++alias	CSIBM1141//		IBM1141//
++module	IBM1141//		INTERNAL		IBM1141		1
++module	INTERNAL		IBM1141//		IBM1141		1
++
++#	from			to			module		cost
++alias	IBM-1142//		IBM1142//
++alias	CP1142//		IBM1142//
++alias	CSIBM1142//		IBM1142//
++module	IBM1142//		INTERNAL		IBM1142		1
++module	INTERNAL		IBM1142//		IBM1142		1
++
++#	from			to			module		cost
++alias	IBM-1143//		IBM1143//
++alias	CP1143//		IBM1143//
++alias	CSIBM1143//		IBM1143//
++module	IBM1143//		INTERNAL		IBM1143		1
++module	INTERNAL		IBM1143//		IBM1143		1
++
++#	from			to			module		cost
++alias	IBM-1144//		IBM1144//
++alias	CP1144//		IBM1144//
++alias	CSIBM1144//		IBM1144//
++module	IBM1144//		INTERNAL		IBM1144		1
++module	INTERNAL		IBM1144//		IBM1144		1
++
++#	from			to			module		cost
++alias	IBM-1145//		IBM1145//
++alias	CP1145//		IBM1145//
++alias	CSIBM1145//		IBM1145//
++module	IBM1145//		INTERNAL		IBM1145		1
++module	INTERNAL		IBM1145//		IBM1145		1
++
++#	from			to			module		cost
++alias	IBM-1146//		IBM1146//
++alias	CP1146//		IBM1146//
++alias	CSIBM1146//		IBM1146//
++module	IBM1146//		INTERNAL		IBM1146		1
++module	INTERNAL		IBM1146//		IBM1146		1
++
++#	from			to			module		cost
++alias	IBM-1147//		IBM1147//
++alias	CP1147//		IBM1147//
++alias	CSIBM1147//		IBM1147//
++module	IBM1147//		INTERNAL		IBM1147		1
++module	INTERNAL		IBM1147//		IBM1147		1
++
++#	from			to			module		cost
++alias	IBM-1148//		IBM1148//
++alias	CP1148//		IBM1148//
++alias	CSIBM1148//		IBM1148//
++module	IBM1148//		INTERNAL		IBM1148		1
++module	INTERNAL		IBM1148//		IBM1148		1
++
++#	from			to			module		cost
++alias	IBM-1149//		IBM1149//
++alias	CP1149//		IBM1149//
++alias	CSIBM1149//		IBM1149//
++module	IBM1149//		INTERNAL		IBM1149		1
++module	INTERNAL		IBM1149//		IBM1149		1
++
++#	from			to			module		cost
++alias	IBM-1166//		IBM1166//
++alias	CP1166//		IBM1166//
++alias	CSIBM1166//		IBM1166//
++module	IBM1166//		INTERNAL		IBM1166		1
++module	INTERNAL		IBM1166//		IBM1166		1
++
++#	from			to			module		cost
++alias	IBM-1167//		IBM1167//
++alias	CP1167//		IBM1167//
++alias	CSIBM1167//		IBM1167//
++module	IBM1167//		INTERNAL		IBM1167		1
++module	INTERNAL		IBM1167//		IBM1167		1
++
++#	from			to			module		cost
++alias	IBM-4517//		IBM4517//
++alias	CP4517//		IBM4517//
++alias	CSIBM4517//		IBM4517//
++module	IBM4517//		INTERNAL		IBM4517		1
++module	INTERNAL		IBM4517//		IBM4517		1
++
++#	from			to			module		cost
++alias	IBM-4899//		IBM4899//
++alias	CP4899//		IBM4899//
++alias	CSIBM4899//		IBM4899//
++module	IBM4899//		INTERNAL		IBM4899		1
++module	INTERNAL		IBM4899//		IBM4899		1
++
++#	from			to			module		cost
++alias	IBM-4909//		IBM4909//
++alias	CP4909//		IBM4909//
++alias	CSIBM4909//		IBM4909//
++module	IBM4909//		INTERNAL		IBM4909		1
++module	INTERNAL		IBM4909//		IBM4909		1
++
++#	from			to			module		cost
++alias	IBM-4971//		IBM4971//
++alias	CP4971//		IBM4971//
++alias	CSIBM4971//		IBM4971//
++module	IBM4971//		INTERNAL		IBM4971		1
++module	INTERNAL		IBM4971//		IBM4971		1
++
++#	from			to			module		cost
++alias	IBM-5347//		IBM5347//
++alias	CP5347//		IBM5347//
++alias	CSIBM5347//		IBM5347//
++module	IBM5347//		INTERNAL		IBM5347		1
++module	INTERNAL		IBM5347//		IBM5347		1
++
++#	from			to			module		cost
++alias	IBM-9030//		IBM9030//
++alias	CP9030//		IBM9030//
++alias	CSIBM9030//		IBM9030//
++module	IBM9030//		INTERNAL		IBM9030		1
++module	INTERNAL		IBM9030//		IBM9030		1
++
++#	from			to			module		cost
++alias	IBM-9066//		IBM9066//
++alias	CP9066//		IBM9066//
++alias	CSIBM9066//		IBM9066//
++module	IBM9066//		INTERNAL		IBM9066		1
++module	INTERNAL		IBM9066//		IBM9066		1
++
++#	from			to			module		cost
++alias	IBM-9448//		IBM9448//
++alias	CP9448//		IBM9448//
++alias	CSIBM9448//		IBM9448//
++module	IBM9448//		INTERNAL		IBM9448		1
++module	INTERNAL		IBM9448//		IBM9448		1
++
++#	from			to			module		cost
++alias	IBM-12712//		IBM12712//
++alias	CP12712//		IBM12712//
++alias	CSIBM12712//		IBM12712//
++module	IBM12712//		INTERNAL		IBM12712		1
++module	INTERNAL		IBM12712//		IBM12712		1
++
++#	from			to			module		cost
++alias	IBM-16804//		IBM16804//
++alias	CP16804//		IBM16804//
++alias	CSIBM16804//		IBM16804//
++module	IBM16804//		INTERNAL		IBM16804		1
++module	INTERNAL		IBM16804//		IBM16804		1
++
++#	from			to			module		cost
++alias	IBM-1364//		IBM1364//
++alias	CP1364//		IBM1364//
++alias	CSIBM1364//		IBM1364//
++module	IBM1364//		INTERNAL		IBM1364		1
++module	INTERNAL		IBM1364//		IBM1364		1
++
++#	from			to			module		cost
++alias	IBM-1371//		IBM1371//
++alias	CP1371//		IBM1371//
++alias	CSIBM1371//		IBM1371//
++module	IBM1371//		INTERNAL		IBM1371		1
++module	INTERNAL		IBM1371//		IBM1371		1
++
++#	from			to			module		cost
++alias	IBM-1388//		IBM1388//
++alias	CP1388//		IBM1388//
++alias	CSIBM1388//		IBM1388//
++module	IBM1388//		INTERNAL		IBM1388		1
++module	INTERNAL		IBM1388//		IBM1388		1
++
++#	from			to			module		cost
++alias	IBM-1390//		IBM1390//
++alias	CP1390//		IBM1390//
++alias	CSIBM1390//		IBM1390//
++module	IBM1390//		INTERNAL		IBM1390		1
++module	INTERNAL		IBM1390//		IBM1390		1
++
++#	from			to			module		cost
++alias	IBM-1399//		IBM1399//
++alias	CP1399//		IBM1399//
++alias	CSIBM1399//		IBM1399//
++module	IBM1399//		INTERNAL		IBM1399		1
++module	INTERNAL		IBM1399//		IBM1399		1
++
++#	from			to			module		cost
++alias	ISO/TR_11548-1/		ISO_11548-1//
++alias	ISO11548-1//		ISO_11548-1//
++module	ISO_11548-1//		INTERNAL		ISO_11548-1	1
++module	INTERNAL		ISO_11548-1//		ISO_11548-1	1
++
++#	from			to			module		cost
++module	MIK//			INTERNAL		MIK		1
++module	INTERNAL		MIK//			MIK		1
++
++#	from			to			module		cost
++module	BRF//			INTERNAL		BRF		1
++module	INTERNAL		BRF//			BRF		1
++
++#	from			to			module		cost
++alias	CP1282//		MAC-CENTRALEUROPE//
++module	MAC-CENTRALEUROPE//	INTERNAL		MAC-CENTRALEUROPE 1
++module	INTERNAL		MAC-CENTRALEUROPE//	MAC-CENTRALEUROPE 1
++
++#	from			to			module		cost
++module	KOI8-RU//		INTERNAL		KOI8-RU		1
++module	INTERNAL		KOI8-RU//		KOI8-RU		1
++
++#	from			to			module		cost
++alias	ISO_8859-9E//		ISO-8859-9E//
++alias	ISO8859-9E//		ISO-8859-9E//
++alias	ISO88599E//		ISO-8859-9E//
++module	ISO-8859-9E//		INTERNAL		ISO8859-9E	1
++module	INTERNAL		ISO-8859-9E//		ISO8859-9E	1
++
++#	from			to			module		cost
++alias	ROMAN9//		HP-ROMAN9//
++alias	R9//			HP-ROMAN9//
++alias	HPROMAN9//		HP-ROMAN9//
++module	HP-ROMAN9//		INTERNAL		HP-ROMAN9	1
++module	INTERNAL		HP-ROMAN9//		HP-ROMAN9	1
++
++#	from			to			module		cost
++alias	TURKISH8//		HP-TURKISH8//
++alias	HPTURKISH8//		HP-TURKISH8//
++alias	OSF10010006//		HP-TURKISH8//
++module	HP-TURKISH8//		INTERNAL		HP-TURKISH8	1
++module	INTERNAL		HP-TURKISH8//		HP-TURKISH8	1
++
++#	from			to			module		cost
++alias	THAI8//			HP-THAI8//
++alias	HPTHAI8//		HP-THAI8//
++module	HP-THAI8//		INTERNAL		HP-THAI8	1
++module	INTERNAL		HP-THAI8//		HP-THAI8	1
++
++#	from			to			module		cost
++alias	HPGREEK8//		HP-GREEK8//
++alias	OSF10010004//		HP-GREEK8//
++module	HP-GREEK8//		INTERNAL		HP-GREEK8	1
++module	INTERNAL		HP-GREEK8//		HP-GREEK8	1
+diff --git a/iconvdata/gconv-modules-extra.conf b/iconvdata/gconv-modules-extra.conf
+index 82d7be5..e69de29 100644
+--- a/iconvdata/gconv-modules-extra.conf
++++ b/iconvdata/gconv-modules-extra.conf
+@@ -1,1889 +0,0 @@
+-# GNU libc iconv configuration.
+-# Copyright (C) 1997-2022 Free Software Foundation, Inc.
+-# This file is part of the GNU C Library.
+-
+-# The GNU C Library is free software; you can redistribute it and/or
+-# modify it under the terms of the GNU Lesser General Public
+-# License as published by the Free Software Foundation; either
+-# version 2.1 of the License, or (at your option) any later version.
+-
+-# The GNU C Library is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-# Lesser General Public License for more details.
+-
+-# You should have received a copy of the GNU Lesser General Public
+-# License along with the GNU C Library; if not, see
+-# <https://www.gnu.org/licenses/>.
+-
+-# All lines contain the following information:
+-
+-# If the lines start with `module'
+-#  fromset:	either a name triple or a regular expression triple.
+-#  toset:	a name triple or an expression with \N to get regular
+-#		expression matching results.
+-#  filename:	filename of the module implementing the transformation.
+-#		If it is not absolute the path is made absolute by prepending
+-#		the directory the configuration file is found in.
+-#  cost:	optional cost of the transformation.  Default is 1.
+-
+-# If the lines start with `alias'
+-#  alias:	alias name which is not really recognized.
+-#  name:	the real name of the character set
+-
+-alias	ISO-IR-4//		BS_4730//
+-alias	ISO646-GB//		BS_4730//
+-alias	GB//			BS_4730//
+-alias	UK//			BS_4730//
+-alias	CSISO4UNITEDKINGDOM//	BS_4730//
+-module	BS_4730//		INTERNAL		ISO646		2
+-module	INTERNAL		BS_4730//		ISO646		2
+-
+-alias	ISO-IR-121//		CSA_Z243.4-1985-1//
+-alias	ISO646-CA//		CSA_Z243.4-1985-1//
+-alias	CSA7-1//		CSA_Z243.4-1985-1//
+-alias	CA//			CSA_Z243.4-1985-1//
+-alias	CSISO121CANADIAN1//	CSA_Z243.4-1985-1//
+-alias	CSA_Z243.419851//	CSA_Z243.4-1985-1//
+-module	CSA_Z243.4-1985-1//	INTERNAL		ISO646		2
+-module	INTERNAL		CSA_Z243.4-1985-1//	ISO646		2
+-
+-alias	ISO-IR-122//		CSA_Z243.4-1985-2//
+-alias	ISO646-CA2//		CSA_Z243.4-1985-2//
+-alias	CSA7-2//		CSA_Z243.4-1985-2//
+-alias	CSISO122CANADIAN2//	CSA_Z243.4-1985-2//
+-alias	CSA_Z243.419852//	CSA_Z243.4-1985-2//
+-module	CSA_Z243.4-1985-2//	INTERNAL		ISO646		2
+-module	INTERNAL		CSA_Z243.4-1985-2//	ISO646		2
+-
+-alias	ISO-IR-21//		DIN_66003//
+-alias	DE//			DIN_66003//
+-alias	ISO646-DE//		DIN_66003//
+-alias	CSISO21GERMAN//		DIN_66003//
+-module	DIN_66003//		INTERNAL		ISO646		2
+-module	INTERNAL		DIN_66003//		ISO646		2
+-
+-alias	DS2089//		DS_2089//
+-alias	ISO646-DK//		DS_2089//
+-alias	DK//			DS_2089//
+-alias	CSISO646DANISH//	DS_2089//
+-module	DS_2089//		INTERNAL		ISO646		2
+-module	INTERNAL		DS_2089//		ISO646		2
+-
+-alias	ISO-IR-17//		ES//
+-alias	ISO646-ES//		ES//
+-alias	CSISO17SPANISH//	ES//
+-module	ES//			INTERNAL		ISO646		2
+-module	INTERNAL		ES//			ISO646		2
+-
+-alias	ISO-IR-85//		ES2//
+-alias	ISO646-ES2//		ES2//
+-alias	CSISO85SPANISH2//	ES2//
+-module	ES2//			INTERNAL		ISO646		2
+-module	INTERNAL		ES2//			ISO646		2
+-
+-alias	ISO-IR-57//		GB_1988-80//
+-alias	CN//			GB_1988-80//
+-alias	ISO646-CN//		GB_1988-80//
+-alias	CSISO58GB1988//		GB_1988-80//
+-alias	GB_198880//		GB_1988-80//
+-module	GB_1988-80//		INTERNAL		ISO646		2
+-module	INTERNAL		GB_1988-80//		ISO646		2
+-
+-alias	ISO-IR-15//		IT//
+-alias	ISO646-IT//		IT//
+-alias	CSISO15ITALIAN//	IT//
+-module	IT//			INTERNAL		ISO646		2
+-module	INTERNAL		IT//			ISO646		2
+-
+-alias	ISO-IR-14//		JIS_C6220-1969-RO//
+-alias	JP//			JIS_C6220-1969-RO//
+-alias	ISO646-JP//		JIS_C6220-1969-RO//
+-alias	CSISO14JISC6220RO//	JIS_C6220-1969-RO//
+-alias	JIS_C62201969RO//	JIS_C6220-1969-RO//
+-module	JIS_C6220-1969-RO//	INTERNAL		ISO646		2
+-module	INTERNAL		JIS_C6220-1969-RO//	ISO646		2
+-
+-alias	ISO-IR-92//		JIS_C6229-1984-B//
+-alias	ISO646-JP-OCR-B//	JIS_C6229-1984-B//
+-alias	JP-OCR-B//		JIS_C6229-1984-B//
+-alias	CSISO92JISC62991984B//	JIS_C6229-1984-B//
+-alias	JIS_C62291984B//	JIS_C6229-1984-B//
+-module	JIS_C6229-1984-B//	INTERNAL		ISO646		2
+-module	INTERNAL		JIS_C6229-1984-B//	ISO646		2
+-
+-alias	ISO-IR-141//		JUS_I.B1.002//
+-alias	ISO646-YU//		JUS_I.B1.002//
+-alias	JS//			JUS_I.B1.002//
+-alias	YU//			JUS_I.B1.002//
+-alias	CSISO141JUSIB1002//	JUS_I.B1.002//
+-module	JUS_I.B1.002//		INTERNAL		ISO646		2
+-module	INTERNAL		JUS_I.B1.002//		ISO646		2
+-
+-alias	ISO646-KR//		KSC5636//
+-alias	CSKSC5636//		KSC5636//
+-module	KSC5636//		INTERNAL		ISO646		2
+-module	INTERNAL		KSC5636//		ISO646		2
+-
+-alias	ISO-IR-86//		MSZ_7795.3//
+-alias	ISO646-HU//		MSZ_7795.3//
+-alias	HU//			MSZ_7795.3//
+-alias	CSISO86HUNGARIAN//	MSZ_7795.3//
+-module	MSZ_7795.3//		INTERNAL		ISO646		2
+-module	INTERNAL		MSZ_7795.3//		ISO646		2
+-
+-alias	CUBA//			NC_NC00-10//
+-alias	NC_NC00-10:81//		NC_NC00-10//
+-alias	ISO-IR-151//		NC_NC00-10//
+-alias	ISO646-CU//		NC_NC00-10//
+-alias	CSISO151CUBA//		NC_NC00-10//
+-alias	NC_NC0010//		NC_NC00-10//
+-module	NC_NC00-10//		INTERNAL		ISO646		2
+-module	INTERNAL		NC_NC00-10//		ISO646		2
+-
+-alias	ISO-IR-69//		NF_Z_62-010//
+-alias	ISO646-FR//		NF_Z_62-010//
+-alias	FR//			NF_Z_62-010//
+-alias	CSISO69FRENCH//		NF_Z_62-010//
+-alias	NF_Z_62010//		NF_Z_62-010//
+-module	NF_Z_62-010//		INTERNAL		ISO646		2
+-module	INTERNAL		NF_Z_62-010//		ISO646		2
+-
+-alias	ISO-IR-25//		NF_Z_62-010_1973//
+-alias	ISO646-FR1//		NF_Z_62-010_1973//
+-alias	NF_Z_62-010_(1973)//	NF_Z_62-010_1973//
+-alias	CSISO25FRENCH//		NF_Z_62-010_1973//
+-alias	NF_Z_62010_1973//	NF_Z_62-010_1973//
+-module	NF_Z_62-010_1973//	INTERNAL		ISO646		2
+-module	INTERNAL		NF_Z_62-010_1973//	ISO646		2
+-
+-alias	ISO-IR-60//		NS_4551-1//
+-alias	ISO646-NO//		NS_4551-1//
+-alias	NO//			NS_4551-1//
+-alias	CSISO60DANISHNORWEGIAN// NS_4551-1//
+-alias	CSISO60NORWEGIAN1//	NS_4551-1//
+-alias	NS_45511//		NS_4551-1//
+-module	NS_4551-1//		INTERNAL		ISO646		2
+-module	INTERNAL		NS_4551-1//		ISO646		2
+-
+-alias	ISO646-NO2//		NS_4551-2//
+-alias	ISO-IR-61//		NS_4551-2//
+-alias	NO2//			NS_4551-2//
+-alias	CSISO61NORWEGIAN2//	NS_4551-2//
+-alias	NS_45512//		NS_4551-2//
+-module	NS_4551-2//		INTERNAL		ISO646		2
+-module	INTERNAL		NS_4551-2//		ISO646		2
+-
+-alias	ISO-IR-16//		PT//
+-alias	ISO646-PT//		PT//
+-alias	CSISO16PORTUGESE//	PT//
+-module	PT//			INTERNAL		ISO646		2
+-module	INTERNAL		PT//			ISO646		2
+-
+-alias	ISO-IR-84//		PT2//
+-alias	ISO646-PT2//		PT2//
+-alias	CSISO84PORTUGUESE2//	PT2//
+-module	PT2//			INTERNAL		ISO646		2
+-module	INTERNAL		PT2//			ISO646		2
+-
+-alias	ISO-IR-10//		SEN_850200_B//
+-alias	FI//			SEN_850200_B//
+-alias	ISO646-FI//		SEN_850200_B//
+-alias	ISO646-SE//		SEN_850200_B//
+-alias	SE//			SEN_850200_B//
+-alias	CSISO10SWEDISH//	SEN_850200_B//
+-alias	SS636127//		SEN_850200_B//
+-module	SEN_850200_B//		INTERNAL		ISO646		2
+-module	INTERNAL		SEN_850200_B//		ISO646		2
+-
+-alias	ISO-IR-11//		SEN_850200_C//
+-alias	ISO646-SE2//		SEN_850200_C//
+-alias	SE2//			SEN_850200_C//
+-alias	CSISO11SWEDISHFORNAMES// SEN_850200_C//
+-module	SEN_850200_C//		INTERNAL		ISO646		2
+-module	INTERNAL		SEN_850200_C//		ISO646		2
+-
+-#	from			to			module		cost
+-alias	ISO-IR-101//		ISO-8859-2//
+-alias	ISO_8859-2:1987//	ISO-8859-2//
+-alias	ISO_8859-2//		ISO-8859-2//
+-alias	ISO8859-2//		ISO-8859-2//
+-alias	ISO88592//		ISO-8859-2//
+-alias	LATIN2//		ISO-8859-2//
+-alias	L2//			ISO-8859-2//
+-alias	CSISOLATIN2//		ISO-8859-2//
+-alias	8859_2//		ISO-8859-2//
+-alias	OSF00010002//		ISO-8859-2//
+-alias	IBM912//		ISO-8859-2//
+-alias	CP912//			ISO-8859-2//
+-module	ISO-8859-2//		INTERNAL		ISO8859-2	1
+-module	INTERNAL		ISO-8859-2//		ISO8859-2	1
+-
+-#	from			to			 module		cost
+-alias	ISO-IR-109//		ISO-8859-3//
+-alias	ISO_8859-3:1988//	ISO-8859-3//
+-alias	ISO_8859-3//		ISO-8859-3//
+-alias	ISO8859-3//		ISO-8859-3//
+-alias	ISO88593//		ISO-8859-3//
+-alias	LATIN3//		ISO-8859-3//
+-alias	L3//			ISO-8859-3//
+-alias	CSISOLATIN3//		ISO-8859-3//
+-alias	8859_3//		ISO-8859-3//
+-alias	OSF00010003//		ISO-8859-3//
+-module	ISO-8859-3//		INTERNAL		ISO8859-3	1
+-module	INTERNAL		ISO-8859-3//		ISO8859-3	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-110//		ISO-8859-4//
+-alias	ISO_8859-4:1988//	ISO-8859-4//
+-alias	ISO_8859-4//		ISO-8859-4//
+-alias	ISO8859-4//		ISO-8859-4//
+-alias	ISO88594//		ISO-8859-4//
+-alias	LATIN4//		ISO-8859-4//
+-alias	L4//			ISO-8859-4//
+-alias	CSISOLATIN4//		ISO-8859-4//
+-alias	8859_4//		ISO-8859-4//
+-alias	OSF00010004//		ISO-8859-4//
+-module	ISO-8859-4//		INTERNAL		ISO8859-4	1
+-module	INTERNAL		ISO-8859-4//		ISO8859-4	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-144//		ISO-8859-5//
+-alias	ISO_8859-5:1988//	ISO-8859-5//
+-alias	ISO_8859-5//		ISO-8859-5//
+-alias	ISO8859-5//		ISO-8859-5//
+-alias	ISO88595//		ISO-8859-5//
+-alias	CYRILLIC//		ISO-8859-5//
+-alias	CSISOLATINCYRILLIC//	ISO-8859-5//
+-alias	8859_5//		ISO-8859-5//
+-alias	OSF00010005//		ISO-8859-5//
+-alias	IBM915//		ISO-8859-5//
+-alias	CP915//			ISO-8859-5//
+-module	ISO-8859-5//		INTERNAL		ISO8859-5	1
+-module	INTERNAL		ISO-8859-5//		ISO8859-5	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-127//		ISO-8859-6//
+-alias	ISO_8859-6:1987//	ISO-8859-6//
+-alias	ISO_8859-6//		ISO-8859-6//
+-alias	ISO8859-6//		ISO-8859-6//
+-alias	ISO88596//		ISO-8859-6//
+-alias	ECMA-114//		ISO-8859-6//
+-alias	ASMO-708//		ISO-8859-6//
+-alias	ARABIC//		ISO-8859-6//
+-alias	CSISOLATINARABIC//	ISO-8859-6//
+-alias	8859_6//		ISO-8859-6//
+-alias	OSF00010006//		ISO-8859-6//
+-alias	IBM1089//		ISO-8859-6//
+-alias	CP1089//		ISO-8859-6//
+-module	ISO-8859-6//		INTERNAL		ISO8859-6	1
+-module	INTERNAL		ISO-8859-6//		ISO8859-6	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-126//		ISO-8859-7//
+-alias	ISO_8859-7:2003//	ISO-8859-7//
+-alias	ISO_8859-7:1987//	ISO-8859-7//
+-alias	ISO_8859-7//		ISO-8859-7//
+-alias	ISO8859-7//		ISO-8859-7//
+-alias	ISO88597//		ISO-8859-7//
+-alias	ELOT_928//		ISO-8859-7//
+-alias	ECMA-118//		ISO-8859-7//
+-alias	GREEK//			ISO-8859-7//
+-alias	GREEK8//		ISO-8859-7//
+-alias	CSISOLATINGREEK//	ISO-8859-7//
+-alias	8859_7//		ISO-8859-7//
+-alias	OSF00010007//		ISO-8859-7//
+-alias	IBM813//		ISO-8859-7//
+-alias	CP813//			ISO-8859-7//
+-module	ISO-8859-7//		INTERNAL		ISO8859-7	1
+-module	INTERNAL		ISO-8859-7//		ISO8859-7	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-138//		ISO-8859-8//
+-alias	ISO_8859-8:1988//	ISO-8859-8//
+-alias	ISO_8859-8//		ISO-8859-8//
+-alias	ISO8859-8//		ISO-8859-8//
+-alias	ISO88598//		ISO-8859-8//
+-alias	HEBREW//		ISO-8859-8//
+-alias	CSISOLATINHEBREW//	ISO-8859-8//
+-alias	8859_8//		ISO-8859-8//
+-alias	OSF00010008//		ISO-8859-8//
+-alias	IBM916//		ISO-8859-8//
+-alias	CP916//			ISO-8859-8//
+-module	ISO-8859-8//		INTERNAL		ISO8859-8	1
+-module	INTERNAL		ISO-8859-8//		ISO8859-8	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-148//		ISO-8859-9//
+-alias	ISO_8859-9:1989//	ISO-8859-9//
+-alias	ISO_8859-9//		ISO-8859-9//
+-alias	ISO8859-9//		ISO-8859-9//
+-alias	ISO88599//		ISO-8859-9//
+-alias	LATIN5//		ISO-8859-9//
+-alias	L5//			ISO-8859-9//
+-alias	CSISOLATIN5//		ISO-8859-9//
+-alias	8859_9//		ISO-8859-9//
+-alias	OSF00010009//		ISO-8859-9//
+-alias	IBM920//		ISO-8859-9//
+-alias	CP920//			ISO-8859-9//
+-alias	TS-5881//		ISO-8859-9//
+-alias	ECMA-128//		ISO-8859-9//
+-module	ISO-8859-9//		INTERNAL		ISO8859-9	1
+-module	INTERNAL		ISO-8859-9//		ISO8859-9	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-157//		ISO-8859-10//
+-alias	ISO_8859-10:1992//	ISO-8859-10//
+-alias	ISO_8859-10//		ISO-8859-10//
+-alias	ISO8859-10//		ISO-8859-10//
+-alias	ISO885910//		ISO-8859-10//
+-alias	LATIN6//		ISO-8859-10//
+-alias	L6//			ISO-8859-10//
+-alias	CSISOLATIN6//		ISO-8859-10//
+-alias	OSF0001000A//		ISO-8859-10//
+-module	ISO-8859-10//		INTERNAL		ISO8859-10	1
+-module	INTERNAL		ISO-8859-10//		ISO8859-10	1
+-
+-#	from			to			module		cost
+-alias	ISO8859-11//		ISO-8859-11//
+-alias	ISO885911//		ISO-8859-11//
+-module	ISO-8859-11//		INTERNAL		ISO8859-11	1
+-module	INTERNAL		ISO-8859-11//		ISO8859-11	1
+-
+-#	from			to			module		cost
+-alias	ISO8859-13//		ISO-8859-13//
+-alias	ISO885913//		ISO-8859-13//
+-alias	ISO-IR-179//		ISO-8859-13//
+-alias	LATIN7//		ISO-8859-13//
+-alias	L7//			ISO-8859-13//
+-alias	BALTIC//		ISO-8859-13//
+-module	ISO-8859-13//		INTERNAL		ISO8859-13	1
+-module	INTERNAL		ISO-8859-13//		ISO8859-13	1
+-
+-#	from			to			module		cost
+-alias	ISO8859-14//		ISO-8859-14//
+-alias	ISO885914//		ISO-8859-14//
+-alias	ISO-IR-199//		ISO-8859-14//
+-alias	LATIN8//		ISO-8859-14//
+-alias	L8//			ISO-8859-14//
+-alias	ISO_8859-14:1998//	ISO-8859-14//
+-alias	ISO_8859-14//		ISO-8859-14//
+-alias	ISO-CELTIC//		ISO-8859-14//
+-module	ISO-8859-14//		INTERNAL		ISO8859-14	1
+-module	INTERNAL		ISO-8859-14//		ISO8859-14	1
+-
+-#	from			to			module		cost
+-alias	ISO8859-16//		ISO-8859-16//
+-alias	ISO885916//		ISO-8859-16//
+-alias	ISO-IR-226//		ISO-8859-16//
+-alias	LATIN10//		ISO-8859-16//
+-alias	L10//			ISO-8859-16//
+-alias	ISO_8859-16:2001//	ISO-8859-16//
+-alias	ISO_8859-16//		ISO-8859-16//
+-module	ISO-8859-16//		INTERNAL		ISO8859-16	1
+-module	INTERNAL		ISO-8859-16//		ISO8859-16	1
+-
+-#	from			to			module		cost
+-alias	T.61//			T.61-8BIT//
+-alias	ISO-IR-103//		T.61-8BIT//
+-alias	CSISO103T618BIT//	T.61-8BIT//
+-alias	T.618BIT//		T.61-8BIT//
+-module	T.61-8BIT//		INTERNAL		T.61		1
+-module	INTERNAL		T.61-8BIT//		T.61		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-156//		ISO_6937//
+-alias	ISO_6937:1992//		ISO_6937//
+-alias	ISO6937//		ISO_6937//
+-module	ISO_6937//		INTERNAL		ISO_6937	1
+-module	INTERNAL		ISO_6937//		ISO_6937	1
+-
+-
+-#	from			to			module		cost
+-alias	ISO-IR-90//		ISO_6937-2//
+-alias	ISO_6937-2:1983//	ISO_6937-2//
+-alias	CSISO90//		ISO_6937-2//
+-alias	ISO_69372//		ISO_6937-2//
+-module	ISO_6937-2//		INTERNAL		ISO_6937-2	1
+-module	INTERNAL		ISO_6937-2//		ISO_6937-2	1
+-
+-#	from			to			module		cost
+-alias	SHIFT-JIS//		SJIS//
+-alias	SHIFT_JIS//		SJIS//
+-alias	MS_KANJI//		SJIS//
+-alias	CSSHIFTJIS//		SJIS//
+-module	SJIS//			INTERNAL		SJIS		1
+-module	INTERNAL		SJIS//			SJIS		1
+-
+-#	from			to			module		cost
+-alias	WINDOWS-31J//		CP932//
+-alias	MS932//			CP932//
+-alias	SJIS-OPEN//		CP932//
+-alias	SJIS-WIN//		CP932//
+-alias	CSWINDOWS31J//		CP932//
+-module	CP932//			INTERNAL		CP932		1
+-module	INTERNAL		CP932//			CP932		1
+-
+-#	from			to			module		cost
+-alias	KOI8//			KOI-8//
+-module	KOI-8//			INTERNAL		KOI-8		1
+-module	INTERNAL		KOI-8//			KOI-8		1
+-
+-#	from			to			module		cost
+-alias	CSKOI8R//		KOI8-R//
+-alias	KOI8R//			KOI8-R//
+-module	KOI8-R//		INTERNAL		KOI8-R		1
+-module	INTERNAL		KOI8-R//		KOI8-R		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-19//		LATIN-GREEK//
+-alias	CSISO19LATINGREEK//	LATIN-GREEK//
+-alias	LATINGREEK//		LATIN-GREEK//
+-module	LATIN-GREEK//		INTERNAL		LATIN-GREEK	1
+-module	INTERNAL		LATIN-GREEK//		LATIN-GREEK	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-27//		LATIN-GREEK-1//
+-alias	CSISO27LATINGREEK1//	LATIN-GREEK-1//
+-alias	LATINGREEK1//		LATIN-GREEK-1//
+-module	LATIN-GREEK-1//		INTERNAL		LATIN-GREEK-1	1
+-module	INTERNAL		LATIN-GREEK-1//		LATIN-GREEK-1	1
+-
+-#	from			to			module		cost
+-alias	ROMAN8//		HP-ROMAN8//
+-alias	R8//			HP-ROMAN8//
+-alias	CSHPROMAN8//		HP-ROMAN8//
+-alias	OSF10010001//		HP-ROMAN8//
+-alias	HPROMAN8//		HP-ROMAN8//
+-module	HP-ROMAN8//		INTERNAL		HP-ROMAN8	1
+-module	INTERNAL		HP-ROMAN8//		HP-ROMAN8	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICATDE//		EBCDIC-AT-DE//
+-alias	EBCDICATDE//		EBCDIC-AT-DE//
+-module	EBCDIC-AT-DE//		INTERNAL		EBCDIC-AT-DE	1
+-module	INTERNAL		EBCDIC-AT-DE//		EBCDIC-AT-DE	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICATDEA//		EBCDIC-AT-DE-A//
+-alias	EBCDICATDEA//		EBCDIC-AT-DE-A//
+-module	EBCDIC-AT-DE-A//	INTERNAL		EBCDIC-AT-DE-A	1
+-module	INTERNAL		EBCDIC-AT-DE-A//	EBCDIC-AT-DE-A	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICCAFR//		EBCDIC-CA-FR//
+-alias	EBCDICCAFR//		EBCDIC-CA-FR//
+-module	EBCDIC-CA-FR//		INTERNAL		EBCDIC-CA-FR	1
+-module	INTERNAL		EBCDIC-CA-FR//		EBCDIC-CA-FR	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICDKNO//		EBCDIC-DK-NO//
+-alias	EBCDICDKNO//		EBCDIC-DK-NO//
+-module	EBCDIC-DK-NO//		INTERNAL		EBCDIC-DK-NO	1
+-module	INTERNAL		EBCDIC-DK-NO//		EBCDIC-DK-NO	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICDKNOA//		EBCDIC-DK-NO-A//
+-alias	EBCDICDKNOA//		EBCDIC-DK-NO-A//
+-module	EBCDIC-DK-NO-A//	INTERNAL		EBCDIC-DK-NO-A	1
+-module	INTERNAL		EBCDIC-DK-NO-A//	EBCDIC-DK-NO-A	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICES//		EBCDIC-ES//
+-alias	EBCDICES//		EBCDIC-ES//
+-module	EBCDIC-ES//		INTERNAL		EBCDIC-ES	1
+-module	INTERNAL		EBCDIC-ES//		EBCDIC-ES	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICESA//		EBCDIC-ES-A//
+-alias	EBCDICESA//		EBCDIC-ES-A//
+-module	EBCDIC-ES-A//		INTERNAL		EBCDIC-ES-A	1
+-module	INTERNAL		EBCDIC-ES-A//		EBCDIC-ES-A	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICESS//		EBCDIC-ES-S//
+-alias	EBCDICESS//		EBCDIC-ES-S//
+-module	EBCDIC-ES-S//		INTERNAL		EBCDIC-ES-S	1
+-module	INTERNAL		EBCDIC-ES-S//		EBCDIC-ES-S	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICFISE//		EBCDIC-FI-SE//
+-alias	EBCDICFISE//		EBCDIC-FI-SE//
+-module	EBCDIC-FI-SE//		INTERNAL		EBCDIC-FI-SE	1
+-module	INTERNAL		EBCDIC-FI-SE//		EBCDIC-FI-SE	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICFISEA//		EBCDIC-FI-SE-A//
+-alias	EBCDICFISEA//		EBCDIC-FI-SE-A//
+-module	EBCDIC-FI-SE-A//	INTERNAL		EBCDIC-FI-SE-A	1
+-module	INTERNAL		EBCDIC-FI-SE-A//	EBCDIC-FI-SE-A	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICFR//		EBCDIC-FR//
+-alias	EBCDICFR//		EBCDIC-FR//
+-module	EBCDIC-FR//		INTERNAL		EBCDIC-FR	1
+-module	INTERNAL		EBCDIC-FR//		EBCDIC-FR	1
+-
+-#	from			to			module		cost
+-alias	EBCDICISFRISS//		EBCDIC-IS-FRISS//
+-module	EBCDIC-IS-FRISS//	INTERNAL		EBCDIC-IS-FRISS	1
+-module	INTERNAL		EBCDIC-IS-FRISS//	EBCDIC-IS-FRISS	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICIT//		EBCDIC-IT//
+-alias	EBCDICIT//		EBCDIC-IT//
+-module	EBCDIC-IT//		INTERNAL		EBCDIC-IT	1
+-module	INTERNAL		EBCDIC-IT//		EBCDIC-IT	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICPT//		EBCDIC-PT//
+-alias	EBCDICPT//		EBCDIC-PT//
+-module	EBCDIC-PT//		INTERNAL		EBCDIC-PT	1
+-module	INTERNAL		EBCDIC-PT//		EBCDIC-PT	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICUK//		EBCDIC-UK//
+-alias	EBCDICUK//		EBCDIC-UK//
+-module	EBCDIC-UK//		INTERNAL		EBCDIC-UK	1
+-module	INTERNAL		EBCDIC-UK//		EBCDIC-UK	1
+-
+-#	from			to			module		cost
+-alias	CSEBCDICUS//		EBCDIC-US//
+-alias	EBCDICUS//		EBCDIC-US//
+-module	EBCDIC-US//		INTERNAL		EBCDIC-US	1
+-module	INTERNAL		EBCDIC-US//		EBCDIC-US	1
+-
+-#	from			to			module		cost
+-alias	CP037//			IBM037//
+-alias	EBCDIC-CP-US//		IBM037//
+-alias	EBCDIC-CP-CA//		IBM037//
+-alias	EBCDIC-CP-WT//		IBM037//
+-alias	EBCDIC-CP-NL//		IBM037//
+-alias	CSIBM037//		IBM037//
+-alias	OSF10020025//		IBM037//
+-alias	CP1070//		IBM037//
+-alias	CP282//			IBM037//
+-module	IBM037//		INTERNAL		IBM037		1
+-module	INTERNAL		IBM037//		IBM037		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-INT//		IBM038//
+-alias	CP038//			IBM038//
+-alias	CSIBM038//		IBM038//
+-module	IBM038//		INTERNAL		IBM038		1
+-module	INTERNAL		IBM038//		IBM038		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-INT1//		IBM256//
+-module	IBM256//		INTERNAL		IBM256		1
+-module	INTERNAL		IBM256//		IBM256		1
+-
+-#	from			to			module		cost
+-alias	CP273//			IBM273//
+-alias	CSIBM273//		IBM273//
+-alias	OSF10020111//		IBM273//
+-module	IBM273//		INTERNAL		IBM273		1
+-module	INTERNAL		IBM273//		IBM273		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-BE//		IBM274//
+-alias	CP274//			IBM274//
+-alias	CSIBM274//		IBM274//
+-module	IBM274//		INTERNAL		IBM274		1
+-module	INTERNAL		IBM274//		IBM274		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-BR//		IBM275//
+-alias	CP275//			IBM275//
+-alias	CSIBM275//		IBM275//
+-module	IBM275//		INTERNAL		IBM275		1
+-module	INTERNAL		IBM275//		IBM275		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-CP-DK//		IBM277//
+-alias	EBCDIC-CP-NO//		IBM277//
+-alias	CSIBM277//		IBM277//
+-alias	OSF10020115//		IBM277//
+-module	IBM277//		INTERNAL		IBM277		1
+-module	INTERNAL		IBM277//		IBM277		1
+-
+-#	from			to			module		cost
+-alias	CP278//			IBM278//
+-alias	EBCDIC-CP-FI//		IBM278//
+-alias	EBCDIC-CP-SE//		IBM278//
+-alias	CSIBM278//		IBM278//
+-alias	OSF10020116//		IBM278//
+-module	IBM278//		INTERNAL		IBM278		1
+-module	INTERNAL		IBM278//		IBM278		1
+-
+-#	from			to			module		cost
+-alias	CP280//			IBM280//
+-alias	EBCDIC-CP-IT//		IBM280//
+-alias	CSIBM280//		IBM280//
+-alias	OSF10020118//		IBM280//
+-module	IBM280//		INTERNAL		IBM280		1
+-module	INTERNAL		IBM280//		IBM280		1
+-
+-#	from			to			module		cost
+-alias	EBCDIC-JP-E//		IBM281//
+-alias	CP281//			IBM281//
+-alias	CSIBM281//		IBM281//
+-module	IBM281//		INTERNAL		IBM281		1
+-module	INTERNAL		IBM281//		IBM281		1
+-
+-#	from			to			module		cost
+-alias	CP284//			IBM284//
+-alias	EBCDIC-CP-ES//		IBM284//
+-alias	CSIBM284//		IBM284//
+-alias	OSF1002011C//		IBM284//
+-alias	CP1079//		IBM284//
+-module	IBM284//		INTERNAL		IBM284		1
+-module	INTERNAL		IBM284//		IBM284		1
+-
+-#	from			to			module		cost
+-alias	CP285//			IBM285//
+-alias	EBCDIC-CP-GB//		IBM285//
+-alias	CSIBM285//		IBM285//
+-alias	OSF1002011D//		IBM285//
+-module	IBM285//		INTERNAL		IBM285		1
+-module	INTERNAL		IBM285//		IBM285		1
+-
+-#	from			to			module		cost
+-alias	CP290//			IBM290//
+-alias	EBCDIC-JP-KANA//	IBM290//
+-alias	CSIBM290//		IBM290//
+-alias	OSF10020122//		IBM290//
+-module	IBM290//		INTERNAL		IBM290		1
+-module	INTERNAL		IBM290//		IBM290		1
+-
+-#	from			to			module		cost
+-alias	CP297//			IBM297//
+-alias	EBCDIC-CP-FR//		IBM297//
+-alias	CSIBM297//		IBM297//
+-alias	OSF10020129//		IBM297//
+-alias	CP1081//		IBM297//
+-module	IBM297//		INTERNAL		IBM297		1
+-module	INTERNAL		IBM297//		IBM297		1
+-
+-#	from			to			module		cost
+-alias	CP420//			IBM420//
+-alias	EBCDIC-CP-AR1//		IBM420//
+-alias	CSIBM420//		IBM420//
+-alias	OSF100201A4//		IBM420//
+-module	IBM420//		INTERNAL		IBM420		1
+-module	INTERNAL		IBM420//		IBM420		1
+-
+-#	from			to			module		cost
+-alias	CP423//			IBM423//
+-alias	EBCDIC-CP-GR//		IBM423//
+-alias	CSIBM423//		IBM423//
+-module	IBM423//		INTERNAL		IBM423		1
+-module	INTERNAL		IBM423//		IBM423		1
+-
+-#	from			to			module		cost
+-alias	CP424//			IBM424//
+-alias	EBCDIC-CP-HE//		IBM424//
+-alias	CSIBM424//		IBM424//
+-alias	OSF100201A8//		IBM424//
+-module	IBM424//		INTERNAL		IBM424		1
+-module	INTERNAL		IBM424//		IBM424		1
+-
+-#	from			to			module		cost
+-alias	CP437//			IBM437//
+-alias	437//			IBM437//
+-alias	CSPC8CODEPAGE437//	IBM437//
+-alias	OSF100201B5//		IBM437//
+-module	IBM437//		INTERNAL		IBM437		1
+-module	INTERNAL		IBM437//		IBM437		1
+-
+-#	from			to			module		cost
+-alias	CP500//			IBM500//
+-alias	500//			IBM500//
+-alias	500V1//			IBM500//
+-alias	EBCDIC-CP-BE//		IBM500//
+-alias	EBCDIC-CP-CH//		IBM500//
+-alias	CSIBM500//		IBM500//
+-alias	OSF100201F4//		IBM500//
+-alias	CP1084//		IBM500//
+-module	IBM500//		INTERNAL		IBM500		1
+-module	INTERNAL		IBM500//		IBM500		1
+-
+-#	from			to			module		cost
+-alias	CP850//			IBM850//
+-alias	850//			IBM850//
+-alias	CSPC850MULTILINGUAL//	IBM850//
+-alias	OSF10020352//		IBM850//
+-module	IBM850//		INTERNAL		IBM850		1
+-module	INTERNAL		IBM850//		IBM850		1
+-
+-#	from			to			module		cost
+-alias	CP858//			IBM858//
+-alias	858//			IBM858//
+-alias	CSPC858MULTILINGUAL//	IBM858//
+-module	IBM858//		INTERNAL		IBM858		1
+-module	INTERNAL		IBM858//		IBM858		1
+-
+-#	from			to			module		cost
+-alias	CP851//			IBM851//
+-alias	851//			IBM851//
+-alias	CSIBM851//		IBM851//
+-module	IBM851//		INTERNAL		IBM851		1
+-module	INTERNAL		IBM851//		IBM851		1
+-
+-#	from			to			module		cost
+-alias	CP852//			IBM852//
+-alias	852//			IBM852//
+-alias	CSPCP852//		IBM852//
+-alias	OSF10020354//		IBM852//
+-module	IBM852//		INTERNAL		IBM852		1
+-module	INTERNAL		IBM852//		IBM852		1
+-
+-#	from			to			module		cost
+-alias	CP855//			IBM855//
+-alias	855//			IBM855//
+-alias	CSIBM855//		IBM855//
+-alias	OSF10020357//		IBM855//
+-module	IBM855//		INTERNAL		IBM855		1
+-module	INTERNAL		IBM855//		IBM855		1
+-
+-#	from			to			module		cost
+-alias	IBM-856//		IBM856//
+-alias	CP856//			IBM856//
+-alias	856//			IBM856//
+-alias	CSIBM856//		IBM856//
+-module	IBM856//		INTERNAL		IBM856		1
+-module	INTERNAL		IBM856//		IBM856		1
+-
+-#	from			to			module		cost
+-alias	CP857//			IBM857//
+-alias	857//			IBM857//
+-alias	CSIBM857//		IBM857//
+-alias	OSF10020359//		IBM857//
+-module	IBM857//		INTERNAL		IBM857		1
+-module	INTERNAL		IBM857//		IBM857		1
+-
+-#	from			to			module		cost
+-alias	CP860//			IBM860//
+-alias	860//			IBM860//
+-alias	CSIBM860//		IBM860//
+-module	IBM860//		INTERNAL		IBM860		1
+-module	INTERNAL		IBM860//		IBM860		1
+-
+-#	from			to			module		cost
+-alias	CP861//			IBM861//
+-alias	861//			IBM861//
+-alias	CPIBM861//		IBM861//
+-alias	OSF1002035D//		IBM861//
+-module	IBM861//		INTERNAL		IBM861		1
+-module	INTERNAL		IBM861//		IBM861		1
+-
+-#	from			to			module		cost
+-alias	CP862//			IBM862//
+-alias	862//			IBM862//
+-alias	CSPC862LATINHEBREW//	IBM862//
+-alias	OSF1002035E//		IBM862//
+-module	IBM862//		INTERNAL		IBM862		1
+-module	INTERNAL		IBM862//		IBM862		1
+-
+-#	from			to			module		cost
+-alias	CP863//			IBM863//
+-alias	863//			IBM863//
+-alias	CSIBM863//		IBM863//
+-alias	OSF1002035F//		IBM863//
+-module	IBM863//		INTERNAL		IBM863		1
+-module	INTERNAL		IBM863//		IBM863		1
+-
+-#	from			to			module		cost
+-alias	CP864//			IBM864//
+-alias	864//			IBM864//
+-alias	CSIBM864//		IBM864//
+-alias	OSF10020360//		IBM864//
+-module	IBM864//		INTERNAL		IBM864		1
+-module	INTERNAL		IBM864//		IBM864		1
+-
+-#	from			to			module		cost
+-alias	CP865//			IBM865//
+-alias	865//			IBM865//
+-alias	CSIBM865//		IBM865//
+-module	IBM865//		INTERNAL		IBM865		1
+-module	INTERNAL		IBM865//		IBM865		1
+-
+-#	from			to			module		cost
+-alias	CP866//			IBM866//
+-alias	866//			IBM866//
+-alias	CSIBM866//		IBM866//
+-module	IBM866//		INTERNAL		IBM866		1
+-module	INTERNAL		IBM866//		IBM866		1
+-
+-#	from			to			module		cost
+-alias	CP866NAV//		IBM866NAV//
+-alias	866NAV//		IBM866NAV//
+-module	IBM866NAV//		INTERNAL		IBM866NAV	1
+-module	INTERNAL		IBM866NAV//		IBM866NAV	1
+-
+-#	from			to			module		cost
+-alias	CP868//			IBM868//
+-alias	CP-AR//			IBM868//
+-alias	CSIBM868//		IBM868//
+-alias	OSF10020364//		IBM868//
+-module	IBM868//		INTERNAL		IBM868		1
+-module	INTERNAL		IBM868//		IBM868		1
+-
+-#	from			to			module		cost
+-alias	CP869//			IBM869//
+-alias	869//			IBM869//
+-alias	CP-GR//			IBM869//
+-alias	CSIBM869//		IBM869//
+-alias	OSF10020365//		IBM869//
+-module	IBM869//		INTERNAL		IBM869		1
+-module	INTERNAL		IBM869//		IBM869		1
+-
+-#	from			to			module		cost
+-alias	CP870//			IBM870//
+-alias	EBCDIC-CP-ROECE//	IBM870//
+-alias	EBCDIC-CP-YU//		IBM870//
+-alias	CSIBM870//		IBM870//
+-alias	OSF10020366//		IBM870//
+-module	IBM870//		INTERNAL		IBM870		1
+-module	INTERNAL		IBM870//		IBM870		1
+-
+-#	from			to			module		cost
+-alias	CP871//			IBM871//
+-alias	EBCDIC-CP-IS//		IBM871//
+-alias	CSIBM871//		IBM871//
+-alias	OSF10020367//		IBM871//
+-module	IBM871//		INTERNAL		IBM871		1
+-module	INTERNAL		IBM871//		IBM871		1
+-
+-#	from			to			module		cost
+-alias	CP875//			IBM875//
+-alias	EBCDIC-GREEK//		IBM875//
+-alias	OSF1002036B//		IBM875//
+-module	IBM875//		INTERNAL		IBM875		1
+-module	INTERNAL		IBM875//		IBM875		1
+-
+-#	from			to			module		cost
+-alias	CP880//			IBM880//
+-alias	EBCDIC-CYRILLIC//	IBM880//
+-alias	CSIBM880//		IBM880//
+-alias	OSF10020370//		IBM880//
+-module	IBM880//		INTERNAL		IBM880		1
+-module	INTERNAL		IBM880//		IBM880		1
+-
+-#	from			to			module		cost
+-alias	CP891//			IBM891//
+-alias	CSIBM891//		IBM891//
+-alias	OSF1002037B//		IBM891//
+-module	IBM891//		INTERNAL		IBM891		1
+-module	INTERNAL		IBM891//		IBM891		1
+-
+-#	from			to			module		cost
+-alias	CP903//			IBM903//
+-alias	CSIBM903//		IBM903//
+-alias	OSF10020387//		IBM903//
+-module	IBM903//		INTERNAL		IBM903		1
+-module	INTERNAL		IBM903//		IBM903		1
+-
+-#	from			to			module		cost
+-alias	CP904//			IBM904//
+-alias	904//			IBM904//
+-alias	CSIBM904//		IBM904//
+-alias	OSF10020388//		IBM904//
+-module	IBM904//		INTERNAL		IBM904		1
+-module	INTERNAL		IBM904//		IBM904		1
+-
+-#	from			to			module		cost
+-alias	CP905//			IBM905//
+-alias	EBCDIC-CP-TR//		IBM905//
+-alias	CSIBM905//		IBM905//
+-module	IBM905//		INTERNAL		IBM905		1
+-module	INTERNAL		IBM905//		IBM905		1
+-
+-#	from			to			module		cost
+-alias	CP918//			IBM918//
+-alias	EBCDIC-CP-AR2//		IBM918//
+-alias	CSIBM918//		IBM918//
+-alias	OSF10020396//		IBM918//
+-module	IBM918//		INTERNAL		IBM918		1
+-module	INTERNAL		IBM918//		IBM918		1
+-
+-#	from			to			module		cost
+-alias	IBM-922//		IBM922//
+-alias	CP922//			IBM922//
+-alias	CSIBM922//		IBM922//
+-module	IBM922//		INTERNAL		IBM922		1
+-module	INTERNAL		IBM922//		IBM922		1
+-
+-#	from			to			module		cost
+-alias	IBM-930//		IBM930//
+-alias	CP930//			IBM930//
+-alias	CSIBM930//		IBM930//
+-module	IBM930//		INTERNAL		IBM930		1
+-module	INTERNAL		IBM930//		IBM930		1
+-
+-#	from			to			module		cost
+-alias	IBM-932//		IBM932//
+-alias	CSIBM932//		IBM932//
+-module	IBM932//		INTERNAL		IBM932		1
+-module	INTERNAL		IBM932//		IBM932		1
+-
+-#	from			to			module		cost
+-alias	IBM-933//		IBM933//
+-alias	CP933//			IBM933//
+-alias	CSIBM933//		IBM933//
+-module	IBM933//		INTERNAL		IBM933		1
+-module	INTERNAL		IBM933//		IBM933		1
+-
+-#	from			to			module		cost
+-alias	IBM-935//		IBM935//
+-alias	CP935//			IBM935//
+-alias	CSIBM935//		IBM935//
+-module	IBM935//		INTERNAL		IBM935		1
+-module	INTERNAL		IBM935//		IBM935		1
+-
+-#	from			to			module		cost
+-alias	IBM-937//		IBM937//
+-alias	CP937//			IBM937//
+-alias	CSIBM937//		IBM937//
+-module	IBM937//		INTERNAL		IBM937		1
+-module	INTERNAL		IBM937//		IBM937		1
+-
+-#	from			to			module		cost
+-alias	IBM-939//		IBM939//
+-alias	CP939//			IBM939//
+-alias	CSIBM939//		IBM939//
+-module	IBM939//		INTERNAL		IBM939		1
+-module	INTERNAL		IBM939//		IBM939		1
+-
+-#	from			to			module		cost
+-alias	IBM-943//		IBM943//
+-alias	CSIBM943//		IBM943//
+-module	IBM943//		INTERNAL		IBM943		1
+-module	INTERNAL		IBM943//		IBM943		1
+-
+-#	from			to			module		cost
+-alias	CP1004//		IBM1004//
+-alias	OS2LATIN1//		IBM1004//
+-module	IBM1004//		INTERNAL		IBM1004		1
+-module	INTERNAL		IBM1004//		IBM1004		1
+-
+-#	from			to			module		cost
+-alias	CP1026//		IBM1026//
+-alias	1026//			IBM1026//
+-alias	CSIBM1026//		IBM1026//
+-alias	OSF10020402//		IBM1026//
+-module	IBM1026//		INTERNAL		IBM1026		1
+-module	INTERNAL		IBM1026//		IBM1026		1
+-
+-#	from			to			module		cost
+-alias	IBM-1046//		IBM1046//
+-alias	CP1046//		IBM1046//
+-alias	1046//			IBM1046//
+-module	IBM1046//		INTERNAL		IBM1046		1
+-module	INTERNAL		IBM1046//		IBM1046		1
+-
+-#	from			to			module		cost
+-alias	IBM-1047//		IBM1047//
+-alias	CP1047//		IBM1047//
+-alias	1047//			IBM1047//
+-alias	OSF10020417//		IBM1047//
+-module	IBM1047//		INTERNAL		IBM1047		1
+-module	INTERNAL		IBM1047//		IBM1047		1
+-
+-#	from			to			module		cost
+-alias	IBM-1124//		IBM1124//
+-alias	CP1124//		IBM1124//
+-alias	CSIBM1124//		IBM1124//
+-module	IBM1124//		INTERNAL		IBM1124		1
+-module	INTERNAL		IBM1124//		IBM1124		1
+-
+-#	from			to			module		cost
+-alias	IBM-1129//		IBM1129//
+-alias	CP1129//		IBM1129//
+-alias	CSIBM1129//		IBM1129//
+-module	IBM1129//		INTERNAL		IBM1129		1
+-module	INTERNAL		IBM1129//		IBM1129		1
+-
+-#	from			to			module		cost
+-alias	IBM-1160//		IBM1160//
+-alias	CP1160//		IBM1160//
+-alias	CSIBM1160//		IBM1160//
+-module	IBM1160//		INTERNAL		IBM1160		1
+-module	INTERNAL		IBM1160//		IBM1160		1
+-
+-#	from			to			module		cost
+-alias	IBM-1161//		IBM1161//
+-alias	CP1161//		IBM1161//
+-alias	CSIBM1161//		IBM1161//
+-module	IBM1161//		INTERNAL		IBM1161		1
+-module	INTERNAL		IBM1161//		IBM1161		1
+-
+-#	from			to			module		cost
+-alias	IBM-1132//		IBM1132//
+-alias	CP1132//		IBM1132//
+-alias	CSIBM1132//		IBM1132//
+-module	IBM1132//		INTERNAL		IBM1132		1
+-module	INTERNAL		IBM1132//		IBM1132		1
+-
+-#	from			to			module		cost
+-alias	IBM-1133//		IBM1133//
+-alias	CP1133//		IBM1133//
+-alias	CSIBM1133//		IBM1133//
+-module	IBM1133//		INTERNAL		IBM1133		1
+-module	INTERNAL		IBM1133//		IBM1133		1
+-
+-#	from			to			module		cost
+-alias	IBM-1162//		IBM1162//
+-alias	CP1162//		IBM1162//
+-alias	CSIBM11621162//		IBM1162//
+-module	IBM1162//		INTERNAL		IBM1162		1
+-module	INTERNAL		IBM1162//		IBM1162		1
+-
+-#	from			to			module		cost
+-alias	IBM-1163//		IBM1163//
+-alias	CP1163//		IBM1163//
+-alias	CSIBM1163//		IBM1163//
+-module	IBM1163//		INTERNAL		IBM1163		1
+-module	INTERNAL		IBM1163//		IBM1163		1
+-
+-#	from			to			module		cost
+-alias	IBM-1164//		IBM1164//
+-alias	CP1164//		IBM1164//
+-alias	CSIBM1164//		IBM1164//
+-module	IBM1164//		INTERNAL		IBM1164		1
+-module	INTERNAL		IBM1164//		IBM1164		1
+-
+-#	from			to			module		cost
+-alias	EUCKR//			EUC-KR//
+-alias	CSEUCKR//		EUC-KR//
+-alias	OSF0004000a//		EUC-KR//
+-module	EUC-KR//		INTERNAL		EUC-KR		1
+-module	INTERNAL		EUC-KR//		EUC-KR		1
+-
+-#	from			to			module		cost
+-alias	MSCP949//		UHC//
+-alias	CP949//			UHC//
+-alias	OSF100203B5//		UHC//
+-module	UHC//			INTERNAL		UHC		1
+-module	INTERNAL		UHC//			UHC		1
+-
+-#	from			to			module		cost
+-alias	MSCP1361//		JOHAB//
+-alias	CP1361//		JOHAB//
+-module	JOHAB//			INTERNAL		JOHAB		1
+-module	INTERNAL		JOHAB//			JOHAB		1
+-
+-#	from			to			module		cost
+-alias	BIG-FIVE//		BIG5//
+-alias	BIGFIVE//		BIG5//
+-alias	BIG-5//			BIG5//
+-alias	CN-BIG5//		BIG5//
+-alias	CP950//			BIG5//
+-module	BIG5//			INTERNAL		BIG5		1
+-module	INTERNAL		BIG5//			BIG5		1
+-
+-#	from			to			module		cost
+-alias	BIG5-HKSCS//		BIG5HKSCS//
+-module	BIG5HKSCS//		INTERNAL		BIG5HKSCS	1
+-module	INTERNAL		BIG5HKSCS//		BIG5HKSCS	1
+-
+-#	from			to			module		cost
+-alias	EUCJP-MS//		EUC-JP-MS//
+-alias	EUCJP-OPEN//		EUC-JP-MS//
+-alias	EUCJP-WIN//		EUC-JP-MS//
+-module	EUC-JP-MS//		INTERNAL		EUC-JP-MS	1
+-module	INTERNAL		EUC-JP-MS//		EUC-JP-MS	1
+-
+-#	from			to			module		cost
+-alias	EUCJP//			EUC-JP//
+-alias	CSEUCPKDFMTJAPANESE//	EUC-JP//
+-alias	OSF00030010//		EUC-JP//
+-alias	UJIS//			EUC-JP//
+-module	EUC-JP//		INTERNAL		EUC-JP		1
+-module	INTERNAL		EUC-JP//		EUC-JP		1
+-
+-#	from			to			module		cost
+-alias	EUCCN//			EUC-CN//
+-alias	GB2312//		EUC-CN//
+-alias	csGB2312//		EUC-CN//
+-alias	CN-GB//			EUC-CN//
+-module	EUC-CN//		INTERNAL		EUC-CN		1
+-module	INTERNAL		EUC-CN//		EUC-CN		1
+-
+-#	from			to			module		cost
+-module	EUC-CN//		BIG5//			GBBIG5		1
+-module	BIG5//			EUC-CN//		GBBIG5		1
+-
+-#	from			to			module		cost
+-alias	GB13000//		GBK//
+-alias	CP936//			GBK//
+-alias	MS936//			GBK//
+-alias	WINDOWS-936//		GBK//
+-module	GBK//			INTERNAL		GBK		1
+-module	INTERNAL		GBK//			GBK		1
+-
+-#	from			to			module		cost
+-module	GBK//			EUC-CN//		GBGBK		1
+-module	EUC-CN//		GBK//			GBGBK		1
+-
+-#	from			to			module		cost
+-alias	EUCTW//			EUC-TW//
+-alias	OSF0005000a//		EUC-TW//
+-module	EUC-TW//		INTERNAL		EUC-TW		1
+-module	INTERNAL		EUC-TW//		EUC-TW		1
+-
+-#	from			to			module		cost
+-alias	RUSCII//		CP1125//
+-alias	IBM848//		CP1125//
+-module	CP1125//		INTERNAL		CP1125		1
+-module	INTERNAL		CP1125//		CP1125		1
+-
+-#	from			to			module		cost
+-alias	MS-EE//			CP1250//
+-alias	WINDOWS-1250//		CP1250//
+-module	CP1250//		INTERNAL		CP1250		1
+-module	INTERNAL		CP1250//		CP1250		1
+-
+-#	from			to			module		cost
+-alias	MS-CYRL//		CP1251//
+-alias	WINDOWS-1251//		CP1251//
+-module	CP1251//		INTERNAL		CP1251		1
+-module	INTERNAL		CP1251//		CP1251		1
+-
+-#	from			to			module		cost
+-alias	MS-GREEK//		CP1253//
+-alias	WINDOWS-1253//		CP1253//
+-module	CP1253//		INTERNAL		CP1253		1
+-module	INTERNAL		CP1253//		CP1253		1
+-
+-#	from			to			module		cost
+-alias	MS-TURK//		CP1254//
+-alias	WINDOWS-1254//		CP1254//
+-module	CP1254//		INTERNAL		CP1254		1
+-module	INTERNAL		CP1254//		CP1254		1
+-
+-#	from			to			module		cost
+-alias	MS-HEBR//		CP1255//
+-alias	WINDOWS-1255//		CP1255//
+-module	CP1255//		INTERNAL		CP1255		1
+-module	INTERNAL		CP1255//		CP1255		1
+-
+-#	from			to			module		cost
+-alias	MS-ARAB//		CP1256//
+-alias	WINDOWS-1256//		CP1256//
+-module	CP1256//		INTERNAL		CP1256		1
+-module	INTERNAL		CP1256//		CP1256		1
+-
+-#	from			to			module		cost
+-alias	WINBALTRIM//		CP1257//
+-alias	WINDOWS-1257//		CP1257//
+-module	CP1257//		INTERNAL		CP1257		1
+-module	INTERNAL		CP1257//		CP1257		1
+-
+-#	from			to			module		cost
+-alias	WINDOWS-1258//		CP1258//
+-module	CP1258//		INTERNAL		CP1258		1
+-module	INTERNAL		CP1258//		CP1258		1
+-
+-#	from			to			module		cost
+-alias	874//			IBM874//
+-alias	CP874//			IBM874//
+-alias	WINDOWS-874//		IBM874//
+-module	IBM874//		INTERNAL		IBM874		1
+-module	INTERNAL		IBM874//		IBM874		1
+-
+-#	from			to			module		cost
+-module	CP737//			INTERNAL		CP737		1
+-module	INTERNAL		CP737//			CP737		1
+-
+-#	from			to			module		cost
+-module	CP770//			INTERNAL		CP770		1
+-module	INTERNAL		CP770//			CP770		1
+-
+-#	from			to			module		cost
+-module	CP771//			INTERNAL		CP771		1
+-module	INTERNAL		CP771//			CP771		1
+-
+-#	from			to			module		cost
+-module	CP772//			INTERNAL		CP772		1
+-module	INTERNAL		CP772//			CP772		1
+-
+-#	from			to			module		cost
+-module	CP773//			INTERNAL		CP773		1
+-module	INTERNAL		CP773//			CP773		1
+-
+-#	from			to			module		cost
+-module	CP774//			INTERNAL		CP774		1
+-module	INTERNAL		CP774//			CP774		1
+-
+-#	from			to			module		cost
+-alias	IBM775//		CP775//
+-alias	CSPC775BALTIC//		CP775//
+-module	CP775//			INTERNAL		CP775		1
+-module	INTERNAL		CP775//			CP775		1
+-
+-#	from			to			module		cost
+-alias	CSISO2022JP//		ISO-2022-JP//
+-alias	ISO2022JP//		ISO-2022-JP//
+-module	ISO-2022-JP//		INTERNAL		ISO-2022-JP	1
+-module	INTERNAL		ISO-2022-JP//		ISO-2022-JP	1
+-
+-#	from			to			module		cost
+-alias	CSISO2022JP2//		ISO-2022-JP-2//
+-alias	ISO2022JP2//		ISO-2022-JP-2//
+-module	ISO-2022-JP-2//		INTERNAL		ISO-2022-JP	1
+-module	INTERNAL		ISO-2022-JP-2//		ISO-2022-JP	1
+-
+-#	from			to			module		cost
+-module	ISO-2022-JP-3//		INTERNAL		ISO-2022-JP-3	1
+-module	INTERNAL		ISO-2022-JP-3//		ISO-2022-JP-3	1
+-
+-#	from			to			module		cost
+-alias	CSISO2022KR//		ISO-2022-KR//
+-alias	ISO2022KR//		ISO-2022-KR//
+-module	ISO-2022-KR//		INTERNAL		ISO-2022-KR	1
+-module	INTERNAL		ISO-2022-KR//		ISO-2022-KR	1
+-
+-#	from			to			module		cost
+-alias	CSISO2022CN//		ISO-2022-CN//
+-alias	ISO2022CN//		ISO-2022-CN//
+-module	ISO-2022-CN//		INTERNAL		ISO-2022-CN	1
+-module	INTERNAL		ISO-2022-CN//		ISO-2022-CN	1
+-
+-#	from			to			module		cost
+-alias	ISO2022CNEXT//		ISO-2022-CN-EXT//
+-module	ISO-2022-CN-EXT//	INTERNAL		ISO-2022-CN-EXT	1
+-module	INTERNAL		ISO-2022-CN-EXT//	ISO-2022-CN-EXT	1
+-
+-#	from			to			module		cost
+-alias	MAC//			MACINTOSH//
+-alias	CSMACINTOSH//		MACINTOSH//
+-module	MACINTOSH//		INTERNAL		MACINTOSH	1
+-module	INTERNAL		MACINTOSH//		MACINTOSH	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-143//		IEC_P27-1//
+-alias	CSISO143IECP271//	IEC_P27-1//
+-alias	IEC_P271//		IEC_P27-1//
+-module	IEC_P27-1//		INTERNAL		IEC_P27-1	1
+-module	INTERNAL		IEC_P27-1//		IEC_P27-1	1
+-
+-#	from			to			module		cost
+-alias	ISO_9036//		ASMO_449//
+-alias	ARABIC7//		ASMO_449//
+-alias	ISO-IR-89//		ASMO_449//
+-alias	CSISO89ASMO449//	ASMO_449//
+-module	ASMO_449//		INTERNAL		ASMO_449	1
+-module	INTERNAL		ASMO_449//		ASMO_449	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-139//		CSN_369103//
+-alias	CSISO139CSN369103//	CSN_369103//
+-module	CSN_369103//		INTERNAL		CSN_369103	1
+-module	INTERNAL		CSN_369103//		CSN_369103	1
+-
+-#	from			to			module		cost
+-alias	CWI-2//			CWI//
+-alias	CP-HU//			CWI//
+-module	CWI//			INTERNAL		CWI		1
+-module	INTERNAL		CWI//			CWI		1
+-
+-#	from			to			module		cost
+-alias	DEC//			DEC-MCS//
+-alias	CSDECMCS//		DEC-MCS//
+-alias	DECMCS//		DEC-MCS//
+-module	DEC-MCS//		INTERNAL		DEC-MCS		1
+-module	INTERNAL		DEC-MCS//		DEC-MCS		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-111//		ECMA-CYRILLIC//
+-alias	CSISO111ECMACYRILLIC//	ECMA-CYRILLIC//
+-alias	ECMACYRILLIC//		ECMA-CYRILLIC//
+-module	ECMA-CYRILLIC//		INTERNAL		ECMA-CYRILLIC	1
+-module	INTERNAL		ECMA-CYRILLIC//		ECMA-CYRILLIC	1
+-
+-#	from			to			module		cost
+-alias	ST_SEV_358-88//		GOST_19768-74//
+-alias	GOST_19768//		GOST_19768-74//
+-alias	ISO-IR-153//		GOST_19768-74//
+-alias	CSISO153GOST1976874//	GOST_19768-74//
+-alias	GOST_1976874//		GOST_19768-74//
+-module	GOST_19768-74//		INTERNAL		GOST_19768-74	1
+-module	INTERNAL		GOST_19768-74//		GOST_19768-74	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-150//		GREEK-CCITT//
+-alias	CSISO150//		GREEK-CCITT//
+-alias	CSISO150GREEKCCITT//	GREEK-CCITT//
+-alias	GREEKCCITT//		GREEK-CCITT//
+-module	GREEK-CCITT//		INTERNAL		GREEK-CCITT	1
+-module	INTERNAL		GREEK-CCITT//		GREEK-CCITT	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-88//		GREEK7//
+-alias	CSISO88GREEK7//		GREEK7//
+-module	GREEK7//		INTERNAL		GREEK7		1
+-module	INTERNAL		GREEK7//		GREEK7		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-18//		GREEK7-OLD//
+-alias	CSISO18GREEK7OLD//	GREEK7-OLD//
+-alias	GREEK7OLD//		GREEK7-OLD//
+-module	GREEK7-OLD//		INTERNAL		GREEK7-OLD	1
+-module	INTERNAL		GREEK7-OLD//		GREEK7-OLD	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-49//		INIS//
+-alias	CSISO49INIS//		INIS//
+-module	INIS//			INTERNAL		INIS		1
+-module	INTERNAL		INIS//			INIS		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-50//		INIS-8//
+-alias	CSISO50INIS8//		INIS-8//
+-alias	INIS8//			INIS-8//
+-module	INIS-8//		INTERNAL		INIS-8		1
+-module	INTERNAL		INIS-8//		INIS-8		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-51//		INIS-CYRILLIC//
+-alias	CSISO51INISCYRILLIC//	INIS-CYRILLIC//
+-alias	INISCYRILLIC//		INIS-CYRILLIC//
+-module	INIS-CYRILLIC//		INTERNAL		INIS-CYRILLIC	1
+-module	INTERNAL		INIS-CYRILLIC//		INIS-CYRILLIC	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-98//		ISO_2033//
+-alias	ISO_2033-1983//		ISO_2033//
+-alias	E13B//			ISO_2033//
+-alias	CSISO2033//		ISO_2033//
+-module	ISO_2033//		INTERNAL		ISO_2033	1
+-module	INTERNAL		ISO_2033//		ISO_2033	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-37//		ISO_5427//
+-alias	KOI-7//			ISO_5427//
+-alias	CSISO5427CYRILLIC//	ISO_5427//
+-module	ISO_5427//		INTERNAL		ISO_5427	1
+-module	INTERNAL		ISO_5427//		ISO_5427	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-54//		ISO_5427-EXT//
+-alias	ISO_5427:1981//		ISO_5427-EXT//
+-alias	CSISO5427CYRILLIC1981//	ISO_5427-EXT//
+-alias	ISO_5427EXT//		ISO_5427-EXT//
+-module	ISO_5427-EXT//		INTERNAL		ISO_5427-EXT	1
+-module	INTERNAL		ISO_5427-EXT//		ISO_5427-EXT	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-55//		ISO_5428//
+-alias	ISO_5428:1980//		ISO_5428//
+-alias	CSISO5428GREEK//	ISO_5428//
+-module	ISO_5428//		INTERNAL		ISO_5428	1
+-module	INTERNAL		ISO_5428//		ISO_5428	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-155//		ISO_10367-BOX//
+-alias	CSISO10367BOX//		ISO_10367-BOX//
+-alias	ISO_10367BOX//		ISO_10367-BOX//
+-module	ISO_10367-BOX//		INTERNAL		ISO_10367-BOX	1
+-module	INTERNAL		ISO_10367-BOX//		ISO_10367-BOX	1
+-
+-#	from			to			module		cost
+-alias	MACIS//			MAC-IS//
+-module	MAC-IS//		INTERNAL		MAC-IS		1
+-module	INTERNAL		MAC-IS//		MAC-IS		1
+-
+-#	from			to			module		cost
+-alias	MACUK//			MAC-UK//
+-alias	MACUKRAINIAN//		MAC-UK//
+-alias	MAC-CYRILLIC//		MAC-UK//
+-alias	MACCYRILLIC//		MAC-UK//
+-module	MAC-UK//		INTERNAL		MAC-UK		1
+-module	INTERNAL		MAC-UK//		MAC-UK		1
+-
+-#	from			to			module		cost
+-alias	MS-MAC-CYRILLIC//	CP10007//
+-alias	MSMACCYRILLIC//		CP10007//
+-module	CP10007//		INTERNAL		CP10007		1
+-module	INTERNAL		CP10007//		CP10007		1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-9-1//		NATS-DANO//
+-alias	CSNATSDANO//		NATS-DANO//
+-alias	NATSDANO//		NATS-DANO//
+-module	NATS-DANO//		INTERNAL		NATS-DANO	1
+-module	INTERNAL		NATS-DANO//		NATS-DANO	1
+-
+-#	from			to			module		cost
+-alias	ISO-IR-8-1//		NATS-SEFI//
+-alias	CSNATSSEFI//		NATS-SEFI//
+-alias	NATSSEFI//		NATS-SEFI//
+-module	NATS-SEFI//		INTERNAL		NATS-SEFI	1
+-module	INTERNAL		NATS-SEFI//		NATS-SEFI	1
+-
+-#	from			to			module		cost
+-alias	WS2//			WIN-SAMI-2//
+-alias	WINSAMI2//		WIN-SAMI-2//
+-module	WIN-SAMI-2//		INTERNAL		SAMI-WS2	1
+-module	INTERNAL		WIN-SAMI-2//		SAMI-WS2	1
+-
+-#	from			to			module		cost
+-module	ISO-IR-197//		INTERNAL		ISO-IR-197	1
+-module	INTERNAL		ISO-IR-197//		ISO-IR-197	1
+-
+-#	from			to			module		cost
+-alias	TIS620//		TIS-620//
+-alias	TIS620-0//		TIS-620//
+-alias	TIS620.2529-1//		TIS-620//
+-alias	TIS620.2533-0//		TIS-620//
+-alias	ISO-IR-166//		TIS-620//
+-module	TIS-620//		INTERNAL		TIS-620		1
+-module	INTERNAL		TIS-620//		TIS-620		1
+-
+-#	from			to			module		cost
+-alias	KOI8U//			KOI8-U//
+-module	KOI8-U//		INTERNAL		KOI8-U		1
+-module	INTERNAL		KOI8-U//		KOI8-U		1
+-
+-#	from			to			module		cost
+-alias	ISIRI3342//		ISIRI-3342//
+-module	ISIRI-3342//		INTERNAL		ISIRI-3342	1
+-module	INTERNAL		ISIRI-3342//		ISIRI-3342	1
+-
+-#	from			to			module		cost
+-module	GB18030//		INTERNAL		GB18030		1
+-module	INTERNAL		GB18030//		GB18030		1
+-
+-#	from			to			module		cost
+-module	VISCII//		INTERNAL		VISCII		1
+-module	INTERNAL		VISCII//		VISCII		1
+-
+-#	from			to			module		cost
+-module	KOI8-T//		INTERNAL		KOI8-T		1
+-module	INTERNAL		KOI8-T//		KOI8-T		1
+-
+-#	from			to			module		cost
+-module	GEORGIAN-PS//		INTERNAL		GEORGIAN-PS	1
+-module	INTERNAL		GEORGIAN-PS//		GEORGIAN-PS	1
+-
+-#	from			to			module		cost
+-module	GEORGIAN-ACADEMY//	INTERNAL		GEORGIAN-ACADEMY 1
+-module	INTERNAL		GEORGIAN-ACADEMY//	GEORGIAN-ACADEMY 1
+-
+-#	from			to			module		cost
+-module	ISO-IR-209//		INTERNAL		ISO-IR-209	1
+-module	INTERNAL		ISO-IR-209//		ISO-IR-209	1
+-
+-#	from			to			module		cost
+-module	MAC-SAMI//		INTERNAL		MAC-SAMI	1
+-module	INTERNAL		MAC-SAMI//		MAC-SAMI	1
+-
+-#	from			to			module		cost
+-alias	ARMSCII8//		ARMSCII-8//
+-module	ARMSCII-8//		INTERNAL		ARMSCII-8	1
+-module	INTERNAL		ARMSCII-8//		ARMSCII-8	1
+-
+-#	from			to			module		cost
+-alias	TCVN//			TCVN5712-1//
+-alias	TCVN-5712//		TCVN5712-1//
+-alias	TCVN5712-1:1993//	TCVN5712-1//
+-module	TCVN5712-1//		INTERNAL		TCVN5712-1	1
+-module	INTERNAL		TCVN5712-1//		TCVN5712-1	1
+-
+-#	from			to			module		cost
+-module	EUC-JISX0213//		INTERNAL		EUC-JISX0213	1
+-module	INTERNAL		EUC-JISX0213//		EUC-JISX0213	1
+-
+-#	from			to			module		cost
+-alias	ShiftJISX0213//		Shift_JISX0213//
+-module	Shift_JISX0213//	INTERNAL		SHIFT_JISX0213	1
+-module	INTERNAL		Shift_JISX0213//	SHIFT_JISX0213	1
+-
+-#	from			to			module		cost
+-module	TSCII//			INTERNAL		TSCII		1
+-module	INTERNAL		TSCII//			TSCII		1
+-
+-#	from			to			module		cost
+-module	PT154//			INTERNAL		PT154		1
+-module	INTERNAL		PT154//			PT154		1
+-
+-#	from			to			module		cost
+-alias	STRK1048-2002//		RK1048//
+-module	RK1048//		INTERNAL		RK1048		1
+-module	INTERNAL		RK1048//		RK1048		1
+-
+-#	from			to			module		cost
+-alias	IBM-1025//		IBM1025//
+-alias	CP1025//		IBM1025//
+-alias	CSIBM1025//		IBM1025//
+-module	IBM1025//		INTERNAL		IBM1025		1
+-module	INTERNAL		IBM1025//		IBM1025		1
+-
+-#	from			to			module		cost
+-alias	IBM-1122//		IBM1122//
+-alias	CP1122//		IBM1122//
+-alias	CSIBM1122//		IBM1122//
+-module	IBM1122//		INTERNAL		IBM1122		1
+-module	INTERNAL		IBM1122//		IBM1122		1
+-
+-#	from			to			module		cost
+-alias	IBM-1137//		IBM1137//
+-alias	CP1137//		IBM1137//
+-alias	CSIBM1137//		IBM1137//
+-module	IBM1137//		INTERNAL		IBM1137		1
+-module	INTERNAL		IBM1137//		IBM1137		1
+-
+-#	from			to			module		cost
+-alias	IBM-1153//		IBM1153//
+-alias	CP1153//		IBM1153//
+-alias	CSIBM1153//		IBM1153//
+-module	IBM1153//		INTERNAL		IBM1153		1
+-module	INTERNAL		IBM1153//		IBM1153		1
+-
+-#	from			to			module		cost
+-alias	IBM-1154//		IBM1154//
+-alias	CP1154//		IBM1154//
+-alias	CSIBM1154//		IBM1154//
+-module	IBM1154//		INTERNAL		IBM1154		1
+-module	INTERNAL		IBM1154//		IBM1154		1
+-
+-#	from			to			module		cost
+-alias	IBM-1155//		IBM1155//
+-alias	CP1155//		IBM1155//
+-alias	CSIBM1155//		IBM1155//
+-module	IBM1155//		INTERNAL		IBM1155		1
+-module	INTERNAL		IBM1155//		IBM1155		1
+-
+-#	from			to			module		cost
+-alias	IBM-1156//		IBM1156//
+-alias	CP1156//		IBM1156//
+-alias	CSIBM1156//		IBM1156//
+-module	IBM1156//		INTERNAL		IBM1156		1
+-module	INTERNAL		IBM1156//		IBM1156		1
+-
+-#	from			to			module		cost
+-alias	IBM-1157//		IBM1157//
+-alias	CP1157//		IBM1157//
+-alias	CSIBM1157//		IBM1157//
+-module	IBM1157//		INTERNAL		IBM1157		1
+-module	INTERNAL		IBM1157//		IBM1157		1
+-
+-#	from			to			module		cost
+-alias	IBM-1158//		IBM1158//
+-alias	CP1158//		IBM1158//
+-alias	CSIBM1158//		IBM1158//
+-module	IBM1158//		INTERNAL		IBM1158		1
+-module	INTERNAL		IBM1158//		IBM1158		1
+-
+-#	from			to			module		cost
+-alias	IBM-803//		IBM803//
+-alias	CP803//		IBM803//
+-alias	CSIBM803//		IBM803//
+-module	IBM803//		INTERNAL		IBM803		1
+-module	INTERNAL		IBM803//		IBM803		1
+-
+-#	from			to			module		cost
+-alias	IBM-901//		IBM901//
+-alias	CP901//		IBM901//
+-alias	CSIBM901//		IBM901//
+-module	IBM901//		INTERNAL		IBM901		1
+-module	INTERNAL		IBM901//		IBM901		1
+-
+-#	from			to			module		cost
+-alias	IBM-902//		IBM902//
+-alias	CP902//		IBM902//
+-alias	CSIBM902//		IBM902//
+-module	IBM902//		INTERNAL		IBM902		1
+-module	INTERNAL		IBM902//		IBM902		1
+-
+-#	from			to			module		cost
+-alias	IBM-921//		IBM921//
+-alias	CP921//		IBM921//
+-alias	CSIBM921//		IBM921//
+-module	IBM921//		INTERNAL		IBM921		1
+-module	INTERNAL		IBM921//		IBM921		1
+-
+-#	from			to			module		cost
+-alias	IBM-1008//		IBM1008//
+-alias	CP1008//		IBM1008//
+-alias	CSIBM1008//		IBM1008//
+-module	IBM1008//		INTERNAL		IBM1008		1
+-module	INTERNAL		IBM1008//		IBM1008		1
+-
+-#	from			to			module		cost
+-module	IBM1008//		IBM420//		IBM1008_420	1
+-module	IBM420//		IBM1008//		IBM1008_420	1
+-
+-#	from			to			module		cost
+-alias	IBM-1097//		IBM1097//
+-alias	CP1097//		IBM1097//
+-alias	CSIBM1097//		IBM1097//
+-module	IBM1097//		INTERNAL		IBM1097		1
+-module	INTERNAL		IBM1097//		IBM1097		1
+-
+-#	from			to			module		cost
+-alias	IBM-1112//		IBM1112//
+-alias	CP1112//		IBM1112//
+-alias	CSIBM1112//		IBM1112//
+-module	IBM1112//		INTERNAL		IBM1112		1
+-module	INTERNAL		IBM1112//		IBM1112		1
+-
+-#	from			to			module		cost
+-alias	IBM-1123//		IBM1123//
+-alias	CP1123//		IBM1123//
+-alias	CSIBM1123//		IBM1123//
+-module	IBM1123//		INTERNAL		IBM1123		1
+-module	INTERNAL		IBM1123//		IBM1123		1
+-
+-#	from			to			module		cost
+-alias	IBM-1130//		IBM1130//
+-alias	CP1130//		IBM1130//
+-alias	CSIBM1130//		IBM1130//
+-module	IBM1130//		INTERNAL		IBM1130		1
+-module	INTERNAL		IBM1130//		IBM1130		1
+-
+-#	from			to			module		cost
+-alias	IBM-1140//		IBM1140//
+-alias	CP1140//		IBM1140//
+-alias	CSIBM1140//		IBM1140//
+-module	IBM1140//		INTERNAL		IBM1140		1
+-module	INTERNAL		IBM1140//		IBM1140		1
+-
+-#	from			to			module		cost
+-alias	IBM-1141//		IBM1141//
+-alias	CP1141//		IBM1141//
+-alias	CSIBM1141//		IBM1141//
+-module	IBM1141//		INTERNAL		IBM1141		1
+-module	INTERNAL		IBM1141//		IBM1141		1
+-
+-#	from			to			module		cost
+-alias	IBM-1142//		IBM1142//
+-alias	CP1142//		IBM1142//
+-alias	CSIBM1142//		IBM1142//
+-module	IBM1142//		INTERNAL		IBM1142		1
+-module	INTERNAL		IBM1142//		IBM1142		1
+-
+-#	from			to			module		cost
+-alias	IBM-1143//		IBM1143//
+-alias	CP1143//		IBM1143//
+-alias	CSIBM1143//		IBM1143//
+-module	IBM1143//		INTERNAL		IBM1143		1
+-module	INTERNAL		IBM1143//		IBM1143		1
+-
+-#	from			to			module		cost
+-alias	IBM-1144//		IBM1144//
+-alias	CP1144//		IBM1144//
+-alias	CSIBM1144//		IBM1144//
+-module	IBM1144//		INTERNAL		IBM1144		1
+-module	INTERNAL		IBM1144//		IBM1144		1
+-
+-#	from			to			module		cost
+-alias	IBM-1145//		IBM1145//
+-alias	CP1145//		IBM1145//
+-alias	CSIBM1145//		IBM1145//
+-module	IBM1145//		INTERNAL		IBM1145		1
+-module	INTERNAL		IBM1145//		IBM1145		1
+-
+-#	from			to			module		cost
+-alias	IBM-1146//		IBM1146//
+-alias	CP1146//		IBM1146//
+-alias	CSIBM1146//		IBM1146//
+-module	IBM1146//		INTERNAL		IBM1146		1
+-module	INTERNAL		IBM1146//		IBM1146		1
+-
+-#	from			to			module		cost
+-alias	IBM-1147//		IBM1147//
+-alias	CP1147//		IBM1147//
+-alias	CSIBM1147//		IBM1147//
+-module	IBM1147//		INTERNAL		IBM1147		1
+-module	INTERNAL		IBM1147//		IBM1147		1
+-
+-#	from			to			module		cost
+-alias	IBM-1148//		IBM1148//
+-alias	CP1148//		IBM1148//
+-alias	CSIBM1148//		IBM1148//
+-module	IBM1148//		INTERNAL		IBM1148		1
+-module	INTERNAL		IBM1148//		IBM1148		1
+-
+-#	from			to			module		cost
+-alias	IBM-1149//		IBM1149//
+-alias	CP1149//		IBM1149//
+-alias	CSIBM1149//		IBM1149//
+-module	IBM1149//		INTERNAL		IBM1149		1
+-module	INTERNAL		IBM1149//		IBM1149		1
+-
+-#	from			to			module		cost
+-alias	IBM-1166//		IBM1166//
+-alias	CP1166//		IBM1166//
+-alias	CSIBM1166//		IBM1166//
+-module	IBM1166//		INTERNAL		IBM1166		1
+-module	INTERNAL		IBM1166//		IBM1166		1
+-
+-#	from			to			module		cost
+-alias	IBM-1167//		IBM1167//
+-alias	CP1167//		IBM1167//
+-alias	CSIBM1167//		IBM1167//
+-module	IBM1167//		INTERNAL		IBM1167		1
+-module	INTERNAL		IBM1167//		IBM1167		1
+-
+-#	from			to			module		cost
+-alias	IBM-4517//		IBM4517//
+-alias	CP4517//		IBM4517//
+-alias	CSIBM4517//		IBM4517//
+-module	IBM4517//		INTERNAL		IBM4517		1
+-module	INTERNAL		IBM4517//		IBM4517		1
+-
+-#	from			to			module		cost
+-alias	IBM-4899//		IBM4899//
+-alias	CP4899//		IBM4899//
+-alias	CSIBM4899//		IBM4899//
+-module	IBM4899//		INTERNAL		IBM4899		1
+-module	INTERNAL		IBM4899//		IBM4899		1
+-
+-#	from			to			module		cost
+-alias	IBM-4909//		IBM4909//
+-alias	CP4909//		IBM4909//
+-alias	CSIBM4909//		IBM4909//
+-module	IBM4909//		INTERNAL		IBM4909		1
+-module	INTERNAL		IBM4909//		IBM4909		1
+-
+-#	from			to			module		cost
+-alias	IBM-4971//		IBM4971//
+-alias	CP4971//		IBM4971//
+-alias	CSIBM4971//		IBM4971//
+-module	IBM4971//		INTERNAL		IBM4971		1
+-module	INTERNAL		IBM4971//		IBM4971		1
+-
+-#	from			to			module		cost
+-alias	IBM-5347//		IBM5347//
+-alias	CP5347//		IBM5347//
+-alias	CSIBM5347//		IBM5347//
+-module	IBM5347//		INTERNAL		IBM5347		1
+-module	INTERNAL		IBM5347//		IBM5347		1
+-
+-#	from			to			module		cost
+-alias	IBM-9030//		IBM9030//
+-alias	CP9030//		IBM9030//
+-alias	CSIBM9030//		IBM9030//
+-module	IBM9030//		INTERNAL		IBM9030		1
+-module	INTERNAL		IBM9030//		IBM9030		1
+-
+-#	from			to			module		cost
+-alias	IBM-9066//		IBM9066//
+-alias	CP9066//		IBM9066//
+-alias	CSIBM9066//		IBM9066//
+-module	IBM9066//		INTERNAL		IBM9066		1
+-module	INTERNAL		IBM9066//		IBM9066		1
+-
+-#	from			to			module		cost
+-alias	IBM-9448//		IBM9448//
+-alias	CP9448//		IBM9448//
+-alias	CSIBM9448//		IBM9448//
+-module	IBM9448//		INTERNAL		IBM9448		1
+-module	INTERNAL		IBM9448//		IBM9448		1
+-
+-#	from			to			module		cost
+-alias	IBM-12712//		IBM12712//
+-alias	CP12712//		IBM12712//
+-alias	CSIBM12712//		IBM12712//
+-module	IBM12712//		INTERNAL		IBM12712		1
+-module	INTERNAL		IBM12712//		IBM12712		1
+-
+-#	from			to			module		cost
+-alias	IBM-16804//		IBM16804//
+-alias	CP16804//		IBM16804//
+-alias	CSIBM16804//		IBM16804//
+-module	IBM16804//		INTERNAL		IBM16804		1
+-module	INTERNAL		IBM16804//		IBM16804		1
+-
+-#	from			to			module		cost
+-alias	IBM-1364//		IBM1364//
+-alias	CP1364//		IBM1364//
+-alias	CSIBM1364//		IBM1364//
+-module	IBM1364//		INTERNAL		IBM1364		1
+-module	INTERNAL		IBM1364//		IBM1364		1
+-
+-#	from			to			module		cost
+-alias	IBM-1371//		IBM1371//
+-alias	CP1371//		IBM1371//
+-alias	CSIBM1371//		IBM1371//
+-module	IBM1371//		INTERNAL		IBM1371		1
+-module	INTERNAL		IBM1371//		IBM1371		1
+-
+-#	from			to			module		cost
+-alias	IBM-1388//		IBM1388//
+-alias	CP1388//		IBM1388//
+-alias	CSIBM1388//		IBM1388//
+-module	IBM1388//		INTERNAL		IBM1388		1
+-module	INTERNAL		IBM1388//		IBM1388		1
+-
+-#	from			to			module		cost
+-alias	IBM-1390//		IBM1390//
+-alias	CP1390//		IBM1390//
+-alias	CSIBM1390//		IBM1390//
+-module	IBM1390//		INTERNAL		IBM1390		1
+-module	INTERNAL		IBM1390//		IBM1390		1
+-
+-#	from			to			module		cost
+-alias	IBM-1399//		IBM1399//
+-alias	CP1399//		IBM1399//
+-alias	CSIBM1399//		IBM1399//
+-module	IBM1399//		INTERNAL		IBM1399		1
+-module	INTERNAL		IBM1399//		IBM1399		1
+-
+-#	from			to			module		cost
+-alias	ISO/TR_11548-1/		ISO_11548-1//
+-alias	ISO11548-1//		ISO_11548-1//
+-module	ISO_11548-1//		INTERNAL		ISO_11548-1	1
+-module	INTERNAL		ISO_11548-1//		ISO_11548-1	1
+-
+-#	from			to			module		cost
+-module	MIK//			INTERNAL		MIK		1
+-module	INTERNAL		MIK//			MIK		1
+-
+-#	from			to			module		cost
+-module	BRF//			INTERNAL		BRF		1
+-module	INTERNAL		BRF//			BRF		1
+-
+-#	from			to			module		cost
+-alias	CP1282//		MAC-CENTRALEUROPE//
+-module	MAC-CENTRALEUROPE//	INTERNAL		MAC-CENTRALEUROPE 1
+-module	INTERNAL		MAC-CENTRALEUROPE//	MAC-CENTRALEUROPE 1
+-
+-#	from			to			module		cost
+-module	KOI8-RU//		INTERNAL		KOI8-RU		1
+-module	INTERNAL		KOI8-RU//		KOI8-RU		1
+-
+-#	from			to			module		cost
+-alias	ISO_8859-9E//		ISO-8859-9E//
+-alias	ISO8859-9E//		ISO-8859-9E//
+-alias	ISO88599E//		ISO-8859-9E//
+-module	ISO-8859-9E//		INTERNAL		ISO8859-9E	1
+-module	INTERNAL		ISO-8859-9E//		ISO8859-9E	1
+-
+-#	from			to			module		cost
+-alias	ROMAN9//		HP-ROMAN9//
+-alias	R9//			HP-ROMAN9//
+-alias	HPROMAN9//		HP-ROMAN9//
+-module	HP-ROMAN9//		INTERNAL		HP-ROMAN9	1
+-module	INTERNAL		HP-ROMAN9//		HP-ROMAN9	1
+-
+-#	from			to			module		cost
+-alias	TURKISH8//		HP-TURKISH8//
+-alias	HPTURKISH8//		HP-TURKISH8//
+-alias	OSF10010006//		HP-TURKISH8//
+-module	HP-TURKISH8//		INTERNAL		HP-TURKISH8	1
+-module	INTERNAL		HP-TURKISH8//		HP-TURKISH8	1
+-
+-#	from			to			module		cost
+-alias	THAI8//			HP-THAI8//
+-alias	HPTHAI8//		HP-THAI8//
+-module	HP-THAI8//		INTERNAL		HP-THAI8	1
+-module	INTERNAL		HP-THAI8//		HP-THAI8	1
+-
+-#	from			to			module		cost
+-alias	HPGREEK8//		HP-GREEK8//
+-alias	OSF10010004//		HP-GREEK8//
+-module	HP-GREEK8//		INTERNAL		HP-GREEK8	1
+-module	INTERNAL		HP-GREEK8//		HP-GREEK8	1


### PR DESCRIPTION
the patch basically copies all lines from extra to normal
if you find a better way to enable it...
(kodi uses zip, that uses utf8 or cp374, and while some kodi packagers uses windows. glibc tries to clean up deprecated software.)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>