### PR TITLE
Finish DLSS

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -10064,6 +10064,12 @@ wine:
             choices:
                 "Off": 0
                 "On":  1
+        nvapi:
+            prompt:      NVAPI
+            description: NVAPI is NVIDIA's core software that allows direct access to NVIDIA GPU.
+            choices:
+                "Off": 0
+                "On":  1
         dxvk_reset_cache:
             group: ADVANCED OPTIONS
             prompt:      DXVK RESET CACHE

--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -83,6 +83,7 @@ wine_options() {
     FORCE_LARGE_ADRESS="$(get_setting force_large_adress "${SYSTEM}" "${ROMGAMENAME}")"
     HEAP_DELAY_FREE="$(get_setting heap_delay_free "${SYSTEM}" "${ROMGAMENAME}")"
     HIDE_NVIDIA_GPU="$(get_setting hide_nvidia_gpu "${SYSTEM}" "${ROMGAMENAME}")"
+    NVAPI="$(get_setting nvapi "${SYSTEM}" "${ROMGAMENAME}")"
     DXVK_RESET_CACHE="$(get_setting dxvk_reset_cache "${SYSTEM}" "${ROMGAMENAME}")"
     WINE_NTFS="$(get_setting wine_ntfs "${SYSTEM}" "${ROMGAMENAME}")"
     WINE_DEBUG="$(get_setting wine_debug "${SYSTEM}" "${ROMGAMENAME}")"
@@ -140,6 +141,9 @@ wine_options() {
 
     export WINE_HIDE_NVIDIA_GPU=0
     test "${HIDE_NVIDIA_GPU}" = 1 && WINE_HIDE_NVIDIA_GPU=1
+
+    export NVAPI=0
+    test "${NVAPI}" = 1 && NVAPI=1
 
     export DXVK_STATE_CACHE=1
     test "${DXVK_RESET_CACHE}" = 1 && DXVK_STATE_CACHE=reset
@@ -363,10 +367,19 @@ dxvk_install() {
     then
         export DXVK_ASYNC=1
         export DXVK_CONFIG_FILE="/userdata/system/wine/dxvk/dxvk.conf"
-        export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};dxgi,d3d8,d3d9,d3d10core,d3d11,d3d12,d3d12core,nvapi64,nvapi=n"
-        #export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};dxgi,d3d9,d3d10core,d3d11,d3d12=n;nvapi64,nvapi="
+        export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};dxgi,d3d8,d3d9,d3d10core,d3d11,d3d12,d3d12core=n"
     else
-    export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};dxgi,d3d8,d3d9,d3d10core,d3d11,d3d12,d3d12core=b"
+        export DXVK_ASYNC=0
+        export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};dxgi,d3d8,d3d9,d3d10core,d3d11,d3d12,d3d12core=b"
+    fi
+
+    if test "${NVAPI}" = 1
+    then
+        export DXVK_ENABLE_NVAPI=1
+        export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};nvapi,nvapi64=n"
+    else
+        export DXVK_ENABLE_NVAPI=0
+        export WINEDLLOVERRIDES="${WINEDLLOVERRIDES};nvapi64,nvapi="
     fi
 
     return 0


### PR DESCRIPTION
Now for enable DLSS we need to use DXVK 2.x & `NVAPI` ON.
Also NVAPI is part of DXVK so you need to enable `DXVK` ON
But you can disable NVAPI and is disable on prefix too that help some games on AMD GPU not support NVAPI. 