### PR TITLE
MAME Mouse Option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -224,14 +224,42 @@ class MameGenerator(Generator):
         if len(pluginsToLoad) > 0:
             commandArray += [ "-plugins", "-plugin", ",".join(pluginsToLoad) ]
 
+        # Mouse
+        useMouse = False
+        if (system.isOptSet('use_mouse') and system.getOptBoolean('use_mouse')) or not (messSysName[messMode] == "" or messMode == -1):
+            useMouse = True
+            commandArray += [ "-dial_device", "mouse" ]
+            commandArray += [ "-trackball_device", "mouse" ]
+            commandArray += [ "-paddle_device", "mouse" ]
+            commandArray += [ "-positional_device", "mouse" ]
+            commandArray += [ "-mouse_device", "mouse" ]
+            commandArray += [ "-ui_mouse" ]
+            if not (system.isOptSet('use_guns') and system.getOptBoolean('use_guns')):
+                commandArray += [ "-lightgun_device", "mouse" ]
+                commandArray += [ "-adstick_device", "mouse" ]
+        else:
+            commandArray += [ "-dial_device", "joystick" ]
+            commandArray += [ "-trackball_device", "joystick" ]
+            commandArray += [ "-paddle_device", "joystick" ]
+            commandArray += [ "-positional_device", "joystick" ]
+            commandArray += [ "-mouse_device", "joystick" ]
+            if not (system.isOptSet('use_guns') and system.getOptBoolean('use_guns')):
+                commandArray += [ "-lightgun_device", "joystick" ]
+                commandArray += [ "-adstick_device", "joystick" ]
+        # Multimouse option currently hidden in ES, SDL only detects one mouse.
+        # Leaving code intact for testing & possible ManyMouse integration
+        multiMouse = False
+        if system.isOptSet('multimouse') and system.getOptBoolean('multimouse'):
+            multiMouse = True
+            commandArray += [ "-multimouse" ]
+
         # guns
+        useGuns = False
         if system.isOptSet('use_guns') and system.getOptBoolean('use_guns'):
+            useGuns = True
             commandArray += [ "-lightgunprovider", "udev" ]
             commandArray += [ "-lightgun_device", "lightgun" ]
             commandArray += [ "-adstick_device", "lightgun" ]
-        else:
-            commandArray += [ "-lightgunprovider", "auto" ]
-            commandArray += [ "-lightgun_device", "mouse" ]
         if system.isOptSet('offscreenreload') and system.getOptBoolean('offscreenreload'):
             commandArray += [ "-offscreen_reload" ]
 
@@ -434,9 +462,9 @@ class MameGenerator(Generator):
         buttonLayout = getMameControlScheme(system, romBasename)
 
         if messMode == -1:
-            mameControllers.generatePadsConfig(cfgPath, playersControllers, "", buttonLayout, customCfg, specialController, bezelSet)
+            mameControllers.generatePadsConfig(cfgPath, playersControllers, "", buttonLayout, customCfg, specialController, bezelSet, useGuns, useMouse, multiMouse)
         else:
-            mameControllers.generatePadsConfig(cfgPath, playersControllers, messModel, buttonLayout, customCfg, specialController, bezelSet)
+            mameControllers.generatePadsConfig(cfgPath, playersControllers, messModel, buttonLayout, customCfg, specialController, bezelSet, useGuns, useMouse, multiMouse)
 
         # Change directory to MAME folder (allows data plugin to load properly)
         os.chdir('/usr/bin/mame')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8453,6 +8453,21 @@ mame:
                     choices:
                         "Enabled":            1
                         "Disabled (Default)": 0
+                use_mouse:
+                    group: ADVANCED OPTIONS
+                    prompt:      ENABLE MOUSE
+                    description: Enable mouse input for trackballs, spinners, lightguns (if no gun connected), and similar controls
+                    choices:
+                        "Enabled":            1
+                        "Disabled (Default)": 0
+#                Placeholder for ManyMouse integration or SDL2 multi mouse support
+#                multimouse:
+#                    group: ADVANCED OPTIONS
+#                    prompt:      MULTI MOUSE
+#                    description: Separate inputs for multiple trackballs, spinners, or other mice (may require manual mapping)
+#                    choices:
+#                        "Enabled":            1
+#                        "Disabled (Default)": 0
        neogeo:
             cfeatures:
                 altlayout:


### PR DESCRIPTION
Adds an "enable mouse" option to standalone MAME.

When off, analog devices (trackball, spinner, lightgun, etc) are mapped to the analog stick. Note that lightgun is not a good experience on a standard gamepad, but would work well with a flightstick or an Operation Wolf-type mounted gun cabinet (adstick).

When on, they are mapped to the mouse instead. In addtion, mouse buttons are mapped to MAME's buttons where available - 1-3 are buttons 1-3, 4 & 5 are coin/start, and 6+ are additional game buttons.

Lightguns being turned on will override both options, and use the lightgun for gun & adstick.

There is code and a commented out option for Multimouse, MAME on Linux only supports SDL for mouse input, which only returns one pointer. If the ManyMouse library can be integrated with MAME, or a future release of SDL2 supports multiple mice, it can be uncommented. This would allow multiplayer lightgun games with two mice on PC, or arcade cabinets with multiple trackballs or spinners.

In some cases, MAME will map both joystick and mouse anyway. The mouse option will ensure the mouse buttons are either mapped or unmapped properly to prevent unwanted inputs. In addition, the gun buttons will only map if guns are enabled.

For MESS systems, mouse is enabled automatically, since most of those will be computers.