### PR TITLE
Add support for zxspectrum .dsk images

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1699,7 +1699,7 @@ zxspectrum:
   manufacturer: Sinclair
   release: 1982
   hardware: computer
-  extensions: [tzx, tap, z80, rzx, scl, trd, zip, 7z]
+  extensions: [tzx, tap, z80, rzx, scl, trd, dsk, zip, 7z]
   emulators:
     libretro:
       fuse: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_FUSE] }


### PR DESCRIPTION
ZX Spectrum is missing support for .dsk images, which are disk images from the ZX Spectrum +3 and a few other third-party add-ons.

fuse-libretro 1.6.0 (and likely earlier versions) support these without any issues, but they aren't recognised by the EmulationStation configuration - loading them manually in RetroArch under Batocera works fine, so it looks like the file type was missed when it was added.