### PR TITLE
Fixed rumble value for disabling with latest RetroArch update

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -211,7 +211,7 @@ shared:
       prompt:      RUMBLE LEVEL
       description: For emulators and controllers supporting force feedback.
       choices:
-        "disabled": 0
+        "disabled": 1
         "20%": 20
         "40%": 40
         "60%": 60


### PR DESCRIPTION
Tested on lr-flycast x86_64 and rg552