### PR TITLE
Batocera-Wine/Windows Line Breaks [v36]

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -387,7 +387,9 @@ getWine_var() {
 
     if test -e "${WINEPOINT}/autorun.cmd"
     then
-	VAL=$(grep "^${WINEVAR}=" "${WINEPOINT}/autorun.cmd" | sed -e s+"^${WINEVAR}="+""+ | head -1)
+        cp "${WINEPOINT}/autorun.cmd" /var/run/autorun.cmd
+        dos2unix -u /var/run/autorun.cmd
+	    VAL=$(grep "^${WINEVAR}=" "/var/run/autorun.cmd" | sed -e s+"^${WINEVAR}="+""+ | head -1)
 	if test -n "${VAL}"
 	then
 	    echo "${VAL}"


### PR DESCRIPTION
Adds a fix for autorun.cmd files that contain Windows-style line breaks (CR+LF instead of just LF).

It will make a temp copy of the autorun.cmd, run dos2unix on it to fix line breaks, and read the values from that copy. That prevents it from editing the user's files.

Tested by loading a game with the current Unix formatted file, editing the line breaks to Windows-style, then opening it again. Probably best to save this one for v36 for further testing just in case.