### PR TITLE
sega32x: add extension chd

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -507,7 +507,7 @@ sega32x:
   manufacturer: Sega
   release: 1994
   hardware: console
-  extensions: [32x, smd, bin, md, zip, 7z]
+  extensions: [32x, chd, smd, bin, md, zip, 7z]
   group:      megadrive
   emulators:
     libretro:


### PR DESCRIPTION
For the six Sega CD titles that require a 32X
- Corpse Killer
- Fahrenheit
- Night Trap
- Slam City with Scotty Pippen
- Supreme Warrior
- Surgical Strike