### PR TITLE
Add Ikemen-Go (only x86_64 at the moment)

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -303,6 +303,7 @@ menu "Emulators"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/play/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/pifba/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/vita3k/Config.in"
+    source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/ikemen/Config.in"
   endmenu
 
   menu "WINE"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/GeneratorImporter.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/GeneratorImporter.py
@@ -271,6 +271,10 @@ def getGenerator(emulator):
         from generators.vita3k.vita3kGenerator import Vita3kGenerator
         return Vita3kGenerator()
 
+    if emulator == "ikemen":
+        from generators.ikemen.ikemenGenerator import IkemenGenerator
+        return IkemenGenerator()
+
     #if emulator == 'play':
     #from generators.play.playGenerator import PlayGenerator
     #return PlayGenerator(),

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
@@ -172,9 +172,8 @@ class IkemenGenerator(Generator):
         except:
             conf = {}
 
-        jconf = conf["JoystickConfig"]
-        # Joystick seems completely broken in 0.98.2, so let's force
-        # keyboad and use a pad2key
+        # Joystick configuration seems completely broken in 0.98.2 Linux
+        # so let's force keyboad and use a pad2key
         conf["KeyConfig"] = Keymapping
         conf["JoystickConfig"] = Joymapping
         conf["Fullscreen"] = True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
