### PR TITLE
MelonDS Fix Part 2 / Libretro Sony Touchpad Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -145,6 +145,12 @@ def generateControllerConfig(controller, retroarchspecials, system, lightgun):
         specialvalue = retroarchspecials['start']
         input = controller.inputs['start']
         config['input_{}_{}'.format(specialvalue, typetoname[input.type])] = getConfigValue(input)
+    # Adjustment for Sony touchpad
+    if "Sony Interactive Entertainment" in controller.configName or controller.configName == "Wireless Controller":
+        mouseShift = getMouseShift(system)
+        if mouseShift > 0:
+            mouseIndex = mouseShift + int(controller.player) - 1
+            config['input_player{}_mouse_index'.format(controller.player)] = mouseIndex
     return config
 
 
@@ -173,3 +179,18 @@ def getAnalogMode(controller, system):
             if (controller.inputs[dirkey].type == 'button') or (controller.inputs[dirkey].type == 'hat'):
                 return '1'
     return '0'
+
+# Scan mouse devices, see if we need to shift them.
+# Returns the number of mouse devices found that are not Sony controllers.
+# If > 0, the shift will be applied to the controller inputs, otherwise it will be left on the defaults.
+def getMouseShift(system):
+    if not system.name in ['nds', '3ds']:
+        return 0
+
+    mouseCount = 0
+    inputDeviceList = sorted(os.listdir('/dev/input/by-id'))
+    for device in inputDeviceList:
+        if 'event-mouse' in device:
+            if not 'Sony' in device:
+                mouseCount += 1
+    return mouseCount


### PR DESCRIPTION
This will (seemingly) properly assign mouse inputs to the Sony controller touchpads in Retroarch. Tested with a DS4 connected via USB & Bluetooth.

The shift will only happen if the controller being mapped is likely a DS4 or DualSense (name contains "Sony Interactive Entertainment" or is just "Wireless Controller") and the system is nds or 3ds - other systems will likely want to use a real mouse.

It checks /dev/input/by-id for mouse inputs, counts the number of non-Sony inputs (USB-connected controllers show up here, Bluetooth does not), and sets the port's mouse index to Player Number + Count of Mice - 1. Since it only applies to nds & 3ds, this will only affect Port 1 in practice.

It may need additional name checks for the DualSense, but as far as I know the names will match those searches.

It has not been tested with mixed controllers or multiple mice connected to make sure the shift is fully accurate. A more ideal solution would be to have a way to match mouse index to controller, but I don't know if the indexes are generated by the OS or Retroarch.

Fix for https://github.com/batocera-linux/batocera.linux/issues/7159