### PR TITLE
fix batocera-nvidia log spam

### DIFF
--- a/package/batocera/gpu/batocera-nvidia/batocera-nvidia
+++ b/package/batocera/gpu/batocera-nvidia/batocera-nvidia
@@ -13,7 +13,7 @@ then
     NVIDIA_DEV=$(lspci -mn | awk '{ gsub("\"",""); if (($2 ~ "030[0-2]") && ($3 == "10de" || $3 == "12d2")) { print $1 } }')
     if [ "$NVIDIA_DEV" ]
     then
-	echo "Detected a NVIDIA GPU" >> $LOG
+	echo "Detected a NVIDIA GPU" > $LOG
 	for d in $NVIDIA_DEV ; do
 	    lspci -nn -s $d | sed -e s+"^"+"*** "+
 	done
@@ -62,7 +62,7 @@ then
 	    fi
 	done
     else
-        echo "No NVIDIA GPU detected" >> $LOG
+        echo "No NVIDIA GPU detected" > $LOG
         echo "Failing back to OpenSource Mesa Nouveau driver"
         test -e /var/run/nvidia/modprobe/blacklist-nouveau.conf && rm -f /var/run/nvidia/modprobe/blacklist-nouveau.conf
         test -e /var/run/nvidia/modprobe/nvidia-drm.conf        && rm -f /var/run/nvidia/modprobe/nvidia-drm.conf


### PR DESCRIPTION
This log is added to every time Batocera boots to `system/logs/batocera.log`:
![image](https://user-images.githubusercontent.com/67527064/189830968-9f4c3bdf-340d-49a6-8177-facf33c9ff20.png)
This will result in a file that increases in size every time Batocera boots.
And the worst thing is that this is logged even when the log level is set to "error".

This PR is a quick solution to the issue, the file will at least be recreated every boot instead of appended to every time, but I intend on looking for a more permanent solution by querying the current log level setting the user has set in dev settings > log level.
