### PR TITLE
use "compress" instead of "compress-force" for btrfs fscompression

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -313,7 +313,7 @@ if [ "$compressenabled" = "1" ]
 then
     if grep -qE "^/dev/[^ ]* /userdata btrfs.*$" /proc/mounts
     then
-        mount -o remount,compress-force=zstd,autodefrag /userdata || exit 1
+        mount -o remount,compress=zstd,autodefrag /userdata || exit 1
     fi
 fi
 


### PR DESCRIPTION
Ordinarily, when using filesystem compression with a BTRFS, the system will check if the compressed file is larger than the original file, and if so; will not compress it. Continue to compress it would only result in the file taking longer to read due to the (albeit fast) decompression with no storage space benefit. This is especially important in Batocera, where there are many ROM containers which use highly efficient compression by default (7z, chd, squashfs, etc.)

The real question here is why compression is using the "force" option in the first place. Looking through the commit history I can see the change was made here when the algorithm was also updated to use zstd instead of the default: https://github.com/batocera-linux/batocera.linux/pull/3145 but no reason for the "force" option being turned on is given.

Also, I have been testing this option on my stable build for a week now, just to see if any issues would creep up over time. No issues, everything is working fine.

Reference: https://btrfs.readthedocs.io/en/latest/Compression.html#how-to-enable-compression