### PR TITLE
mesa3d/panfrost: fix emulationstation and RetroArch menu fps drop

### DIFF
--- a/board/batocera/patches/mesa3d/0001-panfrost-fix-ES-and-RA-menu-FPS-drop.patch
+++ b/board/batocera/patches/mesa3d/0001-panfrost-fix-ES-and-RA-menu-FPS-drop.patch
@@ -1,0 +1,32 @@
+From ea1853ca01c01489a81e9662707bc257504bbbce Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jari=20H=C3=A4m=C3=A4l=C3=A4inen?= <nuumiofi@gmail.com>
+Date: Mon, 26 Sep 2022 15:47:49 +0300
+Subject: [PATCH] panfrost: fix emulationstation and RetroArch menu fps drop
+
+git bisect showed that commit 673f812835be26500958c79cd6f10bd24f99a385
+causes fps drop in Batocera emulationstation and in RetroArch menu.
+
+Fixed by commenting out the line added in that commit.
+
+Tested with rk3399/rockpro64 target.
+---
+ src/gallium/drivers/panfrost/pan_resource.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/gallium/drivers/panfrost/pan_resource.c b/src/gallium/drivers/panfrost/pan_resource.c
+index b673af74370..9c575f5a287 100644
+--- a/src/gallium/drivers/panfrost/pan_resource.c
++++ b/src/gallium/drivers/panfrost/pan_resource.c
+@@ -1061,7 +1061,8 @@ panfrost_ptr_map(struct pipe_context *pctx,
+                                  * accessing this resource, flush them but do
+                                  * not wait for them.
+                                  */
+-                                panfrost_flush_batches_accessing_rsrc(ctx, rsrc, "Resource shadowing");
++                                /* batocera: fix ES and RA menu FPS drop by commenting out next line */
++                                /* panfrost_flush_batches_accessing_rsrc(ctx, rsrc, "Resource shadowing"); */
+ 
+ 	                        if (!copy_resource &&
+                                     drm_is_afbc(rsrc->image.layout.modifier))
+-- 
+2.37.3
+


### PR DESCRIPTION
Add a patch that reverts the change in mesa commit 673f812835be26500958c79cd6f10bd24f99a385 fixing emulationstation and RetroArch menu fps. Found the commit using git bisect on mesa git after finding out that mesa3d v21.3.7 works but any newer release doesn't.

Note that the original commit in mesa actually increased fps in some glmark2 test (based on the commit message). So it's possible that there's a performance drop elsewhere to be found after this patch.

This only changes panfrost so other mesa drivers aren't affected.

Commit in mesa Gitlab: https://gitlab.freedesktop.org/mesa/mesa/-/commit/673f812835be26500958c79cd6f10bd24f99a385

Tested with rk3399/rockpro64 target.