### PR TITLE
Update-powermode

### DIFF
--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -66,6 +66,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-get-nvidia-list           $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-led-effects               $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-powermode                 $(TARGET_DIR)/usr/bin/
+	ln -sf /usr/bin/batocera-powermode 													$(TARGET_DIR)/usr/share/batocera/configgen/scripts/batocera-powermode
 endef
 
 define BATOCERA_SCRIPTS_INSTALL_MOUSE


### PR DESCRIPTION
Add symlink for batocera-powermode to batocera-scripts.mk so that event calls directed to /usr/share/batocera/configgen/scripts/ gets directed to batocera-powermode script.

Without this script is currently broken and does nothing without receiving event calls.

Priority right now is just getting it fixed and working. If a better approach is decided on later can implement a change then.