### PR TITLE
Fix swtrilgy supermodel light gun

### DIFF
--- a/package/batocera/emulators/supermodel/004-volume-adjustments.patch
+++ b/package/batocera/emulators/supermodel/004-volume-adjustments.patch
@@ -126,7 +126,6 @@ index 06acb94d85..b842762102 100644
 +MusicVolume = 100
 +SoundVolume = 100
 +Balance = 0
-+InputSystem=rawinput
 +
 +[ vf3 ]
 +MusicVolume = 100


### PR DESCRIPTION
That value was introduced in v37 beta and it breaks the light gun support for that specific game. Without that added value, the light gun works again. This value is not needed and breaks the light gun patch for the game (it is an analog_joystick instead of analog_gun game).