### PR TITLE
MAME2003Plus Duplicate Control Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -75,7 +75,7 @@ class LibretroGenerator(Generator):
                 lightgun = system.getOptBoolean('lightgun_map')
             else:
                 # Lightgun button mapping breaks lr-mame's inputs, disable if left on auto
-                if system.config['core'] in [ 'mame', 'mess', 'mamevirtual', 'same_cdi' ]:
+                if system.config['core'] in [ 'mame', 'mess', 'mamevirtual', 'same_cdi', 'mame078plus' ]:
                     lightgun = False
                 else:
                     lightgun = True


### PR DESCRIPTION
Fixes https://github.com/batocera-linux/batocera.linux/issues/7198

MAME2003Plus maps multiple physical controls per input - so "Button 1" for example maps to joystick button 1, lightgun button 1, and mouse button 1. As a result, if the default setting of mapping controllers to lightgun inputs is enabled, multiple buttons perform the same action, and some controls can't be mapped.

This is the same fix that was previously applied to lr-MAME - the core is added to an exception list that disables the Controller to Lightgun option unless it is specifically turned on.