### PR TITLE
es_systems.yml: fix a typo and trim trailing spaces

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -230,7 +230,7 @@ n64:
   comment_br: |
     Caso o Mupen64Plus não carregue as ROMs compactadas em formato .zip (tela preta retornando ao menu), descompacte as ROMs e executando nos formatos .z64/.n64.
     Para mais informações: https://wiki.batocera.org/systems:n64
-    
+
 n64dd:
   name:       Nintendo 64 Disk Drive
   manufacturer: Nintendo
@@ -596,7 +596,7 @@ psx:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:psx
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:psx
-    
+
 pcengine:
   name:       PC Engine
   manufacturer: NEC
@@ -794,7 +794,7 @@ devilutionx:
 
     Para a cópia do pacote de voz em polonês:
     https://github.com/diasurgical/devilutionx-assets/releases/download/v1/pl.mpq
-    
+
 fbneo:
   name:       Final Burn Neo
   manufacturer: Arcade
@@ -876,7 +876,7 @@ mame:
     - Adicione seus arquivos de samples em /userdata/bios/mame2003/samples/
 
     Para mais informações: https://wiki.batocera.org/arcade
-    
+
 neogeo:
   name:       Neo-Geo
   manufacturer: SNK
@@ -980,7 +980,7 @@ colecovision:
     JOYPAD_L      = COLECO BUTTON2
     JOYPAD_SELECT = COLECO STAR
     JOYPAD_START  = COLECO HASH
-    
+
 atari800:
   name:       Atari 800
   manufacturer: Atari
@@ -1126,7 +1126,7 @@ prboom:
     Coloque sua trilha sonora no diretório ./game-musics
 
     NÃO APAGUE O ARQUIVO "prboom.wad".
-    
+
 tyrquake:
   name:       TyrQuake
   manufacturer: Ports
@@ -1168,7 +1168,7 @@ mrboom:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:mrboom
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:mrboom
-    
+
 tic80:
   name:       TIC-80
   manufacturer: Fantasy
@@ -1184,7 +1184,7 @@ tic80:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:tic-80
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:tic-80
-    
+
 pico8:
   name:       Pico-8
   manufacturer: Fantasy
@@ -1200,7 +1200,7 @@ pico8:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:pico-8
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:pico-8
-    
+
 lowresnx:
   name:       Lowres NX
   manufacturer: Fantasy
@@ -1254,7 +1254,7 @@ cannonball:
     Adicione as ROMS do mame 'OutRun rev. B' (epr-10187.88, epr-10327a.76.. ) neste diretório e renomeie Cannonball.cannonball.disabled para Cannonball.cannonball.
 
     Para mais informações: https://wiki.batocera.org/systems:cannonball
-    
+
 sdlpop:
   name:       SdlPop
   manufacturer: Ports
@@ -1318,7 +1318,7 @@ lutro:
 
     jogos de demonstração do lutro no site do libretro:
     http://buildbot.libretro.com/assets/cores/Lutro/
-    
+
 cavestory:
   name:       Cave Story
   manufacturer: Daisuke "Pixel" Amaya
@@ -1348,7 +1348,7 @@ cavestory:
 
     Recomenda-se usar a versão em inglês.
     Outras versões podem congelar o sistema.
-    
+
 atarist:
   name:       Atari ST
   manufacturer: Atari
@@ -1379,7 +1379,7 @@ amstradcpc:
   comment_br: |
     Para habilitar o suporte ao controle, vá no menu RetroArch com "Hotkey + B" e altere esta opção:
     De "Quick Menu/Core Input Options/User 1 Device type: Retropad" para "Amstrad Joystick"
-    
+
 msx1:
   name:       MSX1
   manufacturer: Microsoft
@@ -1752,7 +1752,7 @@ zxspectrum:
         Para jogos de teclado: defina os usuários 1 e 2 para nenhum e o usuário 3 para o teclado Sinclair. Você não terá nenhum controle e o teclado embutido não funcionará, mas todo o teclado físico estará disponível para você digitar esses comandos de aventura em texto.
 
     Se você definir um controle junto com o teclado, o controle funcionará bem, exceto pelas ligações para RETURN (ENTER pula linha) e SPACE (Barra de Espaços), e o teclado não registrará as teclas atribuídas aocontrole de cursor ou aos botões L1 e R1 para todos os outros tipos de controle.
