### PR TITLE
Read temperature from hwmon

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -88,7 +88,7 @@ done
 
 # temperature
 # Unit: millidegree Celsius
-TEMPE=$(cat /sys/devices/virtual/thermal/thermal_zone*/temp 2>/dev/null | sort -rn | head -1 | sed -e s+"[0-9][0-9][0-9]$"++)
+TEMPE=$(cat /sys/devices/virtual/thermal/thermal_zone*/temp /sys/class/hwmon/hwmon*/temp*_input 2>/dev/null | sort -rn | head -1 | sed -e s+"[0-9][0-9][0-9]$"++)
 if test -n "${TEMPE}"
 then
     echo "Temperature: ${TEMPE}°C"


### PR DESCRIPTION
This PR extends the `batocera-info` script to read the temperature from `hwmon` in addition to the existing `thermal` node.

Depending on the system configuration, the directory `/sys/devices/virtual/thermal` may exist but not contain any `thermal_zone*` subdirectory. On such a system, the temperature is missing in batocera. I could observe this on a x86_64 system that has 4 `cooling_device*` nodes but no `thermal_zone*` node.