### PR TITLE
bump xemu to 0.7.67

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
@@ -142,7 +142,7 @@ rpcs3configevdev = CONF + '/rpcs3/InputConfigs/Evdev/Default Profile.yml'
 supermodelCustom = CONF + '/supermodel'
 supermodelIni = supermodelCustom + '/Supermodel.ini'
 
-xemuConfig = CONF + '/xemu/xemu.ini'
+xemuConfig = CONF + '/xemu/xemu.toml'
 
 sdlpopConfigDir = CONF + '/sdlpop'
 sdlpopSrcCfg = sdlpopConfigDir + '/SDLPoP.cfg'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
@@ -28,91 +28,100 @@ def writeIniFile(system, rom, playersControllers):
 
 def createXemuConfig(iniConfig, system, rom, playersControllers):
     # Create INI sections
-    if not iniConfig.has_section("system"):
-        iniConfig.add_section("system")
+    if not iniConfig.has_section("general"):
+        iniConfig.add_section("general")
+    if not iniConfig.has_section("sys.files"):
+        iniConfig.add_section("sys.files")
     if not iniConfig.has_section("audio"):
         iniConfig.add_section("audio")
-    if not iniConfig.has_section("display"):
-        iniConfig.add_section("display")
+    if not iniConfig.has_section("display.quality"):
+        iniConfig.add_section("display.quality")
+    if not iniConfig.has_section("display.ui"):
+        iniConfig.add_section("display.ui")
     if not iniConfig.has_section("input"):
         iniConfig.add_section("input")
-    if not iniConfig.has_section("network"):
-        iniConfig.add_section("network")
+    if not iniConfig.has_section("net"):
+        iniConfig.add_section("net")
     if not iniConfig.has_section("misc"):
         iniConfig.add_section("misc")
 
-    # Fill system section
-    iniConfig.set("system", "flash_path", "/userdata/bios/Complex_4627.bin")
-    iniConfig.set("system", "bootrom_path", "/userdata/bios/mcpx_1.0.bin")
-    iniConfig.set("system", "hdd_path", "/userdata/saves/xbox/xbox_hdd.qcow2")
-    iniConfig.set("system", "eeprom_path", "/userdata/saves/xbox/xemu_eeprom.bin")
-    iniConfig.set("system", "dvd_path", rom)
-    iniConfig.set("system", "memory", "64")
-
     # Boot Animation Skip
     if system.isOptSet("xemu_bootanim"):
-        iniConfig.set("system", "shortanim", system.config["xemu_bootanim"])
+        iniConfig.set("general", "skip_boot_anim", system.config["xemu_bootanim"])
     else:
-        iniConfig.set("system", "shortanim", "false")
+        iniConfig.set("general", "skip_boot_anim", "false")
 
-    # Fill audio section
-    iniConfig.set("audio", "use_dsp", "false")
+    # Disable welcome screen on first launch
+    iniConfig.set("general", "show_welcome", "false")
 
-    # Fill display section
-    if system.isOptSet("scaling"):
-        iniConfig.set("display", "scale", system.config["scaling"])
+    # Fill system section
+    iniConfig.set("sys.files", "flashrom_path", "'/userdata/bios/Complex_4627.bin'")
+    iniConfig.set("sys.files", "bootrom_path", "'/userdata/bios/mcpx_1.0.bin'")
+    iniConfig.set("sys.files", "hdd_path", "'/userdata/saves/xbox/xbox_hdd.qcow2'")
+    iniConfig.set("sys.files", "eeprom_path", "'/userdata/saves/xbox/xemu_eeprom.bin'")
+    iniConfig.set("sys.files", "dvd_path", "'" + rom + "'")
+
+    # Audio quality
+    if system.isOptSet("use_dsp"):
+        iniConfig.set("audio", "use_dsp", system.config["use_dsp"])
     else:
-        iniConfig.set("display", "scale", "scale") #4:3
+        iniConfig.set("audio", "use_dsp", "false")
 
