### PR TITLE
Add ES Setting RPCS3 SPU Loop Detection

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -106,7 +106,11 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Core"]["Preferred SPU Threads"] = system.config["rpcs3_sputhreads"]
         else:
             rpcs3ymlconfig["Core"]["Preferred SPU Threads"] = 0
-
+        # SPU Loop Detection
+        if system.isOptSet("rpcs3_spuloopdetection"):
+            rpcs3ymlconfig["Core"]["SPU loop detection"] = system.config["rpcs3_spuloopdetection"]
+        else:
+            rpcs3ymlconfig["Core"]["SPU loop detection"] = False       
         # -= [Video] =-
         # gfx backend - default to Vulkan
         if system.isOptSet("rpcs3_gfxbackend"):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7890,6 +7890,13 @@ rpcs3:
                 "4 threads": 4
                 "5 threads": 5
                 "6 threads": 6
+        rpcs3_spuloopdetection:
+            submenu: CPU
+            prompt: SPU LOOP DETECTION
+            description: May provide performance gain on CPUs with low core/thread count at the expense of possible broken timings.
+            choices:
+                "Off (Default)": False
+                "On": True
         rpcs3_ratio:
             submenu: VIDEO
             prompt: ASPECT RATIO


### PR DESCRIPTION
SPU loop detection can improve performance on CPUs with low core/thread count. But may also result in broken timings in some games.