-    
+
 moonlight:
   name:       Moonlight Embedded
   manufacturer: Misc. System
@@ -1768,7 +1768,7 @@ moonlight:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:moonlight
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:moonlight
-    
+
 apple2:
   name:       Apple II
   manufacturer: Apple
@@ -1877,9 +1877,9 @@ wii:
         por exemplo, para jogar mariokart wii, renomeie-o como mario_kart.side.ti.iso (para obter a inclinação no primeiro eixo e o infravermelho no 2º (ti))
         por exemplo, para jogar mario galaxy, renomeie-o como mario_galaxy.ni.iso (pegue o nunchuk no primeiro eixo e o infravermelho no 2º (ni))
     Para usar texturas personalizadas, coloque-as em /userdata/saves/dolphin-emu/Load/Textures/<game id>.
-  
+
     Para mais informações: https://wiki.batocera.org/systems:wii
-    
+
 ps2:
   name:       PlayStation 2
   manufacturer: Sony
@@ -1900,7 +1900,7 @@ ps2:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:ps2
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:ps2
-    
+
 ps3:
   name:       PlayStation 3
   manufacturer: Sony
@@ -1930,7 +1930,7 @@ ps3:
     A primeira vez que você carrega um jogo, levará tempo para ser processado (uma barra de progresso é visível). Isso não acontece nas próximas vezes.
 
     Para mais informações: https://wiki.batocera.org/systems:ps3
-    
+
 3do:
   name:       3DO Interactive Multiplayer
   manufacturer: Panasonic - Sanyo - Goldstar
@@ -2000,7 +2000,7 @@ openbor:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:openbor
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:openbor
-    
+
 satellaview:
   name:       Satellaview
   manufacturer: Nintendo
@@ -2061,7 +2061,7 @@ daphne:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:daphne
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:daphne
-    
+
 thomson:
   name:       Thomson - MO/TO (Theodore)
   manufacturer: Thomson
@@ -2137,7 +2137,7 @@ ports:
      -------------------------------------------------- -----------------------------
      Aqui você pode encontrar jogos e aplicativos para Linux, iniciados via scripts shell que terminam em
      ".sh". Apenas os scripts ".sh" aparecem no EmulationStation.
-    
+
 amiga:
   name:       Amiga
   manufacturer: Commodore
@@ -2170,7 +2170,7 @@ windows:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:windows
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:windows
-   
+
 windows_installers:
   name:       Install a new Windows game
   manufacturer: Microsoft
@@ -2189,7 +2189,7 @@ windows_installers:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:windows
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:windows
-    
+
 xash3d_fwgs:
   name:       Xash3D-FWGS
   manufacturer: Ports
@@ -2237,7 +2237,7 @@ xash3d_fwgs:
 
     Em seguida, baixe https://github.com/FWGS/xash-extras/releases/latest/download/extras.pak e copie para:
     /userdata/roms/xash3d_fwgs/extras.pak.
-   
+
 wiiu:
   name:       Wii U
   manufacturer: Nintendo
@@ -2255,7 +2255,7 @@ wiiu:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:wiiu
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:wiiu
-    
+
 solarus:
   name:       Solarus
   manufacturer: Solarus Team
@@ -2281,7 +2281,7 @@ easyrpg:
           The EasyRPG engine supports RPG Maker 2000 and 2003 games, you have to put the game's entire folder inside, and add .easyrpg to it's name the game folder is the one containing the RPG_RT.ldb file.
   comment_br: |
           A engine do EasyRPG suporta jogos RPG Maker 2000 e 2003, você deve colocar a pasta inteira do jogo dentro do diretório, e adicionar .easyrpg ao final do nome da pasta do jogo, aquela que contém o arquivo RPG_RT.ldb.
-    
+
 cgenius:
   name:       Commander Genius
   manufacturer: Ports
@@ -2310,7 +2310,7 @@ pygame:
           Créez vos jeux vous-même ! Pygame vous aide à créer vos propres jeux en quelques lignes de code seulement. Vous trouvez sur internet plein d'exemples et de tutoriaux.
   comment_br: |
           Crie seu jogo você mesmo ! Pygame ajuda você a criar jogos com apenas algumas linhas. Encontre um monte de exemplos na internet.
-    
+
 imageviewer:
   name:       Screenshots
   manufacturer: Misc. System
@@ -2436,7 +2436,7 @@ model3:
     Solução de problemas:
     ----------------
 
