### PR TITLE
Since the move to Mame 0.255 the old votrax.zip (speech synthesizer c…

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -614,8 +614,10 @@ systems = {
                                                 { "md5": "2020aa1413ff77fe29353f3ee72dc295", "zippedFile": "341-0027-a.p5", "file": "bios/a2diskiing.zip"},
                                                 { "md5": "", "file": "bios/a2cffa02.zip" },
                                                 { "md5": "80adbc2d79f347ec63f4b771ea32984d", "zippedFile": "cffa20ee02.bin", "file": "bios/a2cffa02.zip"},
-                                                { "md5": "", "file": "bios/votrax.zip" },
-                                                { "md5": "95b91e4a2fe7d6f13d353ba1827d37f9", "zippedFile": "sc01a.bin", "file": "bios/votrax.zip"},
+                                                { "md5": "", "file": "bios/votrsc01.zip" },
+                                                { "md5": "8ccf35a06f5e9a2131b0f42380ee5c15", "zippedFile": "sc01.bin", "file": "bios/votrsc01.zip"},
+                                                { "md5": "", "file": "bios/votrsc01a.zip" },
+                                                { "md5": "95b91e4a2fe7d6f13d353ba1827d37f9", "zippedFile": "sc01a.bin", "file": "bios/votrsc01a.zip"},
                                                 { "md5": "", "file": "bios/d2fdc.zip" },
                                                 { "md5": "5f1be0c1cdff26f5956eef9643911886", "zippedFile": "341-0028-a.rom", "file": "bios/d2fdc.zip"} ] },
 


### PR DESCRIPTION
…hip SC01) bios has been replaced by two.

fixes - https://github.com/batocera-linux/batocera.linux/issues/9188