### PR TITLE
N64 controller auto remap for libreto n64 cores

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -420,6 +420,35 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
             wswanOrientation = system.config['wswan_rotate_display']
         retroarchConfig['wswan_rotate_display'] = wswanOrientation
 
+    ## N64 Controller Remap
+    def update_controller_config(controller_number, option):
+        # Remaps for N64 style controllers
+        remap_values = {
+            'btn_a': '1', 'btn_b': '0', 'btn_x': '23', 'btn_y': '21', 
+            'btn_l2': '22', 'btn_r2': '20', 'btn_select': '12',             
+        }
+            
+        config_option = system.config[f'{option}{controller_number}']
+        # Swap A/B if selected
+        if config_option in ['n64swapped', 'n64limitedswapped']:
+            remap_values['btn_a'] = '0'
+            remap_values['btn_b'] = '1'
+            
+        for btn, value in remap_values.items():
+            retroarchConfig[f'input_player{controller_number}_{btn}'] = value
+            
+            
+    if system.config['core'] == 'mupen64plus-next':
+        option = 'mupen64plus-controller'
+    elif system.config['core'] == 'parallel_n64':
+        option = 'parallel-n64-controller'
+    else:
+        option = None
+        
+    for i in range(1, 5):
+        if option and system.isOptSet(f'{option}{i}') and system.config[f'{option}{i}'] != 'retropad':
+            update_controller_config(i, option)
+                      
     ## PORTS
     ## Quake
     if (system.config['core'] == 'tyrquake'):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -428,12 +428,6 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
             'btn_l2': '22', 'btn_r2': '20', 'btn_select': '12',             
         }
             
-        config_option = system.config[f'{option}{controller_number}']
-        # Swap A/B if selected
-        if config_option in ['n64swapped', 'n64limitedswapped']:
-            remap_values['btn_a'] = '0'
-            remap_values['btn_b'] = '1'
-            
         for btn, value in remap_values.items():
             retroarchConfig[f'input_player{controller_number}_{btn}'] = value
             

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -65,7 +65,7 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
     else:
         option = None
     # Check for limited hotkey setting
-    if option and option in system.config and system.config[option] in ['n64limited', 'n64limitedswapped']:
+    if option and option in system.config and system.config[option] in ['n64limited']:
         retroarchspecials = {'start': 'exit_emulator'}
     
     for controller in controllers:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -55,7 +55,19 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
     # No menu in non full uimode
     if system.config["uimode"] != "Full":
         del retroarchspecials['b']
-
+    
+    # Check if hotkeys need to be removed/disabled (Needed for N64 controllers without a dedicated hotkey button)
+    # Assign value based on core
+    if (system.config['core'] == 'mupen64plus-next'):
+        option = 'mupen64plus-controller1'
+    elif (system.config['core'] == 'parallel_n64'):
+        option = 'parallel-n64-controller1'
+    else:
+        option = None
+    # Check for limited hotkey setting
+    if option and option in system.config and system.config[option] in ['n64limited', 'n64limitedswapped']:
+        retroarchspecials = {'start': 'exit_emulator'}
+    
     for controller in controllers:
         mouseIndex = None
         if system.name in ['nds', '3ds']:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3598,30 +3598,25 @@ libretro:
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
                     "N64 (Limited Hotkeys)": n64limited
-                    "N64 (Limited Hotkeys + A/B Swap)": n64limitedswapped
             mupen64plus-controller2:
                 prompt:     CONTROLLER 2 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
             mupen64plus-controller3:
                 prompt:     CONTROLLER 3 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
             mupen64plus-controller4:
                 prompt:     CONTROLLER 4 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
-                    "N64": n64
-                    "N64 (A/B SWAP)": n64swapped                    
+                    "N64": n64                   
             mupen64plus-Framerate:
                 group: ADVANCED OPTIONS
                 prompt: FRAME RATE
@@ -4083,30 +4078,25 @@ libretro:
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
                     "N64 (Limited Hotkeys)": n64limited
-                    "N64 (Limited Hotkeys + A/B Swap)": n64limitedswapped
             parallel-n64-controller2:
                 prompt:     CONTROLLER 2 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
             parallel-n64-controller3:
                 prompt:     CONTROLLER 3 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
                     "N64": n64
-                    "N64 (A/B SWAP)": n64swapped
             parallel-n64-controller4:
                 prompt:     CONTROLLER 4 TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
-                    "N64": n64
-                    "N64 (A/B SWAP)": n64swapped                
+                    "N64": n64               
     pce:
       features: [netplay, cheevos]
       shared: [rewind, autosave]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3592,6 +3592,36 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+            mupen64plus-controller1:
+                prompt:     CONTROLLER 1 TYPE
+                description: Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+                    "N64 (Limited Hotkeys)": n64limited
+                    "N64 (Limited Hotkeys + A/B Swap)": n64limitedswapped
+            mupen64plus-controller2:
+                prompt:     CONTROLLER 2 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+            mupen64plus-controller3:
+                prompt:     CONTROLLER 3 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+            mupen64plus-controller4:
+                prompt:     CONTROLLER 4 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped                    
             mupen64plus-Framerate:
                 group: ADVANCED OPTIONS
                 prompt: FRAME RATE
@@ -4047,6 +4077,36 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+            parallel-n64-controller1:
+                prompt:     CONTROLLER 1 TYPE
+                description: Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+                    "N64 (Limited Hotkeys)": n64limited
+                    "N64 (Limited Hotkeys + A/B Swap)": n64limitedswapped
+            parallel-n64-controller2:
+                prompt:     CONTROLLER 2 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+            parallel-n64-controller3:
+                prompt:     CONTROLLER 3 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped
+            parallel-n64-controller4:
+                prompt:     CONTROLLER 4 TYPE
+                description: Useful for N64 style controllers.
+                choices:
+                    "RetroPad (Default)": retropad
+                    "N64": n64
+                    "N64 (A/B SWAP)": n64swapped                
     pce:
       features: [netplay, cheevos]
       shared: [rewind, autosave]


### PR DESCRIPTION
For n64 style controllers with libreto n64 cores.

Automagically remaps inputs for users with n64 style controllers based on ES controller type setting. 
Does not break inputs for normal "retropads". Can mix and match! :)

Adds ES setting for P1 only that regenerates hotkey dictionary to only include exit_emulator. Needed for n64 controllers that don't have enough inputs for a dedicated hotkey. Without this users have to give up in-game input for a dedicated hotkey button.

Additional ES setting for A/B swap, so consistency is possible on a per controller basis between ES(with or without dev option to swap CONFIRM/CANCEL) and in-game inputs. 
(Default/Recommended mapping is "A" as SOUTH and "B" as EAST to keep consistency with other controllers/standard setups.)

N64 A/B Swap setting is needed for the below instance:
Example: If user has dev option to swap CONFIRM/CANCEL... "A" needs to be mapped to EAST and "B" to SOUTH. This results in desired behavior in ES but reverses A/B in-game. So the "N64 (A/B Swap)" setting is needed.

It's a bit confusing but the N64 controller is weird and it technically only has 2 face buttons and 4 auxiliary face buttons. So breaking from the standardized mold to ensure that in all instances "A" is confirm and "B" is cancel in-game regardless of UI setting and/or SOUTH and EAST inputs. 