### PR TITLE
lr-MAME save state fix

### DIFF
--- a/batocera-Changelog
+++ b/batocera-Changelog
@@ -38,6 +38,7 @@
         * bump: libretro-melonds to July 12 build
         * bump: libretro-genesisplusgx to Aug 31 2022 build
         * bump: linux kernel for x86_64 to 5.19.8
+        * fix: lr-mame save state file names
         * fix: slow rpcs3 initial ppu compilation times
         * fix: rpcs3 cache & saves dir
           - note: move existing cache from /userdata/saves/rpcs3 to /userdata/system/cache/rpcs3

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -292,7 +292,7 @@ class LibretroGenerator(Generator):
                 corePath = 'lr-' + system.config['core']
             else:
                 corePath = system.config['core']
-            commandArray.append("/var/run/{}.cmd".format(corePath))
+            commandArray.append("/var/run/cmdfiles/{}.cmd".format(os.path.splitext(os.path.basename(rom))[0]))
 
         if dontAppendROM == False:
             commandArray.append(rom)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -319,10 +319,17 @@ def generateMAMEConfigs(playersControllers, system, rom):
         os.makedirs("/userdata/saves/mame/plugins/")
     commandLine += [ "-samplepath", "/userdata/bios/mame/samples/" ]
 
+    # Delete old cmd files & prepare path
+    cmdPath = "/var/run/cmdfiles/"
+    if not os.path.exists(cmdPath):
+        os.makedirs(cmdPath)
+    cmdFileList = os.listdir(cmdPath)
+    for file in cmdFileList:
+        if file.endswith(".cmd"):
+            os.remove(os.path.join(cmdPath, file))
+
     # Write command line file
-    cmdFilename = "/var/run/{}.cmd".format(corePath)
-    if os.path.exists(cmdFilename):
-        os.remove(cmdFilename)
+    cmdFilename = "{}{}.cmd".format(cmdPath, romDrivername)
     cmdFile = open(cmdFilename, "w")
     cmdFile.write(' '.join(commandLine))
     cmdFile.close()


### PR DESCRIPTION
lr-mame was using the name of the cmd file (which was usually lr-mame.cmd) for save states. To fix this, the generated cmd file now uses the ROM file name, minus extension - ie launching pacman.zip produces pacman.cmd. This makes lr-mame save states with the proper name, so they'll work per-game and show up in the ES save states list.

Since the filename is no longer consistent, it now creates a subfolder in the temp folder, and deletes any existing cmd files in that folder before creating the new one. The files are small and it would take a lot of launches without a reboot to build up a problematic amount of files, but safer to remove them.