### PR TITLE
ecwolf fixes (Savegame location, config file)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
@@ -8,15 +8,17 @@ import os
 from os import path
 import codecs
 
-ecwolfConfig = batoceraFiles.CONF + "/ecwolf"
-ecwolfConfigDir = "/userdata/system/.config/ecwolf"
-ecwolfConfigSrc = "/userdata/system/.config/ecwolf/ecwolf.cfg"
-ecwolfConfigDest = batoceraFiles.CONF + "/ecwolf/ecwolf.cfg"
-ecwolfSaves = batoceraFiles.SAVES + "/ecwolf"
-
 class ECWolfGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, guns, wheels, gameResolution):
+
+        ecwolfConfig = batoceraFiles.CONF + "/ecwolf"
+        ecwolfConfigDir = "/userdata/system/.config/ecwolf"
+        ecwolfConfigSrc = "/userdata/system/.config/ecwolf/ecwolf.cfg"
+        ecwolfConfigDest = batoceraFiles.CONF + "/ecwolf/ecwolf.cfg"
+        ecwolfSaves = batoceraFiles.SAVES + "/ecwolf/" + path.basename(rom)
+        ecwolfArray = ["ecwolf"] # Binary for command array
+
         # Create config folders
         if not path.isdir(ecwolfConfig):
             os.mkdir(ecwolfConfig)
@@ -28,6 +30,7 @@ class ECWolfGenerator(Generator):
             f.write('Vid_FullScreen = 1;\n')
             f.write('Vid_Aspect = 0;\n')
             f.write('Vid_Vsync = 1;\n')
+            f.write('QuitOnEscape = 1;\n')
             f.write('FullScreenWidth = {};\n'.format(gameResolution["width"]))
             f.write('FullScreenHeight = {};\n'.format(gameResolution["height"]))
             f.close()
@@ -36,71 +39,68 @@ class ECWolfGenerator(Generator):
         if not path.exists(ecwolfConfigDest):
             os.symlink(ecwolfConfigSrc, ecwolfConfigDest)
 
-        # Set the resolution
-        if path.isfile(ecwolfConfigDest):
-            f = codecs.open(ecwolfConfigDest, "w")
-            f.write('Vid_FullScreen = 1;\n')
-            f.write('Vid_Aspect = 0;\n')
-            f.write('Vid_Vsync = 1;\n')
-            f.write('QuitOnEscape = 1;\n')
+        # Set the resolution and some other defaults
+        if path.isfile(ecwolfConfigSrc):
+            #We ignore some options in default config with py-dictonary...
+            IgnoreConfigKeys = {"FullScreenWidth", "FullScreenHeight", "JoystickEnabled"}
+            with codecs.open(ecwolfConfigSrc, "r") as f:
+                lines = {line for line in f}
+
+            # ... write all the non ignored keys back to config file ...
+            with codecs.open(ecwolfConfigSrc, "w") as f:
+                for line in lines:
+                    if not IgnoreConfigKeys.intersection(line.split()):
+                        f.write(line)
+ 
+            # ... and append the ignored keys with default values now ;)
+            f = codecs.open(ecwolfConfigSrc, "a")
+            f.write('JoystickEnabled = 1;\n')
             f.write('FullScreenWidth = {};\n'.format(gameResolution["width"]))
             f.write('FullScreenHeight = {};\n'.format(gameResolution["height"]))
             f.close()
 
-        # Create save folder
+        # Create save folder, according rom name with extension
         if not path.isdir(ecwolfSaves):
             os.mkdir(ecwolfSaves)
 
         # Use the directory method with ecwolf extension and datafiles (wl6 or sod or nh3) inside
-        if os.path.isdir(rom):
+        if path.isdir(rom):
             try:
                 os.chdir(rom)
             # Only game directories, not .ecwolf or .pk3 files
             except Exception as e:
                 print(f"Error: couldn't go into directory {rom} ({e})")
-            return Command.Command(
-                array=[
-                    'ecwolf',
-                    # Command must be filled with arguments according ecwolf help page
-                    "--savedir", ecwolfSaves,
-                ],
-                env={
-                    'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
-                }
-            )
 
