### PR TITLE
Fix DBP for folders with space in name

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -215,9 +215,9 @@ class LibretroGenerator(Generator):
         elif system.name == 'dos':
             romDOSName, romExtension = os.path.splitext(romName)
             if (romExtension == '.dos' or romExtension == '.pc'):
-                if os.path.exists(os.path.join(rom, romDOSName + ".bat")):
+                if os.path.exists(os.path.join(rom, romDOSName + ".bat")) and not " " in romDOSName:
                     exe = os.path.join(rom, romDOSName + ".bat")
-                elif os.path.exists(os.path.join(rom, "dosbox.bat")):
+                elif os.path.exists(os.path.join(rom, "dosbox.bat")) and not os.path.exists(os.path.join(rom, romDOSName + ".bat")):
                     exe = os.path.join(rom, "dosbox.bat")
                 else:
                     exe = '/tmp/'+ romDOSName # Ugly workaround for dosbox-pure not supporting extensions for dos game folders


### PR DESCRIPTION
Currently DOSBox-Pure gives an error when starting (and starts afterwards) if all these conditions are true

- ROM is in a folder;
- ROM name contains space;
- `ROM name.bat` exists.

This fix maintains maximum compatibility.
An alternative would be simplifying the code and always using the code currently in else statement (removing lines 218-222)