### PR TITLE
Vpinball: Add Lockbar Fire Button

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.keys
+++ b/package/batocera/emulators/vpinball/vpinball.keys
@@ -49,6 +49,12 @@
       "description": "Pull plunger"
 		},
 		{
+      "trigger": ["a"],
+      "type": "key",
+      "target": [ "KEY_LEFTALT" ],
+      "description": "Lockbar Fire Button"
+		},
+		{
       "trigger": ["y"],
       "type": "key",
       "target": [ "KEY_2" ],


### PR DESCRIPTION
A few pinball machines have a canon fired by a button at the bottom of the pinball. Examples: Ac/Dc, Terminator 2,...
It'll be convenient to have this mapped next to launch button on the gamepad.