### PR TITLE
batocera-desktopapps: do not hardcode DISPLAY in file manager launcher

### DIFF
--- a/package/batocera/core/batocera-desktopapps/scripts/filemanagerlauncher
+++ b/package/batocera/core/batocera-desktopapps/scripts/filemanagerlauncher
@@ -24,6 +24,6 @@ EOF
 
 unclutter-remote -s
 
-DISPLAY=:0.0 pcmanfm /userdata
+DISPLAY=${DISPLAY:-:0.0} pcmanfm /userdata
 
 unclutter-remote -h


### PR DESCRIPTION
We should only try to use a specific DISPLAY if the env var is not yet defined. In the file manager launcher, let's check first whether DISPLAY is not defined, before assuming it to be :0.0.