### PR TITLE
Fix pcmanfm trash can, fixes #4644

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -159,6 +159,9 @@ do
     # save the current output in which es is started (used to switch screen, when unplugged)
     batocera-resolution currentOutput > "/var/run/switch_screen_current"
 
+    # dbus launch is required for the gio/gvfs/trash:///...
+    eval "$(dbus-launch --sh-syntax --exit-with-session)"
+
     cd /userdata # es need a PWD
     %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation ${GAMELAUNCHOPT} --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
 

--- a/package/batocera/emulationstation/batocera-emulationstation/xorg/xinitrc
+++ b/package/batocera/emulationstation/batocera-emulationstation/xorg/xinitrc
@@ -14,9 +14,6 @@ xset s off
 # allow coredumps for ES
 ulimit -c unlimited
 
-# dbus launch is required for the gio/gvfs/trash:///...
-eval "$(dbus-launch --sh-syntax --exit-with-session)"
-
 # Check if there are two GPUs in the system
 gpu_count=$(lspci -nn | grep -E '^([[:alnum:]]{2}):([[:alnum:]]{2})\.([[:alnum:]]{1}) (VGA|3D)' | wc -l)
 


### PR DESCRIPTION
dbus-launch is currently run from xinitrc, which causes two bugs:
- Trash can is not visible in pcmanfm on Wayland systems
- Trash can can not be viewed or emptied on X11 systems because HOME is not set in dbus-launch environment (#4644)