+    # Rendering resolution
     if system.isOptSet("render"):
-        iniConfig.set("display", "render_scale", system.config["render"])
+        iniConfig.set("display.quality", "surface_scale", system.config["render"])
     else:
-        iniConfig.set("display", "render_scale", "1") #render scale by default
-        iniConfig.set("display", "ui_scale", "1")
+        iniConfig.set("display.quality", "surface_scale", "1") #render scale by default
+
+    # Aspect ratio
+    if system.isOptSet("scaling"):
+        iniConfig.set("display.ui", "fit", "'" + system.config["scaling"] + "'")
+    else:
+        iniConfig.set("display.ui", "fit", "'scale'") #4:3
 
     # Fill input section
     # first, clear
     for i in range(1,5):
-        iniConfig.set("input", f"controller_{i}_guid", "")
+        iniConfig.remove_option("input", f"controller_{i}_guid")
     nplayer = 1
     for playercontroller, pad in sorted(playersControllers.items()):
         if nplayer <= 4:
-            iniConfig.set("input", f"controller_{nplayer}_guid", pad.guid)
+            iniConfig.set("input", f"controller_{nplayer}_guid", "'" + pad.guid + "'")
         nplayer = nplayer + 1
 
     # Determine the current default network connection
-    currentDefaultNetwork = defaultNetworkInterface()
+    #currentDefaultNetwork = defaultNetworkInterface()
 
-    if currentDefaultNetwork:
-        # Fill network section
-        iniConfig.set("network", "enabled", "true")
-        iniConfig.set("network", "backend", "pcap")
-        iniConfig.set("network", "local_addr", "0.0.0.0:9368")
-        iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
-        iniConfig.set("network", "pcap_iface", currentDefaultNetwork)
-    else:
-        iniConfig.set("network", "enabled", "false")
-        iniConfig.set("network", "backend", "user")
-        iniConfig.set("network", "local_addr", "0.0.0.0:9368")
-        iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
+    #if currentDefaultNetwork:
+        ## Fill network section
+        #iniConfig.set("network", "enabled", "true")
+        #iniConfig.set("network", "backend", "pcap")
+        #iniConfig.set("network", "local_addr", "0.0.0.0:9368")
+        #iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
+        #iniConfig.set("network", "pcap_iface", currentDefaultNetwork)
+    #else:
+        #iniConfig.set("network", "enabled", "false")
+        #iniConfig.set("network", "backend", "user")
+        #iniConfig.set("network", "local_addr", "0.0.0.0:9368")
+        #iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
 
     # Fill misc section
-    iniConfig.set("misc", "user_token", "")
+    #iniConfig.set("misc", "user_token", "")
 
-def defaultNetworkInterface():
-    # This function returns the name of the first interface that routes to the "default" destination. If there is no such interface, return None instead.
+#def defaultNetworkInterface():
+    ## This function returns the name of the first interface that routes to the "default" destination. If there is no such interface, return None instead.
 
-    n = 0
-    # Open the route network information.
-    with open("/proc/net/route") as f:
-        for line in f:
-            n += 1
-            # Check to make sure we are skipping over the first line (as it is just the header).
-            if n > 1:
-                words = line.split("\t")
-                # If the "Destination" of the route is the default "00000000":
-                if words[1] == "00000000":
-                    # Return the name of that "Iface" and immediately exit this function:
-                    return words[0]
-    # Otherwise, this loop repeats for all the remaining routes. If none are found, return None.
-    return None
+    #n = 0
+    ## Open the route network information.
+    #with open("/proc/net/route") as f:
+        #for line in f:
+            #n += 1
+            ## Check to make sure we are skipping over the first line (as it is just the header).
+            #if n > 1:
+                #words = line.split("\t")
+                ## If the "Destination" of the route is the default "00000000":
+                #if words[1] == "00000000":
+                    ## Return the name of that "Iface" and immediately exit this function:
+                    #return words[0]
+    ## Otherwise, this loop repeats for all the remaining routes. If none are found, return None.
+    #return None

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
@@ -55,11 +55,11 @@ def createXemuConfig(iniConfig, system, rom, playersControllers):
     iniConfig.set("general", "show_welcome", "false")
 
     # Fill system section
