### PR TITLE
Compress lr-mame xml DATs with gzip, fixes #8556

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame2003-plus/libretro-mame2003-plus.mk
@@ -42,6 +42,8 @@ define LIBRETRO_MAME2003_PLUS_BUILD_CMDS
 	$(TARGET_CONFIGURE_OPTS) $(MAKE) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" -C $(@D)/ \
 	    -f Makefile platform="$(LIBRETRO_MAME2003_PLUS_PLATFORM)" \
         GIT_VERSION=" $(shell echo $(LIBRETRO_MAME2003_PLUS_VERSION) | cut -c 1-7)"
+        rsync -a --exclude mame2003-plus.xml $(@D)/metadata/ $(@D)/metadata-install/
+        gzip -9c $(@D)/metadata/mame2003-plus.xml > $(@D)/metadata-install/mame2003-plus.xml.gz
 endef
 
 define LIBRETRO_MAME2003_PLUS_INSTALL_TARGET_CMDS
@@ -52,7 +54,7 @@ define LIBRETRO_MAME2003_PLUS_INSTALL_TARGET_CMDS
     # Need to think of another way to use these files.
     # They take up a lot of space on tmpfs.
 	mkdir -p $(TARGET_DIR)/usr/share/batocera/datainit/bios/mame2003-plus/samples
-	cp -r $(@D)/metadata/* \
+	cp -r $(@D)/metadata-install/* \
 		$(TARGET_DIR)/usr/share/batocera/datainit/bios/mame2003-plus
 endef
 

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame2010/libretro-mame2010.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame2010/libretro-mame2010.mk
@@ -45,6 +45,8 @@ define LIBRETRO_MAME2010_BUILD_CMDS
 	mkdir -p $(@D)/obj/mame/cpu/ccpu
 	$(TARGET_CONFIGURE_OPTS) $(MAKE) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" LD="$(TARGET_CC)" -C $(@D)/ -f Makefile platform="$(LIBRETRO_MAME2010_PLATFORM)" $(LIBRETRO_MAME2010_EXTRA_ARGS) \
         GIT_VERSION="-$(shell echo $(LIBRETRO_MAME2010_VERSION) | cut -c 1-7)"
+        rsync -a --exclude mame2010.xml $(@D)/metadata/ $(@D)/metadata-install/
+        gzip -9c $(@D)/metadata/mame2010.xml > $(@D)/metadata-install/mame2010.xml.gz
 endef
 
 # Bios
@@ -55,7 +57,7 @@ define LIBRETRO_MAME2010_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/lib/libretro/mame0139_libretro.so
 
 	mkdir -p $(TARGET_DIR)/usr/share/batocera/datainit/bios/mame2010/samples
-	$(INSTALL) -D $(@D)/metadata/* \
+	$(INSTALL) -D $(@D)/metadata-install/* \
 		$(TARGET_DIR)/usr/share/batocera/datainit/bios/mame2010
 endef
 


### PR DESCRIPTION
Disk space in datainit is at a premium, as the fallback ramdisk has a total of 256M available.

Around 20% of this space is consumed by lr-mame 2003 and 2010 XML DAT files.  While these files are handy to have in the distribution, they are not directly used by the installed system.  A significant chunk of space can be saved by compressing them with gzip at the highest compression ratio.  Users can easily decompress them if needed for reference or to validate a romset.