### PR TITLE
add gamecube controller types to dolphin options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -112,11 +112,14 @@ class DolphinGenerator(Generator):
         # Wiimote scanning
         dolphinSettings.set("Core", "WiimoteContinuousScanning", "True")
 
-        # Gamecube pads forced as standard pad
-        dolphinSettings.set("Core", "SIDevice0", "6")
-        dolphinSettings.set("Core", "SIDevice1", "6")
-        dolphinSettings.set("Core", "SIDevice2", "6")
-        dolphinSettings.set("Core", "SIDevice3", "6")
+        # Gamecube ports
+        # Create a for loop going 1 through to 4 and iterate through it:
+        for i in range(1,5):
+            if system.isOptSet("dolphin_port_" + str(i) + "_type"):
+                # Sub in the appropriate values from es_features, accounting for the 1 integer difference.
+                dolphinSettings.set("Core", "SIDevice" + str(i - 1), system.config["dolphin_port_" + str(i) + "_type"])
+            else:
+                dolphinSettings.set("Core", "SIDevice" + str(i - 1), "6")
 
         # Change discs automatically
         dolphinSettings.set("Core", "AutoDiscChange", "True")
@@ -138,17 +141,17 @@ class DolphinGenerator(Generator):
         if not dolphinGFXSettings.has_section("Hacks"):
             dolphinGFXSettings.add_section("Hacks")
         if not dolphinGFXSettings.has_section("Enhancements"):
-            dolphinGFXSettings.add_section("Enhancements")             
+            dolphinGFXSettings.add_section("Enhancements")
         if not dolphinGFXSettings.has_section("Hardware"):
-            dolphinGFXSettings.add_section("Hardware")  
-            
+            dolphinGFXSettings.add_section("Hardware")
+
         # Graphics setting Aspect Ratio
         if system.isOptSet('dolphin_aspect_ratio'):
             dolphinGFXSettings.set("Settings", "AspectRatio", system.config["dolphin_aspect_ratio"])
         else:
             # set to zero, which is 'Auto' in Dolphin & Batocera
             dolphinGFXSettings.set("Settings", "AspectRatio", "0")
-        
+
         # Show fps
         if system.isOptSet("showFPS") and system.getOptBoolean("showFPS"):
             dolphinGFXSettings.set("Settings", "ShowFPS", "True")
@@ -165,7 +168,7 @@ class DolphinGenerator(Generator):
 
         # Widescreen Hack
         if system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
-            # Prefer Cheats than Hack 
+            # Prefer Cheats than Hack
             if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
                 dolphinGFXSettings.set("Settings", "wideScreenHack", "False")
             else:
@@ -202,7 +205,7 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Enhancements", "ForceFiltering", "True")
             dolphinGFXSettings.set("Enhancements", "ArbitraryMipmapDetection", "True")
             dolphinGFXSettings.set("Enhancements", "DisableCopyFilter", "True")
-            dolphinGFXSettings.set("Enhancements", "ForceTrueColor", "True")            
+            dolphinGFXSettings.set("Enhancements", "ForceTrueColor", "True")
         else:
             if dolphinGFXSettings.has_section("Hacks"):
                 dolphinGFXSettings.remove_option("Hacks", "BBoxEnable")
@@ -216,7 +219,7 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "ForceFiltering")
                 dolphinGFXSettings.remove_option("Enhancements", "ArbitraryMipmapDetection")
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
-                dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")  
+                dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")
 
         # Internal resolution settings
         if system.isOptSet('internal_resolution'):
@@ -263,9 +266,9 @@ class DolphinGenerator(Generator):
             commandArray = ["dolphin-emu-nogui", "-p", system.config["platform"], "-e", rom]
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":batoceraFiles.CONF, "XDG_DATA_HOME":batoceraFiles.SAVES, "QT_QPA_PLATFORM":"xcb"})
-            
+
     def getInGameRatio(self, config, gameResolution, rom):
-        
+
         dolphinGFXSettings = configparser.ConfigParser(interpolation=None)
         # To prevent ConfigParser from converting to lower case
         dolphinGFXSettings.optionxform = str
@@ -300,7 +303,7 @@ class DolphinGenerator(Generator):
         # Stretched (thus depends on physical screen geometry)
         if dolphin_aspect_ratio == "3":
             return gameResolution["width"] / gameResolution["height"]
-                
+
         return 4/3
 
 # Seem to be only for the gamecube. However, while this is not in a gamecube section

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -5952,6 +5952,55 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
+        dolphin_port_1_type:
+            group: ADVANCED OPTIONS
+            prompt:      GAMECUBE PORT 1 TYPE
+            description: Change what's plugged into the virtual GameCube ports.
+            choices:
+                "None":                       0
+                "Standard Controller":        6
+                "GameCube Adapter for Wii U": 12
+                "Steering Wheel":             8
+                "Dance Mat":                  9
+                "DK Bongos":                  10
+                #"GBA (TCP)":                  5
+                "Keyboard":                   7
+        dolphin_port_2_type:
+            group: ADVANCED OPTIONS
+            prompt:      GAMECUBE PORT 2 TYPE
+            choices:
+                "None":                       0
+                "Standard Controller":        6
+                "GameCube Adapter for Wii U": 12
+                "Steering Wheel":             8
+                "Dance Mat":                  9
+                "DK Bongos":                  10
+                #"GBA (TCP)":                  5
+                "Keyboard":                   7
+        dolphin_port_3_type:
+            group: ADVANCED OPTIONS
+            prompt:      GAMECUBE PORT 3 TYPE
+            choices:
+                "None":                       0
+                "Standard Controller":        6
+                "GameCube Adapter for Wii U": 12
+                "Steering Wheel":             8
+                "Dance Mat":                  9
+                "DK Bongos":                  10
+                #"GBA (TCP)":                  5
+                "Keyboard":                   7
+        dolphin_port_4_type:
+            group: ADVANCED OPTIONS
+            prompt:      GAMECUBE PORT 4 TYPE
+            choices:
+                "None":                       0
+                "Standard Controller":        6
+                "GameCube Adapter for Wii U": 12
+                "Steering Wheel":             8
+                "Dance Mat":                  9
+                "DK Bongos":                  10
+                #"GBA (TCP)":                  5
+                "Keyboard":                   7
         anisotropic_filtering:
             group: ADVANCED OPTIONS
             prompt:      ANISOTROPIC FILTERING


### PR DESCRIPTION
![screenshot-2022 10 13-17h29 11](https://user-images.githubusercontent.com/67527064/195520181-37319b30-3c6a-49da-91d6-878715473c66.png)
![screenshot-2022 10 13-17h29 21](https://user-images.githubusercontent.com/67527064/195520189-8ce74113-c0e1-4ab6-8ff9-515c4f58b47e.png)
and clean up some blank spaces in the configgen too.