### PR TITLE
Dolphin ES settings for CC+CC Pro  control type

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -3,6 +3,7 @@
 - Support for Orange Pi Zero 2, Orange Pi 3 LTS, HardKernel ODROID-M1
 
 ### Added
+- ES settings for both types of classic controllers for dolphin. 
 - Additional ES settings for rpcs3
 - ES settings for joystick deadzone/sensitivity for mupen64plus
 - ES settings for N64 controllers for N64 emulators.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -29,7 +29,7 @@ def generateControllerConfig(system, playersControllers, rom, guns):
             # Generate if hardcoded
             generateControllerConfig_emulatedwiimotes(system, playersControllers, rom)
             removeControllerConfig_gamecube()                                           # Because pads will already be used as emulated wiimotes
-        elif (".cc." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom) or system.isOptSet("sideWiimote"):
+        elif (".cc." in rom or ".pro." in rom or ".side." in rom or ".is." in rom or ".it." in rom or ".in." in rom or ".ti." in rom or ".ts." in rom or ".tn." in rom or ".ni." in rom or ".ns." in rom or ".nt." in rom) or system.isOptSet("sideWiimote"):
             # Generate if auto and name extensions are present
             generateControllerConfig_emulatedwiimotes(system, playersControllers, rom)
             removeControllerConfig_gamecube()                                           # Because pads will already be used as emulated wiimotes
@@ -133,19 +133,16 @@ def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
         wiiMapping['joystick2up']   = 'Nunchuk/Stick/Up'
         wiiMapping['joystick2left'] = 'Nunchuk/Stick/Left'
 
-    # cc : Classic Controller Settings
-    if (".cc." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] == 'cc'):
+    # cc : Classic Controller Settings / pro : Classic Controller Pro Settings
+    # Swap shoulder with triggers and vice versa if cc
+    if (".cc." in rom or ".pro." in rom) or (system.isOptSet("controller_mode") and system.config['controller_mode'] in ('cc', 'pro')):
         extraOptions['Extension']   = 'Classic'
         wiiMapping['x'] = 'Classic/Buttons/X'
         wiiMapping['y'] = 'Classic/Buttons/Y'
         wiiMapping['b'] = 'Classic/Buttons/B'
         wiiMapping['a'] = 'Classic/Buttons/A'
         wiiMapping['select'] = 'Classic/Buttons/-'
-        wiiMapping['start'] = 'Classic/Buttons/+'
-        wiiMapping['pageup'] = 'Classic/Triggers/L'
-        wiiMapping['pagedown'] = 'Classic/Triggers/R'
-        wiiMapping['l2'] = 'Classic/Buttons/ZL'
-        wiiMapping['r2'] = 'Classic/Buttons/ZR'
+        wiiMapping['start'] = 'Classic/Buttons/+'     
         wiiMapping['up'] = 'Classic/D-Pad/Up'
         wiiMapping['down'] = 'Classic/D-Pad/Down'
         wiiMapping['left'] = 'Classic/D-Pad/Left'
@@ -153,7 +150,17 @@ def generateControllerConfig_emulatedwiimotes(system, playersControllers, rom):
         wiiMapping['joystick1up'] = 'Classic/Left Stick/Up'
         wiiMapping['joystick1left'] = 'Classic/Left Stick/Left'
         wiiMapping['joystick2up'] = 'Classic/Right Stick/Up'
-        wiiMapping['joystick2left'] = 'Classic/Right Stick/Left'
+        wiiMapping['joystick2left'] = 'Classic/Right Stick/Left'               
+        if (".cc." in rom or system.config['controller_mode'] == 'cc')): 
+            wiiMapping['pageup'] = 'Classic/Buttons/ZL'
+            wiiMapping['pagedown'] = 'Classic/Buttons/ZR'
+            wiiMapping['l2'] = 'Classic/Triggers/L'
+            wiiMapping['r2'] = 'Classic/Triggers/R'
+        else:
+            wiiMapping['pageup'] = 'Classic/Triggers/L'
+            wiiMapping['pagedown'] = 'Classic/Triggers/R'
+            wiiMapping['l2'] = 'Classic/Buttons/ZL'
+            wiiMapping['r2'] = 'Classic/Buttons/ZR'
 
     # This section allows a per ROM override of the default key options.
     configname = rom + ".cfg"       # Define ROM configuration name

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6625,13 +6625,13 @@ dolphin:
                 choices:
                     "Off":                       disabled
                     "Classic Controller":        cc
+                    "Classic Controller Pro":    pro
                     "Wiimote Sideway":           side
                     "Wiimote Sideway + Swing":   is
                     "Wiimote Sideway + Tilt":    it
                     "Wiimote Sideway + Nunchuk": in
             dolphin-lightgun-hide-crosshair:
                 submenu: CONTROLLERS
-                group: LIGHT GUN
                 prompt: SHOW LIGHT GUN CROSSHAIRS
                 choices:
                     "Off": 0


### PR DESCRIPTION
Added controller type classic controller pro(this is the original code for what was classic controller / old cc = pro)
Changed type classic controller to mirror how retroarch classic controller type is mapped(swapped L+R with ZL/ZR).

Also removed submenu from dolphin-lightgun-hide-crosshair in es_features, I assume this was a mistake as it resulted in there being 2 "CONTROLLERS" sub menus in the Wii advanced system settings.
