### PR TITLE
allows fog hack as user select-able option

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7582,6 +7582,20 @@ pcsx2:
                 "Maximum 2 Players (Default)": 2
                 "Maximum 4 Players":           4
                 "Maximum 8 Players":           8
+        pcsx2_texture_replacements:
+            group: ADVANCED OPTIONS
+            prompt: TEXTURE REPLACEMENTS
+            description: Allows user replaceable textures.
+            choices:
+                "Off": "false"
+                "On":  "true"
+        pcsx2_crisis_fog:
+            group: ADVANCED OPTIONS
+            prompt: TIME CRISIS FOG HACK
+            description: Necessary for some guns to replace fog textures as a workaround in Time Crisis - Crisis Zone.
+            choices:
+                "Off": "false"
+                "On":  "true"
 
 ppsspp:
   shared: [videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rewind]


### PR DESCRIPTION
@nadenislamarre for your review...

1. Added the option for alowing custom textures
2. Added the fog hack as an option from users request
3. We now symbolic link the file from `/usr/pcsx2/bin/resources/textures/....` accordingly
4. If the option is not enabled, we remove the symbolic link

Over to you...