### PR TITLE
Force mpv to use SDL for audio output

### DIFF
--- a/package/batocera/core/batocera-splash/scripts/Ssplash-mpv
+++ b/package/batocera/core/batocera-splash/scripts/Ssplash-mpv
@@ -66,7 +66,7 @@ do_videostart ()
 {
     video="$1"
     printf 'Video: %s: ' "$video"
-    mpv_audio=
+    mpv_audio=--ao=sdl
 
     soundDisabled=$(batocera-settings-get splash.screen.sound)
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
Some boards miss splash video sound if ao is not set to sdl.
It is a safe move as this only changes the splash script used on x86 and boards (except rpi) and SDL is built everywhere.
