### PR TITLE
Major Dolphin Configgen Update / Bug Fix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -122,10 +122,14 @@ class DolphinGenerator(Generator):
 
         # Gamecube ports
         # Create a for loop going 1 through to 4 and iterate through it:
-        for i in range(1,5):
-            if system.isOptSet("dolphin_port_" + str(i) + "_type"):
+        for i in range(1, 5):
+            key = "dolphin_port_" + str(i) + "_type"
+            if system.isOptSet(key):
+                value = system.config[key]
+                # Set value to 6 if it is 6a or 6b. This is to differentiate between Standard Controller and GameCube Controller type.
+                value = "6" if value in ["6a", "6b"] else value
                 # Sub in the appropriate values from es_features, accounting for the 1 integer difference.
-                dolphinSettings.set("Core", "SIDevice" + str(i - 1), system.config["dolphin_port_" + str(i) + "_type"])
+                dolphinSettings.set("Core", "SIDevice" + str(i - 1), value)
             else:
                 dolphinSettings.set("Core", "SIDevice" + str(i - 1), "6")
 
@@ -149,6 +153,19 @@ class DolphinGenerator(Generator):
                 dolphinSettings.set("Core", "SkipIPL", "True")
         else:
             dolphinSettings.set("Core", "SkipIPL", "True")
+        
+        # Set audio backend
+        dolphinSettings.set("DSP", "Backend", "Cubeb")
+        
+        # Dolby Pro Logic II for surround sound
+        if system.isOptSet("dplii") and system.getOptBoolean("dplii"):
+            dolphinSettings.set("Core", "DPL2Decoder", "True")
+            dolphinSettings.set("Core", "DSPHLE", "False")
+            dolphinSettings.set("DSP", "EnableJIT", "True")
+        else:
+            dolphinSettings.set("Core", "DPL2Decoder", "False")
+            dolphinSettings.set("Core", "DSPHLE", "True")
+            dolphinSettings.set("DSP", "EnableJIT", "False")   
         
         # Save dolphin.ini
         with open(batoceraFiles.dolphinIni, 'w') as configfile:

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4534,4 +4534,50 @@
 		<input name="x" type="axis" id="3" value="-1" code="5" />
 		<input name="y" type="axis" id="2" value="-1" code="2" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Microsoft X-Box 360 pad" deviceGUID="030000005e0400008e02000010010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="l3" type="button" id="9" value="1" code="317" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
+		<input name="r3" type="button" id="10" value="1" code="318" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="2" value="1" code="307" />
+		<input name="y" type="button" id="3" value="1" code="308" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="ShanWan USB GamePad" deviceGUID="03000000632500007505000011010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="2" value="1" code="306" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="2" value="-1" code="2" />
+		<input name="joystick2up" type="axis" id="3" value="-1" code="5" />
+		<input name="l2" type="button" id="6" value="1" code="310" />
+		<input name="l3" type="button" id="10" value="1" code="314" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="309" />
+		<input name="pageup" type="button" id="4" value="1" code="308" />
+		<input name="r2" type="button" id="7" value="1" code="311" />
+		<input name="r3" type="button" id="11" value="1" code="315" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="8" value="1" code="312" />
+		<input name="start" type="button" id="9" value="1" code="313" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="3" value="1" code="307" />
+		<input name="y" type="button" id="0" value="1" code="304" />
+	</inputConfig>
 </inputList>

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -6606,12 +6606,13 @@ dolphin:
                 "Off": 0
                 "On":  1
         dolphin_port_1_type:
-            submenu: CONTROLLERS
+            submenu: CONTROLLER 1
             prompt: GAMECUBE PORT 1 TYPE
             description: Change what's plugged into the virtual GameCube ports.
             choices:
                 "None":                       0
-                "Standard Controller":        6
+                "Standard Controller":        6a
+                "GameCube Controller":        6b
                 "GameCube Adapter for Wii U": 12
                 "Steering Wheel":             8
                 "Dance Mat":                  9
@@ -6619,11 +6620,13 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_2_type:
-            submenu: CONTROLLERS
+            submenu: CONTROLLER 2
             prompt: GAMECUBE PORT 2 TYPE
