### PR TITLE
odroid-n2 and odroid-n2-plus / Added a boot.ini to support use of petitboot, an onboard kexec-based bootloader

### DIFF
--- a/board/batocera/amlogic/s922x/odroidn2/boot/boot.ini
+++ b/board/batocera/amlogic/s922x/odroidn2/boot/boot.ini
@@ -1,0 +1,24 @@
+ODROIDN2-UBOOT-CONFIG
+
+setenv bootlabel "Batocera"
+setenv variant "n2"
+
+# Set load addresses (from updated U-boot 2023.01 defaults)
+setenv dtb_loadaddr    "0x08008000"
+setenv boot_loadaddr   "0x08080000"
+setenv initrd_loadaddr "0x13000000"
+
+# Default Console Device Setting
+setenv condev "console=ttyAML0,115200n8"   # on both
+
+# Boot Args
+setenv bootargs "label=BATOCERA console=tty3 rootwait quiet loglevel=0 ${condev}"
+
+# Load kernel, dtb and initrd
+load mmc ${devno}:1 ${dtb_loadaddr} boot/meson-g12b-odroid-${variant}.dtb
+load mmc ${devno}:1 ${boot_loadaddr} boot/linux
+load mmc ${devno}:1 ${initrd_loadaddr} boot/initrd.lz4
+fdt addr ${dtb_loadaddr}
+
+# boot
+bootm ${boot_loadaddr} ${initrd_loadaddr} ${dtb_loadaddr}

--- a/board/batocera/amlogic/s922x/odroidn2/create-boot-script.sh
+++ b/board/batocera/amlogic/s922x/odroidn2/create-boot-script.sh
@@ -14,16 +14,17 @@ BINARIES_DIR=$4
 TARGET_DIR=$5
 BATOCERA_BINARIES_DIR=$6
 
-mkdir -p "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2"     || exit 1
-cp "${BOARD_DIR}/build-uboot.sh"          "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2/" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2"                          || exit 1
+cp "${BOARD_DIR}/build-uboot.sh" "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2/" || exit 1
 cd "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2/" && ./build-uboot.sh "${HOST_DIR}" "${BOARD_DIR}" "${BINARIES_DIR}" || exit 1
 
 mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot"     || exit 1
 mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux" || exit 1
 
-cp "${BINARIES_DIR}/Image"            "${BATOCERA_BINARIES_DIR}/boot/boot/linux"             || exit 1
-cp "${BINARIES_DIR}/initrd.lz4"       "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"        || exit 1
-cp "${BINARIES_DIR}/rootfs.squashfs"               "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-cp "${BINARIES_DIR}/meson-g12b-odroid-n2.dtb"      "${BATOCERA_BINARIES_DIR}/boot/boot/"     || exit 1
-cp "${BOARD_DIR}/boot/extlinux.conf"               "${BATOCERA_BINARIES_DIR}/boot/extlinux/" || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"               "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"          || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"                    "${BATOCERA_BINARIES_DIR}/boot/boot/boot.ini"                 || exit 1
+cp "${BINARIES_DIR}/initrd.lz4"                    "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"               || exit 1
+cp "${BINARIES_DIR}/Image"                         "${BATOCERA_BINARIES_DIR}/boot/boot/linux"                    || exit 1
+cp "${BINARIES_DIR}/meson-g12b-odroid-n2.dtb"      "${BATOCERA_BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2.dtb" || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"               "${BATOCERA_BINARIES_DIR}/boot/extlinux/extlinux.conf"        || exit 1
 exit 0

