### PR TITLE
Update vpinball.keys

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.keys
+++ b/package/batocera/emulators/vpinball/vpinball.keys
@@ -63,14 +63,26 @@
     {
       "trigger": ["l2"],
       "type": "key",
-      "target": [ "KEY_LEFTCTRL" ],
-      "description": "Left magnasave"
+      "target": [ "KEY_LEFTSHIFT" ],
+      "description": "Left flipper"
     },
     {
       "trigger": ["r2"],
       "type": "key",
+      "target": [ "KEY_RIGHTSHIFT" ],
+      "description": "Right flipper"
+    },
+   {
+      "trigger": ["l3"],
+      "type": "key",
+      "target": [ "KEY_LEFTCTRL" ],
+      "description": "Left magnasave"
+    },
+    {
+      "trigger": ["r3"],
+      "type": "key",
       "target": [ "KEY_RIGHTCTRL" ],
       "description": "Right magnasave"
-    }
+    }    
     ]
 }

--- a/package/batocera/emulators/vpinball/vpinball.keys
+++ b/package/batocera/emulators/vpinball/vpinball.keys
@@ -63,14 +63,14 @@
     {
       "trigger": ["l2"],
       "type": "key",
-      "target": [ "KEY_LEFTSHIFT" ],
-      "description": "Left flipper"
+      "target": [ "KEY_LEFTCTRL" ],
+      "description": "Left magnasave"
     },
     {
       "trigger": ["r2"],
       "type": "key",
-      "target": [ "KEY_RIGHTSHIFT" ],
-      "description": "Right flipper"
+      "target": [ "KEY_RIGHTCTRL" ],
+      "description": "Right magnasave"
     }
     ]
 }


### PR DESCRIPTION
The right and left magnasaves are not currently mapped on the controller. Haunted House is unplayable without that. It makes sense to map them to the triggers (as the flippers are already mapped to the buttons). This way, tables needing magnasaves will be playable right out of the box with a x360 controller (for example).