### PR TITLE
[Add] m3u to msxturbor

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1719,7 +1719,7 @@ msxturbor:
   manufacturer: Microsoft
   release: 1990
   hardware: computer
-  extensions: [dsk, mx2, rom, zip, 7z, openmsx]
+  extensions: [dsk, mx2, rom, zip, 7z, openmsx, m3u]
   platform:   msx
   group:      msx
   emulators:


### PR DESCRIPTION
Fixed problem:
msxturbor can use m3u
but EmulationStation cannot recognize

The way:
add settings to es-systems.yml
