### PR TITLE
Change cplus4 platform from c64 to cplus4

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -58,7 +58,7 @@ cplus4:
   release: 1984
   hardware: computer
   extensions: [d64, prg, tap, m3u, zip, 7z]
-  platform:   c64
+  platform:   cplus4
   group:      c64
   emulators:
     vice:


### PR DESCRIPTION
Depends on https://github.com/batocera-linux/batocera-emulationstation/pull/1593
