### PR TITLE
fix(cemu): add missing dependency to wxwidgets

### DIFF
--- a/package/batocera/emulators/cemu/Config.in
+++ b/package/batocera/emulators/cemu/Config.in
@@ -15,6 +15,7 @@ config BR2_PACKAGE_CEMU
     select BR2_PACKAGE_ZSTD
     select BR2_PACKAGE_GLM
     select BR2_PACKAGE_LIBPNG
+    select BR2_PACKAGE_WXWIDGETS
     help
       Cemu is a Wii U emulator that now runs natively on Linux.
 


### PR DESCRIPTION
A build without PCSX2 fails because cemu requires wxwidgets but does not declare this requirement.