@@ -1,0 +1,188 @@
+import Command
+from generators.Generator import Generator
+from utils.logger import get_logger
+import controllersConfig
+import json
+
+eslog = get_logger(__name__)
+
+Keymapping =[
+        {
+			"Joystick": -1,
+			"Buttons": [
+				"UP",
+				"DOWN",
+				"LEFT",
+				"RIGHT",
+				"a",
+				"s",
+				"d",
+				"z",
+				"x",
+				"c",
+				"RETURN",
+				"f",
+				"v",
+				"q"
+			]
+		},
+		{
+			"Joystick": -1,
+			"Buttons": [
+				"KP_8",
+				"KP_5",
+				"KP_4",
+				"KP_6",
+				"p",
+				"LBRACKET",
+				"RBRACKET",
+				"SEMICOLON",
+				"QUOTE",
+				"BACKSLASH",
+				"SLASH",
+				"o",
+				"l",
+				"PERIOD"
+			]
+		},
+		{
+			"Joystick": -1,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		},
+		{
+			"Joystick": -1,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		}
+	]
+
+Joymapping =[
+        {
+			"Joystick": 0,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		},
+        {
+			"Joystick": 1,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		},
+		{
+			"Joystick": 2,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		},
+		{
+			"Joystick": 3,
+			"Buttons": [
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used",
+				"Not used"
+			]
+		}
+	]
+
+class IkemenGenerator(Generator):
+
+    def generate(self, system, rom, playersControllers, guns, gameResolution):
+        try:
+            conf = json.load(open(rom+"/save/config.json", "r"))
+        except:
+            conf = {}
+
+        jconf = conf["JoystickConfig"]
+        # Joystick seems completely broken in 0.98.2, so let's force
+        # keyboad and use a pad2key
+        conf["KeyConfig"] = Keymapping
+        conf["JoystickConfig"] = Joymapping
+        conf["Fullscreen"] = True
+
+        js_out = json.dumps(conf, indent=2)
+        with open(rom+"/save/config.json", "w") as jout:
+            jout.write(js_out)
+
+        commandArray = ["/usr/bin/batocera-ikemen", rom]
+
+        return Command.Command(array=commandArray, env={ "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers) })

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -247,6 +247,9 @@ gzdoom:
 hikaru:
   emulator: demul
   core:     demul
+ikemen:
+  emulator: ikemen
+  core:     ikemen
 intellivision:
   emulator: libretro
   core:     freeintv

--- a/package/batocera/core/batocera-scripts/scripts/batocera-ikemen
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-ikemen
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "$1"
+/usr/bin/ikemen

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -627,6 +627,9 @@ config BR2_PACKAGE_BATOCERA_HOMEBREW_SYSTEMS
 	select BR2_PACKAGE_LIBRETRO_RETRO8   # ALL
 	select BR2_PACKAGE_LEXALOFFLE_PICO8  # ALL
 
+	# Fighting games engine
+	select BR2_PACKAGE_IKEMEN                   if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
+
 #### Sega Dreamcast, Naomi and Atomiswave ####
 config BR2_PACKAGE_BATOCERA_SEGADC
 	bool "batocera.linux dreamcast/naomi/atomiswave emulators/cores"
@@ -864,7 +867,6 @@ config BR2_PACKAGE_BATOCERA_PORTS_SYSTEMS
     select BR2_PACKAGE_RAZE                     if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
     # ZMusic: standalone library used by gzdoom and raze source ports
     select BR2_PACKAGE_ZMUSIC                   if BR2_PACKAGE_GZDOOM || BR2_PACKAGE_RAZE
-    select BR2_PACKAGE_IKEMEN                   if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
 
 	help
 		Ports

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -864,6 +864,7 @@ config BR2_PACKAGE_BATOCERA_PORTS_SYSTEMS
     select BR2_PACKAGE_RAZE                     if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
     # ZMusic: standalone library used by gzdoom and raze source ports
     select BR2_PACKAGE_ZMUSIC                   if BR2_PACKAGE_GZDOOM || BR2_PACKAGE_RAZE
+    select BR2_PACKAGE_IKEMEN                   if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
 
 	help
 		Ports

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8832,6 +8832,9 @@ mugen:
             choices:
                 "Off": 0
                 "On":  1
+ikemen:
+  features: [padtokeyboard]
+  shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
 
 ruffle:
   features: [padtokeyboard]

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2439,6 +2439,20 @@ mugen:
       lutris:  { requireAnyOf: [BR2_PACKAGE_WINE_LUTRIS] }
       proton:  { requireAnyOf: [BR2_PACKAGE_WINE_PROTON] }
 
+ikemen:
+  name:       IKEMEN
+  manufacturer: Elecbyte
+  release: 2021
+  hardware: port
+  extensions: [ikemen, pc, squashfs]
+  emulators:
+    ikemen:
+      ikemen:  { requireAnyOf: [BR2_PACKAGE_IKEMEN] }
+  comment_en: |
+    IKEMEN Go is a reimplementation of IKEMEN, an engine which extends the capacities of MUGEN for fighting games
+  comment_fr: |
+    IKEMEN Go est une re-ecriture de IKEMEN, un moteur qui etend les capacites de MUGEN pour les jeux de combat
+
 fpinball:
   name:       Future Pinball
   manufacturer: Christopher Leathley

--- a/package/batocera/emulators/ikemen/Config.in
+++ b/package/batocera/emulators/ikemen/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_IKEMEN
+        bool "ikemen"
+	select BR2_PACKAGE_MESA3D
+
+        help
+          A MUGEN emulator written in GoLang

--- a/package/batocera/emulators/ikemen/Config.in
+++ b/package/batocera/emulators/ikemen/Config.in
@@ -1,6 +1,13 @@
 config BR2_PACKAGE_IKEMEN
-        bool "ikemen"
-	select BR2_PACKAGE_MESA3D
+    bool "ikemen"
+    depends on BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS
+    depends on BR2_PACKAGE_XORG7
+    select BR2_PACKAGE_MESA3D
+    select BR2_PACKAGE_LIBGTK3
+    select BR2_PACKAGE_OPENAL
+    select BR2_PACKAGE_LIBGLFW
+    help
+        A MUGEN emulator written in GoLang
 
-        help
-          A MUGEN emulator written in GoLang
+comment "ikemen needs a toolchain w/ threads"
+	depends on BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS

--- a/package/batocera/emulators/ikemen/ikemen.keys
+++ b/package/batocera/emulators/ikemen/ikemen.keys
@@ -1,0 +1,177 @@
+{
+    "actions_player1": [
+        {
+            "trigger": [
+                "hotkey",
+                "start"
+            ],
+            "type": "key",
+            "target": [
+                "KEY_LEFTALT",
+                "KEY_F4"
+            ]
+        },
+        {
+            "trigger": "up",
+            "type": "key",
+            "target": "KEY_UP"
+        },
+        {
+            "trigger": "down",
+            "type": "key",
+            "target": "KEY_DOWN"
+        },
+        {
+            "trigger": "left",
+            "type": "key",
+            "target": "KEY_LEFT"
+        },
+        {
+            "trigger": "right",
+            "type": "key",
+            "target": "KEY_RIGHT"
+        },
+        {
+            "trigger": "start",
+            "type": "key",
+            "target": "KEY_ENTER"
+        },
+        {
+            "trigger": "select",
+            "type": "key",
+            "target": "KEY_Q"
+        },
+        {
+            "trigger": "a",
+            "type": "key",
+            "target": "KEY_A"
+        },
+        {
+            "trigger": "b",
+            "type": "key",
+            "target": "KEY_S"
+        },
+        {
+            "trigger": "x",
+            "type": "key",
+            "target": "KEY_D"
+        },
+        {
+            "trigger": "y",
+            "type": "key",
+            "target": "KEY_Z"
+        },
+        {
+            "trigger": "joystick1up",
+            "type": "key",
+            "target": "KEY_UP"
+        },
+        {
+            "trigger": "joystick1down",
+            "type": "key",
+            "target": "KEY_DOWN"
+        },
+        {
+            "trigger": "joystick1left",
+            "type": "key",
+            "target": "KEY_LEFT"
+        },
+        {
+            "trigger": "joystick1right",
+            "type": "key",
+            "target": "KEY_RIGHT"
+        },
+        {
+            "trigger": "pageup",
+            "type": "key",
+            "target": "KEY_X"
+        },
+        {
+            "trigger": "pagedown",
+            "type": "key",
+            "target": "KEY_C"
+        }
+    ],
+    "actions_player2": [
+        {
+            "trigger": "up",
+            "type": "key",
+            "target": "KEY_KP8"
+        },
+        {
+            "trigger": "down",
+            "type": "key",
+            "target": "KEY_KP5"
+        },
+        {
+            "trigger": "left",
+            "type": "key",
+            "target": "KEY_KP4"
+        },
+        {
+            "trigger": "right",
+            "type": "key",
+            "target": "KEY_KP6"
+        },
+        {
+            "trigger": "a",
+            "type": "key",
+            "target": "KEY_P"
+        },
+        {
+            "trigger": "b",
+            "type": "key",
+            "target": "KEY_LEFTBRACE"
+        },
+        {
+            "trigger": "x",
+            "type": "key",
+            "target": "KEY_RIGHTBRACE"
+        },
+        {
+            "trigger": "y",
+            "type": "key",
+            "target": "KEY_SEMICOLON"
+        },
+        {
+            "trigger": "joystick1up",
+            "type": "key",
+            "target": "KEY_KP8"
+        },
+        {
+            "trigger": "joystick1down",
+            "type": "key",
+            "target": "KEY_KP5"
+        },
+        {
+            "trigger": "joystick1left",
+            "type": "key",
+            "target": "KEY_KP4"
+        },
+        {
+            "trigger": "joystick1right",
+            "type": "key",
+            "target": "KEY_KP6"
+        },
+        {
+            "trigger": "pageup",
+            "type": "key",
+            "target": "KEY_APOSTROPHE"
+        },
+        {
+            "trigger": "pagedown",
+            "type": "key",
+            "target": "KEY_BACKSLASH"
+        },
+        {
+            "trigger": "select",
+            "type": "key",
+            "target": "KEY_DOT"
+        },
+        {
+            "trigger": "start",
+            "type": "key",
+            "target": "KEY_SLASH"
+        }
+    ]
+}

--- a/package/batocera/emulators/ikemen/ikemen.mk
+++ b/package/batocera/emulators/ikemen/ikemen.mk
@@ -7,30 +7,30 @@
 IKEMEN_VERSION = f586e49413c26646642dc3b5039478bd764d386a
 IKEMEN_SITE = https://github.com/ikemen-engine/Ikemen-GO
 IKEMEN_LICENSE = MIT
-IKEMEN_DEPENDENCIES = host-go
+IKEMEN_DEPENDENCIES = host-go libgtk3 mesa3d openal libglfw
 
 IKEMEN_SITE_METHOD = git
 IKEMEN_GIT_SUBMODULES = YES
 
-IKEMEN_TARGET_ENV = \
-	GOROOT="$(HOST_GO_ROOT)" \
-	GOPATH="$(HOST_GO_GOPATH)" \
-	PATH=$(BR_PATH) \
-    GOCACHE="$(HOST_GO_TARGET_CACHE)" \
-	GOMODCACHE="$(@D)" \
-	GOFLAGS="-modcacherw" \
+HOST_GO_COMMON_ENV = GOFLAGS=-mod=mod \
+		     GO111MODULE=on \
+		     GOROOT="$(HOST_GO_ROOT)" \
+		     GOPATH="$(HOST_GO_GOPATH)" \
+		     GOCACHE="$(HOST_GO_TARGET_CACHE)" \
+		     GOMODCACHE="$(@D)" \
+		     GOFLAGS="-modcacherw" \
+		     PATH=$(BR_PATH) \
+		     GOBIN= \
+		     CGO_ENABLED=$(HOST_GO_CGO_ENABLED)
 
 define IKEMEN_BUILD_CMDS
-	$(IKEMEN_TARGET_ENV) $(MAKE) \
-		CPP="$(TARGET_CPP)" CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" \
-		AS="$(TARGET_CC)" LD="$(TARGET_LD)" STRIP="$(TARGET_STRIP)" \
-		-C $(@D) -f Makefile Ikemen_GO_Linux
+	$(HOST_GO_TARGET_ENV) $(MAKE) -C $(@D) -f Makefile Ikemen_GO_Linux
 endef
 
 define IKEMEN_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin
-
 	$(INSTALL) -D $(@D)/bin/Ikemen_GO_Linux $(TARGET_DIR)/usr/bin/ikemen
+	# evmapuy
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/ikemen/ikemen.keys $(TARGET_DIR)/usr/share/evmapy
 endef

--- a/package/batocera/emulators/ikemen/ikemen.mk
+++ b/package/batocera/emulators/ikemen/ikemen.mk
@@ -1,0 +1,38 @@
+################################################################################
+#
+# IKEMEN GO
+#
+################################################################################
+# Last commit on Oct 27, 2022
+IKEMEN_VERSION = f586e49413c26646642dc3b5039478bd764d386a
+IKEMEN_SITE = https://github.com/ikemen-engine/Ikemen-GO
+IKEMEN_LICENSE = MIT
+IKEMEN_DEPENDENCIES = host-go
+
+IKEMEN_SITE_METHOD = git
+IKEMEN_GIT_SUBMODULES = YES
+
+IKEMEN_TARGET_ENV = \
+	GOROOT="$(HOST_GO_ROOT)" \
+	GOPATH="$(HOST_GO_GOPATH)" \
+	PATH=$(BR_PATH) \
+    GOCACHE="$(HOST_GO_TARGET_CACHE)" \
+	GOMODCACHE="$(@D)" \
+	GOFLAGS="-modcacherw" \
+
+define IKEMEN_BUILD_CMDS
+	$(IKEMEN_TARGET_ENV) $(MAKE) \
+		CPP="$(TARGET_CPP)" CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" \
+		AS="$(TARGET_CC)" LD="$(TARGET_LD)" STRIP="$(TARGET_STRIP)" \
+		-C $(@D) -f Makefile Ikemen_GO_Linux
+endef
+
+define IKEMEN_INSTALL_TARGET_CMDS
+	mkdir -p $(TARGET_DIR)/usr/bin
+
+	$(INSTALL) -D $(@D)/bin/Ikemen_GO_Linux $(TARGET_DIR)/usr/bin/ikemen
+	mkdir -p $(TARGET_DIR)/usr/share/evmapy
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/ikemen/ikemen.keys $(TARGET_DIR)/usr/share/evmapy
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
Ikemen-Go is an extension to MUGEN, with more capacities (and it's an open-source re-implementation of IKEMEN in Golang). Very active in the fighting community. Installation of the games needs a little bit of work, but worth it.
It can theoretically run on a RPi4, but it needs some work to compile it at the moment. At least we have a first step here.