### PR TITLE
emulators/cemu: fix path for keys.txt

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -52,10 +52,7 @@ class CemuGenerator(Generator):
 
         # Create the settings file
         CemuGenerator.CemuConfig(cemuConfig + "/settings.xml", system)
-        
-        # Copy the keys.txt file from where cemu reads it
-        shutil.copyfile(batoceraFiles.BIOS + "/cemu/keys.txt", cemuConfig + "/keys.txt")
-        
+
         # Set-up the controllers
         cemuControllers.generateControllerConfig(system, playersControllers)
 

--- a/package/batocera/emulators/cemu/006-fix-keys-path.patch
+++ b/package/batocera/emulators/cemu/006-fix-keys-path.patch
@@ -1,0 +1,24 @@
+diff --git a/src/Cafe/Filesystem/FST/KeyCache.cpp b/src/Cafe/Filesystem/FST/KeyCache.cpp
+index 5d8d51c..92678e4 100644
+--- a/src/Cafe/Filesystem/FST/KeyCache.cpp
++++ b/src/Cafe/Filesystem/FST/KeyCache.cpp
+@@ -59,7 +59,18 @@ void KeyCache_Prepare()
+ 	sKeyCachePrepared = true;
+ 	g_keyCache.clear();
+ 	// load keys
+-	auto keysPath = ActiveSettings::GetUserDataPath("keys.txt");
++	// Use /userdata/bios/cemu for the keys.txt directory, to match batocera
++	// documentation at https://wiki.batocera.org/systems:wiiu#keystxt
++
++	std::string keysDir = "/userdata/bios/cemu";
++	// Let's first make sure the parent directory exists.
++	std::error_code err;
++	fs::create_directories(keysDir, err);
++	if (err) {
++		wxMessageBox("Unable to create /userdata/bios/cemu directory, to store the keys.txt file\nThis can happen if Cemu does not have write permission to /userdata/bios/ directory, the disk is full or if anti-virus software is blocking Cemu.", "Error", wxOK | wxCENTRE | wxICON_ERROR);
++	}
++
++	auto keysPath = keysDir + "/keys.txt";
+ 	FileStream* fs_keys = FileStream::openFile2(keysPath);
+ 	if( !fs_keys )
+ 	{


### PR DESCRIPTION
Batocera documentation states [1] that the `keys.txt` file needs to go in the `/userdata/bios/cemu/` directory, however cemu looks for this file in the user data path [2], which batocera is then defining to be `/userdata/saves/wiiu`, through a custom patch [3].

This commit changes cemu to look for the keys file in `/userdata/bios/cemu/`, so it matches the documentation. This  makes it so that we do not need to do additional workarounds in the generators, to copy the keys from the bios directory to where cemu would look for it.

strace before the change:
```
[...]
newfstatat(AT_FDCWD, "/userdata/saves/wiiu/keys.txt", 0x7f31487f6d60, 0) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/userdata/saves/wiiu", {st_mode=S_IFDIR|0755, st_size=4096, ...}, 0) = 0
[...]
openat(AT_FDCWD, "/userdata/saves/wiiu/keys.txt", O_RDONLY) = -1 ENOENT (No such file or directory)
newfstatat(AT_FDCWD, "/userdata/saves/wiiu/keys.txt", 0x7f31487f6d60, 0) = -1 ENOENT (No such file or directory)
[...]
```

strace after the change:
```
[...]
newfstatat(AT_FDCWD, "/userdata/bios/cemu/keys.txt", {st_mode=S_IFREG|0644, st_size=408942, ...}, 0) = 0
openat(AT_FDCWD, "/userdata/bios/cemu/keys.txt", O_RDONLY) = 15
newfstatat(AT_FDCWD, "/userdata/bios/cemu/keys.txt", {st_mode=S_IFREG|0644, st_size=408942, ...}, 0) = 0
[...]
```

[1] https://wiki.batocera.org/systems:wiiu#keystxt
[2] https://github.com/cemu-project/Cemu/blob/9d55f46eb1bbd53ae7db27058e820ce209b77aff/src/Cafe/Filesystem/FST/KeyCache.cpp#L62
[3] https://github.com/batocera-linux/batocera.linux/blob/997747/package/batocera/emulators/cemu/002-use-userdata.patch#L59