### PR TITLE
batocera-settings-get-master: cleanup

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings-get-master
+++ b/package/batocera/core/batocera-settings/batocera-settings-get-master
@@ -1,41 +1,39 @@
-#!/bin/bash
+#!/bin/sh
 
 # this script can be used by values that can have a default value by board
 
-KEY=$1
+KEY="$1"
 
 # prefer the user value
-VALUE=$(batocera-settings-get "${KEY}")
+VALUE="$(/usr/bin/batocera-settings-get "${KEY}")"
 # when value is auto, ignore
-if test "$?" = 0 -a "${VALUE}" != "auto"
-then
+if [ "$?" = 0 -a "${VALUE}" != "auto" ]; then
     echo "${VALUE}"
     exit 0
 fi
 
-BOARD_MODEL=$(cat /sys/firmware/devicetree/base/model 2>/dev/null | sed -e s+"[^A-Za-z0-9]"+"_"+g)
-if test -z "${BOARD_MODEL}"
-then
-    # give an other chance with dmi
-    BOARD_MODEL=$(cat /sys/devices/virtual/dmi/id/board_name 2>/dev/null | sed -e s+"[^A-Za-z0-9]"+"_"+g)
+if [ -f /sys/firmware/devicetree/base/model ]; then
+    IFS= read -r BOARD_MODEL </sys/firmware/devicetree/base/model
 fi
+if [ -z "${BOARD_MODEL}" -a -f /sys/devices/virtual/dmi/id/board_name ]; then
+    # give an other chance with dmi
+    IFS= read -r BOARD_MODEL </sys/devices/virtual/dmi/id/board_name
+fi
+BOARD_MODEL="$(echo "$BOARD_MODEL" | sed -e s+"[^A-Za-z0-9]"+"_"+g)"
 
 # prefer the board value
-if test -e "/usr/share/batocera/sysconfigs/batocera.conf.${BOARD_MODEL}"
-then
-    VALUE=$(batocera-settings-get -f "/usr/share/batocera/sysconfigs/batocera.conf.${BOARD_MODEL}" "${KEY}")
+if [ -e "/usr/share/batocera/sysconfigs/batocera.conf.${BOARD_MODEL}" ]; then
+    VALUE="$(/usr/bin/batocera-settings-get -f "/usr/share/batocera/sysconfigs/batocera.conf.${BOARD_MODEL}" "${KEY}")"
     # when value is auto, ignore
-    if test "$?" = 0 -a "${VALUE}" != "auto"
-    then
-	echo "${VALUE}"
-	exit 0
+    if [ "$?" = 0 -a "${VALUE}" != "auto" ]; then
+        echo "${VALUE}"
+        exit 0
     fi
 fi
 
 # prefer the general value
-if test -e "/usr/share/batocera/sysconfigs/batocera.conf"
-then
-    batocera-settings-get -f "/usr/share/batocera/sysconfigs/batocera.conf" "${KEY}" && exit 0
+if [ -e "/usr/share/batocera/sysconfigs/batocera.conf" ]; then
+    /usr/bin/batocera-settings-get -f "/usr/share/batocera/sysconfigs/batocera.conf" "${KEY}" && exit 0
 fi
 
 exit 1


### PR DESCRIPTION
1. Fixes warning:

       /usr/bin/batocera-settings-get-master: line 16: warning: command substitution: ignored null byte in input

2. Fixes `board_name` fallback (the `-z` condition was reversed).

3. Removes bashisms, runs with `sh`, makes the style more consistent with other scripts.