### PR TITLE
Bump lightspark to recent stable release, enable it on ARM

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -613,7 +613,7 @@ config BR2_PACKAGE_BATOCERA_FLASH_SYSTEMS
 
     # Flash Player Emulator
     select BR2_PACKAGE_RUFFLE           if BR2_PACKAGE_XORG7 && BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY # need to be configured to support crosscompilation
-    select BR2_PACKAGE_LIGHTSPARK       if BR2_PACKAGE_XORG7 && BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY
+    select BR2_PACKAGE_LIGHTSPARK       if !BR2_PACKAGE_BATOCERA_TARGET_BCM2835
 
 #### Moonlight / Gamestream ####
 config BR2_PACKAGE_BATOCERA_GAMESTREAM_SYSTEMS

--- a/package/batocera/emulators/lightspark/Config.in
+++ b/package/batocera/emulators/lightspark/Config.in
@@ -5,11 +5,10 @@ config BR2_PACKAGE_LIGHTSPARK
 	depends on BR2_PACKAGE_JPEG
 	depends on BR2_PACKAGE_LIBPNG
 	depends on BR2_PACKAGE_SDL2
-	depends on BR2_PACKAGE_SDL2_MIXER
 	depends on BR2_PACKAGE_CAIRO
 	depends on BR2_PACKAGE_FFMPEG
 	depends on BR2_PACKAGE_LIBCURL
-
+	select BR2_PACKAGE_RTMPDUMP
 	help
           LightSpark
           Flash emulator for windows / mac / linux.

--- a/package/batocera/emulators/lightspark/lightspark.mk
+++ b/package/batocera/emulators/lightspark/lightspark.mk
@@ -3,11 +3,16 @@
 # LIGHTSPARK
 #
 ################################################################################
-# Version.: Commits on Oct 03, 2022
-LIGHTSPARK_VERSION = a1c9a37830f2f01a2031b51c6c2f7ef6c2430a91
+# Version.: Commits on May 28, 2023
+LIGHTSPARK_VERSION = 0.8.7
 LIGHTSPARK_SITE = $(call github,lightspark,lightspark,$(LIGHTSPARK_VERSION))
 LIGHTSPARK_LICENSE = LGPLv3
-LIGHTSPARK_DEPENDENCIES = sdl2 sdl2_mixer freetype pcre jpeg libpng cairo ffmpeg libcurl
+LIGHTSPARK_DEPENDENCIES = sdl2 freetype pcre jpeg libpng cairo ffmpeg libcurl rtmpdump
+
+LIGHTSPARK_CONF_OPTS += -DCOMPILE_NPAPI_PLUGIN=FALSE -DCOMPILE_PPAPI_PLUGIN=FALSE
+ifneq ($(BR2_x86_64),y)
+LIGHTSPARK_CONF_OPTS += -DENABLE_GLES2=TRUE -DCMAKE_C_FLAGS=-DEGL_NO_X11 -DCMAKE_CXX_FLAGS=-DEGL_NO_X11
+endif
 
 define LIGHTSPARK_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin


### PR DESCRIPTION
Lightspark can run plain GLES2, no GL nor X11 needed.
