### PR TITLE
Fix service script name validation

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-services
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-services
@@ -12,6 +12,7 @@ do_help() {
 }
 
 is_valid_service_name() {
+    local LC_ALL=C
     [[ "${1}" =~ ^[_[:alpha:]][_[:alpha:][:digit:]]*$ ]]
 }
 


### PR DESCRIPTION
Alphabetic characters in Bash variable names must be ASCII even in non-ASCII locales.