### PR TITLE
fix-powermode

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-powermode
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-powermode
@@ -62,6 +62,7 @@ handle_powermode() {
 
 # Check for events
 EVENT=$1
+SYSTEM_NAME=$2
 
 # Exit if the event is neither gameStart nor gameStop
 if [ "$EVENT" != "gameStart" ] && [ "$EVENT" != "gameStop" ]; then


### PR DESCRIPTION
Somehow I overlooked the removal of SYSTEM_NAME when I was cleaning up the original script before submitting the PR. Without the system_name event per system powermode settings were being ignored.

Also note that when I manually updated the script after susan moved it to usr/bin it was no longer receiving the proper events.

The script has to either go in a directory receiving applicable events, or if the script is to remain in usr/bin the events need to call that directory from the emulatorlauncher.py script. Otherwise it will be broken.

OR if someone can suggest a way to call the script to pass the needed values before a game launches and again when it closes that could be another option. Currently I just have it in the original location on my personal machine "\usr\share\batocera\configgen\scripts" and it works.