-    iniConfig.set("sys.files", "flashrom_path", "'/userdata/bios/Complex_4627.bin'")
-    iniConfig.set("sys.files", "bootrom_path", "'/userdata/bios/mcpx_1.0.bin'")
-    iniConfig.set("sys.files", "hdd_path", "'/userdata/saves/xbox/xbox_hdd.qcow2'")
-    iniConfig.set("sys.files", "eeprom_path", "'/userdata/saves/xbox/xemu_eeprom.bin'")
-    iniConfig.set("sys.files", "dvd_path", "'" + rom + "'")
+    iniConfig.set("sys.files", "flashrom_path", '"/userdata/bios/Complex_4627.bin"')
+    iniConfig.set("sys.files", "bootrom_path", '"/userdata/bios/mcpx_1.0.bin"')
+    iniConfig.set("sys.files", "hdd_path", '"/userdata/saves/xbox/xbox_hdd.qcow2"')
+    iniConfig.set("sys.files", "eeprom_path", '"/userdata/saves/xbox/xemu_eeprom.bin"')
+    iniConfig.set("sys.files", "dvd_path", '"' + rom + '"')
 
     # Audio quality
     if system.isOptSet("use_dsp"):
@@ -75,9 +75,9 @@ def createXemuConfig(iniConfig, system, rom, playersControllers):
 
     # Aspect ratio
     if system.isOptSet("scaling"):
-        iniConfig.set("display.ui", "fit", "'" + system.config["scaling"] + "'")
+        iniConfig.set("display.ui", "fit", '"' + system.config["scaling"] + '"')
     else:
-        iniConfig.set("display.ui", "fit", "'scale'") #4:3
+        iniConfig.set("display.ui", "fit", '"scale"') #4:3
 
     # Fill input section
     # first, clear
@@ -86,7 +86,7 @@ def createXemuConfig(iniConfig, system, rom, playersControllers):
     nplayer = 1
     for playercontroller, pad in sorted(playersControllers.items()):
         if nplayer <= 4:
-            iniConfig.set("input", f"controller_{nplayer}_guid", "'" + pad.guid + "'")
+            iniConfig.set("input", f"controller_{nplayer}_guid", '"' + pad.guid + '"')
         nplayer = nplayer + 1
 
     # Determine the current default network connection

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2705,7 +2705,7 @@ libretro:
                       description: Speech module installed
                       choices:
                           "Enabled (Default)": 1
-                          "Disabled":          0    
+                          "Disabled":          0
                   altromtype:
                       group: ADVANCED OPTIONS
                       prompt:      MEDIA TYPE
@@ -6119,7 +6119,7 @@ duckstation:
             description: Choose whether to show on the display, configuration messages.
             choices:
                 "Disabled (Default)": "false"
-                "Enabled":            "true"            
+                "Enabled":            "true"
         duckstation_executionmode:
             group: ADVANCED OPTIONS
             prompt:      CPU EXECUTION MODE
@@ -6406,7 +6406,7 @@ flycast:
           description: Enable the Dreamcast DSP. Only recommended for fast systems.
           choices:
             "Disbaled (Default)": "no"
