### PR TITLE
update bios for amiga and atari

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -12,11 +12,13 @@ systems = {
 
     # ---------- Atari ---------- #
     # https://docs.libretro.com/library/atari800/#bios
-    "atari5200": { "name": "Atari 5200 / Atari 800", "biosFiles": [ { "md5": "281f20ea4320404ec820fb7ec0693b38", "file": "bios/5200.rom"    },
-                                                                    { "md5": "06daac977823773a3eea3422fd26a703", "file": "bios/ATARIXL.ROM" },
-                                                                    { "md5": "0bac0c6a50104045d902df4503a4c30b", "file": "bios/ATARIBAS.ROM"},
-                                                                    { "md5": "eb1f32f5d9f382db1bbfb8d7f9cb343a", "file": "bios/ATARIOSA.ROM"},
-                                                                    { "md5": "a3e8d617c95d08031fe1b20d541434b2", "file": "bios/ATARIOSB.ROM"} ] },
+    "atari800": { "name": "Atari 800", "biosFiles": [ { "md5": "eb1f32f5d9f382db1bbfb8d7f9cb343a", "file": "bios/ATARIOSA.ROM"},
+                                                      { "md5": "a3e8d617c95d08031fe1b20d541434b2", "file": "bios/ATARIOSB.ROM"},
+                                                      { "md5": "06daac977823773a3eea3422fd26a703", "file": "bios/ATARIXL.ROM" },
+                                                      # The BASIC cart came with all Atari computers. On the XL and XE, it was built-in, so it's required by those models.
+                                                      { "md5": "0bac0c6a50104045d902df4503a4c30b", "file": "bios/ATARIBAS.ROM"} ] },
+
+    "atari5200": { "name": "Atari 5200", "biosFiles": [ { "md5": "281f20ea4320404ec820fb7ec0693b38", "file": "bios/5200.rom"    } ] },
 
     # https://github.com/libretro/libretro-super/blob/master/dist/info/hatari_libretro.info
     "atarist": { "name": "Atari ST", "biosFiles": [ { "md5": "c1c57ce48e8ee4135885cee9e63a68a2", "file": "bios/tos.img"}, # TOS 1.02 US
@@ -82,9 +84,10 @@ systems = {
     # ---------- Magnavox and Philips ---------- #
     # https://docs.libretro.com/library/o2em/#bios
     "o2em": { "name": "Odyssey 2", "biosFiles": [ { "md5": "562d5ebf9e030a40d6fabfc2f33139fd", "file": "bios/o2rom.bin" },
-                                                  { "md5": "f1071cdb0b6b10dde94d3bc8a6146387", "file": "bios/c52.bin"   },
-                                                  { "md5": "c500ff71236068e0dc0d0603d265ae76", "file": "bios/g7400.bin" },
-                                                  { "md5": "279008e4a0db2dc5f1c048853b033828", "file": "bios/jopac.bin" } ] },
+                                                  { "md5": "f1071cdb0b6b10dde94d3bc8a6146387", "file": "bios/c52.bin"   } ] },
+
+    "videopacplus": { "name": "Videopac+ G7400", "biosFiles": [ { "md5": "c500ff71236068e0dc0d0603d265ae76", "file": "bios/g7400.bin" },
+                                                                { "md5": "279008e4a0db2dc5f1c048853b033828", "file": "bios/jopac.bin" } ] },
 
     # ---------- Mattel ---------- #
     # https://docs.libretro.com/library/freeintv/#bios
@@ -204,11 +207,13 @@ systems = {
                                             { "md5": "8ecd73eb4edf7ed7e81aef1be80031d5", "file": "bios/SGB2.sfc" } ] },
     # ---------- Microsoft ---------- #
     # https://docs.libretro.com/library/fmsx/#bios
-    "msx": { "name": "MSX", "biosFiles": [  { "md5": "364a1a579fe5cb8dba54519bcfcdac0d", "file": "bios/MSX.ROM"      },
-                                            { "md5": "ec3a01c91f24fbddcbcab0ad301bc9ef", "file": "bios/MSX2.ROM"     },
-                                            { "md5": "2183c2aff17cf4297bdb496de78c2e8a", "file": "bios/MSX2EXT.ROM"  },
-                                            { "md5": "847cc025ffae665487940ff2639540e5", "file": "bios/MSX2P.ROM"    },
-                                            { "md5": "7c8243c71d8f143b2531f01afa6a05dc", "file": "bios/MSX2PEXT.ROM" } ] },
+    "msx": { "name": "MSX", "biosFiles": [  { "md5": "364a1a579fe5cb8dba54519bcfcdac0d", "file": "bios/MSX.ROM"      } ] },
+
+    "msx2": { "name": "MSX2", "biosFiles": [ { "md5": "ec3a01c91f24fbddcbcab0ad301bc9ef", "file": "bios/MSX2.ROM"     },
+                                            { "md5": "2183c2aff17cf4297bdb496de78c2e8a", "file": "bios/MSX2EXT.ROM"  } ] },
+
+    "msx2+": { "name": "MSX2+", "biosFiles": [ { "md5": "847cc025ffae665487940ff2639540e5", "file": "bios/MSX2P.ROM"    },
+                                               { "md5": "7c8243c71d8f143b2531f01afa6a05dc", "file": "bios/MSX2PEXT.ROM" } ] },
 
     "xbox": { "name": "Xbox", "biosFiles": [{ "md5": "d49c52a4102f6df7bcf8d0617ac475ed", "file": "bios/mcpx_1.0.bin" },
                                             { "md5": "39cee882148a87f93cb440b99dde3ceb", "file": "bios/Complex_4627.bin" }] },
@@ -216,27 +221,42 @@ systems = {
     # ---------- Commodore ---------- #
     # https://github.com/libretro/libretro-super/blob/master/dist/info/puae_libretro.info
     # https://github.com/midwan/amiberry/wiki/Kickstart-ROMs-(BIOS)
-    "amiga":  { "name": "Amiga",    "biosFiles":  [ { "md5": "85ad74194e87c08904327de1a9443b7a", "file": "bios/kick33180.A500"      },
-                                                    { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/kick34005.A500"      },
-                                                    { "md5": "dc10d7bdd1b6f450773dfb558477c230", "file": "bios/kick37175.A500"      },
-                                                    { "md5": "89da1838a24460e4b93f4f0c5d92d48d", "file": "bios/kick34005.CDTV"      },
-                                                    { "md5": "e40a5dfb3d017ba8779faba30cbd1c8e", "file": "bios/kick40063.A600"      },
-                                                    { "md5": "b7cc148386aa631136f510cd29e42fc3", "file": "bios/kick39106.A1200"     },
-                                                    { "md5": "646773759326fbac3b2311fd8c8793ee", "file": "bios/kick40068.A1200"     },
-                                                    { "md5": "9bdedde6a4f33555b4a270c8ca53297d", "file": "bios/kick40068.A4000"     },
-                                                    { "md5": "5f8924d013dd57a89cf349f4cdedc6b1", "file": "bios/kick40060.CD32"      },
-                                                    { "md5": "bb72565701b1b6faece07d68ea5da639", "file": "bios/kick40060.CD32.ext"  },
-                                                    # https://fs-uae.net/docs/kickstarts
-                                                    { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/amiga-os-130.rom"        },
-                                                    { "md5": "646773759326fbac3b2311fd8c8793ee", "file": "bios/amiga-os-310-a1200.rom"  },
-                                                    { "md5": "dc10d7bdd1b6f450773dfb558477c230", "file": "bios/amiga-os-204.rom"        },
-                                                    { "md5": "465646c9b6729f77eea5314d1f057951", "file": "bios/amiga-os-205.rom"        },
-                                                    { "md5": "413590e50098a056cfec418d3df0212d", "file": "bios/amiga-os-310-a3000.rom"  },
-                                                    { "md5": "730888fb1bd9a3606d51f772ed136528", "file": "bios/amiga-os-310.rom"        },
-                                                    { "md5": "85ad74194e87c08904327de1a9443b7a", "file": "bios/amiga-os-120.rom"        },
-                                                    { "md5": "5f8924d013dd57a89cf349f4cdedc6b1", "file": "bios/amiga-os-310-cd32.rom"   },
-                                                    { "md5": "bb72565701b1b6faece07d68ea5da639", "file": "bios/amiga-ext-310-cd32.rom"  },
-                                                    { "md5": "89da1838a24460e4b93f4f0c5d92d48d", "file": "bios/amiga-ext-130-cdtv.rom"  }] },
+    # https://fs-uae.net/docs/kickstarts
+    "amiga500": { "name": "Amiga 500",     "biosFiles": [  { "md5": "85ad74194e87c08904327de1a9443b7a", "file": "bios/kick33180.A500"      },
+                                                           { "md5": "dc10d7bdd1b6f450773dfb558477c230", "file": "bios/kick37175.A500"      },
+                                                           { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/kick34005.A500"      },
+                                                           # Amiga 600 kickstart. Not really needed but maybe someone out there will want to switch their model to Amiga 600.
+                                                           { "md5": "465646c9b6729f77eea5314d1f057951", "file": "bios/kick37350.A600"      },
+                                                           { "md5": "e40a5dfb3d017ba8779faba30cbd1c8e", "file": "bios/kick40063.A600"      },
+                                                           # The Amiga Forever equivalents. Really are these actually needed? Just so people don't have to rename their stuff?
+                                                           { "md5": "85ad74194e87c08904327de1a9443b7a", "file": "bios/amiga-os-120.rom"    },
+                                                           { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/amiga-os-130.rom"    },
+                                                           { "md5": "dc10d7bdd1b6f450773dfb558477c230", "file": "bios/amiga-os-204.rom"    },
+                                                           { "md5": "465646c9b6729f77eea5314d1f057951", "file": "bios/amiga-os-205.rom"    },
+                                                           { "md5": "e40a5dfb3d017ba8779faba30cbd1c8e", "file": "bios/amiga-os-310-a600.rom" }] },
+
+    "amigacdtv": { "name": "Amiga CDTV",   "biosFiles": [  { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/kick34005.A500"          },
+                                                           { "md5": "89da1838a24460e4b93f4f0c5d92d48d", "file": "bios/kick34005.CDTV"          },
+                                                           # CDTV requires both the Amiga 500 kickstart and its own extended kickstart.
+                                                           { "md5": "82a21c1890cae844b3df741f2762d48d", "file": "bios/amiga-os-130.rom"        },
+                                                           { "md5": "89da1838a24460e4b93f4f0c5d92d48d", "file": "bios/amiga-ext-130-cdtv.rom"  }] },
+
+    "amiga1200": { "name": "Amiga 1200",   "biosFiles": [  { "md5": "b7cc148386aa631136f510cd29e42fc3", "file": "bios/kick39106.A1200"         },
+                                                           { "md5": "646773759326fbac3b2311fd8c8793ee", "file": "bios/kick40068.A1200"         },
+                                                           { "md5": "9bdedde6a4f33555b4a270c8ca53297d", "file": "bios/kick40068.A4000"         },
+                                                           # The Amiga Forever equivalents. a3000 seems to not have a kickstart equivalent. amiga-os-310.rom doesn't match libretro's docs.
+                                                           { "md5": "b7cc148386aa631136f510cd29e42fc3", "file": "bios/amiga-os-300-a1200.rom"  },
+                                                           { "md5": "646773759326fbac3b2311fd8c8793ee", "file": "bios/amiga-os-310-a1200.rom"  },
+                                                           { "md5": "413590e50098a056cfec418d3df0212d", "file": "bios/amiga-os-310-a3000.rom"  },
+                                                           { "md5": "9bdedde6a4f33555b4a270c8ca53297d", "file": "bios/amiga-os-310-a4000.rom"  },
+                                                           { "md5": "730888fb1bd9a3606d51f772ed136528", "file": "bios/amiga-os-310.rom"        }] },
+
+    "amigacd32": { "name": "Amiga CD32",   "biosFiles": [  { "md5": "5f8924d013dd57a89cf349f4cdedc6b1", "file": "bios/kick40060.CD32"          },
+                                                           { "md5": "bb72565701b1b6faece07d68ea5da639", "file": "bios/kick40060.CD32.ext"      },
+                                                           # Unlike the CDTV, CD32 does not need the Amiga 1200 kickstart.
+                                                           # But, it has its own unique "base" anyway, which is required in addition to its extended.
+                                                           { "md5": "5f8924d013dd57a89cf349f4cdedc6b1", "file": "bios/amiga-os-310-cd32.rom"   },
+                                                           { "md5": "bb72565701b1b6faece07d68ea5da639", "file": "bios/amiga-ext-310-cd32.rom"  }] },
 
     # ---------- NEC PC-8800 ---------- #
     # https://github.com/RetroPie/RetroPie-Setup/wiki/PC-8800
@@ -651,7 +671,7 @@ systems = {
                                                 { "md5": "ac0d468be366779c9df633be98da250a", "zippedFile": "cdi220b.rom", "file": "bios/cdimono1.zip"},
                                                 { "md5": "3e59b8a9a423d3ecd612a32fe4e2d748", "zippedFile": "zx405037p__cdi_servo_2.1__b43t__llek9215.mc68hc705c8a_withtestrom.7201", "file": "bios/cdimono1.zip"},
                                                 { "md5": "3d20cf7550f1b723158b42a1fd5bac62", "zippedFile": "zx405042p__cdi_slave_2.0__b43t__zzmk9213.mc68hc705c8a_withtestrom.7206", "file": "bios/cdimono1.zip"} ] },
-    
+
     # ---------- Naomi 2 ---------- #
     "naomi2":   { "name": "Naomi 2", "biosFiles":  [ { "md5": "", "file": "bios/dc/naomi2.zip"  },
                                                 { "md5": "728bfe038ce280872057e365ebfc0fee", "zippedFile": "315-6146.bin", "file": "bios/dc/naomi2.zip"},


### PR DESCRIPTION
Is basically https://github.com/batocera-linux/batocera.linux/pull/7247 but without any of the functionality changes, just the updated BIOS info.