### PR TITLE
update allinuxfirmwares to 20231030

### DIFF
--- a/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
+++ b/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ALLLINUXFIRMWARES_VERSION = 20230919
+ALLLINUXFIRMWARES_VERSION = 20231030
 ALLLINUXFIRMWARES_SOURCE = linux-firmware-$(ALLLINUXFIRMWARES_VERSION).tar.gz
 ALLLINUXFIRMWARES_SITE = https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot
 
@@ -49,14 +49,6 @@ define ALLLINUXFIRMWARES_INSTALL_TARGET_CMDS
             fi \
 		fi ; \
 	done
-endef
-
-# symlink BT firmware - workaround until AX101 BT firmware is added
-define ALLLINUXFIRMWARES_LINK_INTEL_BT
-    ln -sf /lib/firmware/intel/ibt-1040-4150.ddc \
-        $(TARGET_DIR)/lib/firmware/intel/ibt-0040-1050.ddc
-    ln -sf /lib/firmware/intel/ibt-1040-4150.sfi \
-        $(TARGET_DIR)/lib/firmware/intel/ibt-0040-1050.sfi
 endef
 
 ifeq ($(BR2_x86_64),y)


### PR DESCRIPTION
- removed AX101 workaround in favor of the new dedicated firmware