### PR TITLE
ecwolf fix for file pk3 extensions and savegame location

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
@@ -42,6 +42,7 @@ class ECWolfGenerator(Generator):
             f.write('Vid_FullScreen = 1;\n')
             f.write('Vid_Aspect = 0;\n')
             f.write('Vid_Vsync = 1;\n')
+            f.write('QuitOnEscape = 1;\n')
             f.write('FullScreenWidth = {};\n'.format(gameResolution["width"]))
             f.write('FullScreenHeight = {};\n'.format(gameResolution["height"]))
             f.close()
@@ -50,41 +51,52 @@ class ECWolfGenerator(Generator):
         if not path.isdir(ecwolfSaves):
             os.mkdir(ecwolfSaves)
 
+        # Use the directory method with ecwolf extension and datafiles (wl6 or sod or nh3) inside
         if os.path.isdir(rom):
             try:
                 os.chdir(rom)
-            # Only game directories, not .zip
+            # Only game directories, not .ecwolf or .pk3 files
             except Exception as e:
                 print(f"Error: couldn't go into directory {rom} ({e})")
             return Command.Command(
                 array=[
                     'ecwolf',
-                    '--joystick',
-                    # savedir must be a single argument
-                    "--savedir=/userdata/saves/ecwolf",
+                    # Command must be filled with arguments according ecwolf help page
+                    "--savedir", ecwolfSaves,
                 ],
                 env={
                     'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
                 }
             )
 
+        # File method, .ecwolf (recommended) for command parameters, first argument is path to dataset, next parameters according ecwolf --help
+        # Example 1.ecwolf: ./wolf3d --data wl6 --config /userdata/system/configs/ecwolf/mywolf.cfg
+        # Example 2.ecwolf: ./wolf3d --data wl6 --file  ../HD/ECWolf_hdpack.pk3 ./HD/ECWolf_hdmus_3DO.pk3
+        # File method .pk3, put pk3 files next to wl6 dataset and start the mod in ES
+        # the pk3 method fails if the mod needs additional pk3 (see example 2)
         if os.path.isfile(rom):
-            f = open(rom,'r')
-            array=(f.readline().split())
-            f.close()
+            os.chdir(os.path.dirname(rom))
+            fextension = (os.path.splitext(rom)[1]).lower()
 
-            if not "--" in array[0]:
-                os.chdir(os.path.dirname(rom))
-                try:
-                    os.chdir(array[0])
-                except Exception as e:
-                    print(f"Error: couldn't go into directory {array[0]} ({e})")
-                array.pop(0)
+            if fextension == ".ecwolf":
+                f = open(rom,'r')
+                array=(f.readline().split())
+                f.close()
 
+                # If 1. parameter isn't an argument then assume it's a path
+                if not "--" in array[0]:
+                    try:
+                        os.chdir(array[0])
+                    except Exception as e:
+                        print(f"Error: couldn't go into directory {array[0]} ({e})")
+                    array.pop(0)
+
+            if fextension == ".pk3":
+                array = ["--file", os.path.basename(rom)]
+
+            # Here we add the binary first and some additional parameters
             array.insert(0, "ecwolf")
-            array.append("--joystick")
-            array.append("--savedir=/userdata/saves/ecwolf")
-
+            array += ["--savedir", ecwolfSaves]
             return Command.Command(
                  array,
                  env={


### PR DESCRIPTION
I've restored usage of pk3-files, too!
Nevertheless I recommend the use of the .ecwolf method - this offers much more options for fine tuning your games brought by https://github.com/batocera-linux/batocera.linux/pull/9869

We have 3 methods now to launch Wolfenstein now:
1. Directory method: Create a directory with .ecwolf extension for example "Wolfenstein 3d.ecwolf" and then put the wl6 or wl1 data there and you are fine
2. .pk3-mod method: Inside this folder you can put pk3 files for example totenhaus.pk3, in ES you can directly start the mod with pk3 file
3. .ecwolf-file method: Create a file with .ecwolf extension and set aditional parameters there, first argument is intended to be a directory like `./wolf3d` where your Wolfenstein dataset is contained, followed by additional parameters according `ecwolf --help` page.

Examples:
```
Wolfenstein 3D - Spear of Destiny.ecwolf
./wolf3d --data sod
Starts "Spear of Destiny" if sod files are in this dir

Wolfenstein 3D (full version).ecwolf
./wolf3d --data wl6
Starts "Wolfenstein 3D (fullversion) if wl6 filres are in wolf3d-dir
(This works even if sod or nh3-files are present in same dir)
you see you can use relative pathes

Wolfenstein 3D (full version) HD.ecwolf
.wolf3d --data wl6 --file ../HD/ECWolf_hdpack.pk3 ../HD/ECWolf_hdmus_3DO.pk3
You can load more then one pk3 file with this method so I strongly recommend to use the ecwolf-file descriptor method

Attention: Don't use whitespaces!
```

@dmanlfc I've fixed savegame location, too - the error was made in first release stage (--joystick needs an argument, and by default it's 0 so it's not needed) and so savedir=/something was not setted ;)

I also set ESC to not quit game. For me an error accoured (game hanged) as I pressed START-Button several times. Quit with hotkey or ESC and press A-Button ;)

@Hew-ux Where to store the usage? wiki or ecwolf txt file?