### PR TITLE
Bump rclone

### DIFF
--- a/package/batocera/utils/rclone/rclone.mk
+++ b/package/batocera/utils/rclone/rclone.mk
@@ -4,10 +4,11 @@
 #
 ################################################################################
 
-RCLONE_VERSION = v1.59.2
+# 21 Oct 2022
+RCLONE_VERSION = v1.60.0
 RCLONE_SITE = $(call github,rclone,rclone,$(RCLONE_VERSION))
 RCLONE_LICENSE = GPLv2
-RCLONE_DEPENDENCIES = 
+RCLONE_DEPENDENCIES =
 
 define RCLONE_BUILD_CMDS
 	cd $(@D) && $(HOST_GO_TARGET_ENV) $(GO_BIN) build


### PR DESCRIPTION
Previous version no longer builds due to some dependencies having moved to new URLs.