### PR TITLE
hypseus: Version bump to 2.10.2

### DIFF
--- a/package/batocera/emulators/daphne/daphne.mk
+++ b/package/batocera/emulators/daphne/daphne.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DAPHNE_VERSION = 7a63fee71d7c01ac1a90f89d1494c0374d401a10
+DAPHNE_VERSION = v2.10.2
 DAPHNE_SITE = https://github.com/DirtBagXon/hypseus-singe
 DAPHNE_SITE_METHOD=git
 DAPHNE_LICENSE = GPLv3


### PR DESCRIPTION
New **bezel** support +

https://github.com/DirtBagXon/hypseus-singe/releases/tag/v2.10.2