### PR TITLE
Fix visionfive2 dtb location

### DIFF
--- a/board/batocera/riscv/visionfive2/boot/extlinux.conf
+++ b/board/batocera/riscv/visionfive2/boot/extlinux.conf
@@ -1,4 +1,4 @@
 LABEL batocera.linux
 LINUX /boot/linux
-FDT /boot/jh7110-visionfive-v2.dtb
+FDT /dtbs/starfive/jh7110-visionfive-v2.dtb
 APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200 console=tty3 vt.global_cursor_default=0

--- a/board/batocera/riscv/visionfive2/create-boot-script.sh
+++ b/board/batocera/riscv/visionfive2/create-boot-script.sh
@@ -14,14 +14,15 @@ BINARIES_DIR=$4
 TARGET_DIR=$5
 BATOCERA_BINARIES_DIR=$6
 
-mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot"     || exit 1
-mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot"          || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux"      || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/dtbs/starfive" || exit 1
 
-cp "${BINARIES_DIR}/Image"                 "${BATOCERA_BINARIES_DIR}/boot/boot/linux"                || exit 1
-cp "${BINARIES_DIR}/initrd.lz4"             "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"            || exit 1
-cp "${BINARIES_DIR}/rootfs.squashfs"       "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+cp "${BINARIES_DIR}/Image"           "${BATOCERA_BINARIES_DIR}/boot/boot/linux"           || exit 1
+cp "${BINARIES_DIR}/initrd.lz4"      "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"      || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs" "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" || exit 1
 
-cp "${BINARIES_DIR}/jh7110-visionfive-v2.dtb"    "${BATOCERA_BINARIES_DIR}/boot/boot/"     || exit 1
-cp "${BOARD_DIR}/boot/extlinux.conf"             "${BATOCERA_BINARIES_DIR}/boot/extlinux/" || exit 1
+cp "${BINARIES_DIR}/jh7110-visionfive-v2.dtb" "${BATOCERA_BINARIES_DIR}/boot/dtbs/starfive/" || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"          "${BATOCERA_BINARIES_DIR}/boot/extlinux/"      || exit 1
 
 exit 0


### PR DESCRIPTION
To handle multiple board variants, the visionfive2 bootloader determines the specific variant configuration.  The dtb provided by the OS is loaded via the command in the fdt_loaddtb environment variable:

```
fdt_loaddtb=fatload ${bootdev} ${devnum}:${bootpart} ${fdt_addr_r} /dtbs/${fdtfile}; fdt addr ${fdt_addr_r};
fdtfile=starfive/jh7110-visionfive-v2.dtb
```

The dtb is then patched with the board's specific hardware configuration, and rewritten accordingly:

```
set_fdt_distro=run chipa_set_linux; run cpu_vol_set;fatwrite ${bootdev} ${devnum}:${bootpart} ${fdt_addr_r} /dtbs/${fdtfile} ${filesize};
```

In order for this rewrite to occur successfully, the FDT must be stored at a known location under /dtbs in the boot filesystem.

With this patch applied, several known issues are corrected for the boards currently being tested:

- Memory is correctly sized at 8G instead of the base default 4G
- eth0 gigabit port is now functional