### PR TITLE
Set niceness of rngd to 10

### DIFF
--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -73,6 +73,7 @@ fi
 if test -e "${TARGET_DIR}/etc/init.d/S21rngd"
 then
     mv "${TARGET_DIR}/etc/init.d/S21rngd"    "${TARGET_DIR}/etc/init.d/S33rngd"    || exit 1 # move because it takes several seconds (on odroidgoa for example)
+    sed -i "s/start-stop-daemon -S -q /start-stop-daemon -S -q -N 10 /g" "${TARGET_DIR}/etc/init.d/S33rngd"  || exit 1 # set rngd niceness to 10 (to decrease slowdown of other processes)
 fi
 
 # remove kodi default joystick configuration files


### PR DESCRIPTION
Decrease CPU priority of rngd to decrease its impact on system performance.

On ODROID-GO Advance I noticed several CPU usage spikes of rngd. Haven't checked this on other systems.
This PR should decrease effect of such rngd CPU spikes to overall system performance.