### PR TITLE
Allow flatpak emulators to use a Switch Pro Controller

### DIFF
--- a/package/batocera/controllers/joycond/001-fix-udev-path.patch
+++ b/package/batocera/controllers/joycond/001-fix-udev-path.patch
@@ -5,11 +5,11 @@ index b931ec2491..a32b6a2a3f 100644
 @@ -1,8 +1,8 @@
  # Keep steam from accessing hidraw for pro controller
  # Nintendo Switch Pro Controller over USB hidraw
--KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0600", TAG-="uaccess", RUN+="/bin/setfacl -b /dev/%k"
-+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0600", TAG-="uaccess", RUN+="/usr/bin/setfacl -b /dev/%k"
+-KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660", TAG-="uaccess", RUN+="/bin/setfacl -b /dev/%k"
++KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", GROUP="input", MODE="0660", TAG-="uaccess", RUN+="/usr/bin/setfacl -b /dev/%k"
  # Nintendo Switch Pro Controller over bluetooth hidraw
--KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0600", TAG-="uaccess", RUN+="/bin/setfacl -b /dev/%k"
-+KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0600", TAG-="uaccess", RUN+="/usr/bin/setfacl -b /dev/%k"
+-KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0660", TAG-="uaccess", RUN+="/bin/setfacl -b /dev/%k"
++KERNEL=="hidraw*", KERNELS=="*057E:2009*", GROUP="input", MODE="0660", TAG-="uaccess", RUN+="/usr/bin/setfacl -b /dev/%k"
  
  
  ACTION!="add", GOTO="joycond_end"


### PR DESCRIPTION
This PR grants read/write permission for Nintendo Switch Pro Controllers to group `input`.

This permission is required when a non-root user requires access to a Pro Controller.

In batocera, flatpak apps are run as user `batocera` which does not have root privileges but is in group `input`. Thus, flatpak apps that are started from batocera have no permission to use pro controllers. A lot of emulators and games are available as flatpak apps and would benefit from this extension.

The flatpak image of yuzu contains an input settings dialog where the change was and may be tested, even using motion controls. The flatpak image of citra may also be used for testing, also with motion control.