### PR TITLE
thickens white border for Sinden (Daphne)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
@@ -91,11 +91,11 @@ class DaphneGenerator(Generator):
             bordersSize = controllersConfig.gunsBordersSizeName(guns, system.config)
             if bordersSize is not None:
                 if bordersSize == "thin":
-                    commandArray.extend(["-sinden", "1", "w"])
-                elif bordersSize == "medium":
-                    commandArray.extend(["-sinden", "2", "w"])
-                else:
                     commandArray.extend(["-sinden", "3", "w"])
+                elif bordersSize == "medium":
+                    commandArray.extend(["-sinden", "6", "w"])
+                else:
+                    commandArray.extend(["-sinden", "9", "w"])
             else:
                 if len(guns) > 0: # enable manymouse for guns
                     commandArray.extend(["-manymouse"]) # sinden implies manymouse


### PR DESCRIPTION
it's too small. 1 to 3 are very thin border for Sinden Lightgun (it can go from 1 to 10). Current values of the camera are not good enough to track correctly the screen. 2 should be the bare minimum for thin, but I suggest 3. 6 for medium. 9 for big (auto). I've tried tweaking the camera, but 1 is too thin. Some games have very bright white lines and it messes with the tracking. Colors will be required to add afterwards for those specific scenes for some games with very dark or bright colors. Having a contrasted color will help further.