### PR TITLE
Add Xbox Elite 2 Core

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4210,4 +4210,27 @@
 		<input name="x" type="button" id="0" value="1" code="288" />
 		<input name="y" type="button" id="3" value="1" code="291" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Xbox Wireless Controller" deviceGUID="050000005e0400008e02000030110000">
+		<input name="a" type="button" id="3" value="1" code="305" />
+		<input name="b" type="button" id="2" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="314" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="l3" type="button" id="11" value="1" code="317" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
+		<input name="r3" type="button" id="12" value="1" code="318" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="8" value="1" code="314" />
+		<input name="start" type="button" id="9" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="5" value="1" code="308" />
+		<input name="y" type="button" id="4" value="1" code="307" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
This PR need check before merge because it makes a duplicate entry.

`deviceName="Xbox Wireless Controller" deviceGUID="050000005e0400008e02000030110000"` (old) Xbox One Wireless
`deviceName="Xbox Wireless Controller" deviceGUID="050000005e0400008e02000030110000"` (new) Xbox Elite 2
Also have other controller is new Xbox Series X Controller (Starfield Edition) with same entry but not same configuration.
`deviceName="Xbox Wireless Controller" deviceGUID="050000005e0400008e02000030110000"` (new) Xbox Series X (SE)

If we really can't tell them apart then maybe it will be better not to merge this PR and let the user add his controller ? @nadenislamarre 