### PR TITLE
S99userservices - finally

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -6,6 +6,9 @@ if test -e "/userdata/system/custom.sh"; then
     bash /userdata/system/custom.sh $1 &
 fi
 
+# Needed set for proper bash reg-expression
+LC_ALL=C
+
 enabled_services="$(/usr/bin/batocera-settings-get system.services)"
 
 if test -n "${enabled_services}"
@@ -21,18 +24,18 @@ find -L /userdata/system/services -type f |
     while read SERVICE
     do
     BASE_SERVICE=${SERVICE##*/}
-    if echo "${BASE_SERVICE,,}" | grep -q -E ^[a-z].[a-z0-9_]*$; then
+    if [[ ${BASE_SERVICE} =~ ^[_[:alpha:]][[:alpha:][:digit:]_]*$ ]];then
         SRVVAR=__SERVICE__${BASE_SERVICE}
         if test "${!SRVVAR}" = 1; then
     	    bash "${SERVICE}" "${1}" &
-            echo "User Service: ${BASE_SERVICE} - service is enabled - filename [ok]"
+            echo "User Service: ${BASE_SERVICE} -> service is enabled [ok]"
         else
-            echo "User Service: ${BASE_SERVICE} - service is disabled - filename [ok]"            
+            echo "User Service: ${BASE_SERVICE} -> service is disabled [ok]"            
         fi
     else
         string_new=${BASE_SERVICE//[^A-Za-z0-9_]/}
-        string_new=$(echo "$string_new" | sed 's/[[:digit:]]*//')
-        echo "User Service: $BASE_SERVICE needs rename to $string_new - filename [ko]"
+        string_new=$(echo "$string_new" | sed 's/^[[:digit:]]*//')
+        echo "User Service: $BASE_SERVICE -> suggest rename sevice file to: '$string_new' [ko]"
     fi
     done
 
@@ -44,11 +47,11 @@ find -L /usr/share/batocera/services -type f |
     SRVVAR=__SERVICE__${BASE_SERVICE}
     if test "${!SRVVAR}" = 1; then
         bash "${SERVICE}" "${1}" &
-        echo "System Service: ${BASE_SERVICE} - service is enabled - filename [ok]"
+        echo "System Service: ${BASE_SERVICE} -> service is enabled [ok]"
     else
-        echo "System Service: ${BASE_SERVICE} - service is disabled - filename [ok]"
+        echo "System Service: ${BASE_SERVICE} -> service is disabled [ok]"
     fi
     done
 
-# wait scripts to finish on stop condition, shutdown can happen
+# wait for spawned scripts to finish on stop condition, after this shutdown can happen
 test "${1}" = "stop" && wait

--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -17,28 +17,38 @@ then
 fi
 
 # user services
-find /userdata/system/services -type f |
+find -L /userdata/system/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    if echo "${BASE_SERVICE,,}" | grep -q -E ^[a-z].[a-z0-9_]*$; then
+        SRVVAR=__SERVICE__${BASE_SERVICE}
+        if test "${!SRVVAR}" = 1; then
+    	    bash "${SERVICE}" "${1}" &
+            echo "User Service: ${BASE_SERVICE} - service is enabled - filename [ok]"
+        else
+            echo "User Service: ${BASE_SERVICE} - service is disabled - filename [ok]"            
+        fi
+    else
+        string_new=${BASE_SERVICE//[^A-Za-z0-9_]/}
+        string_new=$(echo "$string_new" | sed 's/[[:digit:]]*//')
+        echo "User Service: $BASE_SERVICE needs rename to $string_new - filename [ko]"
+    fi
     done
 
 # system user services
-find /usr/share/batocera/services -type f |
+find -L /usr/share/batocera/services -type f |
     while read SERVICE
     do
-	BASE_SERVICE=${SERVICE##*/}
-	SRVVAR=__SERVICE__${BASE_SERVICE%.*}
-	if test "${!SRVVAR}" = 1
-	then
-	    bash "${SERVICE}" "${1}" &
-	fi
+    BASE_SERVICE=${SERVICE##*/}
+    SRVVAR=__SERVICE__${BASE_SERVICE}
+    if test "${!SRVVAR}" = 1; then
+        bash "${SERVICE}" "${1}" &
+        echo "System Service: ${BASE_SERVICE} - service is enabled - filename [ok]"
+    else
+        echo "System Service: ${BASE_SERVICE} - service is disabled - filename [ok]"
+    fi
     done
 
-# wait so that shutdown can happen
+# wait scripts to finish on stop condition, shutdown can happen
 test "${1}" = "stop" && wait


### PR DESCRIPTION
PS: bash is such as bad - for proper reg expressions use LC_ALL=C
Avoid [[ $a =~ regex-expression ]]

tested and working with suggestion for users how to rename file (@n2qz as you wished, but please do the service-change on your own)

```
[root@BATOCERA /userdata/system/services]# /etc/init.d/S99userservices
User Service: SanitizerApp -> service is disabled [ok]
User Service: GrüßGott -> suggest rename sevice file to: 'GrGott' [ko]
User Service: underscore_test -> service is disabled [ok]
User Service: 1sttest -> suggest rename sevice file to: 'sttest' [ko]
User Service: 12345gh -> suggest rename sevice file to: 'gh' [ko]
User Service: 1234567.sh -> suggest rename sevice file to: 'sh' [ko]
System Service: ledspicer -> service is disabled [ok]
System Service: syncthing -> service is disabled [ok]

```