### PR TITLE
revert lr-o2em to Nov 3, 2021 to fix audio problems

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-o2em/libretro-o2em.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-o2em/libretro-o2em.mk
@@ -3,8 +3,9 @@
 # libretro-o2em
 #
 ################################################################################
-# Version: Commits on Jul 26, 2022
-LIBRETRO_O2EM_VERSION = 3303cc15e4323280084471f694f6d34c78199725
+# Version: Commits on Nov 3, 2021
+# Do not upgrade this commit: https://github.com/libretro/libretro-o2em/issues/57
+LIBRETRO_O2EM_VERSION = c039e83f2589cb9d21b9aa5dc211954234ab8c97
 LIBRETRO_O2EM_SITE = $(call github,libretro,libretro-o2em,$(LIBRETRO_O2EM_VERSION))
 LIBRETRO_O2EM_LICENSE = Artistic License
 


### PR DESCRIPTION
Commits made after this version introduced an audio bug which causes the pitch of the sound to be incorrect. Considering that all commits made after this are just "clean up code" and other house-cleaning, it's probably fine.

The issue has been reported to the original Github page of the core, when that gets fixed it will probably be safe to upgrade this to the current version once again.