### PR TITLE
Fix libretro-mame not building anymore on ARM 32-bit targets by:

### DIFF
--- a/configs/batocera-board.common
+++ b/configs/batocera-board.common
@@ -12,6 +12,9 @@ BR2_TOOLCHAIN_BUILDROOT_CXX=y
 # required for utf-8
 BR2_TOOLCHAIN_GLIBC_GCONV_LIBS_COPY=y
 
+# Allow to build GOLD linker, but do not use as default
+BR2_BINUTILS_EXTRA_CONFIG_OPTIONS="--enable-gold --enable-plugins"
+
 # prefer linux tools over busybox tools
 BR2_PACKAGE_BUSYBOX=n
 BR2_PACKAGE_BC=y

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/libretro-mame.mk
@@ -18,6 +18,8 @@ else ifeq ($(BR2_i386),y)
 LIBRETRO_MAME_EXTRA_ARGS += PTR64=0 LIBRETRO_CPU=x86 PLATFORM=x86
 else ifeq ($(BR2_arm),y)
 LIBRETRO_MAME_EXTRA_ARGS += PTR64=0 LIBRETRO_CPU=arm PLATFORM=arm
+# workaround for linkage failure using ld on arm 32-bit targets
+LIBRETRO_MAME_ARCHOPTS += -fuse-ld=gold -Wl,--long-plt
 # workaround for asmjit broken build system (arm backend is not public)
 LIBRETRO_MAME_ARCHOPTS += -D__arm__ -DASMJIT_BUILD_X86
 else ifeq ($(BR2_aarch64),y)


### PR DESCRIPTION
- Enabling gold linker build in binutils options
- Use gold with --long-lpt option when buildin lr-mame for ARM (32-bit only)