### PR TITLE
fixing mame078plus light gun controls

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -845,6 +845,16 @@ def configureGunInputsForPlayer(n, gun, controllers, retroarchConfig, core):
         retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''
         retroarchConfig['input_player{}_gun_aux_a_mbtn'         .format(n)] = 2
 
+    if core == "mame078plus":
+        retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''
+        retroarchConfig['input_player{}_gun_start_mbtn'         .format(n)] = ''
+        retroarchConfig['input_player{}_gun_select_mbtn'        .format(n)] = ''
+        retroarchConfig['input_player{}_gun_aux_a_mbtn'         .format(n)] = ''
+        retroarchConfig['input_player{}_gun_aux_b_mbtn'         .format(n)] = ''
+        retroarchConfig['input_player{}_gun_start_mbtn'         .format(n)] = 3
+        retroarchConfig['input_player{}_gun_select_mbtn'        .format(n)] = 4
+
+
     # mapping
     mapping = {
         "gun_trigger"        : "b",


### PR DESCRIPTION
At the moment, the core is using its own controls & Batocera controls at the same time, which mixes up everything. Ex.: secondary button reloads offscreen and shoot grenade simultaneously. By removing the Batocera controls to only keep the start/coins buttons, it's working as intended. Tested on various gun games (ex.: le2) and analog stick gun games (ex.: term2, revx). This is only for mame078plus core.