-    Veja as Perguntas e dúvidas mais frequentes sobre supermodelos aqui - https://www.supermodel3.com/FAQ.html 
+    Veja as Perguntas e dúvidas mais frequentes sobre supermodelos aqui - https://www.supermodel3.com/FAQ.html
 
 mugen:
   name:       MUGEN
@@ -2464,7 +2464,7 @@ fpinball:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:windows
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:windows
-    
+
 flash:
   name:       Flash Player
   manufacturer: Adobe
@@ -2492,7 +2492,7 @@ xbox:
     Trouvez la documentation ici: https://wiki.batocera.org/systems:xbox
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:xbox
-    
+
 flatpak:
   name: Applications
   manufacturer:
@@ -2526,7 +2526,7 @@ flatpak:
           Liste seus aplicativos instalados: lista flatpak
           Remova um aplicativo instalado: flatpak remove xmoto
           em seguida, execute batocera-flatpak-update para atualizar o diretório roms de acordo com seus aplicativos instalados.
-    
+
 steam:
   name: Steam
   manufacturer: Valve
@@ -2543,7 +2543,7 @@ steam:
   comment_br: |
           Execute o Steam.
           Em seguida execute o comando batocera-steam-update para atualizar o diretório de roms de acordo com seus jogos instalados.
-    
+
 supervision:
   name:       Supervision
   manufacturer: Watara
@@ -2570,7 +2570,7 @@ gong:
     Ce système est le premier jeu de libretro autonome. Aucune rom n'est requise.
   comment_br: |
     Este sistema é um jogo do libretro idependente. Não requer rom.
-    
+
 ecwolf:
   name:       ECWolf
   manufacturer: Ports
@@ -2643,7 +2643,7 @@ sonicretro:
     diferentes entre os dois, então você pode precisar selecionar manualmente o emulador para alterá-los.
 
     A opção do menu de desenvolvimento é necessária para executar modificações (mods).
-    
+
 model2:
   name:       Model 2
   manufacturer: Sega
@@ -2753,7 +2753,7 @@ model2:
 
     Nota: Necessário teclado.
     Você pode acessar o Menu de Serviço usando o F4 e depois usar o F2 para navegar e o F4 para selecionar.
-    
+
     -----------------
     Atualizações do Batocera
     -----------------
@@ -2774,7 +2774,7 @@ model2:
     Depois, você pode restaurar seus diretórios CFG e NVDATA.
 
     *** Desfrute dos jogos Sega Model 2 no Linux! ***
-    
+
 scv:
   name:       Super Cassette Vision
   manufacturer: Epoch
@@ -2824,7 +2824,7 @@ cdi:
           Requires MAME BIOS file cdimono1.zip
   comment_br: |
           Requer o arquivo cdimono1.zip da BIOS do MAME
-          
+
 advision:
   name:       Adventure Vision
   manufacturer: Entex
@@ -2840,7 +2840,7 @@ advision:
           Requires MAME BIOS file advision.zip
   comment_br: |
           Requer o arquivo advision.zip da BIOS do MAME
-    
+
 plugnplay:
   name:       Plug and Play TV Games
   manufacturer: Various
@@ -2869,7 +2869,7 @@ megaduck:
           Use unzipped ROMs (BIN format) if using Sameduck.
   comment_br: |
            Use ROMs descompactadas (formato BIN) se estiver usando Sameduck.
-           
+
 pv1000:
   name:       PV-1000
   manufacturer: Casio
@@ -2998,7 +2998,7 @@ gamecom:
           Requires MAME BIOS file gamecom.zip
   comment_br: |
           Requer o arquivo gamecom.zip da BIOS do MAME
-          
+
 gamepock:
   name:       Game Pocket Computer
   manufacturer: Epoch
@@ -3014,7 +3014,7 @@ gamepock:
           Requires MAME BIOS file gamepock.zip
   comment_br: |
           Requer o arquivo gamepock.zip da BIOS do MAME
-    
+
 fm7:
   name:       FM-7
   manufacturer: Fujitsu
@@ -3030,7 +3030,7 @@ fm7:
           Requires MAME BIOS file fm7.zip, and optionally fm77av.zip for FM-77AV support.
   comment_br: |
           Requer o arquivo fm7.zip da BIOS do MAME, e opcionalmente o arquivo fm77av.zip para ter suporte a FM-77AV.
