### PR TITLE
samba / Enable samba to recognize and follow wide symlinks.

### DIFF
--- a/board/batocera/fsoverlay/etc/samba/smb.conf
+++ b/board/batocera/fsoverlay/etc/samba/smb.conf
@@ -247,6 +247,9 @@ socket options = TCP_NODELAY
 # public shares, not just authenticated ones
    usershare allow guests = yes
 
+# Allow wide symlinks outside the share directory
+   allow insecure wide links = yes
+
 #======================= Share Definitions =======================
 
 [homes]
@@ -349,3 +352,6 @@ directory mask = 0755
 force user = root
 veto files = /._*/.DS_Store/
 delete veto files = yes
+follow symlinks = yes
+wide links = yes
+


### PR DESCRIPTION
This patch adjusts the default configuration of samba to allow and enable following of symlinks outside the share directory.

This patch enhances the utility of samba sharing for people using symlinks to redirect parts of userdata to a larger disk.

Signed-off-by: Steve Hay <me@stevenhay.com>