### PR TITLE
disable (completly) PINE from pcsx2.

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -458,8 +458,6 @@ ps2:
   core:     pcsx2
   options:
     fullboot: true
-    # temporarily disable until mangohud fixed
-    hud_support: false
 ps3:
   emulator: rpcs3
   core:     rpcs3

--- a/package/batocera/emulators/pcsx2/disable-pine-breaking-mangohud.patch
+++ b/package/batocera/emulators/pcsx2/disable-pine-breaking-mangohud.patch
@@ -1,0 +1,53 @@
+diff --git a/pcsx2/VMManager.cpp b/pcsx2/VMManager.cpp
+index f0745b4..e1b806e 100644
+--- a/pcsx2/VMManager.cpp
++++ b/pcsx2/VMManager.cpp
+@@ -180,7 +180,7 @@ static u64 s_session_start_time = 0;
+ 
+ static bool s_screensaver_inhibited = false;
+ 
+-static PINEServer s_pine_server;
++//static PINEServer s_pine_server;
+ 
+ #ifdef ENABLE_DISCORD_PRESENCE
+ static bool s_discord_presence_active = false;
+@@ -374,7 +374,7 @@ void VMManager::Internal::CPUThreadShutdown()
+ {
+ 	ShutdownDiscordPresence();
+ 
+-	s_pine_server.Deinitialize();
++	//s_pine_server.Deinitialize();
+ 
+ 	Achievements::Shutdown();
+ 
+@@ -2802,18 +2802,18 @@ const std::vector<u32>& VMManager::GetSortedProcessorList()
+ 
+ void VMManager::ReloadPINE()
+ {
+-	if (EmuConfig.EnablePINE && (s_pine_server.m_slot != EmuConfig.PINESlot || s_pine_server.m_end))
+-	{
+-		if (!s_pine_server.m_end)
+-		{
+-			s_pine_server.Deinitialize();
+-		}
+-		s_pine_server.Initialize(EmuConfig.PINESlot);
+-	}
+-	else if ((!EmuConfig.EnablePINE && !s_pine_server.m_end))
+-	{
+-		s_pine_server.Deinitialize();
+-	}
++//	if (EmuConfig.EnablePINE && (s_pine_server.m_slot != EmuConfig.PINESlot || s_pine_server.m_end))
++//	{
++//		if (!s_pine_server.m_end)
++//		{
++//			s_pine_server.Deinitialize();
++//		}
++//		s_pine_server.Initialize(EmuConfig.PINESlot);
++//	}
++//	else if ((!EmuConfig.EnablePINE && !s_pine_server.m_end))
++//	{
++//		s_pine_server.Deinitialize();
++//	}
+ }
+ 
+ #ifdef ENABLE_DISCORD_PRESENCE


### PR DESCRIPTION
Even if not enabled, the PINE server is disabled causing an error when mangohud is enabled, and reseting the emulator to the bios. PINE seems to be a upnp server. The project url provided in pcsx2 seems to not work anymore.