-          
+
 
 archimedes:
   name:       Archimedes
@@ -3190,7 +3190,7 @@ gmaster:
           Requires MAME BIOS file gmaster.zip
   comment_br: |
           Requer o arquivo gmaster.zip da BIOS do MAME
-    
+
 astrocde:
   name:       Astrocade
   manufacturer: Bally
@@ -3225,7 +3225,7 @@ ti99:
   comment_br: |
           Requer o arquivo ti99_4a.zip da BIOS do MAME
           Os cartuchos precisam estar no formato .rpk e descompactados - caso contrário os arquivos da lista de software MAME (.bin) não serão executados corretamente.
-    
+
 tutor:
   name:       Tutor
   manufacturer: Tomy
@@ -3243,7 +3243,7 @@ tutor:
   comment_br: |
           Requer o arquivo tutor.zip da BIOS do MAME
           Para pular o menu de carregamento, pressione R1 para mover para baixo e A/Leste para selecionar.
-    
+
 coco:
   name:       Color Computer
   manufacturer: Tandy Radio Shack
@@ -3396,7 +3396,7 @@ hurrican:
     Ce système est le premier jeu de autonome. Aucune rom n'est requise.
   comment_br: |
     Este sistema é um jogo independente. Não requer arquivo de rom.
-    
+
 hcl:
   name:       Hydra Castle Labyrinth
   manufacturer: Ports
@@ -3414,7 +3414,7 @@ hcl:
     Ce système est le premier jeu de autonome. Aucune rom n'est requise.
   comment_br: |
     Este sistema é um jogo independente. Não requer arquivo de rom.
-    
+
 samcoupe:
   name:       SAM Coupé
   manufacturer: Miles Gordon Technology
@@ -3442,7 +3442,7 @@ abuse:
     Ce système est le premier jeu de autonome. Aucune rom n'est requise.
   comment_br: |
     Este sistema é um jogo independente. Não requer arquivo de rom.
-    
+
 cdogs:
   name:       C-Dogs SDL
   manufacturer: Ports
@@ -3460,7 +3460,7 @@ cdogs:
     Ce système est le premier jeu de autonome. Aucune rom n'est requise.
   comment_br: |
     Este sistema é um jogo independente. Não requer arquivo de rom.
-    
+
 xrick:
   name:       xrick
   manufacturer: Ports
@@ -3478,7 +3478,7 @@ xrick:
     Placez ici vos fichiers data.zip pour xrick.
   comment_br: |
     Coloque o data.zip do jogo xrick neste diretório.
-    
+
 macintosh:
   name:       Macintosh
   manufacturer: Apple
@@ -3521,7 +3521,7 @@ macintosh:
           lr-minivmac requer MacII.ROM e MacIIx.ROM.
           Se inicializar a partir de um disco rígido, os disquetes podem não carregar na inicialização. Para obter melhores resultados, faça uma cópia de uma das unidades de inicialização, carregue os discos manualmente através do menu MAME e copie ou instale-os na imagem do disco rígido.
           As imagens de disco só serão carregadas no Mac IIx e não são inicializáveis.
-    
+
 naomi2:
   name:       Naomi 2
   manufacturer: Sega
@@ -3609,7 +3609,7 @@ naomi2:
 
     Uma alternativa é usar Demul com Wine.
     Nota: Sua placa gráfica requer drivers Vulkan para que o Demul funcione.
-    
+
     O desempenho depende do hardware do sistema x86_64.
     Se você tiver falhas de áudio e música lenta, seu sistema não tem desempenho suficiente para executar este emulador.
 
@@ -3638,7 +3638,7 @@ naomi2:
     Nota: Necessário teclado.
     Você pode acessar o Menu de Serviço usando o F4 e depois usar o F2 para navegar e o F4 para selecionar.
 
-    Desfrute dos jogos Sega Naomi 2 no Linux!  
+    Desfrute dos jogos Sega Naomi 2 no Linux!
 
 hikaru:
   name:       Hikaru
@@ -3729,7 +3729,7 @@ hikaru:
     Você pode acessar o Menu de Serviço usando o F4 e depois usar o F2 para navegar e o F4 para selecionar.
 
     Desfrute dos jogos Sega Hiraku no Linux!
-    
+
 gaelco:
   name:       Gaelco
   manufacturer: Sega
