### PR TITLE
Ability to run specified commands inside Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ dl-dir:
 		make O=/$* BR2_EXTERNAL=/build BR2_GRAPH_OUT=svg -C /build/buildroot graph-depends
 
 %-shell: batocera-docker-image output-dir-%
-	$(if $(BATCH_MODE),$(error "not suppoorted in BATCH_MODE!"),)
+	$(if $(BATCH_MODE),$(if $(CMD),,$(error "not suppoorted in BATCH_MODE if CMD not specified!")),)
 	@$(DOCKER) run -t --init --rm \
 		-v $(PROJECT_DIR):/build \
 		-v $(DL_DIR):/build/buildroot/dl \
@@ -177,7 +177,8 @@ dl-dir:
 		$(DOCKER_OPTS) \
 		-v /etc/passwd:/etc/passwd:ro \
 		-v /etc/group:/etc/group:ro \
-		$(DOCKER_REPO)/$(IMAGE_NAME)
+		$(DOCKER_REPO)/$(IMAGE_NAME) \
+		$(CMD)
 
 %-cleanbuild: %-clean %-build
 	@echo


### PR DESCRIPTION
Ability to run specified commands inside the Docker container.
E.g.:
```
make x86_64-shell CMD="echo This command is run inside the container"
```

This can be useful for scripts that run custom steps of a build (in my case I need to run `mkimage` inside the container as a part of script for building experimental kernel versions).