### PR TITLE
allow loading xbla digital titles from ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -35,7 +35,7 @@ class XeniaGenerator(Generator):
             shutil.copytree("/usr/xenia", emupath, dirs_exist_ok=True)
         if not filecmp.cmp("/usr/xenia-canary/xenia_canary.exe", canarypath + "/xenia_canary.exe"):
             shutil.copytree("/usr/xenia-canary", canarypath, dirs_exist_ok=True)
-        
+
         # create portable txt file to try & stop file spam
         if not os.path.exists(emupath + "/portable.txt"):
             with open(emupath + "/portable.txt", "w") as fp:
@@ -58,7 +58,25 @@ class XeniaGenerator(Generator):
             eslog.error(err.decode())
             with open(wineprefix + "/vcrun2019.done", "w") as f:
                 f.write("done")
-     
+
+        # are we loading a digital title?
+        if os.path.splitext(rom)[1] == ".xbla":
+            eslog.debug(f"Found .xbla playlist: {rom}")
+            pathLead = os.path.dirname(rom)
+            openFile = open(rom, 'r')
+            # Read only the first line of the file.
+            firstLine = openFile.readlines(1)[0]
+            # Strip of any new line characters.
+            firstLine = firstLine.strip('\n').strip('\r')
+            eslog.debug(f"Checking if specified XBLA file actually exists...")
+            xblaFullPath = pathLead + "/" + firstLine
+            if os.path.exists(xblaFullPath):
+                eslog.debug(f"Found! Switching active rom to: {firstLine}")
+                rom = xblaFullPath
+            else:
+                eslog.error(f"XBLA title {firstLine} from {rom} not found, check path or filename.")
+            openFile.close()
+
         # now setup the command array for the emulator
         if rom == 'config':
             if core == 'xenia-canary':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -60,21 +60,21 @@ class XeniaGenerator(Generator):
                 f.write("done")
 
         # are we loading a digital title?
-        if os.path.splitext(rom)[1] == ".xbla":
-            eslog.debug(f"Found .xbla playlist: {rom}")
+        if os.path.splitext(rom)[1] == ".xbox360":
+            eslog.debug(f"Found .xbox360 playlist: {rom}")
             pathLead = os.path.dirname(rom)
             openFile = open(rom, 'r')
             # Read only the first line of the file.
             firstLine = openFile.readlines(1)[0]
             # Strip of any new line characters.
             firstLine = firstLine.strip('\n').strip('\r')
-            eslog.debug(f"Checking if specified XBLA file actually exists...")
+            eslog.debug(f"Checking if specified disc installation/XBLA file actually exists...")
             xblaFullPath = pathLead + "/" + firstLine
             if os.path.exists(xblaFullPath):
                 eslog.debug(f"Found! Switching active rom to: {firstLine}")
                 rom = xblaFullPath
             else:
-                eslog.error(f"XBLA title {firstLine} from {rom} not found, check path or filename.")
+                eslog.error(f"Disc installation/XBLA title {firstLine} from {rom} not found, check path or filename.")
             openFile.close()
 
         # now setup the command array for the emulator

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3946,7 +3946,7 @@ xbox360:
   manufacturer: Microsoft
   release: 2005
   hardware: console
-  extensions: [iso, xex, xbla]
+  extensions: [iso, xex, xbox360]
   emulators:
     xenia:
       xenia: { requireAnyOf: [BR2_PACKAGE_XENIA] }

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3946,7 +3946,7 @@ xbox360:
   manufacturer: Microsoft
   release: 2005
   hardware: console
-  extensions: [iso, xex]
+  extensions: [iso, xex, xbla]
   emulators:
     xenia:
       xenia: { requireAnyOf: [BR2_PACKAGE_XENIA] }


### PR DESCRIPTION
Add a text file containing the filename of the xbla file desired to be loaded. Name the text file "name of game.xbla" (edit: now .xbox360, check commit notes). ES will recognise and boot it in Xenia, very nice.

Might add the ability to define absolute paths later if I feel like it. Going to let it simmer for a bit in case there's any feedback first.