### PR TITLE
Add TheXTech game engine (SMBX)

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -331,6 +331,7 @@ menu "Emulators"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/ikemen/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/bigpemu/Config.in"
     source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/python-pyxel/Config.in"
+    source "$BR2_EXTERNAL_BATOCERA_PATH/package/batocera/emulators/thextech/Config.in"
   endmenu
 
   menu "WINE"

--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -15,6 +15,7 @@
 - vitaquake2 libretro core enabled for AArch64
 - ioquake3 to ports, An updated Quake III engine
 - play! emulator for PS2 but also Namco 246 & 256 systems
+- TheXTech game engine for Super Mario-like SMBX platform games
 ### Fixed
 - Fix wifi/bluetooth on Tinkerboard
 - Fixed crop overscan settings for NES to work with newer core builds

--- a/package/batocera/core/batocera-configgen/batocera-configgen.mk
+++ b/package/batocera/core/batocera-configgen/batocera-configgen.mk
@@ -11,7 +11,7 @@ BATOCERA_CONFIGGEN_DEPENDENCIES = python3 python-pyyaml
 BATOCERA_CONFIGGEN_INSTALL_STAGING = YES
 
 define BATOCERA_CONFIGGEN_EXTRACT_CMDS
-	cp -R $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-configgen/configgen/* $(@D)
+	cp -avf $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-configgen/configgen/* $(@D)
 endef
 
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_BCM2835),y)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/GeneratorImporter.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/GeneratorImporter.py
@@ -291,6 +291,10 @@ def getGenerator(emulator):
         from generators.ioquake3.ioquake3Generator import IOQuake3Generator
         return IOQuake3Generator()
 
+    if emulator == "thextech":
+        from generators.thextech.thextechGenerator import TheXTechGenerator
+        return TheXTechGenerator()
+
     if emulator == 'sh':
         from generators.sh.shGenerator import ShGenerator
         return ShGenerator()

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
@@ -1,0 +1,13 @@
+import Command
+from generators.Generator import Generator
+from utils.logger import get_logger
+
+eslog = get_logger(__name__)
+
+class TheXTechGenerator(Generator):
+
+    def generate(self, system, rom, playersControllers, guns, gameResolution):
+
+        commandArray = ["/usr/bin/thextech", "-c", rom]
+
+        return Command.Command(array=commandArray)

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -542,6 +542,11 @@ switch:
 
 # T-Z
 
+thextech:
+  emulator: thextech
+  core:     thextech
+  options:
+    bezel: none
 thomson:
   emulator: libretro
   core:     theodore

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -663,6 +663,9 @@ config BR2_PACKAGE_BATOCERA_HOMEBREW_SYSTEMS
     # Fighting games engine
     select BR2_PACKAGE_IKEMEN            if BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
 
+    # SMBX engine
+    select BR2_PACKAGE_THEXTECH
+
 #### Sega Dreamcast, Naomi and Atomiswave ####
 config BR2_PACKAGE_BATOCERA_SEGADC
     bool "batocera.linux dreamcast/naomi/atomiswave emulators/cores"

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -10634,3 +10634,8 @@ ioquake3:
         "128MB":           "128"
         "256MB (Default)": "256"
         "512MB":           "512"
+
+thextech:
+  features: [padtokeyboard]
+  shared: [videomode, hud, hud_corner]
+

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2154,6 +2154,16 @@ daphne:
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:daphne
 
+thextech:
+  name:       TheXTech
+  manufacturer: Wohlstand
+  release: 2020
+  hardware: port
+  extensions: [smbx]
+  emulators:
+    thextech:
+      thextech:  { requireAnyOf: [BR2_PACKAGE_THEXTECH] }
+
 thomson:
   name:       Thomson - MO/TO (Theodore)
   manufacturer: Thomson

--- a/package/batocera/emulators/thextech/Config.in
+++ b/package/batocera/emulators/thextech/Config.in
@@ -1,0 +1,10 @@
+config BR2_PACKAGE_THEXTECH
+    bool "thextech"
+    depends on BR2_PACKAGE_SDL2
+    depends on BR2_PACKAGE_SDL2_MIXER
+    select BR2_PACKAGE_SDL2_TTF
+
+    help
+      TheXTech is a C++ SMBX engine
+
+      https://github.com/Wohlstand/TheXTech/

--- a/package/batocera/emulators/thextech/thextech.keys
+++ b/package/batocera/emulators/thextech/thextech.keys
@@ -1,0 +1,9 @@
+{
+    "actions_player1": [
+	{
+            "trigger": ["hotkey", "start"],
+            "type": "key",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ]
+	}
+    ]
+}

--- a/package/batocera/emulators/thextech/thextech.mk
+++ b/package/batocera/emulators/thextech/thextech.mk
@@ -1,0 +1,23 @@
+################################################################################
+#
+# TheXTech
+#
+################################################################################
+# Last stable v 1.3.6 from Sep 12, 2022
+THEXTECH_VERSION = 2c855a76999d60340f63e7d91ab1d1075211ae58
+THEXTECH_SITE = https://github.com/Wohlstand/TheXTech
+THEXTECH_SITE_METHOD = git
+THEXTECH_GIT_SUBMODULES = YES
+THEXTECH_LICENSE = GPLv3
+THEXTECH_DEPENDENCIES = sdl2 sdl2_mixer sdl2_ttf
+
+THEXTECH_CONF_ENV = GIT_DISCOVERY_ACROSS_FILESYSTEM=1
+THEXTECH_CONF_OPTS = -DTHEXTECH_ENABLE_TTF_SUPPORT=ON -DUSE_SYSTEM_LIBS_DEFAULT=ON
+
+define THEXTECH_INSTALL_TARGET_CMDS
+	$(INSTALL) -D $(@D)/output/bin/thextech $(TARGET_DIR)/usr/bin/
+	cp -avf $(@D)/output/lib/libSDL2_mixer_ext.so* $(TARGET_DIR)/usr/lib/
+	cp -avf $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/thextech/thextech.keys $(TARGET_DIR)/usr/share/evmapy/
+endef
+
+$(eval $(cmake-package))


### PR DESCRIPTION
To install TheXTech games, download game assets, and extract them into a folder `/userdata/roms/thextech/<yourgame>.smbx/`

For example, the default SMBX assets can be downloaded from https://wohlsoft.ru/projects/TheXTech/_downloads/thextech-smbx13-assets-full.7z and put into a directory `/userdata/roms/thextech/thextech-smbx13-assets-full.smbx/`

Then you can launch from ES.

PR compiled on x86_64, rk3399 and rk3568. Tested on x86_64.