### PR TITLE
bezel: none for n64 on the cha image

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-cha.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-cha.yml
@@ -23,6 +23,10 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
+n64:
+  options:
+    # mupen crashes with bezel enabled
+    bezel:  none
 snes:
   emulator: libretro
   core:     snes9x


### PR DESCRIPTION
user Paulovich on the Discord confirms the emulator crashes with the bezels enabled