### PR TITLE
Support OSX build and remove exposure of host system files to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,47 @@
 FROM ubuntu:22.04
 ARG DEBIAN_FRONTEND=noninteractive
+
 RUN dpkg --add-architecture i386 && \
 	apt-get update && \
+	# libc6:i386 libncurses5:i386 libstdc++6:i386: required for mame2016
 	apt-get install -y -o APT::Immediate-Configure=0 libc6:i386 \
-		libncurses6:i386 \
-		libstdc++6:i386 \
-		build-essential \
-		cmake \
-		git \
-		libncurses6 \
-		libncurses-dev \
-		libssl-dev \
-		mercurial \
-		texinfo \
-		zip \
-		default-jre \
-		imagemagick \
-		subversion \
-		autoconf \
-		automake \
-		bison \
-		scons \
-		libglib2.0-dev \
-		bc \
-		mtools \
-		u-boot-tools \
-		flex \
-		wget \
-		cpio \
-		dosfstools \
-		libtool \
-		rsync \
-		device-tree-compiler \
-		gettext \
-		locales \
-		graphviz \
-		python3 \
-		gcc-multilib \
-		g++-multilib \
+	libncurses6:i386 \
+	libstdc++6:i386 \
+	build-essential \
+	cmake \
+	git \
+	libncurses6 \
+	libncurses-dev \
+	libssl-dev \
+	mercurial \
+	texinfo \
+	zip \
+	default-jre \
+	imagemagick \
+	subversion \
+	autoconf \
+	automake \
+	bison \
+	scons \
+	libglib2.0-dev \
+	bc \
+	mtools \
+	u-boot-tools \
+	flex \
+	wget \
+	cpio \
+	dosfstools \
+	libtool \
+	rsync \
+	# device-tree-compiler : required for device-trees-aml-s9xx
+	device-tree-compiler \
+	# gettext : required for buildstats.sh
+	gettext \
+	locales \
+	graphviz \
+	python3 \
+	gcc-multilib \
+	g++-multilib \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/*
 
@@ -52,11 +56,17 @@ ENV TZ Europe/Paris
 # Workaround host-tar configure error
 ENV FORCE_UNSAFE_CONFIGURE 1
 
-# device-tree-compiler : required for device-trees-aml-s9xx
-# libc6:i386 libncurses5:i386 libstdc++6:i386: required for mame2016
-# gettext : required for buildstats.sh
+ARG BUILD_USER=builder
+ARG UID=1000
+ARG GID=1000
 
-RUN mkdir -p /build
+# If UID and GID were passed in as build args, they'll be used for the build user.
+RUN	useradd -u $UID -g $GID --create-home $BUILD_USER
+ENV HOME=/home/$BUILD_USER
+
+RUN mkdir -p /build && chown $UID:$GID /build
+
+USER $BUILD_USER
 WORKDIR /build
 
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ vars:
 
 
 build-docker-image:
-	$(DOCKER) build . -t $(DOCKER_REPO)/$(IMAGE_NAME)
+	$(DOCKER) build --build-arg UID=$(UID) --build-arg GID=$(GID) . -t $(DOCKER_REPO)/$(IMAGE_NAME)
 	@touch .ba-docker-image-available
 
 .ba-docker-image-available:
@@ -77,8 +77,6 @@ dl-dir:
 		-v $(PROJECT_DIR):/build \
 		-v $(DL_DIR):/build/buildroot/dl \
 		-v $(OUTPUT_DIR)/$*:/$* \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		-u $(UID):$(GID) \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
@@ -93,8 +91,6 @@ dl-dir:
 		-v $(PROJECT_DIR):/build \
 		-v $(DL_DIR):/build/buildroot/dl \
 		-v $(OUTPUT_DIR)/$*:/$* \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		-u $(UID):$(GID) \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
@@ -107,8 +103,6 @@ dl-dir:
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot $(CMD)
@@ -120,8 +114,6 @@ dl-dir:
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot source
@@ -133,8 +125,6 @@ dl-dir:
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot show-build-order
@@ -146,8 +136,6 @@ dl-dir:
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make $(MAKE_OPTS) O=/$* BR2_EXTERNAL=/build -C /build/buildroot linux-menuconfig
@@ -159,8 +147,6 @@ dl-dir:
 		-v $(OUTPUT_DIR)/$*:/$* \
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_OPTS) \
 		$(DOCKER_REPO)/$(IMAGE_NAME) \
 		make O=/$* BR2_EXTERNAL=/build BR2_GRAPH_OUT=svg -C /build/buildroot graph-depends
@@ -175,8 +161,6 @@ dl-dir:
 		-v $(CCACHE_DIR):$(HOME)/.buildroot-ccache \
 		-u $(UID):$(GID) \
 		$(DOCKER_OPTS) \
-		-v /etc/passwd:/etc/passwd:ro \
-		-v /etc/group:/etc/group:ro \
 		$(DOCKER_REPO)/$(IMAGE_NAME)
 
 %-cleanbuild: %-clean %-build


### PR DESCRIPTION
As titled; I haven't tested this on systems other than OSX, so it'd be great if someone could validate that this does work everywhere before merging.