### PR TITLE
Mupen controller type and additional controller settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenConfig.py
@@ -8,7 +8,7 @@ import json
 def setMupenConfig(iniConfig, system, controllers, gameResolution):
 
     # Hotkeys
-    setHotKeyConfig(iniConfig, controllers)
+    setHotKeyConfig(iniConfig, controllers, system)
 
     # Paths
     if not iniConfig.has_section("Core"):
@@ -207,7 +207,7 @@ def setMupenConfig(iniConfig, system, controllers, gameResolution):
                     iniConfig.add_section(custom_section)
                 iniConfig.set(custom_section, custom_option, str(system.config[user_config]))
 
-def setHotKeyConfig(iniConfig, controllers):
+def setHotKeyConfig(iniConfig, controllers, system):
     if not iniConfig.has_section("CoreEvents"):
         iniConfig.add_section("CoreEvents")
     iniConfig.set("CoreEvents", "Version", "1")
@@ -216,6 +216,23 @@ def setHotKeyConfig(iniConfig, controllers):
         if 'hotkey' in controllers['1'].inputs:
             if 'start' in controllers['1'].inputs:
                 iniConfig.set("CoreEvents", "Joy Mapping Stop", "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['start'])))
+            if system.isOptSet("mupen64-controller1") and system.config["mupen64-controller1"] == "n64limited":
+                if 'y' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Save State", "")
+                if 'x' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Load State", "")
+                if 'pageup' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Screenshot", "")
+                if 'up' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Increment Slot", "")
+                if 'right' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Fast Forward", "")
+                if 'a' in controllers['1'].inputs:
+                    iniConfig.set("CoreEvents", "Joy Mapping Reset", "")
+                if 'b' in controllers['1'].inputs:                   
+                    iniConfig.set("CoreEvents", "Joy Mapping Pause", "")
+                return
+               
             if 'y' in controllers['1'].inputs:
                 iniConfig.set("CoreEvents", "Joy Mapping Save State", "\"J{}{}/{}\"".format(controllers['1'].index, createButtonCode(controllers['1'].inputs['hotkey']), createButtonCode(controllers['1'].inputs['y'])))
             if 'x' in controllers['1'].inputs:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
@@ -23,7 +23,7 @@ class MupenGenerator(Generator):
             iniConfig.read(batoceraFiles.mupenCustom)
 
         mupenConfig.setMupenConfig(iniConfig, system, playersControllers, gameResolution)
-        mupenControllers.setControllersConfig(iniConfig, playersControllers, system.config)
+        mupenControllers.setControllersConfig(iniConfig, playersControllers, system)
 
         # Save the ini file
         if not os.path.exists(os.path.dirname(batoceraFiles.mupenCustom)):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7499,7 +7499,143 @@ mupen64plus:
                 "Game default": -1
                 "Disable":      0
                 "Enable":       1
-
+        mupen64-controller1:
+            submenu: CONTROLLER 1
+            prompt: CONTROLLER TYPE             
+            description: Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey.
+            choices:
+                "RetroPad (Default)": retropad
+                "N64": n64
+                "N64 (Limited Hotkeys)": n64limited
+        mupen64-controller2:
+            submenu: CONTROLLER 2
+            prompt: CONTROLLER TYPE
+            description: Useful for N64 style controllers.
+            choices:
+                "RetroPad (Default)": retropad
+                "N64": n64
+        mupen64-controller3:
+            submenu: CONTROLLER 3
+            prompt: CONTROLLER TYPE
+            description: Useful for N64 style controllers.
+            choices:
+                "RetroPad (Default)": retropad
+                "N64": n64
+        mupen64-controller4:
+            submenu: CONTROLLER 4
+            prompt: CONTROLLER TYPE
+            description: Useful for N64 style controllers.
+            choices:
+                "RetroPad (Default)": retropad
+                "N64": n64
+        mupen64-sensitivity1:
+            submenu: CONTROLLER 1
+            prompt: SENSITIVITY
+            description: Set the sensitivity of the joystick analog sticks.
+            choices:
+                "50%": 50
+                "60%": 60
+                "70%": 70
+                "80%": 80
+                "90%": 90
+                "100% (Default)": 100
+                "110%": 110
+                "120%": 120
+                "130%": 130
+                "140%": 140
+                "150%": 150
+        mupen64-sensitivity2:
+            submenu: CONTROLLER 2
+            prompt: SENSITIVITY
+            description: Set the sensitivity of the joystick analog sticks.
+            choices:
+                "50%": 50
+                "60%": 60
+                "70%": 70
+                "80%": 80
+                "90%": 90
+                "100% (Default)": 100
+                "110%": 110
+                "120%": 120
+                "130%": 130
+                "140%": 140
+                "150%": 150        
+        mupen64-sensitivity3:
+            submenu: CONTROLLER 3
+            prompt: SENSITIVITY
+            description: Set the sensitivity of the joystick analog sticks.
+            choices:
+                "50%": 50
+                "60%": 60
+                "70%": 70
+                "80%": 80
+                "90%": 90
+                "100% (Default)": 100
+                "110%": 110
+                "120%": 120
+                "130%": 130
+                "140%": 140
+                "150%": 150
+        mupen64-sensitivity4:
+            submenu: CONTROLLER 4
+            prompt: SENSITIVITY
+            description: Set the sensitivity of the joystick analog sticks.
+            choices:
+                "50%": 50
+                "60%": 60
+                "70%": 70
+                "80%": 80
+                "90%": 90
+                "100% (Default)": 100
+                "110%": 110
+                "120%": 120
+                "130%": 130
+                "140%": 140
+                "150%": 150
+        mupen64-deadzone1:
+            submenu: CONTROLLER 1
+            prompt: DEADZONE
+            description: Set the deadzone of the joystick analog sticks.
+            choices:
+                "0%": 0
+                "5% (Default)": 5
+                "10%": 10
+                "15%": 15
+                "20%": 20
+                "25%": 25
+        mupen64-deadzone2:
+            submenu: CONTROLLER 2
+            prompt: DEADZONE
+            description: Set the deadzone of the joystick analog sticks.
+            choices:
+                "0%": 0
+                "5% (Default)": 5
+                "10%": 10
+                "15%": 15
+                "20%": 20
+                "25%": 25
+        mupen64-deadzone3:
+            submenu: CONTROLLER 3
+            prompt: DEADZONE
+            description: Set the deadzone of the joystick analog sticks.
+            choices:
+                "0%": 0
+                "5% (Default)": 5
+                "10%": 10
+                "15%": 15
+                "20%": 20
+                "25%": 25
+        mupen64-deadzone4:
+            submenu: CONTROLLER 4
+            prompt: DEADZONE
+            description: Set the deadzone of the joystick analog sticks.
+            choices:
+                "0%": 0
+                "5% (Default)": 5
+                "10%": 10
+                "15%": 15
+                "20%": 20
+                "25%": 25            
 openbor:
   shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
   cfeatures:

--- a/package/batocera/emulators/mupen64plus/mupen64plus-core/controllers/input.xml
+++ b/package/batocera/emulators/mupen64plus/mupen64plus-core/controllers/input.xml
@@ -1,28 +1,59 @@
 <inputList>
-<input name="AnalogDeadzone" value="0,0" />
-<input name="AnalogPeak"     value="32768,32768" />
-<input name="l3"             value="Mempak switch" />
-<input name="r3"             value="Rumblepak switch" />
-<input name="a"        	     value="C Button R" />
-<input name="b"        	     value="A Button" />
-<input name="x"        	     value="C Button U" />
-<input name="y"        	     value="B Button" />
-<input name="start"    	     value="Start" />
-<input name="select"   	     value="" />
-<input name="pageup"   	     value="L Trig" />
-<input name="pagedown" 	     value="R Trig" />
-<input name="l2"       	     value="Z Trig" />
-<input name="r2"       	     value="" />
-<input name="up"       	     value="DPad U" />
-<input name="down"     	     value="DPad D" />
-<input name="right"    	     value="DPad R" />
-<input name="left"     	     value="DPad L" />
-<input name="joystick1up"    value="Y Axis" />
-<input name="joystick1down"  value="Y Axis" />
-<input name="joystick1left"  value="X Axis" />
-<input name="joystick1right" value="X Axis" />
-<input name="joystick2up"    value="C Button U" />
-<input name="joystick2down"  value="C Button D" />
-<input name="joystick2left"  value="C Button L" />
-<input name="joystick2right" value="C Button R" />
+	<defaultInputList>
+		<input name="AnalogDeadzone" value="0,0" />
+		<input name="AnalogPeak"     value="32768,32768" />
+		<input name="l3"             value="Mempak switch" />
+		<input name="r3"             value="Rumblepak switch" />
+		<input name="a"        	     value="C Button R" />
+		<input name="b"        	     value="A Button" />
+		<input name="x"        	     value="C Button U" />
+		<input name="y"        	     value="B Button" />
+		<input name="start"    	     value="Start" />
+		<input name="select"   	     value="" />
+		<input name="pageup"   	     value="L Trig" />
+		<input name="pagedown" 	     value="R Trig" />
+		<input name="l2"       	     value="Z Trig" />
+		<input name="r2"       	     value="" />
+		<input name="up"       	     value="DPad U" />
+		<input name="down"     	     value="DPad D" />
+		<input name="right"    	     value="DPad R" />
+		<input name="left"     	     value="DPad L" />
+		<input name="joystick1up"    value="Y Axis" />
+		<input name="joystick1down"  value="Y Axis" />
+		<input name="joystick1left"  value="X Axis" />
+		<input name="joystick1right" value="X Axis" />
+		<input name="joystick2up"    value="C Button U" />
+		<input name="joystick2down"  value="C Button D" />
+		<input name="joystick2left"  value="C Button L" />
+		<input name="joystick2right" value="C Button R" />
+	</defaultInputList>
+	<!-- Alt inputs for n64 style controllers -->
+	<n64InputList>
+		<input name="AnalogDeadzone" value="0,0" />
+		<input name="AnalogPeak"     value="32768,32768" />
+		<input name="l3"             value="Mempak switch" />
+		<input name="r3"             value="Rumblepak switch" />
+		<input name="a"        	     value="B Button" />
+		<input name="b"        	     value="A Button" />
+		<input name="x"        	     value="C Button U" />
+		<input name="y"        	     value="C Button L" />
+		<input name="start"    	     value="Start" />
+		<input name="select"   	     value="Z Trig" />
+		<input name="pageup"   	     value="L Trig" />
+		<input name="pagedown" 	     value="R Trig" />
+		<input name="l2"       	     value="C Button D" />
+		<input name="r2"       	     value="C Button R" />
+		<input name="up"       	     value="DPad U" />
+		<input name="down"     	     value="DPad D" />
+		<input name="right"    	     value="DPad R" />
+		<input name="left"     	     value="DPad L" />
+		<input name="joystick1up"    value="Y Axis" />
+		<input name="joystick1down"  value="Y Axis" />
+		<input name="joystick1left"  value="X Axis" />
+		<input name="joystick1right" value="X Axis" />
+		<input name="joystick2up"    value="" />
+		<input name="joystick2down"  value="" />
+		<input name="joystick2left"  value="" />
+		<input name="joystick2right" value="" />
+	</n64InputList>
 </inputList>


### PR DESCRIPTION
Add Controller submenu to stand alone mupen emulator in ES
Controller Type for Retropads and N64 controllers, sensitivity, and deadzone options per controller.

Added new function that calculates per controller joystick sensitivity and deadzone. Deadzone is always calculated from peak value. If ES settings auto makes no change to values in xml(to allow for custom amount), however default behavior is to always calculate deadzone from 5% of peak value.

Prior behavior was to always have deadzone at 0, which is very odd and resulted in several controllers having joystick drift. Not good.

Also added additional n64 controllers to es_input.