### PR TITLE
make vice usable on rpi1/rpizero

### DIFF
--- a/package/batocera/emulators/vice/vice.mk
+++ b/package/batocera/emulators/vice/vice.mk
@@ -22,6 +22,7 @@ VICE_CONF_OPTS += --with-alsa
 VICE_CONF_OPTS += --with-zlib
 VICE_CONF_OPTS += --with-jpeg
 VICE_CONF_OPTS += --with-png
+VICE_CONF_OPTS += --with-fastsid
 VICE_CONF_OPTS += --without-pulse
 VICE_CONF_OPTS += --enable-x64
 


### PR DESCRIPTION
resid is to taxing for old devices, please enable fastsid also.