### PR TITLE
MAME Macintosh BIOS Update

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -377,6 +377,8 @@ systems = {
                                                   { "md5": "96665499f5cf2bb5b4aae6fdaf0a9fb5", "zippedFile": "341s0850.bin", "file": "bios/egret.zip", "emulator": "libretro", "core": "mame" },
                                                   { "md5": "b955ecbdf6d2f979f3683dd1d6884643", "zippedFile": "341s0851.bin", "file": "bios/egret.zip", "emulator": "libretro", "core": "mame" },
                                                   { "md5": "5035d321c5d5fa1eab5ce6bf986676e4", "zippedFile": "344s0100.bin", "file": "bios/egret.zip", "emulator": "libretro", "core": "mame" },
+                                                  { "md5": "", "file": "bios/adbmodem.zip", "emulator": "libretro", "core": "mame" },
+                                                  { "md5": "862b8598cecdbc934658c4cb599a8142", "zippedFile": "342s0440-b.bin", "file": "bios/adbmodem.zip", "emulator": "libretro", "core": "mame" },
                                                   { "md5": "", "file": "bios/macos3.img", "emulator": "libretro", "core": "mame" },
                                                   { "md5": "", "file": "bios/macos608.img", "emulator": "libretro", "core": "mame" },
                                                   { "md5": "", "file": "bios/macos701.img", "emulator": "libretro", "core": "mame" },


### PR DESCRIPTION
It appears that MAME now requires the ADB Modem BIOS for Mac emulation, I added it to batocera-systems.