### PR TITLE
Makefile enhancement to expose buildroot show-build-order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,19 @@ dl-dir:
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot source
 
+%-show-build-order: batocera-docker-image %-config ccache-dir dl-dir
+	@$(DOCKER) run -t --init --rm \
+		-v $(PROJECT_DIR):/build \
+		-v $(DL_DIR):/build/buildroot/dl \
+		-v $(OUTPUT_DIR)/$*:/$* \
+		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
+		-u $(UID):$(GID) \
+		-v /etc/passwd:/etc/passwd:ro \
+		-v /etc/group:/etc/group:ro \
+		$(DOCKER_OPTS) \
+		$(DOCKER_REPO)/$(IMAGE_NAME) \
+		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot show-build-order
+
 %-kernel: batocera-docker-image %-config ccache-dir dl-dir
 	@$(DOCKER) run -t --init --rm \
 		-v $(PROJECT_DIR):/build \


### PR DESCRIPTION
Example usage:

Count the number of packages to be built:

```
$ make rk3399-show-build-order | grep -v ' ' | grep -v \# | wc -l
642
```