@@ -4076,7 +4076,7 @@ eduke32:
     For mod support and troubleshooting, please visit the wiki for more information.
 
     More info: https://wiki.batocera.org/systems:eduke32
-  comment_br: |  
+  comment_br: |
     Eduke32 foi portado originalmente da Build Engine para jogar jogos como Duke Nukem 3D.
 
     Os seguintes jogos são oficialmente suportados e devem ser colocados no diretório designado com seus
@@ -4112,7 +4112,7 @@ eduke32:
       CON = /ww2gi/PLATOONL.DEF
 
     Para suporte a mods e solução de problemas, visite o wiki para obter mais informações.
-    
+
     Mais informações em: https://wiki.batocera.org/systems:eduke32
 
 fury:
@@ -4358,7 +4358,7 @@ psvita:
       vita3k: { requireAnyOf: [BR2_PACKAGE_VITA3K] }
   comment_en: |
     The world's first emulator for the PlayStation Vita.
-    
+
     ---------------------------------
     ## VITA3K IMPORTANT INFO ##
     ---------------------------------
@@ -4369,22 +4369,22 @@ psvita:
     Note: You MUST set-up Vita3k using the F1 option, choose applications & then run the Vita3K-config program
 
     1. Go through the wizard hitting next for all the default options & create a user account.
-    
+
     Note: do not change the path for Vita3k to run.
 
     2. You must install the required firmware:
 
     The firmware can be downloaded from the official PlayStation website here:
     https://www.playstation.com/en-us/support/hardware/psvita/system-software/
-    
+
     There's also an additional firmware package that contains the system fonts that needs to be installed.
     The font firmware package can be downloaded straight from the PlayStation servers, here:
     http://dus01.psp2.update.playstation.net/update/psp2/image/2022_0209/sd_59dcf059d3328fb67be7e51f8aa33418/PSP2UPDAT.PUP?dest=us
-    
+
     Ideally save them to /userdata/bios/psvita
 
     Install both firmware packages using the File > Install Firmware menu option to where you have the firmware saved on your system.
-    
+
     Game compatibility is here:
     https://vita3k.org/compatibility.html?lang=en#
 
@@ -4408,7 +4408,7 @@ psvita:
     Le premier émulateur au monde pour la PlayStation Vita.
   comment_br: |
     O primeiro emulador do mundo para o PlayStation Vita.
-    
+
     ----------------------------------
     ## VITA3K INFORMAÇÕES IMPORTANTES ##
     ----------------------------------
@@ -4419,22 +4419,22 @@ psvita:
     Nota: Você DEVE configurar o Vita3k usando a opção F1, escolher aplicativos e executar o programa Vita3K-config
 
     1. Vá até o assistente clicando em próximo para todas as opções padrão e crie uma conta de usuário.
-    
+
     Nota: não altere o caminho para execução do Vita3k.
 
     2. Você deve instalar o firmware necessário:
 
     O firmware pode ser baixado do site oficial da PlayStation aqui:
     https://www.playstation.com/en-us/support/hardware/psvita/system-software/
-    
+
     Há também um pacote de firmware adicional que contém as fontes do sistema que precisam ser instaladas.
     O pacote de firmware da fonte pode ser baixado diretamente dos servidores PlayStation, aqui:
     http://dus01.psp2.update.playstation.net/update/psp2/image/2022_0209/sd_59dcf059d3328fb67be7e51f8aa33418/PSP2UPDAT.PUP?dest=us
-    
+
     Idealmente, salve-os em /userdata/bios/psvita
 
     Instale ambos os pacotes de firmware usando a opção de menu File > Install Firmware onde você salvou o firmware em seu sistema.
-    
+
     A compatibilidade do jogo está aqui:
     https://vita3k.org/compatibility.html?lang=en#
 

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1146,7 +1146,7 @@ tyrquake:
     Placez ici vos fichiers .PAK pour Quake 1.
 
     Trouvez la documentation ici: https://wiki.batocera.org/systems:tyrquake
-  comment_fr: |
+  comment_br: |
     Coloque seus jogos Quake 1 .PAK neste diretório.
 
     Para mais informações: https://wiki.batocera.org/systems:tyrquake


### PR DESCRIPTION
Changes to `es_systems.yml:`:
- Change a `comment_fr` to `comment_br` in `tyrquake`. I don't know either language but it certainly looks like a typo :)
- Trim trailing spaces
