### PR TITLE
batocera-version - just report version + add check 4 symlinks

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-version
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-version
@@ -14,7 +14,7 @@ test -e "/userdata/system/configs/emulationstation/es_systems.cfg" && FIND_CUSTO
 FIND_CUSTOMESFEATURES=
 test -e "/userdata/system/configs/emulationstation/es_features.cfg" && FIND_CUSTOMESFEATURES=1
 
-FIND_CUSTOMSERVICES=$(batocera-services list user | grep '\*$' | head -1)
+FIND_CUSTOMSERVICES=$(find -L /userdata/system/services -type f 2>/dev/null)
 
 EXTRA=
 test -n "${FIND_EXT}"      	   && EXTRA=${EXTRA}e


### PR DESCRIPTION
It just reports version, and isn't dangeling the services.
service-check for SSH/Terminal should be moved to a dedicated file in /etc/profile.de
Symlink check enabled (like the others S99userservice and batocera-service have)