### PR TITLE
Show UEFI boot mode and Secure Boot state

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -161,6 +161,16 @@ if [[ "${FULL_DISPLAY}" != 0 ]]; then
 		    echo "Vulkan Driver Version: none"
 	    fi
 	fi
+
+	# Boot information
+	if [ -d /sys/firmware/efi ]; then
+		echo "UEFI Boot: Yes"
+		if [ -x /usr/bin/mokutil ]; then
+			echo "Secure Boot: $(mokutil --sb-state)"
+		fi
+	else
+		echo "UEFI Boot: No"
+	fi
 fi
 
 # userdata type


### PR DESCRIPTION
Show UEFI boot mode and Secure Boot state in output of `batocera-info --full`
