### PR TITLE
Dockerfile: Install cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN dpkg --add-architecture i386 && \
 		libncurses6:i386 \
 		libstdc++6:i386 \
 		build-essential \
+		cmake \
 		git \
 		libncurses6 \
 		libncurses-dev \


### PR DESCRIPTION
Use system cmake instead of compiling host-cmake
Ubuntu 22.04 has cmake 3.22.1, which is recent enough for everything