### PR TITLE
e-Reader File Select Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -237,7 +237,8 @@ def setupRatpoisonFrames(orientation, splitSize, subCount, reverseScreens):
     splitFrames[currentFrame] = f"(frame :number {currentFrame} :x {screenRes['width'] + 1} :y {screenRes['height'] + 1} :width 1 :height 1 :screenw {screenRes['width']} :screenh {screenRes['height']} :window 0 :last-access {currentFrame} :dedicated 0)"
     newFrameset = ",".join(splitFrames)
 
-    ratpoisonCommands += [ f'setenv frameset {getFrameset()}', 'unmanage emulationstation', 'addhook deletewindow exec batocera-ratpoison reset' ]
+    ratpoisonCommands += [ f'setenv frameset {getFrameset()}', 'unmanage emulationstation', \
+        'addhook deletewindow exec batocera-ratpoison reset', 'set winname title', 'unmanage Select e-Reader Cards' ]
     if reverseScreens:
         ratpoisonCommands += [ 'addhook newwindow focusprev' ]
     else:


### PR DESCRIPTION
The e-Card file selection box was taking over the Dolphin frame as a white screen. This change will unmanage that particular window, allowing it to appear normally.

Note that the `set winname title` command shouldn't be 100% necessary since a previous PR makes that the default, but that will reset it should somebody change it, and make sure the correct window behavior happens.