### PR TITLE
Bump Switchres

### DIFF
--- a/package/batocera/utils/switchres/switchres.mk
+++ b/package/batocera/utils/switchres/switchres.mk
@@ -3,8 +3,8 @@
 # SwitchRes
 #
 ################################################################################
-# Version: Commits on Jan 10, 2023
-SWITCHRES_VERSION = f5b7bdec66b71c69a3465088cbf43b699e32cc1d
+# Version: Commits on Feb 23, 2023
+SWITCHRES_VERSION = ca72648b3253eca8c5addf64d1e4aa1c43f5db94
 SWITCHRES_SITE = $(call github,antonioginer,switchres,$(SWITCHRES_VERSION))
 
 SWITCHRES_DEPENDENCIES = libdrm


### PR DESCRIPTION
**There are a few noticeable changes since last bump.**

- Don't parse crt_range/lcd_range values if they're empty. 

- Make v_shift automatically step by 2 on interlaced modes to preserve parity. 

- Fix several rounding errors on vertical fields calculation when moving back and forth from modeline to crt_range.

- Fix X fractal scale on super res 

- Fix string size error. 

- Extend sr_mode struct to add detailed timings. 

- Fix --modeline option implementation. Simplify indentation. 

- Return (x_scale, y_scale, v_scale) as floats instead of integers, so they can be directly used for scaling on the emulator side

- Refactor rotation handling.

_Handle rotation as a flag passed at mode creation
(get_mode/add_mode/switch_to_mode) instead of a display property. Remove rotation getter/setter in display object and rotation switch in modeline generator settings._