### PR TITLE
Fix touchscreen OneXPlayer (original Kickstarter edition)

### DIFF
--- a/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.xorg
@@ -165,8 +165,8 @@ case "${ACTION}" in
     "setRotation")
         ROTATE=$1
         OUTPUT=$(xrandr --listConnectedOutputs | grep -E '\*$' | sed -e s+'*$'++ | head -1)
-        TOUCHSCREEN=$(xinput | grep pointer | tail -n +2 | grep -Ei 'touchscreen|2808:1015' | sed -E 's/[^a-zA-Z0-9]*((\S+ ?)+[a-zA-Z0-9\(\)]+)\s*id=([0-9]+)\s*(.*)/"\1"/')
-        TOUCHID=$(xinput | grep pointer | tail -n +2 | grep -Ei 'touchscreen|2808:1015' | sed -E 's/[^a-zA-Z0-9]*((\S+ ?)+[a-zA-Z0-9\(\)]+)\s*id=([0-9]+)\s*(.*)/\3/')
+        TOUCHSCREEN=$(xinput | grep pointer | tail -n +2 | grep -Ei 'touchscreen|2808:1015|27C6:011A' | sed -E 's/[^a-zA-Z0-9]*((\S+ ?)+[a-zA-Z0-9\(\)]+)\s*id=([0-9]+)\s*(.*)/"\1"/')
+        TOUCHID=$(xinput | grep pointer | tail -n +2 | grep -Ei 'touchscreen|2808:1015|27C6:011A' | sed -E 's/[^a-zA-Z0-9]*((\S+ ?)+[a-zA-Z0-9\(\)]+)\s*id=([0-9]+)\s*(.*)/\3/')
 
         case "${ROTATE}" in
             "1")


### PR DESCRIPTION
Might work with other handheld PC, now that we're on 6.1.x kernel.
If you have a handheld PC, with the touch screen recognized, but working sideways (i.e, moving up is left or right), connect to SSH and give me the output of `DISPLAY=:0.0 xinput | grep pointer | tail -n +2`