### PR TITLE
Update value for retroarch fps counter interval to be more inline with mangohud

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -77,6 +77,10 @@ def generateRetroarchCustom():
 
     # Disable builtin image viewer (done in ES, and prevents from loading pico-8 .png carts)
     retroarchSettings.save('builtin_imageviewer_enable',        '"false"')
+    
+    # Set fps counter interval (in frames)
+    retroarchSettings.save('fps_update_interval',               '"30"')
+    
 
     retroarchSettings.write()
 


### PR DESCRIPTION
Change default value for the retroarch fps_update_interval value from 256 to 30.

Note that the value is in frames. FPS counter is updated every X frames.

Default of 256 results in on screen fps counter updating every 4.26 seconds based on a 60 Hz display.

Updated value of 30 would update on screen fps counter every 0.5 seconds based on a 60 Hz display.

The updated value is beneficial to those using systems that mangohud is not available for.

If hard coding an updated value is not desirable we could add a user selectable ES setting to allow a user to select from several choices. But I believe there is little benefit in adding yet another ES option and simply hard coding it to a newer value is much better.