### PR TITLE
exclude "light" folder from bios/fbneo

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
@@ -63,6 +63,7 @@ define LIBRETRO_FBNEO_INSTALL_TARGET_CMDS
 
     # Need to think of another way to use these files.
     # They take up a lot of space on tmpfs.
+    # --exclude light as those are for the n3ds build of fbneo, not used by Batocera at all
 	rsync -a $(@D)/dats/* \
 		$(TARGET_DIR)/usr/share/batocera/datainit/bios/fbneo --exclude light
 endef

--- a/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fbneo/libretro-fbneo.mk
@@ -63,8 +63,8 @@ define LIBRETRO_FBNEO_INSTALL_TARGET_CMDS
 
     # Need to think of another way to use these files.
     # They take up a lot of space on tmpfs.
-	cp -r $(@D)/dats/* \
-		$(TARGET_DIR)/usr/share/batocera/datainit/bios/fbneo
+	rsync -a $(@D)/dats/* \
+		$(TARGET_DIR)/usr/share/batocera/datainit/bios/fbneo --exclude light
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
The `bios/fbneo` on a fresh install now includes a `light/` folder. According to its readme:
```
Those "light" dat files are meant for n3ds builds, which can't load a full FBNeo build due to memory limitations.
```

They should be removed, they do nothing for Batocera.

There may be a better way to do this "copy everything but exclude the light folder" but this is the one I know. Will draft for a while so others can think of better ideas.