### PR TITLE
bump cemu to v2.0-28

### DIFF
--- a/package/batocera/emulators/cemu/cemu.mk
+++ b/package/batocera/emulators/cemu/cemu.mk
@@ -3,7 +3,7 @@
 # cemu
 #
 ################################################################################
-CEMU_VERSION = v2.0-22
+CEMU_VERSION = v2.0-28
 CEMU_SITE = https://github.com/cemu-project/Cemu
 CEMU_LICENSE = GPLv2
 CEMU_SITE_METHOD=git


### PR DESCRIPTION
Update cemu to fix SDL motion control issues as reported on the [forum](https://forum.batocera.org/d/9037-batocera-36-beta1/59) (see [Reddit](https://www.reddit.com/r/cemu/comments/zxqjrp/how_to_use_motion_controlls_on_cemu_20_linux/) for details)