### PR TITLE
odroidgoa: display rotated splash image

### DIFF
--- a/package/batocera/core/batocera-splash/scripts/Ssystem-splash
+++ b/package/batocera/core/batocera-splash/scripts/Ssystem-splash
@@ -14,12 +14,24 @@ do_start ()
         N=$((N+1))
     done
 
+    # V_BOARD_MODEL detection from batocera-info
+    V_BOARD_MODEL=$(cat /sys/firmware/devicetree/base/model 2>/dev/null | tr -d '\0' | sed -e s+"[^A-Za-z0-9]"+"_"+g)
+    if test -z "${V_BOARD_MODEL}"
+    then
+        # give an other chance with dmi
+        V_BOARD_MODEL=$(cat /sys/devices/virtual/dmi/id/board_name 2>/dev/null | tr -d '\0' | sed -e s+"[^A-Za-z0-9]"+"_"+g)
+    fi
+    # 3rd time lucky
+    if test -z "${V_BOARD_MODEL}" || test "${V_BOARD_MODEL}" == "Default_string"
+    then
+        V_BOARD_MODEL=$(cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null | tr -d '\0' | sed -e s+"[^A-Za-z0-9]"+"_"+g)
+    fi
     # don't display a rotate image if the screen is not horizontal
     # we can't know if that's left or right, it depends on the device, so, just ignore
-    # maybe in some case we want the rotated image for some boards. maybe a test to add. i don't know which one.
-    if test $(cat /sys/class/graphics/fb0/virtual_size | sed -e s+","+" -lt "+)
+    # maybe in some case we want the rotated image for some boards. add those boards here
+    if test $(cat /sys/class/graphics/fb0/virtual_size | sed -e s+","+" -lt "+) -a "$V_BOARD_MODEL" != "Hardkernel_ODROID_GO2"
     then
-	exit 0
+        exit 0
     fi
 
     if [[ $(batocera-resolution getDisplayMode) == "xorg" ]]; then


### PR DESCRIPTION
Display rotated splash image for ODROID-GO Advance.
Model detection taken from `batocera-info`.