### PR TITLE
Add tree(1)

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -194,6 +194,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_PYTHON_HIDAPI                        # Communication with USB HID devices via Python
     select BR2_PACKAGE_LEDSPICER                            # LED Manager for Linux
     select BR2_PACKAGE_INNOEXTRACT			    # Extract InnoSetup files (useful for Wine and GOG games)
+    select BR2_PACKAGE_TREE				    # recursive directory listing (useful for generating documentation on rom directory structure)
 
     # Python and SSL
     select BR2_PACKAGE_HOST_PYTHON3


### PR DESCRIPTION
Add tree(1) to assist with creating wiki documentation, and for verifying correct directory tree rom layouts.

```
[root@nardole /userdata/roms/ps3]# tree -L 2 example.ps3/
example.ps3/
├── PS3_DISC.SFB
├── PS3_GAME
│   ├── ICON0.PNG
│   ├── LICDIR
│   ├── PARAM.SFO
│   ├── PIC1_00.PNG
│   ├── PIC1_01.PNG
│   ├── PIC1.PNG
│   ├── PS3LOGO.DAT
│   ├── TROPDIR
│   └── USRDIR
└── PS3_UPDATE
    └── PS3UPDAT.PUP

5 directories, 8 files
```
