### PR TITLE
Add non-Pro GUN4IR light gun

### DIFF
--- a/package/batocera/controllers/gun4ir-guns/99-gun4ir.rules
+++ b/package/batocera/controllers/gun4ir-guns/99-gun4ir.rules
@@ -1,2 +1,5 @@
 SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Arduino LLC GUN4IR Pro Micro P*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", RUN+="/usr/bin/virtual-gun4ir-add"
 SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Gun4ir", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", ENV{ID_INPUT_MOUSE}="1", ENV{ID_INPUT_GUN}="1"
+
+# Non-Pro hardware
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="Arduino LLC GUN4IR Micro P*", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-gun4ir-add"


### PR DESCRIPTION
Name of hardware is correct (and tested), but unsure if the code is good. Just delete the `Pro` in the light gun name.