### PR TITLE
Bump GroovyMame to 0.253

### DIFF
--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -3,8 +3,8 @@
 # mame (Groovy Mame)
 #
 ################################################################################
-# Version: GroovyMAME 0.251 - Switchres 2.002o
-MAME_VERSION = gm0251sr002o
+# Version: GroovyMAME 0.253 - Switchres 2.002r
+MAME_VERSION = gm0253sr002r
 MAME_SITE = $(call github,antonioginer,GroovyMAME,$(MAME_VERSION))
 MAME_DEPENDENCIES = sdl2 sdl2_ttf zlib libpng fontconfig sqlite jpeg flac rapidjson expat glm
 MAME_LICENSE = MAME


### PR DESCRIPTION
**GroovyMAME 0.253**

What's new in Switchres 2.002r (March 2023)

- Improve rendering of UI frames and lines in low resolutions. [Oomek]

- Correctly apply rotation after modeline adjustment (using the geometry sliders with rotated games now works).

- Correctly apply syncrefresh (it wasn't applied automatically since v_scale was changed from int to float).


**GroovyMAME 0.252**

What's new in Switchres 2.002q (February 2023)

- Implement integer scaled fonts. Finally clear fonts for CRTs at low resolutions. Set uifont uismall.bdf in mame.ini to enable it. [Oomek & Calamity]

- Force 2-line step for -v_shift (option & slider) on interlaced modes. This way it preserves vertical field parity which is required for correct timings and some hardware. Maybe you need to readjust your previous -v_shift settings.