### PR TITLE
fix pygame borders when default is 16x9 display. remove ratio option …

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pygame/pygameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pygame/pygameGenerator.py
@@ -12,3 +12,6 @@ class PygameGenerator(Generator):
 
     def executionDirectory(self, config, rom):
         return os.path.dirname(rom)
+
+    def getInGameRatio(self, config, gameResolution, rom):
+        return 16/9

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8175,7 +8175,7 @@ ppsspp:
 
 pygame:
   features: [padtokeyboard]
-  shared: [videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns]
+  shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns]
 
 reicast:
   shared: [videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]


### PR DESCRIPTION
…(has no effect)