### PR TITLE
Fix some bugs in batocera-install

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-install
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-install
@@ -48,7 +48,7 @@ disks_to_keep() {
 
 do_listDisks() {
     lsblk -n -P -o TYPE,NAME,SIZE,MODEL |
-	grep -E '^TYPE=\"disk\" ' |
+	grep -E '^TYPE="disk" ' |
 	sed -e s+' [ ]*"$'+'"'+ | # remove trailing spaces
 	sed -e s+'^TYPE="[^"]*" NAME=\"\([^"]*\)\" SIZE=\"\([^"]*\)\" MODEL=\"\([^"]*\)\"$'+'\1 \3 (\2)'+ |
 	while read XDRIVE XTEXT
@@ -80,7 +80,7 @@ getPer() {
 
     while true
     do
-	CURVAL=$(stat "${TARFILE}" | grep -E '^[ ]*Size:' | sed -e s+'^[ ]*Size: \([0-9][0-9]*\) .*$'+'\1'+)
+	CURVAL=$(stat "${TARFILE}" | grep -E '^\s*Size:' | sed -e s+'^\s*Size: \([0-9][0-9]*\)\s.*$'+'\1'+)
 	CURVAL=$((CURVAL / 1024 / 1024))
 	PER=$(expr ${CURVAL} '*' 100 / ${TARVAL})
 	echo "downloading >>> ${PER}%"
@@ -150,7 +150,7 @@ do_install() {
 	FILETHERE=0
 	if test -f "${INSIMG}"
 	then
-	    CURVAL=$(stat "${INSIMG}" | grep -E '^[ ]*Size:' | sed -e s+'^[ ]*Size: \([0-9][0-9]*\) .*$'+'\1'+)
+	    CURVAL=$(stat "${INSIMG}" | grep -E '^\s*Size:' | sed -e s+'^\s*Size: \([0-9][0-9]*\)\s.*$'+'\1'+)
 	    if test "${CURVAL}" = "${bytessize}"
 	    then
 		FILETHERE=1


### PR DESCRIPTION
Fix some bugs in batocera-install:
- warning about stray backslash before quotes in "grep" regexp
- progress indication stopping around 31% of download
- image file being redownloaded when present and correct size

Fixes #6588
