### PR TITLE
update vpinball.keys to add buy extraball button

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.keys
+++ b/package/batocera/emulators/vpinball/vpinball.keys
@@ -48,41 +48,47 @@
       "target": [ "KEY_ENTER" ],
       "description": "Pull plunger"
 		},
-    {
+		{
+      "trigger": ["y"],
+      "type": "key",
+      "target": [ "KEY_2" ],
+      "description": "Buy extraball for a credit"
+		},
+		{
       "trigger": ["pageup"],
       "type": "key",
       "target": [ "KEY_LEFTSHIFT" ],
       "description": "Left flipper"
-    },
-    {
+		},
+		{
       "trigger": ["pagedown"],
       "type": "key",
       "target": [ "KEY_RIGHTSHIFT" ],
       "description": "Right flipper"
-    },
-    {
+		},
+		{
       "trigger": ["l2"],
       "type": "key",
       "target": [ "KEY_LEFTSHIFT" ],
       "description": "Left flipper"
-    },
-    {
+		},
+		{
       "trigger": ["r2"],
       "type": "key",
       "target": [ "KEY_RIGHTSHIFT" ],
       "description": "Right flipper"
-    },
-   {
+		},
+		{
       "trigger": ["l3"],
       "type": "key",
       "target": [ "KEY_LEFTCTRL" ],
       "description": "Left magnasave"
-    },
-    {
+		},
+		{
       "trigger": ["r3"],
       "type": "key",
       "target": [ "KEY_RIGHTCTRL" ],
       "description": "Right magnasave"
-    }    
+		}
     ]
 }


### PR DESCRIPTION
Some tables (Indiana Jones TPA, Judge Dredd,...) allow the player to buy an extraball (or multiball session with Judge Dredd) for a credit. It's mapped to "2" key, but this will allow to fully control the pinball with a gamepad.
I also cleaned up the file a little bit (with the spaces).