### PR TITLE
S99userservices - symlink + check filenames

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -17,28 +17,36 @@ then
 fi
 
 # user services
-find /userdata/system/services -type f |
+find -L /userdata/system/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    if [[ "${BASE_SERVICE}" =~ ^[_[:alpha:]][_[:alpha:][:digit:]]*$ ]]; then
+        SRVVAR=__SERVICE__${BASE_SERVICE}
+        if test "${!SRVVAR}" = 1; then
+    	    bash "${SERVICE}" "${1}" &
+            echo "User Service: ${BASE_SERVICE} - ${1} condition [ok]"
+        else
+            echo "User Service: ${BASE_SERVICE} - ${1} condition [ok] - service disabled"            
+        fi
+    else
+        echo "User Service: ${BASE_SERVICE} - ${1} condition [ko] - invalid filename"
+    fi
     done
 
 # system user services
-find /usr/share/batocera/services -type f |
+find -L /usr/share/batocera/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    SRVVAR=__SERVICE__${BASE_SERVICE}
+    if test "${!SRVVAR}" = 1; then
+        bash "${SERVICE}" "${1}" &
+        echo "System Service: ${BASE_SERVICE} - ${1} condition [ok]"
+    else
+        echo "System Service: ${BASE_SERVICE} - ${1} condition [ok] - service disabled"
+    fi
     done
 
-# wait so that shutdown can happen
+# wait scripts to finish on stop condition, shutdown can happen
 test "${1}" = "stop" && wait


### PR DESCRIPTION
Errors with invalid filenames are catched exactly according batocera-service
Symlinked services can now be started exactly according batocera-service
Removed the remove of **.fileextension** it's a filename with invalid character and therefore an invalid action -- this case is catched by filename check

User Output per SSH
```
[root@BATOCERA /userdata/system/services]# /etc/init.d/S99userservices stop
User Service: blaaaa - stop condition [ok]
User Service: lmmaaa - stop condition [ok] - service disabled
User Service: lmaaa - stop condition [ok]
User Service: lma.sh - stop condition [ko] - invalid filename
System Service: ledspicer - stop condition [ok] - service disabled
System Service: syncthing - stop condition [ok] - service disabled
```