### PR TITLE
fixed S99userservices

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -17,28 +17,36 @@ then
 fi
 
 # user services
-find /userdata/system/services -type f |
+find -L /userdata/system/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    if [[ "$BASE_SERVICE" == ${BASE_SERVICE//[^0-9A-Za-z_]/} ]]; then
+        SRVVAR=__SERVICE__${BASE_SERVICE}
+        if test "${!SRVVAR}" = 1; then
+            bash "${SERVICE}" "${1}" &
+            echo "User Service: ${BASE_SERVICE} - ${1} condition [ok] - service enabled"
+        else
+            echo "User Service: ${BASE_SERVICE} - ${1} condition [ok] - service disabled"
+        fi
+    else
+        echo "User Service: ${BASE_SERVICE} - ${1} condition [ko] - invalid filename"
+    fi
     done
 
 # system user services
-find /usr/share/batocera/services -type f |
+find -L /usr/share/batocera/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    SRVVAR=__SERVICE__${BASE_SERVICE}
+    if test "${!SRVVAR}" = 1; then
+        bash "${SERVICE}" "${1}" &
+        echo "System Service: ${BASE_SERVICE} - ${1} condition [ok] - service enabled"
+    else
+        echo "System Service: ${BASE_SERVICE} - ${1} condition [ok] - service disabled"
+    fi
     done
 
-# wait so that shutdown can happen
+# wait scripts to finish on stop condition, shutdown can happen
 test "${1}" = "stop" && wait

--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -21,7 +21,7 @@ find -L /userdata/system/services -type f |
     while read SERVICE
     do
     BASE_SERVICE=${SERVICE##*/}
-    if [[ "$BASE_SERVICE" == ${BASE_SERVICE//[^0-9A-Za-z_]/} ]]; then
+    if [[ "$BASE_SERVICE" == ${BASE_SERVICE//[^0-9A-Za-z_]/} && ${BASE_SERVICE:0:1} =~ ^[[:alpha:]] ]]; then
         SRVVAR=__SERVICE__${BASE_SERVICE}
         if test "${!SRVVAR}" = 1; then
             bash "${SERVICE}" "${1}" &


### PR DESCRIPTION
Allowed Characters: a-z, A-Z, 0-9, undersore _

TESTSET:
```
[root@BATOCERA]# touch mit.sh
[root@BATOCERA]# touch germanystyleöäü
[root@BATOCERA]# touch germanystyleß
[root@BATOCERA]# touch germany-style
[root@BATOCERA]# touch underscore_istok
```

Before fix:
```
[root@BATOCERA]# /etc/init.d/S99userservices start
User Service: SanitizerApp - start condition [ok] - service disabled
User Service: mit.sh - start condition [ko] - invalid filename
/etc/init.d/S99userservices: line 26: __SERVICE__germanystyleöäü: invalid variable name
System Service: ledspicer - start condition [ok] - service disabled
System Service: syncthing - start condition [ok] - service disabled
```
You see loop is broken, services are not started!


Fixed!
```
[root@BATOCERA]# /etc/init.d/S99userservices start
User Service: SanitizerApp - start condition [ok] - service enabled
User Service: mit.sh - start condition [ko] - invalid filename
User Service: germanystyleöäü - start condition [ko] - invalid filename
User Service: germanystyleß - start condition [ko] - invalid filename
User Service: germany-style - start condition [ko] - invalid filename
User Service: underscore_istok - start condition [ok] - service disabled
System Service: ledspicer - start condition [ok] - service disabled
System Service: syncthing - start condition [ok] - service disabled
```

Need to fix batocera-services, too
```
[root@BATOCERA]# batocera-services enable germanystyleöäü
[root@BATOCERA]# nano ~/batocera.conf
[root@BATOCERA]# THIS IS SIMPLY WRONG -- I'll fix this
```