### PR TITLE
DS Mouse Fix, Part 1

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1140,7 +1140,10 @@ def generateCoreSettings(coreSettings, system, rom, guns):
         # Enable threaded rendering
         coreSettings.save('melonds_threaded_renderer', '"enabled"')
         # Emulate Stylus on Right Stick
-        coreSettings.save('melonds_touch_mode',        '"Joystick"')
+        if system.isOptSet('melonds_touch_mode'):
+            coreSettings.save('melonds_touch_mode',  '"' + system.config['melonds_touch_mode'] + '"')
+        else:
+            coreSettings.save('melonds_touch_mode','"Joystick"')
         # Boot game directly
         if system.isOptSet('melonds_boot_directly'):
             coreSettings.save('melonds_boot_directly', system.config['melonds_boot_directly'])

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -668,6 +668,14 @@ libretro:
                     "hybrid top ratio 3":    Hybrid Top-Ratio3
                     "hybrid bottom ratio 2": Hybrid Bottom-Ratio2
                     "hybrid bottom ratio 3": Hybrid Bottom-Ratio3
+            melonds_touch_mode:
+                prompt:      TOUCH SCREEN MODE
+                description: Select the input type to navigate the touch screen
+                choices:
+                    "None":         Disabled
+                    "Mouse":        Mouse
+                    "Touch Screen": Touch
+                    "Right Stick":  Joystick
     #dolphin:
     dosbox:
       features: [padtokeyboard]


### PR DESCRIPTION
This enables an option for mouse (or touchscreen) input for the touch screen in MelonDS. Previously we were forcing joystick, MelonDS' touchscreen controls are mutually exclusive.

Part 2 is a fix for Retroarch mouse assignments on Sony controllers.