### PR TITLE
fix(cemu): improve rpx location for squashfs

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -12,6 +12,7 @@ import controllersConfig
 import shutil
 import filecmp
 import subprocess
+import glob
 from . import cemuControllers
 
 from utils.logger import get_logger
@@ -32,12 +33,9 @@ class CemuGenerator(Generator):
 
         # in case of squashfs, the root directory is passed
         rpxrom = rom
-        if os.path.isdir(rom + "/code"):
-            rpxInDir = os.listdir(rom + "/code")
-            for file in rpxInDir:
-                basename, extension = os.path.splitext(file)
-                if extension == ".rpx":
-                    rpxrom = rom + "/code/" + basename + extension
+        paths = list(glob.iglob(os.path.join(rom, '**/code/*.rpx'), recursive=True))
+        if len(paths) >= 1:
+            rpxrom = paths[0]
 
         cemu_exe = cemuConfig + "/cemu"
         if not path.isdir(batoceraFiles.BIOS + "/cemu"):


### PR DESCRIPTION
This is a proposal to fix https://github.com/batocera-linux/batocera.linux/issues/5659

It looks like not all (loadiine) squashfs images have the same structure, e.g.
* Single rpx file: `mlc01/usr/title/00050000/10145c00/code/RedCarpet.rpx`
* Multiple rpx files:
  * `mlc01/usr/title/00050000/10180600/code/Kinopio.rpx`
  * `mlc01/usr/title/0005000e/10180600/code/Kinopio.rpx`

This commit selects the first rpx file in a `code` directory, no matter where the exact location in the squashfs image is.