### PR TITLE
minor corrections to label for off-screen reload

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1868,8 +1868,8 @@ libretro:
                     "Off": 0
             offscreenreload:
                 group: LIGHT GUN
-                prompt:      OFF SCREEN RELOAD
-                description: Set gun button 2 to reload for games that require shooting off screen
+                prompt:      OFF-SCREEN RELOAD BUTTON
+                description: Set gun button 2 to reload.
                 choices:
                     "On":            1
                     "Off (Default)": 0
@@ -7418,8 +7418,8 @@ mame:
                 "Disabled (Default)": 0
         offscreenreload:
             group: LIGHT GUN
-            prompt:      OFF SCREEN RELOAD
-            description: Set gun button 2 to reload for games that require shooting off screen
+            prompt:      OFF-SCREEN RELOAD BUTTON
+            description: Set gun button 2 to reload.
             choices:
                 "On":            1
                 "Off (Default)": 0


### PR DESCRIPTION
This setting is not required for certain games, apparently off-screen reloading works with most devices. However, the wiimote is currently bugged, where this setting comes into play. Fixes up the labelling to remove this confusing "required" statement.