### PR TITLE
Implement the hidapi interface for Python

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -439,6 +439,7 @@ menu "Libraries"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/libraries/python-pyftdi/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/libraries/python-sysv-ipc/Config.in"
   source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/libraries/python-pyqt5-sip/Config.in"
+  source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/libraries/python-hidapi/Config.in"
 endmenu
 
 endmenu

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -193,6 +193,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_OPENVPN                              # VPN support
 	select BR2_PACKAGE_USB_MODESWITCH                       # USB modeswitch support
 	select BR2_PACKAGE_UMTOOL								# command line tool for configuring Ultimarc arcade hardware
+	select BR2_PACKAGE_PYTHON_HIDAPI                        # Communication with USB HID devices via Python
 
 	# Deprecated, which what library should we replace ?
 	select BR2_PACKAGE_PARTED                               # partition management (for the first boot)

--- a/package/batocera/libraries/python-hidapi/Config.in
+++ b/package/batocera/libraries/python-hidapi/Config.in
@@ -1,0 +1,7 @@
+config BR2_PACKAGE_PYTHON_HIDAPI
+	bool "python-hidapi"
+	depends on BR2_PACKAGE_HAS_UDEV
+	select BR2_PACKAGE_PYTHON3
+	select BR2_PACKAGE_LIBUSB
+	help
+	 https://pypi.org/project/hidapi

--- a/package/batocera/libraries/python-hidapi/python-hidapi.mk
+++ b/package/batocera/libraries/python-hidapi/python-hidapi.mk
@@ -1,0 +1,20 @@
+################################################################################
+#
+# python-hidapi
+#
+################################################################################
+
+PYTHON_HIDAPI_VERSION = 0.12.0.post2
+PYTHON_HIDAPI_SOURCE = hidapi-$(PYTHON_HIDAPI_VERSION).tar.gz
+PYTHON_HIDAPI_SETUP_TYPE = setuptools
+PYTHON_HIDAPI_SITE = https://pypi.python.org/packages/source/h/hidapi
+PYTHON_HIDAPI_LICENSE = GPLv3
+PYTHON_HIDAPI_LICENSE_FILES = LICENSE-gpl3.txt
+PYTHON_HIDAPI_DEPENDENCIES = libusb udev
+
+define PYTHON_HIDAPI_UPDATE_INCLUDE_PATH
+	sed -i "s+/usr/include/+$(STAGING_DIR)/usr/include/+g" $(@D)/setup.py
+endef
+PYTHON_HIDAPI_PRE_CONFIGURE_HOOKS += PYTHON_HIDAPI_UPDATE_INCLUDE_PATH
+
+$(eval $(python-package))


### PR DESCRIPTION
Adds the [hidapi](https://pypi.org/project/hidapi/) Python module to Batocera.

The hidapi library is already available in Batocera.  Including the Python interface allows game start/stop scripts to take advantage of it.  This is particularly useful for general-purpose, low-level interaction with certain game controllers, to either read their capabilities, or to write new configuration on the fly.

My particular use case relates to the [BlissBox 4-Play](https://bliss-box.net), which allows numerous original game controllers to connect via USB.  The BlissBox API allows me to query which kind of device is connected through it.  I use this information at game launch to modify input mappings and other emulator configurations.  I can also use the hid interface to update settings on the BlissBox itself, if desired.

As an example, here is a Python script that reads the BlissBox 4-Play's connected controllers via the HID interface.

```python
# Based on the Bliss-Box API: https://sourceforge.net/projects/bliss-box-api/

from enum import Enum

import hid

VENDOR_ID=0x16D0
PRODUCT_ID=0x0D04

REPORT_GET_ADAPTER_INFO = 0x11
REPORT_LENGTH_GET_ADAPTER_INFO = 5

class Controller(Enum):
    NO_DETECTION = 0
    COL = 1                 # ColecoVision
    gx4000 = 2              
    SATURN_DIGITAL = 3      
    A7800 = 4               # atari
    VEC = 5                 # vectrex
    A5200 = 6               # atari
    HPD = 7                 # sega paddle
    SATURN_ANALOG = 8       
    GC = 9                  # gamecube
    ATMARK = 10             
    JAG = 11                # jaguar
    PSX_WHEEL = 12          
    WII_NUNCHUK = 13        
    INTELI = 14             # intellivision
    DC_ASCI = 15            # dreamcast
    DC_PAD = 16             # dreamcast
    NES = 17                
    GC_WHEEL = 18           
    N64 = 19                
    GEN_3 = 20              # sega
    GEN_6 = 21              # sega
    SMS = 22                # sega
    TG16 = 23               
    CD32 = 24               
    THREE_DO = 25           
    PC_FX = 26              
    SNES = 27               
    NES_GUN = 28            
    V_BOY = 29              
    NES_ARKANOID = 30       
    WII_CLASSIC = 31        
    WII_MPLUS = 32          
    CDI = 33                
    SAC = 34                
    DC_TWIN = 35            
    NES_POWERPAD = 36       
    THREE_DO_ANALOG = 37    
    GRAVIS_EX = 38          
    MSSW = 39               
    HAMMERHEAD = 40         
    PADDLES = 41            
    BALLY = 42              
    ATARI_KEYPAD = 43       
    ZXSINC = 44             
    SPEEK = 45              
    PC_GAMEPAD = 46         
    SNESS_NTT = 47          
    COL_FLASH_BACK =48      
    NEO = 49                
    A5200_TB = 50           
    PSX_NEGCON = 51         
    FC_NES = 52             
    FC_ARKANOID = 53        
    TG16_6BUTTON = 54       
    WII_DRUM = 55           
    ARCADE = 56             
    SUPERGUN = 57           
    SATURN_GUN = 58         
    SMS_GUN = 59            
    DC_GUN = 60             
    PADDLES_GEMINI = 61     
    DC_PAD_RF = 62          
    FC_POWERPAD = 63        
    ATARI_TB = 64           
    PSX_DIGITAL = 65        
    WII_DRUM_2 = 66         
    WII_GUITAR = 67         
    WII_DJHERO = 68         
    WII_TABLET = 69         
    PSX_DS = 115            
    PSX_DS2 = 121           
    PSX_FS = 83             
    PSX_JOGCON = 127        

device = hid.device()

for player_num in range(4):
    try:
        device.open(VENDOR_ID, PRODUCT_ID + player_num)
        report = device.get_feature_report(REPORT_GET_ADAPTER_INFO, REPORT_LENGTH_GET_ADAPTER_INFO)
        controller_type = report[0]
        modes = report[1]
        minor_version = report[2]
        player_id = report[3] - 3
        major_version = report[4]
        print(f"Player: {player_id}        Controller: {Controller(controller_type).name}")
    except IOError as e:
        print(f"ERROR: {e}")
    finally:
        device.close()
```