### PR TITLE
User/system service init script improvements

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S99userservices
+++ b/board/batocera/fsoverlay/etc/init.d/S99userservices
@@ -1,13 +1,56 @@
 #!/bin/bash
 
+call_service()
+{
+    local service_file_path="${1}"
+    local service_state="${2}"
+
+    if [ -x "${service_file_path}" ]
+    then
+        # Executable bit set (chmod +x), call service directly
+        "${service_file_path}" "${service_state}" &
+    else
+        # Executable bit not set, call service via bash interpeter
+        bash "${service_file_path}" "${service_state}" &
+    fi
+}
+
+is_valid_service_name() {
+    local LC_ALL=C
+    [[ "${1}" =~ ^[_[:alpha:]][_[:alpha:][:digit:]]*$ ]]
+}
+
+process_services() {
+    local service_type="${1}"
+    local service_dir="${2}"
+    local service_state="${3}"
+    local BASE_SERVICE SERVICE SRVVAR BASE_SERVICE_SUGGEST
+
+    find -L "${service_dir}" -type f |
+        while read SERVICE
+        do
+            BASE_SERVICE=${SERVICE##*/}
+            if is_valid_service_name "${BASE_SERVICE}"
+            then
+                SRVVAR=__SERVICE__${BASE_SERVICE}
+                if test "${!SRVVAR}" = 1; then
+                    call_service "${SERVICE}" "${service_state}"
+                    echo "${service_type} Service: ${BASE_SERVICE} -> service is enabled [ok]"
+                else
+                    echo "${service_type} Service: ${BASE_SERVICE} -> service is disabled [ok]"
+                fi
+            else
+                BASE_SERVICE_SUGGEST=$(echo "$BASE_SERVICE" | sed -e 's/[^_A-Za-z0-9]//g' -e 's/^[0-9]*//')
+                echo "${service_type} Service: $BASE_SERVICE -> invalid service name, suggest rename service file to: '$BASE_SERVICE_SUGGEST' [failed]"
+            fi
+        done
+}
+
 # custom.sh : deprecated
 if test -e "/userdata/system/custom.sh"; then
     #bash interpreter executes scripts without x-flag e.g. for vFAT
     bash /userdata/system/custom.sh $1 &
 fi
-
-# Needed set for proper bash reg-expression
-LC_ALL=C
 
 enabled_services="$(/usr/bin/batocera-settings-get system.services)"
 
@@ -15,43 +58,15 @@ if test -n "${enabled_services}"
 then
     for SERVICE in ${enabled_services}
     do
-	export __SERVICE__${SERVICE}=1
+        export __SERVICE__${SERVICE}=1
     done
 fi
 
 # user services
-find -L /userdata/system/services -type f |
-    while read SERVICE
-    do
-    BASE_SERVICE=${SERVICE##*/}
-    if [[ ${BASE_SERVICE} =~ ^[_[:alpha:]][[:alpha:][:digit:]_]*$ ]];then
-        SRVVAR=__SERVICE__${BASE_SERVICE}
-        if test "${!SRVVAR}" = 1; then
-    	    bash "${SERVICE}" "${1}" &
-            echo "User Service: ${BASE_SERVICE} -> service is enabled [ok]"
-        else
-            echo "User Service: ${BASE_SERVICE} -> service is disabled [ok]"            
-        fi
-    else
-        string_new=${BASE_SERVICE//[^A-Za-z0-9_]/}
-        string_new=$(echo "$string_new" | sed 's/^[[:digit:]]*//')
-        echo "User Service: $BASE_SERVICE -> suggest rename sevice file to: '$string_new' [ko]"
-    fi
-    done
+process_services User /userdata/system/services "${1}"
 
 # system user services
-find -L /usr/share/batocera/services -type f |
-    while read SERVICE
-    do
-    BASE_SERVICE=${SERVICE##*/}
-    SRVVAR=__SERVICE__${BASE_SERVICE}
-    if test "${!SRVVAR}" = 1; then
-        bash "${SERVICE}" "${1}" &
-        echo "System Service: ${BASE_SERVICE} -> service is enabled [ok]"
-    else
-        echo "System Service: ${BASE_SERVICE} -> service is disabled [ok]"
-    fi
-    done
+process_services System /usr/share/batocera/services "${1}"
 
 # wait for spawned scripts to finish on stop condition, after this shutdown can happen
 test "${1}" = "stop" && wait


### PR DESCRIPTION
- Implement suggestion given on discord, allowing executable scripts/programs other than bash, if executable bit is set

- Rework with functions to keep it DRY

- Fix suggested renaming of scripts for code readability and correctness - improper renames would be suggested for leading strings of digits with embedded non-alphanumeric, e.g. '123^456test'