### PR TITLE
xterm.desktop  >  add scrollbar & UTF-8 support

### DIFF
--- a/package/batocera/core/batocera-desktopapps/apps/xterm.desktop
+++ b/package/batocera/core/batocera-desktopapps/apps/xterm.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Icon=xterm-color_48x48
-Exec=xterm -bg black -fg white -fa Monospace -fs 14 -e bash -c "cd ~/; PS1='[\u@\h \$PWD]# ' /bin/bash"
+Exec=xterm -fs 14 -fg white -bg black -fa "Monospace" -en UTF-8 -sb -rightbar -e bash -c "cd ~/; PS1='[\u@\h \$PWD]# ' /bin/bash"
 Terminal=false
 Type=Application
 Categories=System;batocera.linux;


### PR DESCRIPTION
UTF-8 is needed for special/extended characters (without it it's just jibberish), scrollbar increases ux/legibility (reviewing history)