### PR TITLE
Provide a default system language for WINE

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -18,7 +18,10 @@ class WineGenerator(Generator):
             
             environment = {}
             #system.language
-            language = subprocess.check_output("batocera-settings-get system.language", shell=True, text=True).strip()
+            try:
+                language = subprocess.check_output("batocera-settings-get system.language", shell=True, text=True).strip()
+            except subprocess.CalledProcessError:
+                language = 'en_US'
             if language:
                 environment.update({
                     "LANG": language + ".UTF-8",


### PR DESCRIPTION
Default configuration of batocera.conf is system.language is unset.  This results in a crash of any WINE game in the current butterfly beta.

```
evmapy: no process found
2023-08-13 20:55:52,716 ERROR (emulatorlauncher:594):<module> configgen exception:
Traceback (most recent call last):
  File "/usr/bin/emulatorlauncher", line 592, in <module>
    exitcode = main(args, maxnbplayers)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/emulatorlauncher", line 99, in main
    return start_rom(args, maxnbplayers, args.rom, args.rom)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/emulatorlauncher", line 260, in start_rom
    cmd = generator.generate(system, rom, playersControllers, guns, gameResolution)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/configgen/generators/wine/wineGenerator.py", line 21, in generate
    language = subprocess.check_output("batocera-settings-get system.language", shell=True, text=True).strip()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command 'batocera-settings-get system.language' returned non-zero exit status 1.
```