### PR TITLE
MAME Additional Options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -160,6 +160,10 @@ def generateMAMEConfigs(playersControllers, system, rom):
                         commandLine += ["-gameio", system.config['gameio']]
                         specialController = system.config['gameio']
 
+            # RAM size (Mac excluded, special handling below)
+            if system.name != "macintosh" and system.isOptSet("ramsize"):
+                commandLine += [ '-ramsize', str(system.config["ramsize"]) + 'M' ]
+
             # Mac RAM & Image Reader (if applicable)
             if system.name == "macintosh":
                 if system.isOptSet("ramsize"):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -272,7 +272,6 @@ class MameGenerator(Generator):
                 messModel = system.config["altmodel"]
             commandArray += [ messModel ]
 
-
             #TI-99 32k RAM expansion & speech modules - enabled by default
             if system.name == "ti99":
                 commandArray += [ "-ioport", "peb" ]
@@ -305,6 +304,10 @@ class MameGenerator(Generator):
                     else:
                         commandArray += ["-gameio", system.config['gameio']]
                         specialController = system.config['gameio']
+
+            # RAM size (Mac excluded, special handling below)
+            if system.name != "macintosh" and system.isOptSet("ramsize"):
+                commandArray += [ '-ramsize', str(system.config["ramsize"]) + 'M' ]
 
             # Mac RAM & Image Reader (if applicable)
             if system.name == "macintosh":

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2485,6 +2485,15 @@ libretro:
                       choices:
                           "Electron w/64k Master RAM Board (default)": electron64
                           "Electron":                                  electron
+                  altromtype:
+                      group: ADVANCED OPTIONS
+                      prompt:      MEDIA TYPE
+                      description: Type of ROM file to load.
+                      choices:
+                          "Floppy Disk":        flop
+                          "Cassette":           cass
+                          "Cartridge (Slot 1)": cart1
+                          "Cartridge (Slot 2)": cart2
                   enableui:
                       group: ADVANCED OPTIONS
                       prompt:      UI KEYS
@@ -2547,6 +2556,13 @@ libretro:
                           "FM Towns Marty (Default)": fmtmarty
                           "FM Towns (Model 1/2)":     fmtowns
                           "FM Towns II UX":           fmtownsux
+                  ramsize:
+                      group: ADVANCED OPTIONS
+                      prompt:      RAM SIZE
+                      description: How much RAM the emulated FM Towns will have installed
+                      choices:
+                          "2MB":    2
+                          "4MB":    4
                   addblankdisk:
                       group: ADVANCED OPTIONS
                       prompt:      ADD USER DISK
@@ -8234,6 +8250,15 @@ mame:
                     choices:
                         "Electron w/64k Master RAM Board (default)": electron64
                         "Electron":                                  electron
+                altromtype:
+                    group: ADVANCED OPTIONS
+                    prompt:      MEDIA TYPE
+                    description: Type of ROM file to load.
+                    choices:
+                        "Floppy Disk":        flop
+                        "Cassette":           cass
+                        "Cartridge (Slot 1)": cart1
+                        "Cartridge (Slot 2)": cart2
                 enableui:
                     group: ADVANCED OPTIONS
                     prompt:      UI KEYS
@@ -8304,6 +8329,13 @@ mame:
                         "FM Towns Marty (Default)": fmtmarty
                         "FM Towns (Model 1/2)":     fmtowns
                         "FM Towns II UX":           fmtownsux
+                ramsize:
+                      group: ADVANCED OPTIONS
+                      prompt:      RAM SIZE
+                      description: How much RAM the emulated FM Towns will have installed
+                      choices:
+                          "2MB":    2
+                          "4MB":    4
                 addblankdisk:
                     group: ADVANCED OPTIONS
                     prompt:      ADD USER DISK


### PR DESCRIPTION
Added RAM Size option for FM Towns (2MB default, 4MB available) and media type options for Acorn Electron.