### PR TITLE
fix issue #8180 (system volume reverts to 40 at reboot)

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -48,6 +48,10 @@ case "${ACTION}" in
 			;;
 			*)
 			    LANG=C pactl set-default-sink "${MODE}" || exit 1
+					if [[ $(LANG=C pactl get-default-sink) != "${MODE}" ]]; then
+						# default-sink didn't switch right away for some reason, try again later
+						exit 1
+					fi
 		esac
 		;;
 
@@ -63,10 +67,15 @@ case "${ACTION}" in
 	set-profile)
 	    MODE="$2"
 	    if test "${MODE}" != "auto"
-	    then
-		PROFILE_NAME=$(echo "${MODE}" | cut -d @ -f 1)
-		CARD_NAME=$(echo "${MODE}" | cut -d @ -f 2)
-		LANG=C pactl set-card-profile "${CARD_NAME}" "${PROFILE_NAME}" || exit 1
+	    then			
+				if [[ $(batocera-audio list-profiles) =~ "${MODE}" ]]; then
+					PROFILE_NAME=$(echo "${MODE}" | cut -d @ -f 1)
+					CARD_NAME=$(echo "${MODE}" | cut -d @ -f 2)
+					LANG=C pactl set-card-profile "${CARD_NAME}" "${PROFILE_NAME}" || exit 1
+				else
+					# the profile isn't available yet, try again later
+					exit 1
+				fi		
 	    fi
 	    ;;
 


### PR DESCRIPTION
Fixes the issue where when `S27audioconfig` first starts, not all audio profiles are `"available=1"` during that time (e.g., the Nvidia HDMI audio profiles in my environment).  Doing `batocera-audio set-profile` during that time results in subsequently doing `setSystemVolume` on the default device (on-board audio) instead of the intended device (Nvidia HDMI), because `batocera-audio set-profile` never checks if the switch really did happen. 

The change adds additional checks in `batocera-audio set-profile` and `batocera-audio set` to see if the switch really did happen.  If not it returns 1 so that `S27audioconfig` would try again.