### PR TITLE
Enable uinput for riscv

### DIFF
--- a/board/batocera/riscv/linux-defconfig-fragment.config
+++ b/board/batocera/riscv/linux-defconfig-fragment.config
@@ -3,6 +3,7 @@ CONFIG_INPUT_FF_MEMLESS=m
 CONFIG_POWER_SUPPLY=y
 
 # required for evmapy
+CONFIG_INPUT_MISC=y
 CONFIG_INPUT_UINPUT=y
 
 # required for squashfs + overlayfs


### PR DESCRIPTION
On riscv, CONFIG_INPUT_UINPUT is set in kernel config fragment, but is dependent on CONFIG_INPUT_MISC which is not set.  Therefore the /dev/uinput device is missing, and libevdev_new() will always fail (ENOENT).

This patch enables the missing config option.