### PR TITLE
Sony Touchpad Fix v2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -3,6 +3,9 @@
 import xml.etree.ElementTree as ET
 import batoceraFiles
 import os
+import pyudev
+import re
+import pprint
 
 from utils.logger import get_logger
 eslog = get_logger(__name__)
@@ -48,7 +51,6 @@ class Controller:
 
     def generateSDLGameDBLine(self):
         return _generateSdlGameControllerConfig(self)
-
 
 # Load all controllers from the es_input.cfg
 def loadAllControllersConfig():
@@ -307,3 +309,54 @@ def getGameGunsMetaData(system, rom):
                         res[attribute] = nodegame.get(attribute)
                     return res
     return res
+
+def getDevicesInformation():
+  groups    = {}
+  devices   = {}
+  context   = pyudev.Context()
+  events    = context.list_devices(subsystem='input')
+  mouses    = []
+  joysticks = []
+  for ev in events:
+    matches = re.match(r"^/dev/input/event([0-9]*)$", str(ev.device_node))
+    if matches != None:
+      eventId = int(matches.group(1))
+      isJoystick = ("ID_INPUT_JOYSTICK" in ev.properties and ev.properties["ID_INPUT_JOYSTICK"] == "1")
+      isMouse    = ("ID_INPUT_MOUSE" in ev.properties and ev.properties["ID_INPUT_MOUSE"] == "1") or ("ID_INPUT_TOUCHPAD" in ev.properties and ev.properties["ID_INPUT_TOUCHPAD"] == "1")
+      group = None
+      if "ID_PATH" in ev.properties:
+        group = ev.properties["ID_PATH"]
+      if isJoystick or isMouse:
+        if isJoystick:
+          joysticks.append(eventId)
+        if isMouse:
+          mouses.append(eventId)
+        if "ID_PATH" in ev.properties:
+          devices[eventId] = { "node": ev.device_node, "group": ev.properties["ID_PATH"], "isJoystick": isJoystick, "isMouse": isMouse }
+          if group not in groups:
+            groups[group] = []
+          groups[group].append(ev.device_node)
+  mouses.sort()
+  joysticks.sort()
+  res = {}
+  for device in devices:
+    d = devices[device]
+    dgroup = groups[d["group"]].copy()
+    dgroup.remove(d["node"])
+    nmouse    = None
+    njoystick = None
+    if d["isJoystick"]:
+      njoystick = joysticks.index(device)
+    nmouse = None
+    if d["isMouse"]:
+      nmouse = mouses.index(device)
+    res[d["node"]] = { "isJoystick": d["isJoystick"], "isMouse": d["isMouse"], "associatedDevices": dgroup, "joystick_index": njoystick, "mouse_index": nmouse }
+  return res
+
+def getAssociatedMouse(devicesInformation, dev):
+    if dev not in devicesInformation:
+        return None
+    for candidate in devicesInformation[dev]["associatedDevices"]:
+        if devicesInformation[candidate]["isMouse"]:
+            return candidate
+    return None

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -5,7 +5,6 @@ import batoceraFiles
 import os
 import pyudev
 import re
-import pprint
 
 from utils.logger import get_logger
 eslog = get_logger(__name__)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 import sys
 import os
+from controllersConfig import getDevicesInformation
+from controllersConfig import getAssociatedMouse
 
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
@@ -55,7 +57,14 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
         del retroarchspecials['b']
 
     for controller in controllers:
-        writeControllerConfig(retroconfig, controllers[controller], controller, system, retroarchspecials, lightgun)
+        mouseIndex = None
+        if system.name in ['nds', '3ds']:
+            deviceList = getDevicesInformation()
+            mouseIndex = getAssociatedMouse(deviceList, controllers[controller].dev)
+        if mouseIndex == None:
+            mouseIndex = 0
+        writeControllerConfig(retroconfig, controllers[controller], controller, system, retroarchspecials, lightgun, mouseIndex)
+
     writeHotKeyConfig(retroconfig, controllers)
 
 # Remove all controller configurations
@@ -73,8 +82,8 @@ def writeHotKeyConfig(retroconfig, controllers):
 
 
 # Write a configuration for a specified controller
-def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarchspecials, lightgun):
-    generatedConfig = generateControllerConfig(controller, retroarchspecials, system, lightgun)
+def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarchspecials, lightgun, mouseIndex=0):
+    generatedConfig = generateControllerConfig(controller, retroarchspecials, system, lightgun, mouseIndex)
     for key in generatedConfig:
         retroconfig.save(key, generatedConfig[key])
 
@@ -83,7 +92,7 @@ def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarc
 
 
 # Create a configuration for a given controller
-def generateControllerConfig(controller, retroarchspecials, system, lightgun):
+def generateControllerConfig(controller, retroarchspecials, system, lightgun, mouseIndex=0):
 # Map an emulationstation button name to the corresponding retroarch name
     retroarchbtns = {'a': 'a', 'b': 'b', 'x': 'x', 'y': 'y', \
                      'pageup': 'l', 'pagedown': 'r', 'l2': 'l2', 'r2': 'r2', \
@@ -145,6 +154,7 @@ def generateControllerConfig(controller, retroarchspecials, system, lightgun):
         specialvalue = retroarchspecials['start']
         input = controller.inputs['start']
         config['input_{}_{}'.format(specialvalue, typetoname[input.type])] = getConfigValue(input)
+    config['input_player{}_mouse_index'.format(controller.player)] = mouseIndex
     return config
 
 


### PR DESCRIPTION
Replaces https://github.com/batocera-linux/batocera.linux/pull/7182

New method: uses evdev to determine what is a mouse or gamepad based on available inputs. If a mouse and gamepad have the same physical ID (checks out on BT and USB), the input device of the controller is stored. If there's a mouse with no matching gamepad, a dummy value gets stored to keep proper indexing.

When Retroarch generates the controller config, if the system is NDS or 3DS (we assume other systems will want a real mouse, but others can be added), it will check to see if the current controller matches one of the input devices in the list. If so, it will set the mouse index to the index in the list.