### PR TITLE
Propagate PROBE_DEFER in singleadcjoy

### DIFF
--- a/board/batocera/rockchip/rk3399/linux_patches/linux-0001-drivers-add_rg552_singleadcjoy.patch
+++ b/board/batocera/rockchip/rk3399/linux_patches/linux-0001-drivers-add_rg552_singleadcjoy.patch
@@ -1286,6 +1286,8 @@ index e69de29..e5ab241 100644
 +	}
 +	amux = joypad->amux;
 +	amux->iio_ch = devm_iio_channel_get(dev, "amux_adc");
++	if (PTR_ERR(amux->iio_ch) == -EPROBE_DEFER)
++		return -EPROBE_DEFER;
 +	if (IS_ERR(amux->iio_ch)) {
 +		dev_err(dev, "iio channel get error\n");
 +		return -EINVAL;


### PR DESCRIPTION
Prevents a race condition, where singleadcjoy gets probed and starts initialising before the IIO channel is probed.