### PR TITLE
Dolphin GBA Path Fix

### DIFF
--- a/package/batocera/emulators/dolphin-emu/011-gba-path-fix.patch
+++ b/package/batocera/emulators/dolphin-emu/011-gba-path-fix.patch
@@ -1,0 +1,14 @@
+--- a/Source/Core/Common/FileUtil.cpp	2022-12-01 17:37:53.440262785 -0500
++++ b/Source/Core/Common/FileUtil.cpp	2022-10-22 06:37:27.000000000 -0400
+@@ -1004,8 +1004,8 @@
+         s_user_paths[D_MEMORYWATCHER_IDX] + MEMORYWATCHER_SOCKET;
+ 
+     s_user_paths[D_GBAUSER_IDX] = s_user_paths[D_USER_IDX] + GBA_USER_DIR DIR_SEP;
+-    s_user_paths[D_GBASAVES_IDX] = s_user_paths[D_GBAUSER_IDX] + GBASAVES_DIR DIR_SEP;
+-    s_user_paths[F_GBABIOS_IDX] = s_user_paths[D_GBAUSER_IDX] + GBA_BIOS;
++    s_user_paths[D_GBASAVES_IDX] = "/var/run/dolphin-gba/";
++    s_user_paths[F_GBABIOS_IDX] = "/userdata/bios/gba_bios.bin";
+
+ 
+     // The shader cache has moved to the cache directory, so remove the old one.
+     // TODO: remove that someday.


### PR DESCRIPTION
Apparently, Dolphin ignores the GBA BIOS and Save path options - you can test it by opening Dolphin-config, changing them, then exiting and re-opening. It will update Dolphin.ini, but apparently never reads it and will always use the defaults.

I missed this during initial testing because I had files there from some early tests, so everything worked as expected.

This patch sets the defaults to Batocera's BIOS file (shared with GBA) and temporary save path (for symlinking existing saves). Tested after deleting /userdata/saves/dolphin-emu/GBA, and everything worked.