### PR TITLE
fix(citra): fix language/region setting

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
@@ -225,11 +225,26 @@ class CitraGenerator(Generator):
             return "left"
         return "unknown"
 
-# Lauguage auto setting
+# Language auto setting
 def getCitraLangFromEnvironment():
+    region = { "AUTO": -1, "JPN": 0, "USA": 1, "EUR": 2, "AUS": 3, "CHN": 4, "KOR": 5, "TWN": 6 }
+    availableLanguages = {
+        "ja_JP": "JPN",
+        "en_US": "USA",
+        "de_DE": "EUR",
+        "es_ES": "EUR",
+        "fr_FR": "EUR",
+        "it_IT": "EUR",
+        "hu_HU": "EUR",
+        "pt_PT": "EUR",
+        "ru_RU": "EUR",
+        "en_AU": "AUS",
+        "zh_CN": "CHN",
+        "ko_KR": "KOR",
+        "zh_TW": "TWN"
+    }
     lang = environ['LANG'][:5]
-    availableLanguages = { "ja_JP": 0, "en_US": 1, "fr_FR": 2, "de_DE": 3, "it_IT": 4, "es_ES": 5, "zh_CN": 6, "ko_KR": 7, "hu_HU": 8, "pt_PT": 9, "ru_RU": 10, "zh_TW": 11 }
     if lang in availableLanguages:
-        return availableLanguages[lang]
+        return region[availableLanguages[lang]]
     else:
-        return availableLanguages["en_US"]
+        return region["AUTO"]


### PR DESCRIPTION
This is a fix for broken language auto-selection in standalone Citra.

`citraGenerator.py` contains a per-locale mapping. The configuration of current Citra (nightly-1784 from 2022-09-09 / Batocera v35) contains a per-region mapping.

This issue was probably reported in #4671