### PR TITLE
Find/remove older files in `dl/` and `build/` directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,22 @@ dl-dir:
 	@$(MAKE) $*-build CMD=llvm
 	@$(MAKE) $*-snapshot
 
+%-find-build-dups: %-supported
+	@find $(OUTPUT_DIR)/$*/build -maxdepth 1 -type d -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2
+
+%-remove-build-dups: %-supported
+	@while [ `find $(OUTPUT_DIR)/$*/build -maxdepth 1 -type d -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2 | grep .` ]; do \
+		find $(OUTPUT_DIR)/$*/build -maxdepth 1 -type d -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2 | xargs rm -rf ; \
+	done
+
+find-dl-dups:
+	@find $(DL_DIR) -maxdepth 2 -type f -name "*.zip" -o -name "*.tar.*" -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+(\.zip|\.tar\.[2a-z]+)$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2
+
+remove-dl-dups:
+	@while [ `find $(DL_DIR) -maxdepth 2 -type f -name "*.zip" -o -name "*.tar.*" -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+(\.zip|\.tar\.[2a-z]+)$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2 | grep .` ] ; do \
+		find $(DL_DIR) -maxdepth 2 -type f -name "*.zip" -o -name "*.tar.*" -printf '%T@ %p %f\n' | sed -r 's:\-[0-9a-f\.]+(\.zip|\.tar\.[2a-z]+)$$::' | sort -k3 -k1 | uniq -f 2 -d | cut -d' ' -f2 | xargs rm -rf ; \
+	done
+
 uart:
 	$(if $(shell which picocom 2>/dev/null),, $(error "picocom not found!"))
 	$(if $(SERIAL_DEV),,$(error "SERIAL_DEV not specified!"))


### PR DESCRIPTION
That's how I reclaimed 48GB from my batocera build machine: removing old archive files and build sub-trees that are now superseded by newer versions.

This introduces the following commands:

- `make find-dl-dups`: show packages that are outdated, because a newer has been downloaded
- `make remove-dl-dups`: remove all these outdated packages from your `dl/` directory
- `make x86_64-find-build-dups`: show directories in the `x86_64/build/` tree that are outdated because a newer one has been created
- `make x86_64-remove-build-dups`: remove all these outdated directories

Of course `x86_64` is an example, you can use any supported arch.