### PR TITLE
add justifier gun type as default for justifier gun games

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -12,6 +12,8 @@
 - DXX-Rebirth: Play Descent 1 & 2 with enhanced graphics.
 - Added RetroAchievements for Uzebox
 - ETLegacy: play Wolfenstein: Enemy Territory online multiplayer game with enhanced graphics.
+- Konami Justifier / Hyper Blaster light gun in PCSX reARMed core
+  - Not compatible with nuvee GunCon patch, use clean ROM. 
 ### Fixed
 - Dolphin bug that prevented full range of analog trigger axis being used.
 - Flycast per pixel sorting option if renderer not explicitly set

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -754,7 +754,8 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
         "flycast"       : { "default" : { "device":   4, "p1": 0, "p2": 1 } },
         "flycastvl"     : { "default" : { "device":   4, "p1": 0, "p2": 1 } },
         "mednafen_psx"  : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
-        "pcsx_rearmed"  : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
+        "pcsx_rearmed"  : { "default" : { "device": 260, "p1": 0, "p2": 1,
+                                          "gameDependant": [ { "key": "gun", "value": "justifier", "mapkey": "device", "mapvalue": "516" } ]} },
         "swanstation"   : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
         "beetle-saturn" : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
         "opera"         : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
@@ -790,7 +791,7 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
                             retroarchConfig['input_libretro_device_p'+str(nplayer)] = ragunconf["device"]
                         else:
                             retroarchConfig['input_libretro_device_p'+str(nplayer)] = ""
-                    configureGunInputsForPlayer(nplayer, guns[ragunconf["p"+str(nplayer)]], controllers, retroarchConfig, system.config['core'])
+                    configureGunInputsForPlayer(nplayer, guns[ragunconf["p"+str(nplayer)]], controllers, retroarchConfig, system.config['core'], gunsmetadata)
 
             # override core settings
             for key in raguncoreconf:
@@ -821,7 +822,7 @@ def clearGunInputsForPlayer(n, retroarchConfig):
         for type in ["btn", "mbtn"]:
             retroarchConfig['input_player{}_{}_{}'.format(n, key, type)] = ''
 
-def configureGunInputsForPlayer(n, gun, controllers, retroarchConfig, core):
+def configureGunInputsForPlayer(n, gun, controllers, retroarchConfig, core, gunsmetadata):
     # gun mapping
     retroarchConfig['input_player{}_mouse_index'            .format(n)] = gun["id_mouse"]
     retroarchConfig['input_player{}_gun_trigger_mbtn'       .format(n)] = 1
@@ -840,10 +841,14 @@ def configureGunInputsForPlayer(n, gun, controllers, retroarchConfig, core):
     # custom mapping by core to match more with avaible gun batocera buttons
     # different mapping for ps1 which has only 3 buttons and maps on aux_a and aux_b not available on all guns
     if core == "pcsx_rearmed":
-        retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''
-        retroarchConfig['input_player{}_gun_start_mbtn'         .format(n)] = ''
-        retroarchConfig['input_player{}_gun_aux_a_mbtn'         .format(n)] = 2
-        retroarchConfig['input_player{}_gun_aux_b_mbtn'         .format(n)] = 3
+        if gunsmetadata["gun"] == "justifier":
+            retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''
+            retroarchConfig['input_player{}_gun_aux_a_mbtn'         .format(n)] = 2
+        else:
+            retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''
+            retroarchConfig['input_player{}_gun_start_mbtn'         .format(n)] = ''
+            retroarchConfig['input_player{}_gun_aux_a_mbtn'         .format(n)] = 2
+            retroarchConfig['input_player{}_gun_aux_b_mbtn'         .format(n)] = 3
 
     if core == "fbneo":
         retroarchConfig['input_player{}_gun_offscreen_shot_mbtn'.format(n)] = ''

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -2417,6 +2417,17 @@ def generateCoreSettings(coreSettings, system, rom, guns):
                 coreSettings.save('pcsx_rearmed_gpu_peops_lazy_screen_update',  '"enabled"')
             elif system.config['game_fixes_pcsx'] == 'Dark_Forces':
                 coreSettings.save('pcsx_rearmed_gpu_peops_repeated_triangles',  '"enabled"')
+        # gun cross
+        # Crossbar Colors
+        for player in [ {"id": 1, "color": "red"}, {"id": 2, "color": "blue"} ]:
+          if system.isOptSet('pcsx_rearmed_crosshair'+str(player["id"])):
+            coreSettings.save('pcsx_rearmed_crosshair'+str(player["id"]), '"' + system.config['pcsx_rearmed_crosshair'+str(player["id"])] + '"')
+          else:
+            if controllersConfig.gunsNeedCrosses(guns):
+                status = '"'+player["color"]+'"'
+            else:
+                status = '"disabled"'
+            coreSettings.save('pcsx_rearmed_crosshair'+str(player["id"]), status)
 
     # Thomson MO5 / TO7
     if (system.config['core'] == 'theodore'):


### PR DESCRIPTION
Justifier controller type (PSX) + crosshair (disabled by default) + correct mapping.

Only affecting default core (libretro:pcsx_rearmed). Use clean ROMs or force GunCon controller type. Nuvee patch is incompatible.