### PR TITLE
Update xash3d to the latest release

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
@@ -122,7 +122,7 @@ class Xash3dFwgsGenerator(Generator):
             array=commandArray,
             env={
                 'XASH3D_BASEDIR': _ROMS_DIR,
-                'XASH3D_EXTRAS_PAK1': _ROMS_DIR + '/extras.pak',
+                'XASH3D_EXTRAS_PAK1': '/usr/share/xash3d/valve/extras.pk3',
                 'LD_LIBRARY_PATH': '/usr/lib/xash3d',
                 'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
             })

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2216,9 +2216,6 @@ xash3d_fwgs:
     to /userdata/roms/xash3d_fwgs/<game folder> and create an empty `<game folder>.game` file in the same directory.
 
     For Half-Life 1, the game folder is `valve/`.
-
-    Then, download https://github.com/FWGS/xash-extras/releases/latest/download/extras.pak and copy it to:
-    /userdata/roms/xash3d_fwgs/extras.pak.
   comment_br: |
     Engine Half-Life 1.
 
@@ -2234,9 +2231,6 @@ xash3d_fwgs:
     para /userdata/roms/xash3d_fwgs/<pasta do jogo> e crie um arquivo `<pasta do jogo>.game` vazio no mesmo diretório.
 
     Para Half-Life 1, a pasta do jogo é `valve/`.
-
-    Em seguida, baixe https://github.com/FWGS/xash-extras/releases/latest/download/extras.pak e copie para:
-    /userdata/roms/xash3d_fwgs/extras.pak.
 
 wiiu:
   name:       Wii U

--- a/package/batocera/ports/xash3d/hlsdk-xash3d-dmc/hlsdk-xash3d-dmc.hash
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d-dmc/hlsdk-xash3d-dmc.hash
@@ -1,3 +1,3 @@
 # Computed locally
-sha256  bc4f5d78cf4a68e7f4319f93e973e7ca82cdf63b002e52fac6bbda6d0a361488  hlsdk-xash3d-dmc-2c76a059.tar.gz
+sha256  23e4776e5d91478e26b238e2bcc575f63754c41e5102f0135f208d8f9e3a5024  hlsdk-xash3d-dmc-3f87fa33.tar.gz
 sha256  131212c5a670489679af77614fed8089c7ed71ce9ae3aa9333ff7718b643af84  LICENSE

--- a/package/batocera/ports/xash3d/hlsdk-xash3d-dmc/hlsdk-xash3d-dmc.mk
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d-dmc/hlsdk-xash3d-dmc.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-# "dmc" branch
-HLSDK_XASH3D_DMC_VERSION = 2c76a059
+# "dmc" branch on 26 Oct 2022
+HLSDK_XASH3D_DMC_VERSION = 3f87fa33
 HLSDK_XASH3D_DMC_SITE = $(call github,FWGS,hlsdk-xash3d,$(HLSDK_XASH3D_DMC_VERSION))
 HLSDK_XASH3D_DMC_DEPENDENCIES = sdl2 sdl2_mixer sdl2_image sdl2_ttf libsodium
 HLSDK_XASH3D_DMC_LICENSE = Half Life 1 SDK LICENSE

--- a/package/batocera/ports/xash3d/hlsdk-xash3d-opfor/hlsdk-xash3d-opfor.hash
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d-opfor/hlsdk-xash3d-opfor.hash
@@ -1,3 +1,3 @@
 # Computed locally
-sha256  2b5e36ceb2e165f2df02de946c9823375433988ad6a2f93e502fbd259762ccbc  hlsdk-xash3d-opfor-660e21df.tar.gz
+sha256  572e2c8ada3d2b345cf517e4dd32761914772cc0b8d41c2978a02f943c348159  hlsdk-xash3d-opfor-79ff4903.tar.gz
 sha256  131212c5a670489679af77614fed8089c7ed71ce9ae3aa9333ff7718b643af84  LICENSE

--- a/package/batocera/ports/xash3d/hlsdk-xash3d-opfor/hlsdk-xash3d-opfor.mk
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d-opfor/hlsdk-xash3d-opfor.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-# "opfor" branch
-HLSDK_XASH3D_OPFOR_VERSION = 660e21df
+# "opforfixed" branch on 26 Oct 2022
+HLSDK_XASH3D_OPFOR_VERSION = 79ff4903
 HLSDK_XASH3D_OPFOR_SITE = $(call github,FWGS,hlsdk-xash3d,$(HLSDK_XASH3D_OPFOR_VERSION))
 HLSDK_XASH3D_OPFOR_DEPENDENCIES = sdl2 sdl2_mixer sdl2_image sdl2_ttf libsodium
 HLSDK_XASH3D_OPFOR_LICENSE = Half Life 1 SDK LICENSE