+            description: Change what's plugged into the virtual GameCube ports.
             choices:
                 "None":                       0
-                "Standard Controller":        6
+                "Standard Controller":        6a
+                "GameCube Controller":        6b
                 "GameCube Adapter for Wii U": 12
                 "Steering Wheel":             8
                 "Dance Mat":                  9
@@ -6631,11 +6634,13 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_3_type:
-            submenu: CONTROLLERS
+            submenu: CONTROLLER 3
             prompt: GAMECUBE PORT 3 TYPE
+            description: Change what's plugged into the virtual GameCube ports.
             choices:
                 "None":                       0
-                "Standard Controller":        6
+                "Standard Controller":        6a
+                "GameCube Controller":        6b
                 "GameCube Adapter for Wii U": 12
                 "Steering Wheel":             8
                 "Dance Mat":                  9
@@ -6643,17 +6648,47 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_4_type:
-            submenu: CONTROLLERS
+            submenu: CONTROLLER 4
             prompt: GAMECUBE PORT 4 TYPE
+            description: Change what's plugged into the virtual GameCube ports.
             choices:
                 "None":                       0
-                "Standard Controller":        6
+                "Standard Controller":        6a
+                "GameCube Controller":        6b 
                 "GameCube Adapter for Wii U": 12
                 "Steering Wheel":             8
                 "Dance Mat":                  9
                 "DK Bongos":                  10
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
+        alt_mappings_1:
+            submenu: CONTROLLER 1
+            prompt: ALT INPUT MAPPING
+            description: Use alternative input mappings. Only applies to Standard Controller type.
+            choices:
+                "Face Buttons (CW)":         buttons_cw
+                "Face Buttons (CCW)":        buttons_ccw
+        alt_mappings_2:
+            submenu: CONTROLLER 2
+            prompt: ALT INPUT MAPPING
+            description: Use alternative input mappings. Only applies to Standard Controller type.
+            choices:
+                "Face Buttons (CW)":         buttons_cw
+                "Face Buttons (CCW)":        buttons_ccw
+        alt_mappings_3:
+            submenu: CONTROLLER 3
+            prompt: ALT INPUT MAPPING
+            description: Use alternative input mappings. Only applies to Standard Controller type.
+            choices:
+                "Face Buttons (CW)":         buttons_cw
+                "Face Buttons (CCW)":        buttons_ccw
+        alt_mappings_4:
+            submenu: CONTROLLER 4
+            prompt: ALT INPUT MAPPING
+            description: Use alternative input mappings. Only applies to Standard Controller type.
+            choices:
+                "Face Buttons (CW)":         buttons_cw
+                "Face Buttons (CCW)":        buttons_ccw        
         anisotropic_filtering:
             submenu: RENDERING
             prompt: ANISOTROPIC FILTERING
@@ -6742,20 +6777,6 @@ dolphin:
             choices:
                 "Off": 0
                 "On":  1
-        dsmotion:
-            submenu: CONTROLLERS
-            prompt: DUALSHOCK MOTION CONTROL
-            description: Emulate the Wiimote pointer with a DS4's gyroscope.
-            choices:
-                "Off": 0
-                "On":  1
-        mouseir:
-            submenu: CONTROLLERS
-            prompt: MOUSE AS WIIMOTE POINTER
-            description: Emulate the Wiimote pointer with a mouse.
-            choices:
-                "Off": 0
-                "On":  1
         rumble:
             submenu: CONTROLLERS
             prompt: RUMBLE
@@ -6769,7 +6790,93 @@ dolphin:
             choices:
                 "Off": "False"
                 "On":  "True"
