### PR TITLE
Add pad2key to macintosh, atom, bbc, electron

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2706,6 +2706,7 @@ libretro:
                           "On":  1
                           "Off": 0
          macintosh:
+              features: [padtokeyboard]
               cfeatures:
                   softList:
                       group: ADVANCED OPTIONS
@@ -8020,6 +8021,7 @@ mame:
                         "On":  1
                         "Off": 0
        atom:
+            features: [padtokeyboard]
             cfeatures:
                 softList:
                     group: ADVANCED OPTIONS
@@ -8055,6 +8057,7 @@ mame:
                         "On":  1
                         "Off": 0
        bbc:
+            features: [padtokeyboard]
             cfeatures:
                 sticktype:
                     group: ADVANCED OPTIONS
@@ -8213,6 +8216,7 @@ mame:
                         "On":  1
                         "Off": 0
        electron:
+            features: [padtokeyboard]
             cfeatures:
                 softList:
                     group: ADVANCED OPTIONS


### PR DESCRIPTION
Fix #8068 