### PR TITLE
add zoom option for bluemsx

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -843,6 +843,11 @@ def generateCoreSettings(coreSettings, system, rom, guns):
             coreSettings.save('bluemsx_nospritelimits', '"OFF"')
         else:
             coreSettings.save('bluemsx_nospritelimits', '"ON"')
+        # Zoom, Hide Video Border
+        if system.isOptSet('bluemsx_overscan'):
+            coreSettings.save('bluemsx_overscan', system.config['bluemsx_overscan'])
+        else:
+            coreSettings.save('bluemsx_overscan', '"MSX2"')
 
     # Nec PC Engine / CD
     if system.config['core'] == 'pce' or system.config['core'] == 'pce_fast':
@@ -1211,7 +1216,7 @@ def generateCoreSettings(coreSettings, system, rom, guns):
                     coreSettings.save('gambatte_gb_colorization',     '"custom"')
                     coreSettings.save('gambatte_gb_internal_palette', '"Special 1"')
                 else:                                                                    #User Selection
-                    coreSettings.save('gambatte_gb_colorization',     '"internal"')           
+                    coreSettings.save('gambatte_gb_colorization',     '"internal"')
                     coreSettings.save('gambatte_gb_internal_palette', '"' + system.config['gb_colorization'] + '"')
             else:
                 coreSettings.save('gambatte_gb_colorization',         '"internal"')      #It's an empty file, set to Classic Green

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -367,6 +367,13 @@ libretro:
       features: [padtokeyboard, cheevos]
       shared: [rewind, autosave]
       cfeatures:
+            bluemsx_overscan:
+                prompt:      ZOOM (HIDE BORDERS)
+                description: Hides borders on many games. Some games used the borders.
+                choices:
+                    "Off":  disabled
+                    "On":   enabled
+                    "MSX2": MSX2
             bluemsx_nospritelimits:
                 prompt:      REDUCE SPRITE FLICKERING
                 description: Enhancement. Remove the four sprites per line limit.


### PR DESCRIPTION
Also changes the default zoom level to "MSX2" as the default "ON" seems to cut out important content of the game:

"ON":
![screenshot-2022 09 25-11h35 29](https://user-images.githubusercontent.com/67527064/192125071-34016af6-f5ee-432d-af97-d17f066edcc2.png)

"MSX2":
![screenshot-2022 09 25-11h35 47](https://user-images.githubusercontent.com/67527064/192125072-b54158d2-c4e2-4b68-8e8e-0d3c1717ab1e.png)