-            "Enabled"           : "yes"      
+            "Enabled"           : "yes"
 
 fpinball:
   shared: [videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
@@ -6545,7 +6545,7 @@ melonds:
             description: Enable cheats for MelonDS.
             choices:
                 "Off (Default)":   0
-                "On":              1    
+                "On":              1
         melonds_osd:
             prompt: ENABLE OSD
             description: Enable the on screen display.
@@ -6643,7 +6643,7 @@ mupen64plus:
             prompt:      AUDIO BUFFER (SAMPLES)
             description: Lower values reduce audio latency and improve performance, but can cause audio issues.
             choices:
-                "Very High":     Very High 
+                "Very High":     Very High
                 "High":          High
                 "Medium":        Medium
                 "Low":           Low
@@ -8228,7 +8228,7 @@ mame:
                     description: Speech module installed
                     choices:
                         "Enabled (Default)": 1
-                        "Disabled":          0    
+                        "Disabled":          0
                 altromtype:
                     group: ADVANCED OPTIONS
                     prompt:      MEDIA TYPE
@@ -8387,7 +8387,7 @@ mame:
                     choices:
                         "On":  1
                         "Off": 0
-       mame: 
+       mame:
             features: [netplay, padtokeyboard]
             cfeatures:
                 altlayout:
@@ -8416,7 +8416,7 @@ mame:
                     choices:
                         "Enabled":            1
                         "Disabled (Default)": 0
-       neogeo: 
+       neogeo:
             cfeatures:
                 altlayout:
                     prompt:      SPECIAL CONTROL LAYOUTS
@@ -8673,7 +8673,8 @@ xemu:
                 "Original resolution": center
                 "Scale to best fit":   scale
                 "Stretch to full":     stretch
-                "Stretch to 16:9":     scale_ws169
+                "Stretch to 16:9":     scale_16_9
+                "Stretch to 4:3":      scale_4_3
         render:
             prompt:       RENDERING RESOLUTION
             choices:
@@ -8685,12 +8686,20 @@ xemu:
                 "6x (3840x2880)":   6
                 "7x (4480x3360)":   7
                 "8x (5120x3840)":   8
+                "9x (5760x4320)":   9
+                "10x (6400x4800)":  10
         xemu_bootanim:
             prompt:      SHOW BIOS BOOTLOGO
             description: Enhancement.
             choices:
                 "Show":        "false"
                 "Skip":        "true"
+        use_dsp:
+            prompt:      USE DSP AUDIO
+            description: Improve audio accuracy (experimental).
+            choices:
+                "Enabled":      "true"
+                "Disabled":     "false"
 
 lexaloffle:
   features: [padtokeyboard]

--- a/package/batocera/emulators/xemu/001-fix-optionrom-makefile.patch
+++ b/package/batocera/emulators/xemu/001-fix-optionrom-makefile.patch
@@ -1,6 +1,8 @@
---- a/pc-bios/optionrom/Makefile	2021-03-03 23:50:42.960966174 +0100
-+++ b/pc-bios/optionrom/Makefile	2021-03-03 23:50:59.880525808 +0100
-@@ -47,7 +47,7 @@
+diff --git a/pc-bios/optionrom/Makefile b/pc-bios/optionrom/Makefile
+index 30771f8..1055073 100644
+--- a/pc-bios/optionrom/Makefile
++++ b/pc-bios/optionrom/Makefile
+@@ -47,7 +47,7 @@ all: multiboot.bin linuxboot.bin linuxboot_dma.bin kvmvapic.bin pvh.bin
  pvh.img: pvh.o pvh_main.o
  
  %.o: %.S

--- a/package/batocera/emulators/xemu/002-eeprom.patch
+++ b/package/batocera/emulators/xemu/002-eeprom.patch
@@ -1,35 +1,36 @@
 diff --git a/softmmu/vl.c b/softmmu/vl.c
-index 4ab4a4f..fe3040c 100644
+index 2eecce1..f169ec6 100644
 --- a/softmmu/vl.c
 +++ b/softmmu/vl.c
-@@ -2995,19 +2995,19 @@ void qemu_init(int argc, char **argv, char **envp)
-     if (strlen(eeprom_path) > 0) {
-         int eeprom_size = get_image_size(eeprom_path);
-         if (eeprom_size < 0) {
--            char *msg = g_strdup_printf("Failed to open EEPROM file '%s'.\n\n"
--                "Automatically generating a new one instead. "
--                "Please check machine settings for the new path and move if desired.", eeprom_path);
+@@ -2777,11 +2777,11 @@ static const char *get_eeprom_path(void)
+ 
+     if (qemu_access(path, F_OK) == -1) {
+         if (!xbox_eeprom_generate(path, XBOX_EEPROM_VERSION_R1)) {
+-            char *msg = g_strdup_printf("Failed to generate EEPROM file '%s'."
+-                                        "\n\nPlease check machine settings.",
+-                                        path);
 -            xemu_queue_error_message(msg);
 -            g_free(msg);
-+            //char *msg = g_strdup_printf("Failed to open EEPROM file '%s'.\n\n"
-+            //    "Automatically generating a new one instead. "
-+            //    "Please check machine settings for the new path and move if desired.", eeprom_path);
++            //char *msg = g_strdup_printf("Failed to generate EEPROM file '%s'."
++            //                            "\n\nPlease check machine settings.",
++            //                            path);
 +            //xemu_queue_error_message(msg);
 +            //g_free(msg);
-             eeprom_path = "";
-         } else if (eeprom_size != 256) {
--            char *msg = g_strdup_printf(
--                "Invalid EEPROM file '%s' size of %d; should be 256 bytes.\n\n"
--                "Automatically generating a new one instead. "
--                "Please check machine settings for the new path and move if desired.", eeprom_path, eeprom_size);
--            xemu_queue_error_message(msg);
--            g_free(msg);
-+            //char *msg = g_strdup_printf(
-+            //    "Invalid EEPROM file '%s' size of %d; should be 256 bytes.\n\n"
-+            //    "Automatically generating a new one instead. "
-+            //    "Please check machine settings for the new path and move if desired.", eeprom_path, eeprom_size);
-+            //xemu_queue_error_message(msg);
-+            //g_free(msg);
-             eeprom_path = "";
-         } else {
-             fake_argv[fake_argc++] = strdup("-device");
+             return NULL;
+         }
+     }
+@@ -2789,10 +2789,10 @@ static const char *get_eeprom_path(void)
+     int size = get_image_size(path);
+ 
+     if (size < 0) {
+-        char *msg = g_strdup_printf("Failed to open EEPROM file '%s'.\n\n"
+-                                    "Please check machine settings.", path);
+-        xemu_queue_error_message(msg);
+-        g_free(msg);
++        //char *msg = g_strdup_printf("Failed to open EEPROM file '%s'.\n\n"
++        //                            "Please check machine settings.", path);
++        //xemu_queue_error_message(msg);
++        //g_free(msg);
+         return NULL;
+     }
+ 

--- a/package/batocera/emulators/xemu/003-eeprom-path.patch
+++ b/package/batocera/emulators/xemu/003-eeprom-path.patch
@@ -1,14 +1,14 @@
-diff --git a/ui/xemu-settings.c b/ui/xemu-settings.c
-index 6fe65ab..f459e90 100644
---- a/ui/xemu-settings.c
-+++ b/ui/xemu-settings.c
-@@ -255,6 +255,9 @@ const char *xemu_settings_get_path(void)
+diff --git a/ui/xemu-settings.cc b/ui/xemu-settings.cc
+index ae380fb..3962ed1 100644
+--- a/ui/xemu-settings.cc
++++ b/ui/xemu-settings.cc
+@@ -88,6 +88,9 @@ const char *xemu_settings_get_path(void)
  const char *xemu_settings_get_default_eeprom_path(void)
  {
- 	static char *eeprom_path = NULL;
+     static char *eeprom_path = NULL;
 +
 +        return "/userdata/saves/xbox/xemu_eeprom.bin";
 +
- 	if (eeprom_path != NULL) {
- 		return eeprom_path;
- 	}
+     if (eeprom_path != NULL) {
+         return eeprom_path;
+     }

--- a/package/batocera/emulators/xemu/004-hide-menu.patch
+++ b/package/batocera/emulators/xemu/004-hide-menu.patch
@@ -1,20 +1,8 @@
-diff --git a/ui/xemu-hud.cc b/ui/xemu-hud.cc
-index a88f420..6f969f5 100644
---- a/ui/xemu-hud.cc
-+++ b/ui/xemu-hud.cc
-@@ -1696,6 +1696,7 @@ static void process_keyboard_shortcuts(void)
- 
- static void ShowMainMenu()
- {
-+  return;
-     bool running = runstate_is_running();
- 
-     if (ImGui::BeginMainMenuBar())
 diff --git a/ui/xemu-input.c b/ui/xemu-input.c
-index 1c29507..69efe24 100644
+index b8ca2bd..d3b6653 100644
 --- a/ui/xemu-input.c
 +++ b/ui/xemu-input.c
-@@ -83,9 +83,9 @@ void xemu_input_init(void)
+@@ -161,9 +161,9 @@ void xemu_input_init(void)
      int port = xemu_input_get_controller_default_bind_port(new_con, 0);
      if (port >= 0) {
          xemu_input_bind(port, new_con, 0);
@@ -25,18 +13,18 @@ index 1c29507..69efe24 100644
 +        //snprintf(buf, sizeof(buf), "Connected '%s' to port %d", new_con->name, port+1);
 +        //xemu_queue_notification(buf);
      }
- 
+
      QTAILQ_INSERT_TAIL(&available_controllers, new_con, entry);
-@@ -167,9 +167,9 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
-                 continue;
-             }
-             xemu_input_bind(port, new_con, 0);
+@@ -261,9 +261,9 @@ void xemu_input_process_sdl_events(const SDL_Event *event)
+         }
+
+         if (did_bind) {
 -            char buf[128];
 -            snprintf(buf, sizeof(buf), "Connected '%s' to port %d", new_con->name, port+1);
 -            xemu_queue_notification(buf);
 +            //char buf[128];
 +            //snprintf(buf, sizeof(buf), "Connected '%s' to port %d", new_con->name, port+1);
 +            //xemu_queue_notification(buf);
-             break;
          }
- 
+     } else if (event->type == SDL_CONTROLLERDEVICEREMOVED) {
+         DPRINTF("Controller Removed: %d\n", event->cdevice.which);

--- a/package/batocera/emulators/xemu/xemu.hash
+++ b/package/batocera/emulators/xemu/xemu.hash
@@ -1,3 +1,3 @@
 # Locally calculated after checking pgp signature
 sha256 d9f5a4c1224ff24cf9066067bda70cc8b9c874ea22b9c542eb2edbfc4621bb39  xbox_hdd.qcow2.zip
-sha256 1317174a6da58e5d57d9b86c60a8100332fa0ae4691fb6dd44d07630099353ec  xemu-0.6.2-90-g6f507c80af-br1.tar.gz
+sha256 5c203256cc996a7f417432ecf7dd77d40dcb385608de8b7a76f98c1e7748dc3e  xemu-940bee452cc34127ecf3f364c3c5f52e4e6a80a4-br1.tar.gz

--- a/package/batocera/emulators/xemu/xemu.mk
+++ b/package/batocera/emulators/xemu/xemu.mk
@@ -4,8 +4,9 @@
 #
 ################################################################################
 
-# Mar 23, 2022
-XEMU_VERSION = 0.6.2-90-g6f507c80af
+# Aug 6, 2022
+# Version 0.7.67
+XEMU_VERSION = 940bee452cc34127ecf3f364c3c5f52e4e6a80a4
 XEMU_SITE = https://github.com/mborgerson/xemu.git
 XEMU_SITE_METHOD=git
 XEMU_GIT_SUBMODULES=YES


### PR DESCRIPTION
Allows more games to run, notably midnight club 3.

Includes updates to the patches, configgen and es_features to accomodate for changes within the emulator. Notably, Xemu will now reject the config file if there are any options with empty values in them, something the old configgen for this system relied on. All of those instances had to be removed. Tested and working fine.

Also took liberty to add "Enable DSP audio" as a user editable option, instead of just hard-coding it to be off.

Networking should work out of box, but I won't be able to test for that for a while.