### PR TITLE
Relabel new hw hacks pcsx2 feature

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2705,7 +2705,7 @@ libretro:
                       description: Speech module installed
                       choices:
                           "Enabled (Default)": 1
-                          "Disabled":          0    
+                          "Disabled":          0
                   altromtype:
                       group: ADVANCED OPTIONS
                       prompt:      MEDIA TYPE
@@ -6119,7 +6119,7 @@ duckstation:
             description: Choose whether to show on the display, configuration messages.
             choices:
                 "Disabled (Default)": "false"
-                "Enabled":            "true"            
+                "Enabled":            "true"
         duckstation_executionmode:
             group: ADVANCED OPTIONS
             prompt:      CPU EXECUTION MODE
@@ -6406,7 +6406,7 @@ flycast:
           description: Enable the Dreamcast DSP. Only recommended for fast systems.
           choices:
             "Disbaled (Default)": "no"
-            "Enabled"           : "yes"      
+            "Enabled"           : "yes"
 
 fpinball:
   shared: [videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
@@ -6545,7 +6545,7 @@ melonds:
             description: Enable cheats for MelonDS.
             choices:
                 "Off (Default)":   0
-                "On":              1    
+                "On":              1
         melonds_osd:
             prompt: ENABLE OSD
             description: Enable the on screen display.
@@ -6643,7 +6643,7 @@ mupen64plus:
             prompt:      AUDIO BUFFER (SAMPLES)
             description: Lower values reduce audio latency and improve performance, but can cause audio issues.
             choices:
-                "Very High":     Very High 
+                "Very High":     Very High
                 "High":          High
                 "Medium":        Medium
                 "Low":           Low
@@ -6866,11 +6866,11 @@ pcsx2:
                 "VU0 Kickstart to avoid sync problems with VU1":     VU0KickstartHack
         ManualHWHacks:
             group: ADVANCED OPTIONS
-            prompt:      MANUAL HW HACKS
-            description: Enable or disable hardware hacks. Use pcsx2-config via F1 to granularly adjust if enabled.
+            prompt:      AUTOMATIC GRAPHICS HARDWARE HACKS
+            description: Automatically use hardware hacks as appropriate. Refer to pcsx2-config for individual hacks.
             choices:
-                "Disable":          0
-                "Enable (default)": 1
+                "Off (default)": 1
+                "On":            0
         multitap:
             prompt:      MULTITAP
             description: Allows up to 5 or 8 controllers in supported games.
@@ -8235,7 +8235,7 @@ mame:
                     description: Speech module installed
                     choices:
                         "Enabled (Default)": 1
-                        "Disabled":          0    
+                        "Disabled":          0
                 altromtype:
                     group: ADVANCED OPTIONS
                     prompt:      MEDIA TYPE
@@ -8394,7 +8394,7 @@ mame:
                     choices:
                         "On":  1
                         "Off": 0
-       mame: 
+       mame:
             features: [netplay, padtokeyboard]
             cfeatures:
                 altlayout:
@@ -8423,7 +8423,7 @@ mame:
                     choices:
                         "Enabled":            1
                         "Disabled (Default)": 0
-       neogeo: 
+       neogeo:
             cfeatures:
                 altlayout:
                     prompt:      SPECIAL CONTROL LAYOUTS


### PR DESCRIPTION
Makes it consistent with the other similar "automatic game fixes" option. Also clarifies what the hacks in question are actually in relation to (the graphics instead of the games themselves).