### PR TITLE
Fix various lr-dosbox-pure issues for 35

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -217,9 +217,12 @@ class LibretroGenerator(Generator):
             if (romExtension == '.dos' or romExtension == '.pc'):
                 if os.path.exists(os.path.join(rom, romDOSName + ".bat")):
                     exe = os.path.join(rom, romDOSName + ".bat")
-                else:
+                elif os.path.exists(os.path.join(rom, "dosbox.bat")):
                     exe = os.path.join(rom, "dosbox.bat")
+                else:
+                    exe = '/userdata/roms/dos' # Ugly workaround for dosbox-pure not supporting extensions for dos game folders
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], exe]
+                dontAppendROM = True
             else:
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile']]
         # Pico-8 multi-carts (might work only with official Lexaloffe engine right now)

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/dos.keys
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/dos.keys
@@ -1,0 +1,48 @@
+{
+    "actions_player1": [
+        {
+            "trigger": "start",
+            "type": "key",
+            "target": "KEY_ENTER"
+        },
+        {
+            "trigger": "select",
+            "type": "key",
+            "target": "KEY_J"
+        },
+        {
+            "trigger": "joystick1up",
+            "type": "key",
+            "target": "KEY_UP"
+        },
+        {
+            "trigger": "joystick1down",
+            "type": "key",
+            "target": "KEY_DOWN"
+        },
+        {
+            "trigger": "joystick1left",
+            "type": "key",
+            "target": "KEY_LEFT"
+        },
+        {
+            "trigger": "joystick1right",
+            "type": "key",
+            "target": "KEY_RIGHT"
+        },
+        {
+            "trigger": "joystick2",
+            "type": "mouse"
+        },
+        {
+            "trigger": "l2",
+            "type": "key",
+            "target": "KEY_Y"
+        },
+        {
+            "trigger": "r2",
+            "type": "key",
+            "target": "KEY_N"
+        }
+    ]
+}

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -49,6 +49,7 @@ endef
 define LIBRETRO_DOSBOX_PURE_INSTALL_TARGET_CMDS
 	$(INSTALL) -D $(@D)/dosbox_pure_libretro.so \
 	  $(TARGET_DIR)/usr/lib/libretro/dosbox_pure_libretro.so
+	cp -f $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/dos.keys $(TARGET_DIR)/usr/share/evmapy/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
- Don't add rom name twice in the command line
- Workaround for https://github.com/schellingb/dosbox-pure/issues/343
- Add default pad2key