### PR TITLE
s905gen3: fix dts names

### DIFF
--- a/board/batocera/amlogic/s905gen3/tvbox-gen3/create-boot-script.sh
+++ b/board/batocera/amlogic/s905gen3/tvbox-gen3/create-boot-script.sh
@@ -26,7 +26,7 @@ cp "${BOARD_DIR}/boot/README.txt"                      "${BATOCERA_BINARIES_DIR}
 cp "${BOARD_DIR}/boot/uEnv.txt"                        "${BATOCERA_BINARIES_DIR}/boot/"          || exit 1
 cp "${BOARD_DIR}/boot/boot.ini"                        "${BATOCERA_BINARIES_DIR}/boot/"          || exit 1
 
-for DTB in meson-sm1-h96-max.dtb meson-sm1-sei610.dtb meson-sm1-khadas-vim3l.dtb meson-sm1-odroid-c4.dtb meson-sm1-x96-air-2g.dtb meson-sm1-x96-air-4g.dtb meson-sm1-a95xf3-air-100.dtb meson-sm1-a95xf3-air-1000.dtb
+for DTB in meson-sm1-h96-max.dtb meson-sm1-sei610.dtb meson-sm1-khadas-vim3l.dtb meson-sm1-odroid-c4.dtb meson-sm1-x96-air.dtb meson-sm1-x96-air-gbit.dtb meson-sm1-a95xf3-air.dtb meson-sm1-a95xf3-air-gbit.dtb
 do
         cp "${BINARIES_DIR}/${DTB}" "${BATOCERA_BINARIES_DIR}/boot/boot/" || exit 1
 done

--- a/configs/batocera-s905gen3.board
+++ b/configs/batocera-s905gen3.board
@@ -27,7 +27,7 @@ BR2_LINUX_KERNEL_NEEDS_HOST_OPENSSL=y
 
 # Build the DTB from the kernel sources
 BR2_LINUX_KERNEL_DTS_SUPPORT=y
-BR2_LINUX_KERNEL_INTREE_DTS_NAME="amlogic/meson-sm1-odroid-c4 amlogic/meson-sm1-khadas-vim3l amlogic/meson-sm1-h96-max amlogic/meson-sm1-sei610 amlogic/meson-sm1-x96-air-2g amlogic/meson-sm1-x96-air-4g amlogic/meson-sm1-a95xf3-air-100 amlogic/meson-sm1-a95xf3-air-1000"
+BR2_LINUX_KERNEL_INTREE_DTS_NAME="amlogic/meson-sm1-odroid-c4 amlogic/meson-sm1-khadas-vim3l amlogic/meson-sm1-h96-max amlogic/meson-sm1-sei610 amlogic/meson-sm1-x96-air amlogic/meson-sm1-x96-air-gbit amlogic/meson-sm1-a95xf3-air amlogic/meson-sm1-a95xf3-air-gbit"
 
 # System
 BR2_PACKAGE_BATOCERA_KODI19=y


### PR DESCRIPTION
Tested with a v36 build on the target.