### PR TITLE
fix(cemu): allow special chars in squashfs path

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -33,7 +33,7 @@ class CemuGenerator(Generator):
 
         # in case of squashfs, the root directory is passed
         rpxrom = rom
-        paths = list(glob.iglob(os.path.join(rom, '**/code/*.rpx'), recursive=True))
+        paths = list(glob.iglob(os.path.join(glob.escape(rom), '**/code/*.rpx'), recursive=True))
         if len(paths) >= 1:
             rpxrom = paths[0]
 


### PR DESCRIPTION
This is a fix for a bug introduced with https://github.com/batocera-linux/batocera.linux/pull/8052: path resolution fails when the path contains glob special characters (e.g. square brackes as in `Game Title [ABC]`)