### PR TITLE
Fix PCSX2 OSD warning (missing PCSX2 patches):

### DIFF
--- a/package/batocera/emulators/pcsx2/006-patches-in-bios-folder.patch
+++ b/package/batocera/emulators/pcsx2/006-patches-in-bios-folder.patch
@@ -1,0 +1,11 @@
+--- a/pcsx2/Patch.cpp	2023-10-01 12:11:29.837825347 +0200
++++ b/pcsx2/Patch.cpp	2023-10-01 12:11:48.690284822 +0200
+@@ -288,7 +288,7 @@
+ 	if (s_patches_zip)
+ 		return true;
+ 
+-	const std::string filename = Path::Combine(EmuFolders::Resources, PATCHES_ZIP_NAME);
++	const std::string filename = Path::Combine(EmuFolders::Bios, PATCHES_ZIP_NAME);
+ 
+ 	zip_error ze = {};
+ 	zip_source_t* zs = zip_source_file_create(filename.c_str(), 0, 0, &ze);

--- a/package/batocera/emulators/pcsx2/pcsx2.mk
+++ b/package/batocera/emulators/pcsx2/pcsx2.mk
@@ -77,6 +77,13 @@ define PCSX2_TEXTURES
         $(TARGET_DIR)/usr/pcsx2/bin/resources/
 endef
 
+# Download and copy PCSX2 patches.zip to BIOS folder
+define PCSX2_PATCHES
+        mkdir -p $(TARGET_DIR)/usr/share/batocera/datainit/bios/pcsx2
+        $(HOST_DIR)/bin/curl -L https://github.com/PCSX2/pcsx2_patches/releases/download/latest/patches.zip -o $(TARGET_DIR)/usr/share/batocera/datainit/bios/pcsx2/patches.zip
+endef
+
 PCSX2_POST_INSTALL_TARGET_HOOKS += PCSX2_TEXTURES
+PCSX2_POST_INSTALL_TARGET_HOOKS += PCSX2_PATCHES
 
 $(eval $(cmake-package))


### PR DESCRIPTION
- Download PCSX2 patches at build time
- Patch PCSX2 to look into BIOS folder