### PR TITLE
make connman compatible with docker/podman

### DIFF
--- a/board/batocera/fsoverlay/etc/connman/main.conf
+++ b/board/batocera/fsoverlay/etc/connman/main.conf
@@ -2,4 +2,4 @@
 PreferredTechnologies=ethernet,wifi
 DefaultAutoConnectTechnologies=ethernet,wifi
 SingleConnectedTechnology=true
-NetworkInterfaceBlacklist=p2p
+NetworkInterfaceBlacklist=p2p,vmnet,vboxnet,virbr,ifb,docker,podman,veth

--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -66,7 +66,7 @@ case "$1" in
 	start)
 	        wifi_configure_all
 	        printf "Starting connman: "
-		start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n
+		start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r
 
 		# wait connmann is started. otherwise, S10wifi is unable to execute connmanctl commands
 		N=0


### PR DESCRIPTION
these changes open way to running docker/podman containers inside batocera (which in turn opens way to make bato a very viable always-on box)

1. starting connmand with -r prevents it from occupying dns port 53, which opens way for running eg containerised pihole; port 53 is currently used to run the default dnscache service (which seems unnecessary in batocera (?))

2. updated etc/connman/main.conf blacklist prevents connman from getting lost and jumping ship when a docker/podman instance with -p is started; without this bato/host will lose connectivity (unless containers are run with --network=host instead of -p)