### PR TITLE
Update batocera-format

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-format
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-format
@@ -130,17 +130,20 @@ do_format() {
 	echo "created partition not found for ${FORMATDISK}" >&2
 	return 1
     fi
-
+    
+    nr=$(blkid | grep "SHARE" | wc -l); nr=$(($nr + 1)); SHAREnr=SHARE$nr;
+    if [[ "$nr" -le "1" ]]; then SHAREnr=SHARE; fi
+    if [[ "$(blkid | grep \"SHARE\")" = "" ]]; then SHAREnr=SHARE; fi
     echo "formatting partition ${FORMATPARTNAME} in ${FORMATTYPE}"
     case "${FORMATTYPE}" in
 	"btrfs")
-	    mkfs.btrfs -L SHARE "${FORMATPARTNAME}" || return 1
+	    mkfs.btrfs -L $SHAREnr "${FORMATPARTNAME}" || return 1
 	;;
 	"ext4")
-	    mkfs.ext4 -L SHARE "${FORMATPARTNAME}" || return 1
+	    mkfs.ext4 -L $SHAREnr "${FORMATPARTNAME}" || return 1
 	;;
 	"exfat")
-	    mkfs.exfat -n SHARE "${FORMATPARTNAME}" || return 1
+	    mkfs.exfat -n $SHAREnr "${FORMATPARTNAME}" || return 1
 	;;
 	*)
 	    echo "unknown partition type ${FORMATTYPE}" >&2


### PR DESCRIPTION
+ create dynamic-numbered disk labels for each additional drive being formatted; 

current behaviour, each drive becomes: SHARE, SHARE, SHARE, SHARE, SHARE... new behaviour: SHARE, SHARE2, SHARE3, etc 

reason: clarity + specifically: current behaviour makes additional disks >2 unmountable/inaccesible unless the labels are manually changed after formatting