### PR TITLE
Expose the atari800_internalbasic option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -67,6 +67,11 @@ def generateCoreSettings(coreSettings, system, rom, guns):
                 coreSettings.save('atari800_resolution', '"' + system.config['atari800_resolution'] + '"')
             else:
                 coreSettings.save('atari800_resolution', '""') # Default : 336x240
+            # Internal BASIC interpreter
+            if system.isOptSet('atari800_internalbasic'):
+                coreSettings.save('atari800_internalbasic', '"' + system.config['atari800_internalbasic'] + '"')
+            else:
+                coreSettings.save('atari800_internalbasic', '"disabled"')
 
             # WARNING: Now we must stop to use "atari800.cfg" because core options crush them
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -403,6 +403,12 @@ libretro:
                             "384x272": 384x272
                             "384x288": 384x288
                             "400x300": 400x300
+                    atari800_internalbasic:
+                        prompt:      INTERNAL BASIC INTERPRETER
+                        description: Enable the BASIC interpreter. Some games need this.
+                        choices:
+                            "Off":     disabled
+                            "On":      enabled
             atari5200:
                 cfeatures:
                     atari800_opt2:


### PR DESCRIPTION
This adds a flag in the advanced game options for atari800 to enable or disable the Atari BASIC ROM. BASIC is disabled by default in the atari800 emulator, so this is necessary for booting into BASIC disks or cartridges.

This adds two new translatable strings, and I included the automatic .po file changes in this commit. 