### PR TITLE
remove vulkan as default api for psx on rpi4

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-rpi4.yml
@@ -11,9 +11,6 @@ flash:
 fmtowns:
   emulator: libretro
   core:     mame
-psx:
-  options:
-    gfxbackend: vulkan
 model3:
   options:
     videomode: max-720x576


### PR DESCRIPTION
Option was originally added in https://github.com/batocera-linux/batocera.linux/pull/6213, citing that swanstation was not functional with opengl. Swanstation is now able to run with opengl just fine. Opengl is also more performant than Vulkan is on the RPi 4. Testing the game Tomb Raider III, in "Lara's home" running around the corner and looking into the lobby there is sever slowdown with Vulkan. This is handled much better with OpenGL.