### PR TITLE
Bump hypseus to v2.11.1

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/daphne/daphneGenerator.py
@@ -93,12 +93,12 @@ class DaphneGenerator(Generator):
         else:
             commandArray.append("-opengl")
 
-        # Disable Bilinear Filtering
+        # Enable Bilinear Filtering
         if system.isOptSet('bilinear_filter') and system.getOptBoolean("bilinear_filter"):
-            commandArray.append("-nolinear_scale")
+            commandArray.append("-linear_scale")
 
         #The following options should only be set when os.path.isfile(singeFile) is true.
-        #-blend_sprites, -set_overlay oversize, -nocrosshair, -sinden or -manymouse
+        #-blend_sprites, -nocrosshair, -sinden or -manymouse
         if os.path.isfile(singeFile):
             # Blend Sprites (Singe)
             if system.isOptSet('blend_sprites') and system.getOptBoolean("blend_sprites"):
@@ -132,14 +132,6 @@ class DaphneGenerator(Generator):
                     if system.isOptSet('abs_mouse_input') and system.getOptBoolean("abs_mouse_input"):
                         commandArray.extend(["-manymouse"]) # this is causing issues on some "non-gun" games
 
-            # Overlay sizes (Singe) for HD lightgun and Singe 2 games
-            if system.isOptSet('overlay_size') and system.config['overlay_size'] == 'oversize':
-                commandArray.extend(["-set_overlay", "oversize"])
-            elif system.isOptSet('overlay_size') and system.config['overlay_size'] == 'full':
-                commandArray.extend(["-set_overlay", "full"])
-            elif system.isOptSet('overlay_size') and system.config['overlay_size'] == 'half':
-                commandArray.extend(["-set_overlay", "half"])
-            
             # crosshair
             if system.isOptSet('daphne_crosshair'):
                 if not system.getOptBoolean("daphne_crosshair"):
@@ -148,7 +140,7 @@ class DaphneGenerator(Generator):
                     if not controllersConfig.gunsNeedCrosses(guns):
                         commandArray.append("-nocrosshair")
 
-        # Invert Axis
+        # Invert HAT Axis
         if system.isOptSet('invert_axis') and system.getOptBoolean("invert_axis"):
             commandArray.append("-tiphat")
 
@@ -170,7 +162,7 @@ class DaphneGenerator(Generator):
         if system.isOptSet('daphne_scanlines') and system.getOptBoolean("daphne_scanlines"):
             commandArray.append("-scanlines")
 
-        # Hide crosshair in supported games (e.g. ActionMax)
+        # Hide crosshair in supported games (e.g. ActionMax, ALG)
         if system.isOptSet('singe_crosshair') and system.getOptBoolean("singe_crosshair"):
             commandArray.append("-nocrosshair")
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6305,8 +6305,8 @@ daphne:
         bilinear_filter:
             prompt:      SMOOTH GAMES (BILINEAR FILTERING)
             choices:
-                "On":  0
-                "Off": 1
+                "On":  1
+                "Off": 0
         daphne_scanlines:
             archs_include: [x86, x86_64]
             group: ADVANCED OPTIONS
@@ -6322,14 +6322,6 @@ daphne:
             choices:
                 "Off": 0
                 "On":  1
-        overlay_size:
-            group: ADVANCED OPTIONS
-            prompt:      OVERLAY SIZE (SINGE)
-            choices:
-                "Standard": 0
-                "HD Gun Games":  oversize
-                "Singe 2 Full":  full
-                "Singe 2 Half":  half
         abs_mouse_input:
             group: ADVANCED OPTIONS
             prompt:      ABSOLUTE MOUSE INPUT

--- a/package/batocera/emulators/daphne/daphne.mk
+++ b/package/batocera/emulators/daphne/daphne.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DAPHNE_VERSION = 88e27c57927f0549419b653404d410fb62112c2c
+DAPHNE_VERSION = v2.11.1
 DAPHNE_SITE = https://github.com/DirtBagXon/hypseus-singe
 DAPHNE_SITE_METHOD=git
 DAPHNE_LICENSE = GPLv3


### PR DESCRIPTION
https://github.com/DirtBagXon/hypseus-singe/releases/tag/v2.11.1

New Daphne game, overlay restructure and removal of legacy Singe overlay functions.

See Changelog on link above for full list of changes, hopefully this catches the argument changes.