### PR TITLE
Realign lr-mame with mame standalone 0.251

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -89,9 +89,9 @@
 - linux kernel for x86_64 to 6.1 lts
 - daphne emulator hypseus-singe to v2.10.1 (now uses SDL controller)
 - amiberry to v5.4
-- mame to v0.248
+- mame to v0.251
 - switchres to sep 25th 2022 build
-- lr-mame to v0.248
+- lr-mame to v0.251
 - retroarch to v1.14.0
 - libretro cores synced with retroarch v1.11.1 [#7245](https://github.com/batocera-linux/batocera.linux/pull/7245)
 - libretro-core-info to Oct 04 2022 build

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -3,8 +3,8 @@
 # libretro-mame
 #
 ################################################################################
-# Version: Commits on Sep 29, 2022 (v0.248)
-LIBRETRO_MAME_VERSION = fcacbc7811a9b69874fd09b91e7217e44c6a0980
+# Version: Commits on Jan 13, 2023 (v0.251)
+LIBRETRO_MAME_VERSION = f7761a9902d59030882c58d4482446196e748c50
 LIBRETRO_MAME_SITE = $(call github,libretro,mame,$(LIBRETRO_MAME_VERSION))
 LIBRETRO_MAME_LICENSE = MAME
 LIBRETRO_MAME_DEPENDENCIES = retroarch


### PR DESCRIPTION
MAME was bumped through #7911 resulting in a discrepancy with lr-mame (and outdated changelog).