### PR TITLE
rename + unify the pcsx2 ratio settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -46,7 +46,7 @@ class Pcsx2Generator(Generator):
             eslog.debug("Fast Boot and skip BIOS")
         else:
             commandArray.append("--fullboot")
-        
+
         # Arch
         arch = "x86"
         with open('/usr/share/batocera/batocera.arch', 'r') as content_file:
@@ -74,10 +74,10 @@ class Pcsx2Generator(Generator):
 
 def getGfxRatioFromConfig(config, gameResolution):
     # 2: 4:3 ; 1: 16:9
-    if "pcsx2_tv_mode" in config:
-        if config["pcsx2_tv_mode"] == "16/9":
+    if "ratio" in config:
+        if config["ratio"] == "16/9":
             return "16:9"
-        elif config["pcsx2_tv_mode"] == "Stretch":
+        elif config["ratio"] == "full":
             return "Stretch"
     return "4:3"
 
@@ -97,28 +97,28 @@ def configureReg(config_directory):
 def configureVM(config_directory, system):
 
     configFileName = "{}/{}".format(config_directory + "/inis", "PCSX2_vm.ini")
-    
+
     if not os.path.exists(config_directory + "/inis"):
         os.makedirs(config_directory + "/inis")
-        
+
     if not os.path.isfile(configFileName):
         f = open(configFileName, "w")
         f.write("[EmuCore]\n")
         f.close()
-    
+
     # This file looks like a .ini
     pcsx2VMConfig = configparser.ConfigParser(interpolation=None)
     # To prevent ConfigParser from converting to lower case
-    pcsx2VMConfig.optionxform = str   
-    
-    if os.path.isfile(configFileName):  
+    pcsx2VMConfig.optionxform = str
+
+    if os.path.isfile(configFileName):
         pcsx2VMConfig.read(configFileName)
-    
+
     ## [EMUCORE/GS]
     if not pcsx2VMConfig.has_section("EmuCore/GS"):
         pcsx2VMConfig.add_section("EmuCore/GS")
 
-    # Some defaults needed on first run 
+    # Some defaults needed on first run
     pcsx2VMConfig.set("EmuCore/GS","VsyncQueueSize", "2")
     pcsx2VMConfig.set("EmuCore/GS","FrameLimitEnable", "1")
     pcsx2VMConfig.set("EmuCore/GS","SynchronousMTGS", "disabled")
@@ -133,7 +133,7 @@ def configureVM(config_directory, system):
     if system.isOptSet('vsync'):
         pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", system.config["vsync"])
     else:
-        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", "1")    
+        pcsx2VMConfig.set("EmuCore/GS","VsyncEnable", "1")
 
     if not pcsx2VMConfig.has_section("EmuCore/Speedhacks"):
         pcsx2VMConfig.add_section("EmuCore/Speedhacks")
@@ -227,18 +227,18 @@ def configureGFX(config_directory, system):
     configFileName = "{}/{}".format(config_directory + "/inis", "GS.ini")
     if not os.path.exists(config_directory):
         os.makedirs(config_directory + "/inis")
-    
+
     # Create the config file if it doesn't exist
     if not os.path.exists(configFileName):
         f = open(configFileName, "w")
         f.write("osd_fontname = /usr/share/fonts/dejavu/DejaVuSans.ttf\n")
         f.close()
-    
+
     # Update settings
     pcsx2GFXSettings = UnixSettings(configFileName, separator=' ')
     pcsx2GFXSettings.save("osd_fontname", "/usr/share/fonts/dejavu/DejaVuSans.ttf")
     pcsx2GFXSettings.save("osd_indicator_enabled", 1)
-    
+
     if system.isOptSet('ManualHWHacks'):
         pcsx2GFXSettings.save("UserHacks", system.config["ManualHWHacks"])
     else:
@@ -331,7 +331,7 @@ def configureUI(config_directory, bios_directory, system_config, gameResolution)
     for section in [ "ProgramLog", "Filenames", "GSWindow", "NO_SECTION" ]:
         if not iniConfig.has_section(section):
             iniConfig.add_section(section)
-    
+
     iniConfig.set("NO_SECTION","EnablePresets","disabled")
     # manually allow speed hacks
     iniConfig.set("NO_SECTION","EnableSpeedHacks","enabled")

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6292,7 +6292,7 @@ duckstation:
             description: Allows loading protected games without subchannel information.
             choices:
                 "Disabled (Default)": "false"
-                "Enabled":            "true"            
+                "Enabled":            "true"
 
 flycast:
   shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
@@ -6749,6 +6749,13 @@ openbor:
 pcsx2:
   shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
   cfeatures:
+        ratio:
+            prompt:      GAME ASPECT RATIO
+            description: Force the game to render in this aspect ratio. Not all systems support all ratios.
+            choices:
+                "4:3":     4/3
+                "16:9":    16/9
+                "Full":    full
         gfxbackend:
             prompt:      GRAPHICS API
             description: Choose which graphics API library to use. Vulkan is better, when supported.
@@ -6756,13 +6763,6 @@ pcsx2:
                 "OpenGL":      12
                 "Software":    13
                 "Vulkan":      14
-        pcsx2_tv_mode:
-            prompt:      TV MODE
-            description: PS2's internal ratio setting. Some games only support 4/3.
-            choices:
-                "4:3":     4/3
-                "16:9":    16/9
-                "Stretch": Stretch
         fullboot:
             prompt:      SHOW BIOS BOOTLOGO
             description: Some games have issues when the animation is shown, others require it.


### PR DESCRIPTION
The ratio setting set in the global game configuration screen will now be respected by pcsx2.

Also fixes https://github.com/batocera-linux/batocera.linux/issues/6958

Makes way for the actual tv_mode setting which is to be implemented in the future.

Clean up the empty lines in the pcsx2generator too.