### PR TITLE
Fix Windows "hardware" Tag

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2157,7 +2157,7 @@ windows:
   name:       Windows
   manufacturer: Microsoft
   release: 1992
-  hardware: pc
+  hardware: computer
   extensions: [pc, exe, wine, wsquashfs, wtgz]
   platform:   pc
   theme:      windows
@@ -2176,7 +2176,7 @@ windows_installers:
   name:       Install a new Windows game
   manufacturer: Microsoft
   release: 1992
-  hardware: pc
+  hardware: computer
   extensions: [exe, iso]
   platform:   pc
   group:      windows


### PR DESCRIPTION
The Windows and Windows Installer systems are tagged as "pc" rather than "computer." This causes it to show up in the wrong place in the "sort by type" and recently added "sort by manufacturer and type" lists.

These were also the only two platforms with that tag, every other computer is tagged as "computer."