### PR TITLE
Fixing copyright of the RG552, I wrote this DTS.

### DIFF
--- a/board/batocera/rockchip/rk3399/dts/rk3399-anbernic-rg552.dts
+++ b/board/batocera/rockchip/rk3399/dts/rk3399-anbernic-rg552.dts
@@ -3,6 +3,7 @@
  * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd.
  * Copyright (c) 2018 Akash Gajjar <Akash_Gajjar@mentor.com>
  * Copyright (c) 2022 Maya Matuszczyk <maccraft123mc@gmail.com>
+ * Copyright (C) 2022 BrooksyTech (https://github.com/brooksytech)
  */
 
 


### PR DESCRIPTION
You need to give me proper credit of this DTS. I forked this from maccraft12 and spent nearly 100 hours getting it to boot on the 552 for JELOS. Its fine if you use but when you copied the patch from Jelos and made your changes you never thanked me or gave me credit. 

https://github.com/brooksytech/rk3399-kernel-5.19/blob/main/arch/arm64/boot/dts/rockchip/rk3399-rg552-linux.dts

https://github.com/brooksytech/rk3399-kernel-5.19

Thank you.