### PR TITLE
Added Sinden border color options to daphne (singe) gun games

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
@@ -90,12 +90,18 @@ class DaphneGenerator(Generator):
 
             bordersSize = controllersConfig.gunsBordersSizeName(guns, system.config)
             if bordersSize is not None:
-                if bordersSize == "thin":
-                    commandArray.extend(["-sinden", "3", "w"])
-                elif bordersSize == "medium":
-                    commandArray.extend(["-sinden", "6", "w"])
+
+                if system.isOptSet('border_color'):
+                    borderColor = system.config['border_color']
                 else:
-                    commandArray.extend(["-sinden", "9", "w"])
+                    borderColor = "w"
+
+                if bordersSize == "thin":
+                    commandArray.extend(["-sinden", "2", borderColor])
+                elif bordersSize == "medium":
+                    commandArray.extend(["-sinden", "4", borderColor])
+                else:
+                    commandArray.extend(["-sinden", "6", borderColor])
             else:
                 if len(guns) > 0: # enable manymouse for guns
                     commandArray.extend(["-manymouse"]) # sinden implies manymouse
@@ -105,11 +111,11 @@ class DaphneGenerator(Generator):
 
             # Overlay sizes (Singe) for HD lightgun and Singe 2 games
             if system.isOptSet('overlay_size') and system.config['overlay_size'] == 'oversize':
-                commandArray.append("-set_overlay", "oversize")
+                commandArray.extend(["-set_overlay", "oversize"])
             elif system.isOptSet('overlay_size') and system.config['overlay_size'] == 'full':
-                commandArray.append("-set_overlay", "full")
+                commandArray.extend(["-set_overlay", "full"])
             elif system.isOptSet('overlay_size') and system.config['overlay_size'] == 'half':
-                commandArray.append("-set_overlay", "half")
+                commandArray.extend(["-set_overlay", "half"])
             
             # crosshair
             if system.isOptSet('daphne_crosshair'):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6036,6 +6036,15 @@ daphne:
                 "HD Gun Games":  oversize
                 "Singe 2 Full":  full
                 "Singe 2 Half":  half
+        border_color:
+            group: LIGHT GUN
+            prompt:      SINDEN BORDER COLORS (SINGE)
+            description: Change Sinden border color.
+            choices:
+                "White": w
+                "Red":   r
+                "Green": g
+                "Blue":  b
         abs_mouse_input:
             group: ADVANCED OPTIONS
             prompt:      ABSOLUTE MOUSE INPUT


### PR DESCRIPTION
  - Also fixes a previous commandArray.append() commandArray.extend() mixup in https://github.com/batocera-linux/batocera.linux/commit/e2206bb03a117c7719fb90af1f910f5952af3c80

This will update a recent commit by @Tovarichtch (https://github.com/batocera-linux/batocera.linux/commit/1ffb85b405c6e64257b8ee3b09808fcafab4e3bd)

Border widths have been optimised for both SD and HD video resolutions.