### PR TITLE
configgen: Change default crop overscan for NES to vertical only

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -67,6 +67,7 @@
 - ppsspp now fully uses SDL2 controller config
 - more rpcs3 ES options
 - more pcsx2 options
+- Default crop overscan setting for NES is now vertical only
 ### Updated
 - lr-snes9x to v1.62.3
 - xenia to v1.0.2798

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1429,11 +1429,11 @@ def generateCoreSettings(coreSettings, system, rom, guns):
         elif system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "h":
             coreSettings.save('nestopia_overscan_h',    '"enabled"')
             coreSettings.save('nestopia_overscan_v',    '"disabled"')
-        elif system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "v":
-            coreSettings.save('nestopia_overscan_h',    '"disabled"')
+        elif system.isOptSet('nestopia_cropoverscan') and system.config['nestopia_cropoverscan'] == "both":
+            coreSettings.save('nestopia_overscan_h',    '"enabled"')
             coreSettings.save('nestopia_overscan_v',    '"enabled"')
         else:
-            coreSettings.save('nestopia_overscan_h',    '"enabled"')
+            coreSettings.save('nestopia_overscan_h',    '"disabled"')
             coreSettings.save('nestopia_overscan_v',    '"enabled"')
         # Palette Choice
         if system.isOptSet('nestopia_palette'):
@@ -1486,11 +1486,11 @@ def generateCoreSettings(coreSettings, system, rom, guns):
         elif system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "h":
             coreSettings.save('fceumm_overscan_h',    '"enabled"')
             coreSettings.save('fceumm_overscan_v',    '"disabled"')
-        elif system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "v":
-            coreSettings.save('fceumm_overscan_h',    '"disabled"')
+        elif system.isOptSet('fceumm_cropoverscan') and system.config['fceumm_cropoverscan'] == "both":
+            coreSettings.save('fceumm_overscan_h',    '"enabled"')
             coreSettings.save('fceumm_overscan_v',    '"enabled"')
         else:
-            coreSettings.save('fceumm_overscan_h',    '"enabled"')
+            coreSettings.save('fceumm_overscan_h',    '"disabled"')
             coreSettings.save('fceumm_overscan_v',    '"enabled"')
         # Palette Choice
         if system.isOptSet('fceumm_palette'):


### PR DESCRIPTION
Cropping horizontal overscan leads to text being cut off in certain games (e.g. Castlevania). The default for both Nestopia and FCEUmm libretro cores is to only crop the vertical overscan.