### PR TITLE
Fix GL Version Check [v35]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -74,7 +74,10 @@ def getGLVersion():
         glxVerCmd = 'glxinfo | grep "OpenGL version"'
         glVerOutput = subprocess.check_output(glxVerCmd, shell=True).decode(sys.stdout.encoding)
         glVerString = glVerOutput.split()
-        glVersion = float(glVerString[3])
+        glVerTemp = glVerString[3].split(".")
+        if len(glVerTemp) > 2:
+            del glVerTemp[2:]
+        glVersion = float('.'.join(glVerTemp))
         return glVersion
     except:
         return 0


### PR DESCRIPTION
A user on Discord was defaulting to OpenGL over GLCore on a GT1030. After having them check the output strings, it turned out the OpenGL version had two decimal points - it was returning 4.6.0 instead of the usual 4.6 - which Python couldn't translate into a float.

This change will check the string and drop the extra decimal if it exists. It was tested with both my AMD driver (which reports properly), and I fed it the string with the extra decimal, and it worked in both cases.

This is a bug fix that is safe for v35.