### PR TITLE
Validate service names, disable correct service

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-services
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-services
@@ -11,6 +11,10 @@ do_help() {
     echo "${0} start service1"
 }
 
+is_valid_service_name() {
+    [[ "${1}" =~ ^[_[:alpha:]][_[:alpha:][:digit:]]*$ ]]
+}
+
 do_list() {
     enabled_services="$(/usr/bin/batocera-settings-get system.services)"
     if test -n "${enabled_services}"
@@ -25,6 +29,11 @@ do_list() {
 	while read SERVICE
 	do
 	    SNAME=$(basename "${SERVICE}")
+	    if ! is_valid_service_name "${SNAME}"
+	    then
+		echo "WARNING: Invalid service script name: ${SNAME}" 1>&2
+		continue
+	    fi
 	    SVAR=__SERVICE__${SNAME}
 	    if test "${!SVAR}" = 1
 	    then
@@ -62,6 +71,12 @@ do_stop() {
 }
 
 do_enable() {
+    if ! is_valid_service_name "${1}"
+    then
+	echo "ERROR: Invalid service name: ${1}" 1>&2
+	return
+    fi
+
     enabled_services="$(/usr/bin/batocera-settings-get system.services)"
 
     # check if already set
@@ -100,9 +115,9 @@ do_disable() {
 	    then
 		if test -n "${NEW_ENABLED_SERVICES}"
 		then
-		    NEW_ENABLED_SERVICES=${NEW_ENABLED_SERVICES} ${1}
+		    NEW_ENABLED_SERVICES="${NEW_ENABLED_SERVICES} ${SERVICE}"
 		else
-		    NEW_ENABLED_SERVICES=${1}
+		    NEW_ENABLED_SERVICES="${SERVICE}"
 		fi
 	    else
 		JDONE=1


### PR DESCRIPTION
- Ensure service name is valid before enabling service
- Warn if script name is invalid when listing services
- Correctly construct list of remaining services during disable