### PR TITLE
gzdoom: Fix build

### DIFF
--- a/package/batocera/ports/gzdoom/0002-Add-an-option-to-only-build-the-tools.patch
+++ b/package/batocera/ports/gzdoom/0002-Add-an-option-to-only-build-the-tools.patch
@@ -1,0 +1,206 @@
+From 5663c1b276a69a9a4506013113f7a48f94606bfa Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Mon, 7 Nov 2022 14:32:21 +0000
+Subject: [PATCH] Add an option to only build the tools
+
+This is useful when cross-compiling.
+Rather than building all of gzdoom for host, only configure and build the CROSS_EXPORTS tools.
+---
+ CMakeLists.txt | 139 ++++++++++++++++++++++++++-----------------------
+ 1 file changed, 75 insertions(+), 64 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c0b8ac9df..17407e954 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,6 +19,8 @@ list( APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake )
+ include( FindPackageHandleStandardArgs )
+ 
+ # Support cross compiling
++option(TOOLS_ONLY "Only build the tools, not gzdoom itself (useful for cross-compiling)" OFF)
++
+ option( FORCE_CROSSCOMPILE "Turn on cross compiling." NO )
+ if( FORCE_CROSSCOMPILE )
+ 	set( CMAKE_CROSSCOMPILING TRUE )
+@@ -188,9 +190,11 @@ endmacro()
+ option( NO_OPENAL "Disable OpenAL sound support" OFF )
+ 
+ find_package( BZip2 )
+-find_package( JPEG )
+-find_package( VPX )
+ find_package( ZLIB )
++if(NOT TOOLS_ONLY)
++	find_package( JPEG )
++	find_package( VPX )
++endif()
+ 
+ include( TargetArch )
+ 
+@@ -323,17 +327,6 @@ option(FORCE_INTERNAL_BZIP2 "Use internal bzip2")
+ option(FORCE_INTERNAL_ASMJIT "Use internal asmjit" ON)
+ mark_as_advanced( FORCE_INTERNAL_ASMJIT )
+ 
+-if (HAVE_VULKAN)
+-	add_subdirectory( libraries/glslang/glslang)
+-	add_subdirectory( libraries/glslang/spirv )
+-	add_subdirectory( libraries/glslang/OGLCompilersDLL )
+-endif()
+-
+-add_subdirectory( libraries/discordrpc EXCLUDE_FROM_ALL )
+-set( DRPC_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/discordrpc/include" )
+-set( DRPC_LIBRARIES discord-rpc )
+-set( DRPC_LIBRARY discord-rpc )
+-
+ if( ZLIB_FOUND AND NOT FORCE_INTERNAL_ZLIB )
+ 	message( STATUS "Using system zlib, includes found at ${ZLIB_INCLUDE_DIR}" )
+ else()
+@@ -345,43 +338,6 @@ else()
+ 	set( ZLIB_LIBRARY z )
+ endif()
+ 
+-if( HAVE_VM_JIT AND UNIX )
+-	check_symbol_exists( "backtrace" "execinfo.h" HAVE_BACKTRACE )
+-	if( NOT HAVE_BACKTRACE )
+-		set( CMAKE_REQUIRED_FLAGS "-lexecinfo" )
+-		check_symbol_exists( "backtrace" "execinfo.h" HAVE_LIBEXECINFO )
+-		if( HAVE_LIBEXECINFO )
+-			set( ALL_C_FLAGS "${ALL_C_FLAGS} -lexecinfo" )
+-		else( HAVE_LIBEXECINFO )
+-			set( HAVE_VM_JIT NO )
+-		endif( HAVE_LIBEXECINFO )
+-		set( CMAKE_REQUIRED_FLAGS )
+-	endif( NOT HAVE_BACKTRACE )
+-endif( HAVE_VM_JIT AND UNIX )
+-
+-if( ${HAVE_VM_JIT} )
+-	if( ASMJIT_FOUND AND NOT FORCE_INTERNAL_ASMJIT )
+-		message( STATUS "Using system asmjit, includes found at ${ASMJIT_INCLUDE_DIR}" )
+-	else()
+-		message( STATUS "Using internal asmjit" )
+-		set( SKIP_INSTALL_ALL TRUE ) # Avoid installing asmjit alongside zdoom
+-		add_subdirectory( libraries/asmjit )
+-		set( ASMJIT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libraries/asmjit )
+-		set( ASMJIT_LIBRARIES asmjit )
+-		set( ASMJIT_LIBRARY asmjit )
+-	endif()
+-endif()
+-
+-if( JPEG_FOUND AND NOT FORCE_INTERNAL_JPEG )
+-	message( STATUS "Using system jpeg library, includes found at ${JPEG_INCLUDE_DIR}" )
+-else()
+-	message( STATUS "Using internal jpeg library" )
+-	add_subdirectory( libraries/jpeg )
+-	set( JPEG_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libraries/jpeg )
+-	set( JPEG_LIBRARIES jpeg )
+-	set( JPEG_LIBRARY jpeg )
+-endif()
+-
+ if( BZIP2_FOUND AND NOT FORCE_INTERNAL_BZIP2 )
+ 	message( STATUS "Using system bzip2 library, includes found at ${BZIP2_INCLUDE_DIR}" )
+ else()
+@@ -394,6 +350,56 @@ endif()
+ 
+ set( LZMA_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/lzma/C" )
+ 
++if(NOT TOOLS_ONLY)
++	if (HAVE_VULKAN)
++		add_subdirectory( libraries/glslang/glslang)
++		add_subdirectory( libraries/glslang/spirv )
++		add_subdirectory( libraries/glslang/OGLCompilersDLL )
++	endif()
++
++	add_subdirectory( libraries/discordrpc EXCLUDE_FROM_ALL )
++	set( DRPC_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/discordrpc/include" )
++	set( DRPC_LIBRARIES discord-rpc )
++	set( DRPC_LIBRARY discord-rpc )
++
++	if( HAVE_VM_JIT AND UNIX )
++		check_symbol_exists( "backtrace" "execinfo.h" HAVE_BACKTRACE )
++		if( NOT HAVE_BACKTRACE )
++			set( CMAKE_REQUIRED_FLAGS "-lexecinfo" )
++			check_symbol_exists( "backtrace" "execinfo.h" HAVE_LIBEXECINFO )
++			if( HAVE_LIBEXECINFO )
++				set( ALL_C_FLAGS "${ALL_C_FLAGS} -lexecinfo" )
++			else( HAVE_LIBEXECINFO )
++				set( HAVE_VM_JIT NO )
++			endif( HAVE_LIBEXECINFO )
++			set( CMAKE_REQUIRED_FLAGS )
++		endif( NOT HAVE_BACKTRACE )
++	endif( HAVE_VM_JIT AND UNIX )
++
++	if( ${HAVE_VM_JIT} )
++		if( ASMJIT_FOUND AND NOT FORCE_INTERNAL_ASMJIT )
++			message( STATUS "Using system asmjit, includes found at ${ASMJIT_INCLUDE_DIR}" )
++		else()
++			message( STATUS "Using internal asmjit" )
++			set( SKIP_INSTALL_ALL TRUE ) # Avoid installing asmjit alongside zdoom
++			add_subdirectory( libraries/asmjit )
++			set( ASMJIT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libraries/asmjit )
++			set( ASMJIT_LIBRARIES asmjit )
++			set( ASMJIT_LIBRARY asmjit )
++		endif()
++	endif()
++
++	if( JPEG_FOUND AND NOT FORCE_INTERNAL_JPEG )
++		message( STATUS "Using system jpeg library, includes found at ${JPEG_INCLUDE_DIR}" )
++	else()
++		message( STATUS "Using internal jpeg library" )
++		add_subdirectory( libraries/jpeg )
++		set( JPEG_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libraries/jpeg )
++		set( JPEG_LIBRARIES jpeg )
++		set( JPEG_LIBRARY jpeg )
++	endif()
++endif()
++
+ if( NOT CMAKE_CROSSCOMPILING )
+ 	if( NOT CROSS_EXPORTS )
+ 		set( CROSS_EXPORTS "" )
+@@ -401,26 +407,31 @@ if( NOT CMAKE_CROSSCOMPILING )
+ endif()
+ 
+ # Install the entire docs directory in the distributed zip package
+-if( WIN32 )
+-	set( INSTALL_DOCS_PATH docs CACHE STRING "Directory where the documentation will be placed during install." )
+-else()
+-	set( INSTALL_DOCS_PATH share/doc/${ZDOOM_EXE_NAME} CACHE STRING "Directory where the zdoom documentation will be placed during install." )
++if(NOT TOOLS_ONLY)
++	if( WIN32 )
++		set( INSTALL_DOCS_PATH docs CACHE STRING "Directory where the documentation will be placed during install." )
++	else()
++		set( INSTALL_DOCS_PATH share/doc/${ZDOOM_EXE_NAME} CACHE STRING "Directory where the zdoom documentation will be placed during install." )
++	endif()
++	install(DIRECTORY docs/
++			DESTINATION ${INSTALL_DOCS_PATH}
++			COMPONENT "Documentation")
+ endif()
+-install(DIRECTORY docs/
+-		DESTINATION ${INSTALL_DOCS_PATH}
+-		COMPONENT "Documentation")
+ 
+ option( DYN_OPENAL "Dynamically load OpenAL" ON )
+ 
+ add_subdirectory( libraries/lzma )
+ add_subdirectory( tools )
+-add_subdirectory( libraries/gdtoa )
+-add_subdirectory( wadsrc )
+-add_subdirectory( wadsrc_bm )
+-add_subdirectory( wadsrc_lights )
+-add_subdirectory( wadsrc_extra )
+-add_subdirectory( wadsrc_widepix )
+-add_subdirectory( src )
++
++if(NOT TOOLS_ONLY)
++	add_subdirectory( libraries/gdtoa )
++	add_subdirectory( wadsrc )
++	add_subdirectory( wadsrc_bm )
++	add_subdirectory( wadsrc_lights )
++	add_subdirectory( wadsrc_extra )
++	add_subdirectory( wadsrc_widepix )
++	add_subdirectory( src )
++endif()
+ 
+ if( NOT CMAKE_CROSSCOMPILING )
+ 	export(TARGETS ${CROSS_EXPORTS} FILE "${CMAKE_BINARY_DIR}/ImportExecutables.cmake" )
+-- 
+2.37.2
+

--- a/package/batocera/ports/gzdoom/0003-gdtoa-Fix-cross-compiling.patch
+++ b/package/batocera/ports/gzdoom/0003-gdtoa-Fix-cross-compiling.patch
@@ -1,0 +1,47 @@
+From 3aba32fb28f939d1e568959af8657e7d18e843d3 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Mon, 7 Nov 2022 14:52:36 +0000
+Subject: [PATCH] gdtoa: Fix cross-compiling
+
+When cross-compiling, these headers must be provided as they cannot be
+generated.
+
+Fixes the following error:
+
+> make[4]: *** No rule to make target 'libraries/gdtoa/qnan', needed by 'libraries/gdtoa/gd_qnan.h'.  Stop.
+---
+ libraries/gdtoa/CMakeLists.txt | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/libraries/gdtoa/CMakeLists.txt b/libraries/gdtoa/CMakeLists.txt
+index 834340909..ea3155f9b 100644
+--- a/libraries/gdtoa/CMakeLists.txt
++++ b/libraries/gdtoa/CMakeLists.txt
+@@ -18,18 +18,18 @@ add_definitions( -DINFNAN_CHECK -DMULTIPLE_THREADS )
+ if( NOT MSVC AND NOT APPLE )
+ 	if( NOT CMAKE_CROSSCOMPILING )
+ 		add_executable( arithchk arithchk.c )
++		add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arith.h
++			COMMAND arithchk >${CMAKE_CURRENT_BINARY_DIR}/arith.h
++			DEPENDS arithchk )
+ 	endif()
+-	add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/arith.h 
+-		COMMAND arithchk >${CMAKE_CURRENT_BINARY_DIR}/arith.h
+-		DEPENDS arithchk )
+ 
+ 	if( NOT CMAKE_CROSSCOMPILING )
+ 		add_executable( qnan qnan.c arith.h )
+ 		set( CROSS_EXPORTS ${CROSS_EXPORTS} arithchk qnan PARENT_SCOPE )
++		add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h
++			COMMAND qnan >${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h
++			DEPENDS qnan )
+ 	endif()
+-	add_custom_command( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h
+-		COMMAND qnan >${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h
+-		DEPENDS qnan )
+ 		
+ 	set( GEN_FP_FILES arith.h gd_qnan.h )
+ 	set( GEN_FP_DEPS ${CMAKE_CURRENT_BINARY_DIR}/arith.h ${CMAKE_CURRENT_BINARY_DIR}/gd_qnan.h )
+-- 
+2.37.2
+

--- a/package/batocera/ports/gzdoom/Config.in
+++ b/package/batocera/ports/gzdoom/Config.in
@@ -1,5 +1,6 @@
 config BR2_PACKAGE_GZDOOM
     bool "gzdoom"
+    select BR2_PACKAGE_HOST_GZDOOM
     select BR2_PACKAGE_SDL2
     select BR2_PACKAGE_SDL2_NET
     select BR2_PACKAGE_SDL2_MIXER

--- a/package/batocera/ports/gzdoom/Config.in.host
+++ b/package/batocera/ports/gzdoom/Config.in.host
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_HOST_GZDOOM
+	bool "host gzdoom tools"
+	select BR2_PACKAGE_HOST_ZLIB
+	select BR2_PACKAGE_HOST_BZIP2
+	help
+	  This package is required for building gzdoom.

--- a/package/batocera/ports/gzdoom/arith.h
+++ b/package/batocera/ports/gzdoom/arith.h
@@ -1,0 +1,6 @@
+#define IEEE_8087
+#define Arith_Kind_ASL 1
+#define Long int
+#define Intcast (int)(long)
+#define Double_Align
+#define X64_bit_pointers

--- a/package/batocera/ports/gzdoom/gd_qnan.h
+++ b/package/batocera/ports/gzdoom/gd_qnan.h
@@ -1,0 +1,3 @@
+#define f_QNAN 0x7fc00000
+#define d_QNAN0 0x7ff80000
+#define d_QNAN1 0x0

--- a/package/batocera/ports/gzdoom/gzdoom.mk
+++ b/package/batocera/ports/gzdoom/gzdoom.mk
@@ -8,12 +8,31 @@ GZDOOM_SITE = https://github.com/coelckers/gzdoom.git
 GZDOOM_SITE_METHOD=git
 GZDOOM_GIT_SUBMODULES=YES
 GZDOOM_LICENSE = GPLv3
-GZDOOM_DEPENDENCIES = sdl2 bzip2 fluidsynth libgtk3 openal mesa3d libglu libglew zmusic
+GZDOOM_DEPENDENCIES = host-gzdoom sdl2 bzip2 fluidsynth libgtk3 openal mesa3d libglu libglew zmusic
 GZDOOM_SUPPORTS_IN_SOURCE_BUILD = NO
 
+# We need the tools from the host package to build the target package
+HOST_GZDOOM_DEPENDENCIES = zlib bzip2
+HOST_GZDOOM_CONF_OPTS += -DTOOLS_ONLY=ON -DSKIP_INSTALL_ALL=ON -DCMAKE_BUILD_TYPE=Release
+HOST_GZDOOM_SUPPORTS_IN_SOURCE_BUILD = NO
+
+define HOST_GZDOOM_INSTALL_CMDS
+	# Skipping install, the tools are used directly via `ImportExecutables.cmake` from the build directory.
+endef
+
 GZDOOM_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
-GZDOOM_CONF_OPTS += -DCMAKE_CROSSCOMPILING=FALSE
+GZDOOM_CONF_OPTS += -DFORCE_CROSSCOMPILE=ON
 GZDOOM_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
+GZDOOM_CONF_OPTS += -DIMPORT_EXECUTABLES="$(HOST_GZDOOM_BUILDDIR)/ImportExecutables.cmake"
+
+# Copy the headers that are usually generated on the target machine
+# but must be provided when cross-compiling.
+define GZDOOM_COPY_GENERATED_HEADERS
+	mkdir -p $(GZDOOM_BUILDDIR)/libraries/gdtoa/
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/ports/gzdoom/*.h $(GZDOOM_BUILDDIR)/libraries/gdtoa/
+endef
+
+GZDOOM_PRE_CONFIGURE_HOOKS += GZDOOM_COPY_GENERATED_HEADERS
 
 ifeq ($(BR2_PACKAGE_VULKAN_HEADERS)$(BR2_PACKAGE_VULKAN_LOADER),yy)
     GZDOOM_CONF_OPTS += -DHAVE_VULKAN=ON
@@ -38,3 +57,4 @@ define GZDOOM_INSTALL_TARGET_CMDS
 endef
 
 $(eval $(cmake-package))
+$(eval $(host-cmake-package))


### PR DESCRIPTION
gzdoom compilation requires some host tools and generated headers. Build the host tools first, and provide generated headers.

The headers were generated on an x86_64 machine which is OK for now as gzdoom is currently set to `BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY`.

Support for other architectures can be added by generating the appropriate headers on the target machine:

```bash
cmake -S. -Bbuild && cmake --build build -j $(nproc) && find build/deps -iname '*.h'
```

I've sent the cross-compiling patches upstream:

1. https://github.com/ZDoom/gzdoom/pull/1794
2. https://github.com/ZDoom/gzdoom/pull/1795

This is similar to the fix for ecwolf at https://github.com/batocera-linux/batocera.linux/pull/7446