### PR TITLE
MAME Combo Key Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -648,8 +648,8 @@ def generateMAMEPadConfig(cfgPath, playersControllers, system, messSysName, romB
                             mappings_use[thisControl['decMapping']], retroPad[mappings_use[thisControl['useMapping1']]], retroPad[mappings_use[thisControl['useMapping2']]], thisControl['reversed'], \
                             thisControl['mask'], thisControl['default'], thisControl['delta'], thisControl['axis']))
                     elif thisControl['type'] == 'combo':
-                        xml_input_alt.appendChild(generateComboPortElement(pad, config_alt, thisControl['tag'], pad.index, thisControl['key'], thisControl['kbkey'], thisControl['mapping'], \
-                            retroPad[mappings_use[thisControl['usemapping']]], thisControl['reversed'], thisControl['mask'], thisControl['default']))
+                        xml_input_alt.appendChild(generateComboPortElement(pad, config_alt, thisControl['tag'], pad.index, thisControl['key'], thisControl['kbMapping'], thisControl['mapping'], \
+                            retroPad[mappings_use[thisControl['useMapping']]], thisControl['reversed'], thisControl['mask'], thisControl['default']))
 
         nplayer = nplayer + 1
         

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
@@ -18,6 +18,8 @@ import csv
 from xml.dom import minidom
 from PIL import Image, ImageOps
 
+eslog = get_logger(__name__)
+
 def generatePadsConfig(cfgPath, playersControllers, sysName, altButtons, customCfg, specialController, decorations, useGuns, useMouse, multiMouse):
     # config file
     config = minidom.Document()
@@ -228,8 +230,8 @@ def generatePadsConfig(cfgPath, playersControllers, sysName, altButtons, customC
                             mappings_use[thisControl['decMapping']], pad.inputs[mappings_use[thisControl['useMapping1']]], pad.inputs[mappings_use[thisControl['useMapping2']]], thisControl['reversed'], \
                             thisControl['mask'], thisControl['default'], thisControl['delta'], thisControl['axis']))
                     elif thisControl['type'] == 'combo':
-                        xml_input_alt.appendChild(generateComboPortElement(pad, config_alt, thisControl['tag'], pad.index, thisControl['key'], thisControl['kbkey'], thisControl['mapping'], \
-                            pad.inputs[mappings_use[thisControl['usemapping']]], thisControl['reversed'], thisControl['mask'], thisControl['default']))
+                        xml_input_alt.appendChild(generateComboPortElement(pad, config_alt, thisControl['tag'], pad.index, thisControl['key'], thisControl['kbMapping'], thisControl['mapping'], \
+                            pad.inputs[mappings_use[thisControl['useMapping']]], thisControl['reversed'], thisControl['mask'], thisControl['default']))
 
         nplayer = nplayer + 1
 


### PR DESCRIPTION
Fix for MAME/LR-MAME "combo" keys (gamepad with keyboard alternative). This was affecting a couple of systems, like PDP-1.