### PR TITLE
sinden guns modes

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -230,8 +230,14 @@ def gunsBordersSizeName(guns, config):
     bordersSize = "big"
     if "controllers.guns.borderssize" in config and config["controllers.guns.borderssize"]:
         bordersSize = config["controllers.guns.borderssize"]
-    if "controllers.guns.forceborders" in config and config["controllers.guns.forceborders"]:
-        return bordersSize
+
+    if "controllers.guns.bordersmode" in config and config["controllers.guns.bordersmode"]:
+        # others are gameonly and normal
+        if config["controllers.guns.bordersmode"] == "hidden":
+            return None
+        if config["controllers.guns.bordersmode"] == "force":
+            return bordersSize
+
     for gun in guns:
         if guns[gun]["need_borders"]:
             return bordersSize


### PR DESCRIPTION
- normal : draw borders when required
- hidden : the border are not displayed (assume that there are provided by an other way like bezels)
- force  : force even if no gun requires it (or even no gun at all)
- gameonly : borders are not visible in es, just in game (for boards having a sinden gun alway plugged in)

Signed-off-by: Nicolas Adenis-Lamarre <nicolas.adenis.lamarre@gmail.com>