### PR TITLE
Fix error message in script for hot switching of video outputs on x86_64

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-switch-screen-checker
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-switch-screen-checker
@@ -3,7 +3,7 @@
 # required for x
 export DISPLAY=:0
 # required for wayland
-. /etc/profile.d/04-sway.sh
+[ -f /etc/profile.d/04-sway.sh ] && . /etc/profile.d/04-sway.sh
 
 if test "${1}" == "--init"
 then


### PR DESCRIPTION
Fix a mostly-harmless error message from the switch-screen-checker

```
[root@nardole /userdata/system]# /usr/bin/batocera-switch-screen-checker
/usr/bin/batocera-switch-screen-checker: line 6: /etc/profile.d/04-sway.sh: No such file or directory
```