-
+        deadzone_1:
+            submenu: CONTROLLER 1
+            prompt: DEADZONE
+            description: Set joystick deadzone.
+            choices:
+                "0%":            0.0
+                "5% (Default)":  5.0        
+                "10%":           10.0
+                "15%":           15.0
+                "20%":           20.0
+                "25%":           25.0
+                "30%":           30.0
+        deadzone_2:
+            submenu: CONTROLLER 2
+            prompt: DEADZONE
+            description: Set joystick deadzone.
+            choices:
+                "0%":            0.0
+                "5% (Default)":  5.0        
+                "10%":           10.0
+                "15%":           15.0
+                "20%":           20.0
+                "25%":           25.0
+                "30%":           30.0
+        deadzone_3:
+            submenu: CONTROLLER 3
+            prompt: DEADZONE
+            description: Set joystick deadzone.
+            choices:
+                "0%":            0.0
+                "5% (Default)":  5.0        
+                "10%":           10.0
+                "15%":           15.0
+                "20%":           20.0
+                "25%":           25.0
+                "30%":           30.0
+        deadzone_4:
+            submenu: CONTROLLER 4
+            prompt: DEADZONE
+            description: Set joystick deadzone.
+            choices:
+                "0%":            0.0
+                "5% (Default)":  5.0        
+                "10%":           10.0
+                "15%":           15.0
+                "20%":           20.0
+                "25%":           25.0
+                "30%":           30.0
+        jsgate_size_1:
+            submenu: CONTROLLER 1
+            prompt: JOYSTICK GATE SIZE
+            description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
+            choices:
+                "Smaller":          smaller
+                "Normal (Default)": normal        
+                "Larger":           larger
+        jsgate_size_2:
+            submenu: CONTROLLER 2
+            prompt: JOYSTICK GATE SIZE
+            description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
+            choices:
+                "Smaller":          smaller
+                "Normal (Default)": normal        
+                "Larger":           larger 
+        jsgate_size_3:
+            submenu: CONTROLLER 3
+            prompt: JOYSTICK GATE SIZE
+            description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
+            choices:
+                "Smaller":          smaller
+                "Normal (Default)": normal        
+                "Larger":           larger 
+        jsgate_size_4:
+            submenu: CONTROLLER 4
+            prompt: JOYSTICK GATE SIZE
+            description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
+            choices:
+                "Smaller":          smaller
+                "Normal (Default)": normal        
+                "Larger":           larger
+        dplii:
+            group: ADVANCED OPTIONS
+            prompt: DOLBY PRO LOGIC II
+            description: Enables Dolby Pro Logic II for surround sound. May impact performance.
+            choices:
+                "Off": 0
+                "On":  1        
   systems:
     gamecube:
         shared: [use_wheels]
@@ -6816,6 +6923,20 @@ dolphin:
                     "Wiimote Sideway + Swing":   is
                     "Wiimote Sideway + Tilt":    it
                     "Wiimote Sideway + Nunchuk": in
+            dsmotion:
+                submenu: CONTROLLERS
+                prompt: DUALSHOCK MOTION CONTROL
+                description: Emulate the Wiimote pointer with a DS4's gyroscope.
+                choices:
+                    "Off": 0
+                    "On":  1
+            mouseir:
+                submenu: CONTROLLERS
+                prompt: MOUSE AS WIIMOTE POINTER
+                description: Emulate the Wiimote pointer with a mouse.
+                choices:
+                    "Off": 0
+                    "On":  1
             dolphin-lightgun-hide-crosshair:
                 submenu: CONTROLLERS
                 prompt: SHOW LIGHT GUN CROSSHAIRS


### PR DESCRIPTION
- ES - Move DS4 gyro and mouse controllers settings in Wii system
- ES - Add Controller 1-4 submenu and move GC Port controller type into new submenus, and add new GameCube controller type
- ES - Add alt input mapping settings for standard controller type per controller. (Rotate face buttons CW/CCW)
- ES - Add deadzone and joystick gate size settings per controller
- ES - Add Dolby Pro Logic II setting


+Dolphin+
New logic for controller type and various other controller settings on a per controller basis.

Changed default audio backend to Cubeb. ALSA(current default) is not compatible with DPLII+surround, moreover Cubeb is now the recommended default on Dolphin windows side.

If L1 is mapped on a controller GC games will now utilize either L1 or R1 as "Z". No more button that doesn't do anything.

Fixed bug where surround was broken, DPLII+Surround sound now working via ES setting(note there is a performance cost due to LLE being required instead of the faster HLE, which is reflected in the ES setting description).

Fixed bug that prevented full analog values being used for Triggers. (Before values would only register above 50%)

- ES_INPUT -
Added mappings for retrofighter GC style controller. Both Xinput and Dinput modes.



