### PR TITLE
fix vpinball with pinmame and b2s backglasses

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Sept 26, 2023
+# Version: Commits on Oct 5, 2023
 # uses standalone tree for now
-VPINBALL_VERSION = 3c39f9ba6ef9891d8747b8b2b085a785d06a413f
+VPINBALL_VERSION = 1b98109e9605cf0f3698cbdab923757f767e478a
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Sep 26, 2023
-LIBPINMAME_VERSION = 51667e2ef60d9db7a14dfbc2e425cc04f6ca0ddd
+# Version: Commits on Oct 5, 2023
+LIBPINMAME_VERSION = 2e9701e18bcd1491856f413eab1a5de5b128cd54
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE


### PR DESCRIPTION
The latest versions include several bug fixes for VPinball and B2S Backglasses:

- Solenoid fixes
- Rotation fixes
- Animations
- LED Segments
- FlexDMD tween fixes
- B2S DMD displays
- DMD and B2S rendering only on changes