### PR TITLE
Set EFI variable instructing shim fallback loader to not reboot

### DIFF
--- a/board/batocera/x86/fsoverlay/etc/init.d/S98shimfallback
+++ b/board/batocera/x86/fsoverlay/etc/init.d/S98shimfallback
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Sets EFI shim fallback loader to not reboot
+#
+
+case "$1" in
+    start)
+        [ -d "/sys/firmware/efi" ] && [ -x /usr/bin/mokutil ] && /usr/bin/mokutil --set-fallback-noreboot true
+    ;;
+    stop)
+    ;;
+    restart|reload)
+    ;;
+    *)
+        echo "Usage: $0 {start|stop|restart}"
+        exit 1
+    ;;
+esac
+
+exit $?


### PR DESCRIPTION
With the new shim EFI fallback scheme introduced for secureboot support, when a TPM is present and enabled, the fallback loader (fbx86.efi) will reboot after installing the new EFI loader entry.

If the system firmware has created a bootloader entry for the fallback EFI loader, and that entry is first in the boot order, this reboot will cause an endless reboot cycle.

The user can currently break the loop by resetting the "Batocera" entry to have a higher priority in the boot order.

This change will allow the user to break that reboot loop more easily, by booting Batocera from the boot menu (usually F12 at startup). After booting, Batocera will turn off the reboot behavior, causing the fallback loader to load the Batocera EFI loader instead of rebooting.