### PR TITLE
Atari VCS 2600 classic controller support (1st part)

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4580,4 +4580,17 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="0" value="1" code="304" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Atari Classic Controller" deviceGUID="03000000503200000110000000000000">
+		<input name="a" type="button" id="5" value="1" code="305" />
+		<input name="b" type="button" id="4" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="1" value="1" code="158" />
+		<input name="joystick1left" type="axis" id="0" value="1" code="7" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="1" value="1" code="158" />
+		<input name="start" type="button" id="0" value="1" code="139" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="2" value="1" code="172" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
The new version, not the one from the 80s.