### PR TITLE
Switch automatic HW hacks for pcsx2 to on

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -242,7 +242,7 @@ def configureGFX(config_directory, system):
     if system.isOptSet('ManualHWHacks'):
         pcsx2GFXSettings.save("UserHacks", system.config["ManualHWHacks"])
     else:
-        pcsx2GFXSettings.save("UserHacks", 1)
+        pcsx2GFXSettings.save("UserHacks", 0)
 
     # Internal resolution
     if system.isOptSet('internal_resolution'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6885,8 +6885,8 @@ pcsx2:
             prompt:      AUTOMATIC GRAPHICS HARDWARE HACKS
             description: Automatically use hardware hacks as appropriate. Refer to pcsx2-config for individual hacks.
             choices:
-                "Off (default)": 1
-                "On":            0
+                "Off":          1
+                "On (default)": 0
         multitap:
             prompt:      MULTITAP
             description: Allows up to 5 or 8 controllers in supported games.


### PR DESCRIPTION
Having this setting on (in actuality off, ie. to tell PCSX2 to not use the user-define hacks (which no one using all auto settings is going to be using anyway)) fixes a variety of issues within PS2 games.

With the current default (off), Burnout 3 has black skyboxes:
![image](https://user-images.githubusercontent.com/67527064/188617130-8a8c7bee-740a-4c02-ab66-23abc3976841.png)
(the actual glitch is that the skybox texture does not get updated, so if the game is loaded once with HWhacks enabled it will become that skybox permanently until HWhacks are used again, so I cannot get a high-quality screenshot of this myself in Batocera)

By turning HWhacks on, skyboxes are fixed:
![screenshot-2022 09 06-20h54 34](https://user-images.githubusercontent.com/67527064/188617696-b372c9ed-82ed-410f-9fb4-b7fe633db20e.png)

With the current default (off), God of War has glitch vertical bars rendered when using upscaling:
![screenshot-2022 09 06-20h49 30](https://user-images.githubusercontent.com/67527064/188616758-714a16ea-23d9-4427-a5fd-1b23ffaa7fb6.png)

By turning HWhacks on, no vertical bars:
![screenshot-2022 09 06-20h50 15](https://user-images.githubusercontent.com/67527064/188616824-112670c6-836c-4709-a3fc-996f47c78e24.png)

I'm sure there are many other cases where issues are fixed. While playing various other games with HWhacks on, I had not noticed any issues. I imagine this is similar in functionality to Dolphin's default included GameINIs, where "logical" hacks are enabled if they greatly benefit the emulation of a game or avoid an issue with it (even though it may not be as accurate when compared to original hardware).