### PR TITLE
Allow sway to start with no keyboard or libinput devices, fixes #10098

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/wayland/sway-launch
+++ b/package/batocera/emulationstation/batocera-emulationstation/wayland/sway-launch
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 SWAY_LOG_FILE=/userdata/system/logs/sway.log
-/usr/bin/sway -d > ${SWAY_LOG_FILE} 2>&1
+WLR_LIBINPUT_NO_DEVICES=1 /usr/bin/sway -d > ${SWAY_LOG_FILE} 2>&1


### PR DESCRIPTION
Patch from @retro98boy