--- a/package/batocera/ports/xash3d/hlsdk-xash3d/hlsdk-xash3d.hash
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d/hlsdk-xash3d.hash
@@ -1,3 +1,3 @@
 # Computed locally
-sha256  e4c81eb03983e5ebd88045590f97d5335802fa16790d471ed508222f46dac7cb  hlsdk-xash3d-74f9375f.tar.gz
+sha256  b6e47c134cbdce0e7f83d1bf44c39dd95a5d4a256605e85b58c7ff14ccda9203  hlsdk-xash3d-08cb9e6b.tar.gz
 sha256  131212c5a670489679af77614fed8089c7ed71ce9ae3aa9333ff7718b643af84  LICENSE

--- a/package/batocera/ports/xash3d/hlsdk-xash3d/hlsdk-xash3d.mk
+++ b/package/batocera/ports/xash3d/hlsdk-xash3d/hlsdk-xash3d.mk
@@ -12,13 +12,15 @@
 # List of games that require custom libraries (a few are covered by the `mobile_hacks` branch):
 #
 #   https://github.com/FWGS/xash3d-fwgs/blob/master/Documentation/supported-mod-list.md#list-of-games-and-mods-with-custom-gamedll
-HLSDK_XASH3D_VERSION = 74f9375f
+#
+# "mobile_hacks" branch on 3 Nov 2022
+HLSDK_XASH3D_VERSION = 08cb9e6b
 HLSDK_XASH3D_SITE = $(call github,FWGS,hlsdk-xash3d,$(HLSDK_XASH3D_VERSION))
 HLSDK_XASH3D_DEPENDENCIES = sdl2 sdl2_mixer sdl2_image sdl2_ttf libsodium
 HLSDK_XASH3D_LICENSE = Half Life 1 SDK LICENSE
 HLSDK_XASH3D_LICENSE_FILES = LICENSE
 
-HLSDK_XASH3D_CONF_OPTS = --build-type=release --enable-goldsrc-support
+HLSDK_XASH3D_CONF_OPTS = --build-type=release --enable-simple-mod-hacks
 
 ifeq ($(BR2_ARCH_IS_64),y)
 HLSDK_XASH3D_CONF_OPTS += --64bits

--- a/package/batocera/ports/xash3d/xash3d-fwgs/xash3d-fwgs.hash
+++ b/package/batocera/ports/xash3d/xash3d-fwgs/xash3d-fwgs.hash
@@ -1,3 +1,2 @@
 # Computed locally
-sha256  25d1fcf87d13c700b06821feea1e29925f767bfd038394e97ccf8210422f88e4  xash3d-fwgs-d9ed654-br1.tar.gz
-sha256  7262ea7b5bd7470ad7ec150375bf52eddffbb07e49cc4e233cd27c0980b5d86b  xash3d-fwgs-d9ed654.tar.gz
+sha256  cf4c969d4390ba7e82f239dc8970cc1affbe703e2b8d4a12c2a459e00a100a26  xash3d-fwgs-1064b41-br1.tar.gz

--- a/package/batocera/ports/xash3d/xash3d-fwgs/xash3d-fwgs.mk
+++ b/package/batocera/ports/xash3d/xash3d-fwgs/xash3d-fwgs.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-# Master on 3 Feb 2021.
-XASH3D_FWGS_VERSION = d9ed654
+# Master on 5 Nov 2022.
+XASH3D_FWGS_VERSION = 1064b41
 XASH3D_FWGS_SITE = https://github.com/FWGS/xash3d-fwgs.git
 XASH3D_FWGS_SITE_METHOD = git
 XASH3D_FWGS_GIT_SUBMODULES = yes
@@ -13,6 +13,7 @@ XASH3D_LICENSE = GPL-3.0+
 XASH3D_FWGS_DEPENDENCIES = sdl2 sdl2_mixer sdl2_image sdl2_ttf freetype fontconfig hlsdk-xash3d
 
 XASH3D_FWGS_CONF_OPTS += --build-type=release \
+  --enable-packaging \
   --sdl2=$(STAGING_DIR)/usr/ \
   --disable-vgui \
   --disable-menu-changegame


### PR DESCRIPTION
The new version includes multiple bugfixes

The `extras` package is now built as part of the release and included in the installation.
It is no longer available as a separate download.

This simplifies the installation process but increases the image size by 2.4 MiB.