### PR TITLE
fix RPCS3 select button

### DIFF
--- a/package/batocera/emulators/rpcs3/013-gun-support.patch
+++ b/package/batocera/emulators/rpcs3/013-gun-support.patch
@@ -87,14 +87,14 @@ index 111c05c..e42edd9 100644
 +  if(gh->getButton(gem_no, EVDEV_GUN_BUTTON_BTN2) == 1)
 +    digital_buttons |= CELL_GEM_CTRL_CIRCLE;
 +
-+  if(gh->getButton(gem_no, EVDEV_GUN_BUTTON_BTN3) == 1)
-+    digital_buttons |= CELL_GEM_CTRL_SELECT;
-+
 +  if(gh->getButton(gem_no, EVDEV_GUN_BUTTON_BTN5) == 1)
 +    digital_buttons |= CELL_GEM_CTRL_TRIANGLE;
 +
 +  if(gh->getButton(gem_no, EVDEV_GUN_BUTTON_BTN6) == 1)
 +    digital_buttons |= CELL_GEM_CTRL_SQUARE;
++
++  if(gh->getButton(gem_no, EVDEV_GUN_BUTTON_BTN7) == 1)
++    digital_buttons |= CELL_GEM_CTRL_SELECT;
 +
 +  analog_t = (gh->getButton(gem_no, EVDEV_GUN_BUTTON_LEFT) == 1) ? 0xFFFF : 0;
 +  return true;


### PR DESCRIPTION
Making SELECT pushable so that the game Child of Eden can be played with a gun. This is the only game from my tests that requires SELECT button to be pressed on the emulated PS Move. So, left d-pad on the gun will be SELECT.