### PR TITLE
Scale refresh rates to Hz for Wayland mode list

### DIFF
--- a/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.wayland
+++ b/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.wayland
@@ -61,7 +61,7 @@ case "${ACTION}" in
     "listModes")
         echo "max-1920x1080:maximum 1920x1080"
         echo "max-640x480:maximum 640x480"
-        swaymsg -t get_outputs | jq -r '.[] | select (.focused).modes[] | "\(.width)x\(.height).\(.refresh):\(.width)x\(.height) \(.refresh) Hz"' | uniq
+        swaymsg -t get_outputs | jq -r '.[] | select (.focused).modes[] | "\(.width)x\(.height).\(.refresh):\(.width)x\(.height) \(.refresh / 1000) Hz"' | uniq
     ;;
     "setMode")
         MODE=$1


### PR DESCRIPTION
Convert mHz to Hz for correct human-readable units in wayland batocera-resolution listModes

Tested on bcm2711 Raspberry_Pi_4_Model_B_Rev_1_4

Old output:
```
max-1920x1080:maximum 1920x1080
max-640x480:maximum 640x480
1920x1080.60000:1920x1080 60000 Hz
1920x1080.59940:1920x1080 59940 Hz
1920x1080.50000:1920x1080 50000 Hz
1920x1080.30000:1920x1080 30000 Hz
1920x1080.29970:1920x1080 29970 Hz
1920x1080.24000:1920x1080 24000 Hz
1920x1080.23976:1920x1080 23976 Hz
1680x1050.59954:1680x1050 59954 Hz
1400x1050.59948:1400x1050 59948 Hz
1600x900.60000:1600x900 60000 Hz
1280x1024.75025:1280x1024 75025 Hz
1280x1024.60020:1280x1024 60020 Hz
1440x900.59901:1440x900 59901 Hz
1280x800.59910:1280x800 59910 Hz
1152x864.75000:1152x864 75000 Hz
1280x720.60000:1280x720 60000 Hz
1280x720.59940:1280x720 59940 Hz
1280x720.50000:1280x720 50000 Hz
1024x768.75029:1024x768 75029 Hz
1024x768.70069:1024x768 70069 Hz
1024x768.60004:1024x768 60004 Hz
832x624.74551:832x624 74551 Hz
800x600.75000:800x600 75000 Hz
800x600.60317:800x600 60317 Hz
720x576.50000:720x576 50000 Hz
720x480.60000:720x480 60000 Hz
720x480.59940:720x480 59940 Hz
640x480.75000:640x480 75000 Hz
640x480.60000:640x480 60000 Hz
640x480.59940:640x480 59940 Hz
720x400.70082:720x400 70082 Hz
```

New output:
```
max-1920x1080:maximum 1920x1080
max-640x480:maximum 640x480
1920x1080.60000:1920x1080 60 Hz
1920x1080.59940:1920x1080 59.94 Hz
1920x1080.50000:1920x1080 50 Hz
1920x1080.30000:1920x1080 30 Hz
1920x1080.29970:1920x1080 29.97 Hz
1920x1080.24000:1920x1080 24 Hz
1920x1080.23976:1920x1080 23.976 Hz
1680x1050.59954:1680x1050 59.954 Hz
1400x1050.59948:1400x1050 59.948 Hz
1600x900.60000:1600x900 60 Hz
1280x1024.75025:1280x1024 75.025 Hz
1280x1024.60020:1280x1024 60.02 Hz
1440x900.59901:1440x900 59.901 Hz
1280x800.59910:1280x800 59.91 Hz
1152x864.75000:1152x864 75 Hz
1280x720.60000:1280x720 60 Hz
1280x720.59940:1280x720 59.94 Hz
1280x720.50000:1280x720 50 Hz
1024x768.75029:1024x768 75.029 Hz
1024x768.70069:1024x768 70.069 Hz
1024x768.60004:1024x768 60.004 Hz
832x624.74551:832x624 74.551 Hz
800x600.75000:800x600 75 Hz
800x600.60317:800x600 60.317 Hz
720x576.50000:720x576 50 Hz
720x480.60000:720x480 60 Hz
720x480.59940:720x480 59.94 Hz
640x480.75000:640x480 75 Hz
640x480.60000:640x480 60 Hz
640x480.59940:640x480 59.94 Hz
720x400.70082:720x400 70.082 Hz
```
