### PR TITLE
Fix for B36 Steamdeck: exit for standalone MAME

### DIFF
--- a/package/batocera/emulators/mame/mame.mame.keys
+++ b/package/batocera/emulators/mame/mame.mame.keys
@@ -2,8 +2,8 @@
     "actions_player1": [
 	{
             "trigger": ["hotkey", "start"],
-            "type": "key",
-            "target": [ "KEY_ESC" ]
+            "type": "exec",
+            "target": "killall -9 mame"
 	},
 	{
             "trigger": ["hotkey", "b"],


### PR DESCRIPTION
**This is a temporary fix** so that we can release B36. If you use ESC with standalone MAME on the SteamDeck, the right side of the screen stays on forever. With this hard kill, it seems to fix it. 