### PR TITLE
GunCon 2 Driver Update

### DIFF
--- a/package/batocera/controllers/guncon/guncon.mk
+++ b/package/batocera/controllers/guncon/guncon.mk
@@ -3,7 +3,7 @@
 # guncon
 #
 ################################################################################
-GUNCON_VERSION = b73e65b537da3ffa68d8aebe6fbd10830930cc16
+GUNCON_VERSION = 2ea212ee7bab6cdab9d4e1339731680aaa7bd213
 GUNCON_SITE = $(call github,Redemp,guncon2,$(GUNCON_VERSION))
 
 define GUNCON_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Adding new functions from @psakhis fork. 

- calibrate -32768 to 32767
- Normalize in kernel
- micro calibration added
- Update calibration script for new functions 
- Button C + D-pad left/right -> decrease x-min -> apply if your gun is out on left of the screen
- Button C + D-pad up/down -> increase x-max -> apply if your gun is out on right of the screen

You need to do a first calibration only once 
Now calibration tool adjust real values to RX analog And emulators use ABS_X where position values are interpolated inside driver In other words, ABS_X min and max values are -32768,32767 always, and ABS_RX min and max are real gun values