### PR TITLE
Bump xa to 2.4.0

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -127,6 +127,8 @@
 - SOF Firmware to 2023.09.1
 - Streamlined x86_64 Secure Boot support
 - Added tree(1) utility
+### Build host
+- xa to 2.4.0
 
 # 2023/10/16 - batocera.linux 38 - Blue Moon
 ### Hardware

--- a/package/batocera/utils-host/xa/xa.mk
+++ b/package/batocera/utils-host/xa/xa.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-XA_VERSION = 2.3.14
+XA_VERSION = 2.4.0
 XA_SOURCE=xa-$(XA_VERSION).tar.gz
 XA_SITE = https://www.floodgap.com/retrotech/xa/dists
 


### PR DESCRIPTION
Bump xa to 2.4.0 to fix build failure on clean system after source package was moved to archive directory.

Built and tested with vice for x86_64 and bcm2711.