### PR TITLE
Create symlink for dropbear SSH root authorized_keys, fixes #5540

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -91,6 +91,10 @@ done
 # ssh : create directory, but not keys because lack of entropy, dropbear will automatically generate key on client connection
 mkdir -p /userdata/system/ssh
 
+# ssh : create directory for user keys, and symlink authorized_keys target for ssh-copy-id to populate later
+mkdir -p /userdata/system/.ssh
+ln -s ../.ssh/authorized_keys /userdata/system/ssh/authorized_keys
+
 # udev : create a link for rules persistance
 mkdir -p /userdata/system/udev/rules.d
 rm -rf /run/udev/rules.d


### PR DESCRIPTION
Create symlink for authorized_keys file, as described in [my comment on issue #5540](https://github.com/batocera-linux/batocera.linux/issues/5540#issuecomment-1593894740)
