### PR TITLE
utils/jstest2: fix path for gamecontrollerdb

### DIFF
--- a/package/batocera/utils/jstest2/006-fix-gamecontrollerdb-path.patch
+++ b/package/batocera/utils/jstest2/006-fix-gamecontrollerdb-path.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3946dc2..a798706 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -105,7 +105,7 @@ if(BUILD_SDL2_JSTEST)
+   file(COPY sdl2-jstest.1
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-  file(COPY gamecontrollerdb.txt
++  file(COPY external/sdl_gamecontrollerdb/gamecontrollerdb.txt
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ 
+   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gamecontrollerdb.txt


### PR DESCRIPTION
When running `batocera-padsinfo`, the following message always pops up: `"error: failed to read gamecontrollerdb.txt: Invalid RWops"`

It turns out it is trying to read `gamecontrollerdb.txt` that should be located at `/usr/share/sdl-jstest`; however that is a broken symlink pointing to `SDL_GameControllerDB/gamecontrollerdb.txt`.

After digging a little, it seems that when building `jstest2`, we do not copy the db file from the submodule we checked out. Let's fix this by adjusting the path.