### PR TITLE
guncon2 driver and calibration

### DIFF
--- a/package/batocera/controllers/guncon/guncon.mk
+++ b/package/batocera/controllers/guncon/guncon.mk
@@ -3,12 +3,14 @@
 # guncon
 #
 ################################################################################
-GUNCON_VERSION = e50b612d7c77879fb3df9402a3eaa88a5526fe3f
-GUNCON_SITE = $(call github,beardypig,guncon2,$(GUNCON_VERSION))
+GUNCON_VERSION = b73e65b537da3ffa68d8aebe6fbd10830930cc16
+GUNCON_SITE = $(call github,Redemp,guncon2,$(GUNCON_VERSION))
 
 define GUNCON_INSTALL_TARGET_CMDS
-	$(INSTALL) -m 0644 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guncon/99-guncon.rules $(TARGET_DIR)/etc/udev/rules.d/99-guncon.rules
-	$(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guncon/guncon-add      $(TARGET_DIR)/usr/bin/guncon-add
+    $(INSTALL) -m 0644 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guncon/99-guncon.rules $(TARGET_DIR)/etc/udev/rules.d/99-guncon.rules
+    $(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guncon/guncon-add      $(TARGET_DIR)/usr/bin/guncon-add
+    $(INSTALL) -D -m 0755 $(@D)/guncon2_calibrate.sh $(TARGET_DIR)/usr/bin/guncon2_calibrate.sh
+    $(INSTALL) -D -m 0755 $(@D)/calibrate.py $(TARGET_DIR)/usr/bin/calibrate.py
 endef
 
 


### PR DESCRIPTION
My repository has then the following changes

Substring:
Allow side buttons to quit the calibration app
Better screen resolution handling
Use the guncon DPAD to calibrate the cross-hair

homefefeld: 
smooth controls : holding down an arrow on the dpad to control the hair cross

Redemp (Rion):
Remove double button press when C is pressed.
guncon2_calibrate.sh (For Batocera)
Disable Trigger (So not to mess up the calibration by accident) Thank you Lbrpdx 

For v36