--- a/board/batocera/amlogic/s922x/odroidn2plus/boot/boot.ini
+++ b/board/batocera/amlogic/s922x/odroidn2plus/boot/boot.ini
@@ -1,0 +1,24 @@
+ODROIDN2-UBOOT-CONFIG
+
+setenv bootlabel "Batocera"
+setenv variant "n2-plus"
+
+# Set load addresses (from updated U-boot 2023.01 defaults)
+setenv dtb_loadaddr    "0x08008000"
+setenv boot_loadaddr   "0x08080000"
+setenv initrd_loadaddr "0x13000000"
+
+# Default Console Device Setting
+setenv condev "console=ttyAML0,115200n8"   # on both
+
+# Boot Args
+setenv bootargs "label=BATOCERA console=tty3 rootwait quiet loglevel=0 ${condev}"
+
+# Load kernel, dtb and initrd
+load mmc ${devno}:1 ${dtb_loadaddr} boot/meson-g12b-odroid-${variant}.dtb
+load mmc ${devno}:1 ${boot_loadaddr} boot/linux
+load mmc ${devno}:1 ${initrd_loadaddr} boot/initrd.lz4
+fdt addr ${dtb_loadaddr}
+
+# boot
+bootm ${boot_loadaddr} ${initrd_loadaddr} ${dtb_loadaddr}

--- a/board/batocera/amlogic/s922x/odroidn2plus/create-boot-script.sh
+++ b/board/batocera/amlogic/s922x/odroidn2plus/create-boot-script.sh
@@ -14,21 +14,18 @@ BINARIES_DIR=$4
 TARGET_DIR=$5
 BATOCERA_BINARIES_DIR=$6
 
-mkdir -p "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2plus" || exit 1
-cp "${BOARD_DIR}/build-uboot.sh"          "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2plus/" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2plus"                          || exit 1
+cp "${BOARD_DIR}/build-uboot.sh" "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2plus/" || exit 1
 cd "${BATOCERA_BINARIES_DIR}/build-uboot-odroidn2plus/" && ./build-uboot.sh "${HOST_DIR}" "${BOARD_DIR}" "${BINARIES_DIR}" || exit 1
 
 mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot"     || exit 1
 mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux" || exit 1
 
-# "${HOST_DIR}/bin/mkimage" -A arm64 -O linux -T kernel -C none -a 0x1080000 -e 0x1080000 -n linux -d "${BINARIES_DIR}/Image" "${BATOCERA_BINARIES_DIR}/boot/boot/linux" || exit 1
-cp "${BINARIES_DIR}/Image"            "${BATOCERA_BINARIES_DIR}/boot/boot/linux"           || exit 1
-cp "${BINARIES_DIR}/initrd.lz4"       "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"      || exit 1
-cp "${BINARIES_DIR}/rootfs.squashfs"  "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" || exit 1
-
-cp "${BOARD_DIR}/boot/boot-logo.bmp.gz"            "${BATOCERA_BINARIES_DIR}/boot/"                                   || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"               "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"               || exit 1
+cp "${BOARD_DIR}/boot/boot.ini"                    "${BATOCERA_BINARIES_DIR}/boot/boot/boot.ini"                      || exit 1
+cp "${BINARIES_DIR}/initrd.lz4"                    "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"                    || exit 1
+cp "${BINARIES_DIR}/Image"                         "${BATOCERA_BINARIES_DIR}/boot/boot/linux"                         || exit 1
 cp "${BINARIES_DIR}/meson-g12b-odroid-n2-plus.dtb" "${BATOCERA_BINARIES_DIR}/boot/boot/meson-g12b-odroid-n2-plus.dtb" || exit 1
-cp "${BOARD_DIR}/boot/extlinux.conf"               "${BATOCERA_BINARIES_DIR}/boot/extlinux/"                          || exit 1
-cp "${BOARD_DIR}/boot/extlinux.conf"               "${BATOCERA_BINARIES_DIR}/boot/boot/"                              || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"               "${BATOCERA_BINARIES_DIR}/boot/extlinux/extlinux.conf"             || exit 1
 
 exit 0


### PR DESCRIPTION
The N2 and N2-plus have a boot switch that loads a bootloader (Petitboot) from SPI NOR. This reintroduction of the boot.ini file enables Batocera to boot from Petitboot, which is helpful for people that want to run Batocera on an SD card while having another OS on emmc. (Boot order in the other position is emmc first)

- boot.ini adapted from previous version in batocera
- config.ini (from previous) not included, not needed
- create-boot-script aligned between the two boards

If someone has a straight-up N2 maybe they can test.