### PR TITLE
Fix es.resolution not being honored properly

### DIFF
--- a/package/batocera/core/batocera-settings/batocera-settings-get-master
+++ b/package/batocera/core/batocera-settings/batocera-settings-get-master
@@ -3,6 +3,15 @@
 # this script can be used by values that can have a default value by board
 
 KEY="$1"
+FILE="/usr/share/batocera/sysconfigs/batocera.conf"
+
+# handle -f flag properly
+while getopts "f:" arg; do
+  case $arg in
+    f)
+      FILE="$OPTARG";;
+  esac
+done
 
 # prefer the user value
 VALUE="$(/usr/bin/batocera-settings-get "${KEY}")"
@@ -32,8 +41,8 @@ if [ -e "/usr/share/batocera/sysconfigs/batocera.conf.${BOARD_MODEL}" ]; then
 fi
 
 # prefer the general value
-if [ -e "/usr/share/batocera/sysconfigs/batocera.conf" ]; then
-    /usr/bin/batocera-settings-get -f "/usr/share/batocera/sysconfigs/batocera.conf" "${KEY}" && exit 0
+if [ -e "${FILE}" ]; then
+    /usr/bin/batocera-settings-get -f "${FILE}" "${KEY}" && exit 0
 fi
 
 exit 1

--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -68,7 +68,7 @@ do
     ###################
 
     ### resolution ###
-    bootresolution="$(batocera-settings-get-master -f "$BOOTCONF" es.resolution)"
+    bootresolution="$(batocera-settings-get-master es.resolution -f "$BOOTCONF")"
     if test -z "${bootresolution}"
     then
 	    batocera-resolution minTomaxResolution-secure
@@ -116,7 +116,7 @@ do
         which xrandr && xrandr -r "${FRAMERATE}"
         ###################
 
-        forcedresolution="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf es.forcedresolution)"
+        forcedresolution="$(/usr/bin/batocera-settings-get -f "$BOOTCONF" es.forcedresolution)"
         if test -n "${forcedresolution}"
         then
             batocera-resolution forceMode "${forcedresolution}"


### PR DESCRIPTION
When using sysconfigs to override es.resolution it is not honored because -f flag is not taked into account in batocera-settings-get-master script.
Implement it.
Adjust emulationstation-standalone not using BOOTCONF but hardcoded path for forcedresolution.

@lbrpdx @Ntemis @jdorigao please review.