### PR TITLE
Alt-Tab Enhancement & Message Functionality

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-ratpoison
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-ratpoison
@@ -22,6 +22,13 @@ def redrawWindow():
 	runRatpoisonCommand('only')
 	runRatpoisonCommand('redisplay')
 
+def altTab():
+	runRatpoisonCommand('next')
+	showMessage(getRatpoisonCommand('windows %s %n:%t (%a)'))
+
+def showMessage(message):
+	runRatpoisonCommand(f'echo {message}')
+
 def runRatpoisonCommand(command):
 	print(f'Running ratpoison command {command}')
 	try:
@@ -37,7 +44,7 @@ def getRatpoisonCommand(command):
 	except:
 		return False
 	print(f'Ratpoison Output = {tempVar}')
-	return tempVar
+	return tempVar.strip()
 
 if __name__ == '__main__':
 	if len(sys.argv) == 1:
@@ -46,4 +53,7 @@ if __name__ == '__main__':
 		clearHooks()
 		restoreFrameset()
 		redrawWindow()
-
+	elif sys.argv[1] == 'switchapp':
+		altTab()
+	elif sys.argv[1] == 'message':
+		showMessage(sys.argv[2])

--- a/package/batocera/emulationstation/batocera-emulationstation/ratpoisonrc
+++ b/package/batocera/emulationstation/batocera-emulationstation/ratpoisonrc
@@ -5,9 +5,9 @@ set msgwait 2
 set wingravity c
 set maxsizegravity c
 set transgravity c
-set bargravity s
-set winname name
-definekey top M-Tab next
+set bargravity c
+set winname title
+definekey top M-Tab exec batocera-ratpoison switchapp
 definekey top M-F4 delete
 definekey top C-M-Tab swap 0 1
 banish


### PR DESCRIPTION
batocera-ratpoison script and default keybind/ratpoison settings changes so that alt-tab will now show a window list for a couple of seconds when pressed. The list will be in the format `Window Number: Title (Process Name)` with the currently focused window indicated with a *.

In addition, `batocera-ratpoison message` can be used to display a pop-up message on screen via ratpoison, should we need to do so in any other scripts (warnings, errors, status messages, etc). The message should be in quotes - ie `batocera-ratpoison message "Hello, World!"`