### PR TITLE
Update openbox/rc.xml to support flatpak Lutris

### DIFF
--- a/board/batocera/fsoverlay/etc/openbox/rc.xml
+++ b/board/batocera/fsoverlay/etc/openbox/rc.xml
@@ -8,5 +8,11 @@
 	  <application type="normal">
 	    <fullscreen>yes</fullscreen>
 	  </application>
+      <application class="flatpak-bwrap">
+        <fullscreen>no</fullscreen>
+      </application>
+      <application class="Lutris">
+        <fullscreen>no</fullscreen>
+      </application>
 	</applications>
 </openbox_config>


### PR DESCRIPTION
This change exclusively enables flatpak Lutris to run in windowed mode, which it needs, because it uses a gtk-styled layout that has an add/"+" button on the window titlebar

The app is entirely unusable without this change 

![image](https://github.com/batocera-linux/batocera.linux/assets/116395185/6c356b3b-b8a3-4653-a896-eed65ba24bb3)
