### PR TITLE
Bump switchres

### DIFF
--- a/package/batocera/utils/switchres/switchres.mk
+++ b/package/batocera/utils/switchres/switchres.mk
@@ -3,8 +3,8 @@
 # SwitchRes
 #
 ################################################################################
-# Version: Commits on Sep 25, 2022
-SWITCHRES_VERSION = 66c09e68d0dcad5cc397f886fef3a7f3b6276cf9
+# Version: Commits on Jan 10, 2023
+SWITCHRES_VERSION = f5b7bdec66b71c69a3465088cbf43b699e32cc1d
 SWITCHRES_SITE = $(call github,antonioginer,switchres,$(SWITCHRES_VERSION))
 
 SWITCHRES_DEPENDENCIES = libdrm


### PR DESCRIPTION
There are a few noticeable changes since last bump.

 - Correctly store desktop rotation in linux and sdl display backends.
 - -g, --geometry <h_size>:<h_shift>:<v_shift>  Adjust geometry of generated modeline
 - Increase h_size range maximum to 2.0