### PR TITLE
Capture stderr when fetching sb-state

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -166,7 +166,7 @@ if [[ "${FULL_DISPLAY}" != 0 ]]; then
 	if [ -d /sys/firmware/efi ]; then
 		echo "UEFI Boot: Yes"
 		if [ -x /usr/bin/mokutil ]; then
-			echo "Secure Boot: $(mokutil --sb-state)"
+			echo "Secure Boot: $(mokutil --sb-state 2>&1)"
 		fi
 	else
 		echo "UEFI Boot: No"


### PR DESCRIPTION
Capture stderr messages such as "This system doesn't support Secure Boot" when querying Secure Boot status