### PR TITLE
Bug fix, efibootmgr cannot set boot entries active/inactive

### DIFF
--- a/board/batocera/patches/efibootmgr/001-return-entry-if-found-before-end-of-list.patch
+++ b/board/batocera/patches/efibootmgr/001-return-entry-if-found-before-end-of-list.patch
@@ -1,0 +1,23 @@
+# https://github.com/rhboot/efibootmgr/issues/186
+commit 3eac27c5fccf93d2d6e634d6fe2a76d06708ec6e
+Author: kmicki <1463619+kmicki@users.noreply.github.com>
+Date:   Tue Nov 15 14:37:25 2022 +0100
+
+    Update efibootmgr.c
+    
+    get_entry: return entry if it was found before reaching the end of the list
+    
+    Signed-off-by: kmicki <1463619+kmicki@users.noreply.github.com>
+
+diff --git a/src/efibootmgr.c b/src/efibootmgr.c
+index b980bcd..4b15d6d 100644
+--- a/src/efibootmgr.c
++++ b/src/efibootmgr.c
+@@ -1192,6 +1192,7 @@ get_entry(list_t *entries, uint16_t num)
+ 			entry = NULL;
+ 			continue;
+ 		}
++		return entry;
+ 	}
+ 
+ 	return entry;


### PR DESCRIPTION
Patch to address a bug in the current version of efibootmgr, described at https://github.com/rhboot/efibootmgr/issues/186