### PR TITLE
Fixup libopenmpt requiring mpg123 and Config.in help text

### DIFF
--- a/package/batocera/libraries/libopenmpt/Config.in
+++ b/package/batocera/libraries/libopenmpt/Config.in
@@ -2,7 +2,9 @@ config BR2_PACKAGE_LIBOPENMPT
 	bool "libopenmpt"
 	select BR2_PACKAGE_HOST_DOXYGEN
 	select BR2_PACKAGE_ZLIB
+	select BR2_PACKAGE_MPG123
 	help 
-	    This library provides objects and helper methods to help reading and writing AppStream metadata.
+	    OpenMPT and libopenmpt
+	    OpenMPT, a free Windows/Wine-based tracker and libopenmpt, a library to render tracker music.
 
-		https://github.com/hughsie/appstream-glib
+		https://github.com/OpenMPT/openmpt

--- a/package/batocera/libraries/libopenmpt/libopenmpt.mk
+++ b/package/batocera/libraries/libopenmpt/libopenmpt.mk
@@ -10,6 +10,6 @@ LIBOPENMPT_SOURCE = libopenmpt-${LIBOPENMPT_VERSION}+release.autotools.tar.gz
 LIBOPENMPT_SITE = https://lib.openmpt.org/files/libopenmpt/src
 LIBOPENMPT_INSTALL_STAGING = YES
 LIBOPENMPT_AUTORECONF = YES
-LIBOPENMPT_DEPENDENCIES = host-pkgconf zlib host-doxygen
+LIBOPENMPT_DEPENDENCIES = host-pkgconf zlib host-doxygen mpg123
 
 $(eval $(autotools-package))


### PR DESCRIPTION
It used to work only because mpg123 is selected by other packages, but doing a build without emulators ALL_SYSTEMS and only Kodi brings a failure.
Fix that and broken help text.