### PR TITLE
change MENU SHIFTKEY to MENU HIDDEN for syslinux

### DIFF
--- a/board/batocera/x86/boot/syslinux.cfg
+++ b/board/batocera/x86/boot/syslinux.cfg
@@ -1,13 +1,13 @@
 UI menu.c32
 
-TIMEOUT 50
+TIMEOUT 20
 TOTALTIMEOUT 300
 
 SAY Booting Batocera.linux...
 
 MENU CLEAR
 MENU TITLE Batocera.linux
-MENU SHIFTKEY
+MENU HIDDEN
 
 LABEL batocera
 	MENU LABEL Batocera.linux (^normal)


### PR DESCRIPTION
This allows the user to access the syslinux boot menu to select one of the boot modes. This can greatly assist in helping the user debug booting issues.

This however comes at the cost of actually having to wait for the timeout, hence the need to reduce the TIMEOUT value as well.