### PR TITLE
Dolphin GBA Screen Swap Hotkey

### DIFF
--- a/package/batocera/emulators/dolphin-emu/gamecube.dolphin.keys
+++ b/package/batocera/emulators/dolphin-emu/gamecube.dolphin.keys
@@ -5,6 +5,12 @@
             "type": "key",
             "target": ["KEY_LEFTALT", "KEY_F4"],
             "description": "Exit emulator"
+    },
+    {
+        "trigger": ["hotkey", "r2"],
+         "type": "key",
+         "target": ["KEY_LEFTALT", "KEY_LEFTCTRL", "KEY_TAB"],
+         "description": "Swap GBA and GC frames"
     }
     ]
 }


### PR DESCRIPTION
Swap GBA & GC screens - useful for games that download demos & other software to the GBA. USes the same hotkey+r2 that Cemu does.