### PR TITLE
Align x86 partitions to 1M

### DIFF
--- a/board/batocera/x86/genimage.cfg
+++ b/board/batocera/x86/genimage.cfg
@@ -12,6 +12,7 @@ image userdata.ext4 {
 image batocera.img {
     hdimage {
         partition-table-type = "gpt"
+        align = 1M
     }
     partition boot {
         in-partition-table = false


### PR DESCRIPTION
Improves disk performance and reduces wear.
Ref: https://www.thomas-krenn.com/en/wiki/Partition_Alignment_detailed_explanation