### PR TITLE
Enable mouse cursor when required for soniccd

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -235,7 +235,7 @@ def start_rom(args, maxnbplayers, rom, romConfiguration):
         if args.state_filename is not None:
             system.config["state_filename"] = args.state_filename
 
-        if generator.getMouseMode(system.config):
+        if generator.getMouseMode(system.config, rom):
             mouseChanged = True
             videoMode.changeMouse(True)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/Generator.py
@@ -11,7 +11,7 @@ class Generator(object):
     def getResolutionMode(self, config):
         return config['videomode']
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return False
 
     def executionDirectory(self, config, rom):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -247,7 +247,7 @@ class CemuGenerator(Generator):
         xml.write(dom_string)
     
     # Show mouse for touchscreen actions    
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         if "cemu_touchpad" in config and config["cemu_touchpad"] == "1":
             return True
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cgenius/cgeniusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cgenius/cgeniusGenerator.py
@@ -125,5 +125,5 @@ class CGeniusGenerator(Generator):
         )
 
     # Show mouse on screen for the Config Screen
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
@@ -28,7 +28,7 @@ class CitraGenerator(Generator):
         )
 
     # Show mouse on screen
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         if "citra_screen_layout" in config and config["citra_screen_layout"] == "1-false":
             return False
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flatpak/flatpakGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flatpak/flatpakGenerator.py
@@ -20,5 +20,5 @@ class FlatpakGenerator(Generator):
         commandArray = ["su", "-", "batocera", "-c",  "DISPLAY=:0.0 flatpak run -v " + romId]
         return Command.Command(array=commandArray)
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lightspark/lightsparkGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lightspark/lightsparkGenerator.py
@@ -12,5 +12,5 @@ class LightsparkGenerator(Generator):
         return Command.Command(
             array=commandArray)
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppGenerator.py
@@ -67,7 +67,7 @@ class PPSSPPGenerator(Generator):
         return gameResolution["width"] <= 480 or gameResolution["height"] <= 480
 
     # Show mouse on screen for the Config Screen
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True
 
     def getInGameRatio(self, config, gameResolution, rom):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ruffle/ruffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ruffle/ruffleGenerator.py
@@ -12,5 +12,5 @@ class RuffleGenerator(Generator):
         return Command.Command(
             array=commandArray)
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -21,5 +21,5 @@ class ShGenerator(Generator):
             "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers)
         })
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sonicretro/sonicretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sonicretro/sonicretroGenerator.py
@@ -55,7 +55,7 @@ class SonicRetroGenerator(Generator):
             "Select":   "43"
         }
         
-         # ini file
+        # ini file
         sonicConfig = configparser.RawConfigParser(strict=False)
         sonicConfig.optionxform=str             # Add Case Sensitive comportement
         if os.path.exists(iniFile):
@@ -162,3 +162,23 @@ class SonicRetroGenerator(Generator):
             env={
                 'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
             })
+
+    def getMouseMode(self, config, rom):
+        # Determine the emulator to use
+        if (rom.lower()).endswith("son"):
+            emu = "sonic2013"
+        else:
+            emu = "soniccd"
+
+        mouseRoms = [
+            "1bd5ad366df1765c98d20b53c092a528", # iOS version of SonicCD
+        ]
+
+        enableMouse = False
+        if (emu == "soniccd"):
+            import hashlib
+            enableMouse = hashlib.md5(open(f"{rom}/Data.rsdk", "rb").read()).hexdigest() in mouseRoms
+        else:
+            enableMouse = False
+
+        return enableMouse

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/steam/steamGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/steam/steamGenerator.py
@@ -20,5 +20,5 @@ class SteamGenerator(Generator):
             commandArray = ["batocera-steam", gameId]
         return Command.Command(array=commandArray)
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/theforceengine/theforceengineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/theforceengine/theforceengineGenerator.py
@@ -219,7 +219,7 @@ class TheForceEngineGenerator(Generator):
         )
 
     # Show mouse for menu actions
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True
 
     def getInGameRatio(self, config, gameResolution, rom):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
@@ -98,5 +98,5 @@ class Vita3kGenerator(Generator):
             })
     
     # Show mouse for touchscreen actions
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -39,7 +39,7 @@ class WineGenerator(Generator):
         
         raise Exception("invalid system " + system.name)
 
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         if "force_mouse" in config and config["force_mouse"] == "0":
             return False
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -210,5 +210,5 @@ class XeniaGenerator(Generator):
 
     # Show mouse on screen when needed
     # xenia auto-hides
-    def getMouseMode(self, config):
+    def getMouseMode(self, config, rom):
         return True


### PR DESCRIPTION
- Enable mouse for known versions of soniccd roms requiring
  touchscreen navigation.  See wiki for details on this rom:
  https://wiki.batocera.org/systems:sonicretro

- Add rom parameter to getMouseMode() method on Generator objects
  (BREAKING API CHANGE)