### PR TITLE
Tweaking Sinden Lightgun settings to recommended

### DIFF
--- a/package/batocera/controllers/sinden-guns/LightgunMono.exe.config.template
+++ b/package/batocera/controllers/sinden-guns/LightgunMono.exe.config.template
@@ -16,11 +16,11 @@
     <add key="CameraRes" value="640,480" />
     <add key="SaveEachFrameToFile" value="0" />
     <add key="OffscreenReload" value="0" />
-    <add key="CameraExposureAuto" value="1" />
-    <add key="CameraExposure" value="" />
-    <add key="CameraBrightness" value="100" />
+    <add key="CameraExposureAuto" value="" />
+    <add key="CameraExposure" value="-7" />
+    <add key="CameraBrightness" value="120" />
     <add key="CameraZoom" value="0" />
-    <add key="CameraContrast" value="50" />
+    <add key="CameraContrast" value="60" />
     <add key="CameraSaturation" value="40" />
     <add key="CameraHue" value="0" />
     <add key="CameraWhiteBalanceAuto" value="0" />


### PR DESCRIPTION
Default should be Exposure -7, Contrast 100, Brightness 50. ExposureAuto is very bad when light in gun games fluctuates. Sinden Lightgun community and testers recommend Exposure set to -7, Contrast to 120 and Brightness to 60 as a starting point. I've tested countless and it works best for thinner borders with high light. Camera is losing track with current values, sadly.