### PR TITLE
Show text diagnostics on the console instead of black screen

### DIFF
--- a/board/batocera/patches/xapp_xinit/002-failure-diagnostics.patch
+++ b/board/batocera/patches/xapp_xinit/002-failure-diagnostics.patch
@@ -1,0 +1,23 @@
+--- a/startx.cpp
++++ b/startx.cpp
+@@ -333,5 +333,20 @@
+ kbd_mode -a
+ #endif
+ 
++if [ $retval -ne 0 ]; then
++    XCOMM X has crashed or otherwise failed
++    XCOMM Display some diagnostics instead of leaving the user at a Black Screen of Death
++
++    XCOMM Switch to the system console virtual terminal
++    chvt "$(cat /sys/devices/virtual/tty/console/active | tr -d 'a-z')"
++
++    XCOMM Pause to allow any system initialization messages to finish printing
++    sleep 10
++
++    XCOMM Display diagnostic information, omitting potentially confusing reference to X.Org wiki
++    sed -e '/X\.Org Foundation support/,+3d' /var/log/Xorg.0.log > /dev/console
++    echo "$(date): X server failed to start!  Log file is: /var/log/Xorg.0.log" > /dev/console
++fi
++
+ exit $retval
+ 


### PR DESCRIPTION
Show text diagnostics on the console instead of black screen, if xinit fails to start X from startx

There are several different failure modes which can result in Batocera booting, displaying the splash screen and video, and then leaving the user at a black screen.

Diagnosing these black screen problems, and providing assistance in the Discord channels or elsewhere is challenging.  Wrong outputs, bad/incompatible resolution settings, and Xorg failing or crashing all lead to a similar result.

This PR will make the last category behave distinctly from the others, and will provide more information in these Xorg failure scenarios.  Instead of being left on a black screen, the user will be switched to a text virtual terminal console, the Xorg log will be dumped onto that terminal, and the user will be left at a root shell console prompt.