### PR TITLE
ecwolf modable again

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
@@ -50,19 +50,45 @@ class ECWolfGenerator(Generator):
         if not path.isdir(ecwolfSaves):
             os.mkdir(ecwolfSaves)
 
-        try:
-            os.chdir(rom)
-        # Only game directories, not .zip
-        except Exception as e:
-            print(f"Error: couldn't go into directory {rom} ({e})")
-        return Command.Command(
-            array=[
-                'ecwolf',
-                '--joystick',
-                # savedir must be a single argument
-                "--savedir=/userdata/saves/ecwolf",
-            ],
-            env={
-                'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
-            }
-        )
+        if os.path.isdir(rom):
+            try:
+                os.chdir(rom)
+            # Only game directories, not .zip
+            except Exception as e:
+                print(f"Error: couldn't go into directory {rom} ({e})")
+            return Command.Command(
+                array=[
+                    'ecwolf',
+                    '--joystick',
+                    # savedir must be a single argument
+                    "--savedir=/userdata/saves/ecwolf",
+                ],
+                env={
+                    'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
+                }
+            )
+
+        if os.path.isfile(rom):
+            f = open(rom,'r')
+            array=(f.readline().split())
+            f.close()
+
+            if not "--" in array[0]:
+                os.chdir(os.path.dirname(rom))
+                try:
+                    os.chdir(array[0])
+                except Exception as e:
+                    print(f"Error: couldn't go into directory {array[0]} ({e})")
+                array.pop(0)
+
+            array.insert(0, "ecwolf")
+            array.append("--joystick")
+            array.append("--savedir=/userdata/saves/ecwolf")
+
+            return Command.Command(
+                 array,
+                 env={
+                     'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
+
+                }
+            )


### PR DESCRIPTION
As long times promised, I'll bring back modability back to the ecwolf core.

ecwolf offers lot of command line parameters like
```
--data {wl6, sod, wl1 extension}
--extravbls
--file (this is the resource for mods)

type ecwolf --help for more
```

I slightly changed the generator to differ between a directory (Wolfstein 3D.ecwolf) with the separated game files (sod, wl6, n3a) inside and a file (Wolfenstein 3D High Resolution and Music Pack.ecwolf)

A file example could be
**Wolfenstein 3D High Resolution and Music Pack.ecwolf**
```
./wolf3d_14 --data wl6 --file ../addons/HD/ECWolf_hdpack.pk3 ../addons/HD/ECWolf_hdmus_3DO.pk3
```

To explain
My wolf3d_14 works as basedir for the full version of Wolfenstein but does also contain Spear of Destiny therefore I've to set dataset to wl6 extension, the file parameter loads the two files for HD music and HD textures.

So enjoy and have fun with Wolfenstein from 1991 with HD textures

![36193413gr](https://github.com/crcerror/batocera.linux/assets/29715650/25ab279b-2a07-45b5-84a7-265483eb6b9d)