### PR TITLE
Add RPCS3 ES settings for audio buffer duration

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -209,7 +209,11 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Audio"]["Enable Buffering"] = system.config["rpcs3_audiobuffer"]
         else:
             rpcs3ymlconfig["Audio"]["Enable Buffering"] = True
-        rpcs3ymlconfig["Audio"]["Desired Audio Buffer Duration"] = 100
+        # audio buffer duration
+        if system.isOptSet("rpcs3_audiobuffer_duration"):
+            rpcs3ymlconfig["Audio"]["Desired Audio Buffer Duration"] = system.config["rpcs3_audiobuffer_duration"]
+        else:
+            rpcs3ymlconfig["Audio"]["Desired Audio Buffer Duration"] = 100
         # time stretching
         if system.isOptSet("rpcs3_timestretch") and system.config["rpcs3_timestretch"] == "True":
             rpcs3ymlconfig["Audio"]["Enable Time Stretching"] = True

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7973,6 +7973,19 @@ rpcs3:
             choices:
                 "Off":          False
                 "On (Default)": True
+        rpcs3_audiobuffer_duration:
+            group: AUDIO
+            prompt: AUDIO BUFFER DURATION
+            description: Duration of audio buffer in milliseconds.
+            choices:
+                "10": 10
+                "20": 20
+                "40": 40
+                "60": 60
+                "80": 80
+                "100 (Default)": 100
+                "120": 120
+                "140": 140
         rpcs3_timestretch:
             group: AUDIO
             prompt: ENABLE TIME STRETCHING


### PR DESCRIPTION
Edit for use with added audio buffer duration settings in es_features