### PR TITLE
Fix dropbear directory layout for ssh-copy-id, fixes #5540

### DIFF
--- a/board/batocera/dropbear_localoptions.h
+++ b/board/batocera/dropbear_localoptions.h
@@ -1,1 +1,6 @@
 #define DEFAULT_RECV_WINDOW 10485760
+
+#define DSS_PRIV_FILENAME "/userdata/system/ssh/dropbear_dss_host_key"
+#define RSA_PRIV_FILENAME "/userdata/system/ssh/dropbear_rsa_host_key"
+#define ECDSA_PRIV_FILENAME "/userdata/system/ssh/dropbear_ecdsa_host_key"
+#define ED25519_PRIV_FILENAME "/userdata/system/ssh/dropbear_ed25519_host_key"

--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -91,6 +91,10 @@ done
 # ssh : create directory, but not keys because lack of entropy, dropbear will automatically generate key on client connection
 mkdir -p /userdata/system/ssh
 
+# ssh : create directory for SSH user data (including identity keys, authorized_keys, known_hosts)
+mkdir -p -m 0700 /userdata/system/.ssh
+chmod 0700 /userdata/system/.ssh
+
 # udev : create a link for rules persistance
 mkdir -p /userdata/system/udev/rules.d
 rm -rf /run/udev/rules.d

--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -15,7 +15,7 @@ BATOCERA_TARGET=$(grep -E "^BR2_PACKAGE_BATOCERA_TARGET_[A-Z_0-9]*=y$" "${BR2_CO
 sed -i "s|^root:x:.*$|root:x:0:0:root:/userdata/system:/bin/bash|g" "${TARGET_DIR}/etc/passwd" || exit 1
 
 rm -rf "${TARGET_DIR}/etc/dropbear" || exit 1
-ln -sf "/userdata/system/ssh" "${TARGET_DIR}/etc/dropbear" || exit 1
+ln -sf "/userdata/system/.ssh" "${TARGET_DIR}/etc/dropbear" || exit 1
 
 mkdir -p ${TARGET_DIR}/etc/emulationstation || exit 1
 ln -sf "/usr/share/emulationstation/es_systems.cfg" "${TARGET_DIR}/etc/emulationstation/es_systems.cfg" || exit 1


### PR DESCRIPTION
Savvy users will use the OpenSSH `ssh-copy-id` script on remote systems to install their SSH keys to the authorized_keys file on Batocera.  The behavior of that widely deployed script is to target /etc/dropbear/authorized_keys when the remote system is running dropbear.

Before this patch, /etc/dropbear was a symlink to /userdata/system/ssh so that system keys would be written to that location. User keys are stored in /userdata/system/.ssh along with the authorized_keys and known_hosts files.

This patch maintains the separation of user keys/data from system keys, while allowing ssh-copy-id to function properly.