### PR TITLE
S99userservices - sanitize user scripts

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -12,33 +12,44 @@ if test -n "${enabled_services}"
 then
     for SERVICE in ${enabled_services}
     do
-	export __SERVICE__${SERVICE}=1
+    export __SERVICE__${SERVICE}=1
     done
 fi
 
 # user services
-find /userdata/system/services -type f |
+# printf removes path data, all non alaphanumeric chars are converted to underscore
+pushd /userdata/system/services
+
+find -type f  -printf '%f\n' |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    SANITIZE=${SERVICE//[^0-9A-Za-z]/_}
+    if ! test "${SERVICE}" = "${SANITIZE}"; then
+        mv "${SERVICE}" "${SANITIZE}"
+        SERVICE=${SANITIZE}
+    fi
+    SRVVAR=__SERVICE__${SERVICE}
+    if test "${!SRVVAR}" = 1
+    then
+        bash "${SERVICE}" "${1}" &
+    fi
     done
+popd
 
 # system user services
-find /usr/share/batocera/services -type f |
+# here the sanitize is not needed, only a-z0-9 allowed for filename
+pushd /usr/share/batocera/services
+
+find -type f -printf '%f\n' |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    SRVVAR=__SERVICE__${SERVICE}
+    if test "${!SRVVAR}" = 1
+    then
+        bash "${SERVICE}" "${1}" &
+    fi
     done
+popd
 
-# wait so that shutdown can happen
+# wait for scrtips to finish, then shutdown can happen
 test "${1}" = "stop" && wait


### PR DESCRIPTION
Only A-Z and 0-9 is allowed as charcter name. Other chars will be transformed to underscore

```
My 1st LED Spicer Script-1.sh
-->
My_1st_LED_Spicer_Script_1_sh
```

This is only effective for the user scripts, devs should know what to do.