### PR TITLE
[Fix] settings name on configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -21,13 +21,15 @@ class Emulator():
         system_emulator = self.config["emulator"]
         system_core     = self.config["core"]
 
+        gsname = self.game_settings_name(rom)
+
         # load configuration from batocera.conf
         recalSettings = UnixSettings(batoceraFiles.batoceraConf)
         globalSettings = recalSettings.loadAll('global')
         controllersSettings = recalSettings.loadAll('controllers', True)
         systemSettings = recalSettings.loadAll(self.name)
         folderSettings = recalSettings.loadAll(self.name + ".folder[\"" + os.path.dirname(rom) + "\"]")
-        gameSettings = recalSettings.loadAll(self.name + "[\"" + os.path.basename(rom) + "\"]")
+        gameSettings = recalSettings.loadAll(self.name + "[\"" + gsname + "\"]")
 
         # add some other options
         displaySettings = recalSettings.loadAll('display')
@@ -66,11 +68,22 @@ class Emulator():
         # but it should be reviewed when we refactor configgen (to Python3?)
         # so that we can fetch them from system.shader without -renderer
         systemSettings = recalSettings.loadAll(self.name + "-renderer")
-        gameSettings = recalSettings.loadAll(self.name + "[\"" + os.path.basename(rom) + "\"]" + "-renderer")
+        gameSettings = recalSettings.loadAll(self.name + "[\"" + gsname + "\"]" + "-renderer")
 
         # es only allow to update systemSettings and gameSettings in fact for the moment
         Emulator.updateConfiguration(self.renderconfig, systemSettings)
         Emulator.updateConfiguration(self.renderconfig, gameSettings)
+
+    def game_settings_name(self,rom):
+
+        rom = os.path.basename(rom)
+
+        # sanitize rule by EmulationStation 
+        # see FileData::getConfigurationName() on batocera-emulationstation 
+        rom = rom.replace('=','')
+        rom = rom.replace('#','')
+        eslog.info("game settings name: "+rom)
+        return rom
 
     # to be updated for python3: https://gist.github.com/angstwad/bf22d1822c38a92ec0a9
     @staticmethod


### PR DESCRIPTION
Fixed problem:
EmulationStation sanitize a game name (if include # or =)
but batocera-configgen cannot recognized the name

The way:
do the same sanitize rule in configggen
