### PR TITLE
WINE registry file fix & raw input option

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8622,6 +8622,13 @@ wine:
             choices:
                 "Off": 0
                 "On":  1
+        raw_input:
+            group: ADVANCED OPTIONS
+            prompt:      RAW CONTROLLER INPUT
+            description: Disabling this may help compatibility with certain controllers and games.
+            choices:
+                "Off": 1
+                "On":  0
         wine_debug:
             group: ADVANCED OPTIONS
             prompt:      ENABLE DEBUG

--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -83,6 +83,7 @@ wine_options() {
     FORCE_LARGE_ADRESS="$(get_setting force_large_adress "${SYSTEM}" "${ROMGAMENAME}")"
     HEAP_DELAY_FREE="$(get_setting heap_delay_free "${SYSTEM}" "${ROMGAMENAME}")"
     HIDE_NVIDIA_GPU="$(get_setting hide_nvidia_gpu "${SYSTEM}" "${ROMGAMENAME}")"
+    RAW_INPUT="$(get_setting raw_input "${SYSTEM}" "${ROMGAMENAME}")"
     WINE_DEBUG="$(get_setting wine_debug "${SYSTEM}" "${ROMGAMENAME}")"
     KEYBOARD="$(/usr/bin/batocera-settings-get system.kblayout)"
     VIRTUAL_DESKTOP="$(get_setting virtual_desktop "${SYSTEM}" "${ROMGAMENAME}")"
@@ -149,6 +150,15 @@ wine_options() {
     fi
 
     setxkbmap "${KEYBOARD}"
+
+    # Create registry file for raw input
+    echo 'Windows Registry Editor Version 5.00' >| /var/run/rawinput.reg
+    echo '' >> /var/run/rawinput.reg
+    echo '[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\winebus]' >> /var/run/rawinput.reg
+    echo '"DisableHidraw"=dword:0000000'"${RAW_INPUT}" >> /var/run/rawinput.reg
+    echo '' >> /var/run/rawinput.reg
+    echo '' >> /var/run/rawinput.reg
+    unix2dos /var/run/rawinput.reg
 }
 
 mf_install() {
@@ -271,12 +281,18 @@ WINEPREFIX=$1
 
 reg_install() {
 WINEPREFIX=$1
+    if test -e "/var/run/rawinput.reg"; then
+        WINEPREFIX=${WINEPOINT} "${WINE}" regedit //?/unix/var/run/rawinput.reg &>/dev/null || return 1
+        WINEPREFIX=${WINEPOINT} "${WINE64}" regedit //?/unix/var/run/rawinput.reg &>/dev/null || return 1
+        rm /var/run/rawinput.reg
+    fi
+
     if test -e "${USER_DIR}/regs"; then
 
         for file in ${USER_DIR}/regs/*.reg; do
             echo "Importing registry $file"
-            WINEPREFIX=${WINEPOINT} "${WINE}" regedit "${file}" &>/dev/null || return 1
-            WINEPREFIX=${WINEPOINT} "${WINE64}" regedit "${file}" &>/dev/null || return 1
+            WINEPREFIX=${WINEPOINT} "${WINE}" regedit //?/unix"${file}" &>/dev/null || return 1
+            WINEPREFIX=${WINEPOINT} "${WINE64}" regedit //?/unix"${file}" &>/dev/null || return 1
         done
 
         mv "${USER_DIR}/regs" "${USER_DIR}/regs.bak" || return 1


### PR DESCRIPTION
This adds an option to Wine to enable/disable raw input for HID devices. Some games have issues detecting non-xinput controllers if raw input is enabled (the default). It builds a .reg file when loading options, and applies it during launch.

In addition, while working on this, I found that .reg files were not being loaded from the regs folder - the folder would rename, but the keys would not apply. Testing using regedit inside the wine bottle showed that regedit was prefixing files loaded from the Linux filesystem with "\\?\unix", adding this to the regedit command in the script as //?/unix allowed it to load properly.