### PR TITLE
Bugfix/kodi resolution restore

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -122,17 +122,11 @@ case ${1,,} in
         RC_PID=$(check_emurun)
         [[ -n $RC_PID ]] && emu_kill && sleep 2
 
-        # save current resolution
-        current_resolution=$(batocera-resolution currentMode)
-        
         /etc/init.d/S31emulationstation stop
         batocera-kodilauncher &
         wait $!
         exitcode=$?
-        if [[ $exitcode -eq 0 ]]; then
-            /usr/bin/batocera-resolution setMode "$current_resolution"
-            /etc/init.d/S31emulationstation start
-        fi
+        [[ $exitcode -eq 0 ]] && /etc/init.d/S31emulationstation start
         [[ $exitcode -eq 10 ]] && shutdown -r now
         [[ $exitcode -eq 11 ]] && shutdown -h now
     ;;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-kodilauncher
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-kodilauncher
@@ -42,6 +42,9 @@ fi
 # Kodi complains about these directories not existing in the logs
 mkdir -p /userdata/system/.kodi/userdata/addon_data/pvr.{iptvsimple,nextpvr,vbox,vuplus}
 
+# save current resolution
+current_resolution=$(batocera-resolution currentMode)
+
 (
     LD_LIBRARY_PATH="/usr/lib/mysql" /usr/lib/kodi/kodi.bin --standalone -fs
     echo "Kodi process ended." >&2
@@ -64,6 +67,7 @@ do
 	"EXIT")
 	    kodiLastChance
 	    wait
+	    /usr/bin/batocera-resolution setMode "$current_resolution"
 	    exit 0 # code for success
 	    ;;
 	"RESTART")


### PR DESCRIPTION

Previous patch in PR #8986 was insufficient (and failed in my testing), as it only affects execution via batocera-es-swissknife.  The change is reverted in this PR.

This patch affects all relevant invocation paths: batocera-es-swissknife, batocera-kodi, and batocera-kodilauncher.