### PR TITLE
Enable Wii balance board with native controllers

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -216,6 +216,7 @@ def generateControllerConfig_realwiimotes(filename, anyDefKey):
         f.write("[" + anyDefKey + str(nplayer) + "]" + "\n")
         f.write("Source = 2\n")
         nplayer += 1
+    f.write("[BalanceBoard]\nSource = 2\n")
     f.write
     f.close()
 


### PR DESCRIPTION
It won't work otherwise since Dolphin's default is for it to be disabled.