-        # File method, .ecwolf (recommended) for command parameters, first argument is path to dataset, next parameters according ecwolf --help
-        # Example 1.ecwolf: ./wolf3d --data wl6 --config /userdata/system/configs/ecwolf/mywolf.cfg
-        # Example 2.ecwolf: ./wolf3d --data wl6 --file  ../HD/ECWolf_hdpack.pk3 ./HD/ECWolf_hdmus_3DO.pk3
+        # File method .ecwolf (recommended) for command parameters, first argument is path to dataset, next parameters according ecwolf --help
         # File method .pk3, put pk3 files next to wl6 dataset and start the mod in ES
-        # the pk3 method fails if the mod needs additional pk3 (see example 2)
-        if os.path.isfile(rom):
-            os.chdir(os.path.dirname(rom))
-            fextension = (os.path.splitext(rom)[1]).lower()
+        if path.isfile(rom):
+            os.chdir(path.dirname(rom))
+            fextension = (path.splitext(rom)[1]).lower()
 
             if fextension == ".ecwolf":
-                f = open(rom,'r')
-                array=(f.readline().split())
+                f = codecs.open(rom,"r")
+                ecwolfArray += (f.readline().split())
                 f.close()
 
                 # If 1. parameter isn't an argument then assume it's a path
-                if not "--" in array[0]:
+                if not "--" in ecwolfArray[1]:
                     try:
-                        os.chdir(array[0])
+                        os.chdir(ecwolfArray[1])
                     except Exception as e:
-                        print(f"Error: couldn't go into directory {array[0]} ({e})")
-                    array.pop(0)
+                        print(f"Error: couldn't go into directory {ecwolfArray[1]} ({e})")
+                    ecwolfArray.pop(1)
 
             if fextension == ".pk3":
-                array = ["--file", os.path.basename(rom)]
+                ecwolfArray += ["--file", path.basename(rom)]
+ 
+        ecwolfArray += [
+                 #Use values according ecwolf --help, do not miss any parameter  
+                 "--savedir", ecwolfSaves
+        ]
 
-            # Here we add the binary first and some additional parameters
-            array.insert(0, "ecwolf")
-            array += ["--savedir", ecwolfSaves]
-            return Command.Command(
-                 array,
-                 env={
-                     'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
-
-                }
-            )
+        return Command.Command(
+             ecwolfArray,
+             env={
+                 'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
+            }
+        )


### PR DESCRIPTION
1. Savegames are now saved to a directory according to the called file/dir ecwolf was started from
2. config file is not fully recreated per ecwolf-start now, that keeps highscore and some specfic settings alive. Resolution is still changed according ES settings, joypad is always enabled **(devs: take looks to line 43 and 55 if you plan to add more options to EmulationStation-ecwolf setup)**
3. Changes according PR https://github.com/batocera-linux/batocera.linux/pull/9869 and https://github.com/batocera-linux/batocera.linux/pull/9893 are still working

Start methods:
1. Directory .ecwolf with gameset included (as descriped to wiki)
2. File .ecwolf with one line of commands, first argument can work as relative path to point to Wolfenstein/Spear/Noahs gameset
3. File .pk3 - but pk3 files directly to your directory, were games data is located. You can start only one pk3 file

Examples:
```
Wolfenstein 3D - Spear of Destiny.ecwolf
./wolf3d --data sod
Starts "Spear of Destiny" if sod files are in this dir

Wolfenstein 3D (full version).ecwolf
./wolf3d --data wl6
Starts "Wolfenstein 3D (fullversion) if wl6 filres are in wolf3d-dir
(This works even if sod or nh3-files are present in same dir)
you see you can use relative pathes

Wolfenstein 3D (full version) HD.ecwolf
.wolf3d --data wl6 --file ../HD/ECWolf_hdpack.pk3 ../HD/ECWolf_hdmus_3DO.pk3
You can load more then one pk3 file with this method so I strongly recommend to use the ecwolf-file descriptor method

Attention: Don't use whitespaces in pathes and files!
```