### PR TITLE
GunCon2 remapping

### DIFF
--- a/package/batocera/controllers/guncon/guncon.mk
+++ b/package/batocera/controllers/guncon/guncon.mk
@@ -3,7 +3,7 @@
 # guncon
 #
 ################################################################################
-GUNCON_VERSION = 7e2999ad0abc9da1dae48432c2c5e6aa1e888aa4
+GUNCON_VERSION = 4e959300f14b9ad364ea66dce6189c076de63a27
 GUNCON_SITE = $(call github,Redemp,guncon2,$(GUNCON_VERSION))
 
 define GUNCON_INSTALL_TARGET_CMDS


### PR DESCRIPTION
Rewrote the driver for the GunCon2 for compatibility and changed button & dpad presses from gamepad & joystick hat to keyboard inputs.

This basically mimics how the Gun4ir is reporting it's buttons.  

Worked together with @Tovarichtch 

I separate pr for the updated GunCon2 Virtual-gun mapping will follow.