### PR TITLE
Set SDL_GAMECONTROLLERCONFIG when launching ports

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -2,6 +2,7 @@
 
 from generators.Generator import Generator
 import Command
+import controllersConfig
 import glob
 
 class ShGenerator(Generator):
@@ -16,7 +17,9 @@ class ShGenerator(Generator):
             shrom = rom
 
         commandArray = ["/bin/bash", shrom]
-        return Command.Command(array=commandArray)
+        return Command.Command(array=commandArray,env={
+            "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)
+        })
 
     def getMouseMode(self, config):
         return True


### PR DESCRIPTION
Most Linux ports are written in SDL, therefore it is extremely useful to export the (known working) controller mappings as it is done for other systems. This is invaluable for older binaries with their own copy of SDL and controller mappings, as they won't work out-of-the-box with new controllers and/or kernel drivers.

This does not have any impact on non-SDL ports.