### PR TITLE
Bump libretro-dosbox-pure to 0.9.8 and remove workaround

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -220,12 +220,7 @@ class LibretroGenerator(Generator):
                 elif os.path.exists(os.path.join(rom, "dosbox.bat")) and not os.path.exists(os.path.join(rom, romDOSName + ".bat")):
                     exe = os.path.join(rom, "dosbox.bat")
                 else:
-                    exe = '/tmp/'+ romDOSName # Ugly workaround for dosbox-pure not supporting extensions for dos game folders
-                    try:
-                        os.remove(exe)
-                    except OSError:
-                        pass
-                    os.symlink(rom, exe)
+                    exe = rom
                 commandArray = [batoceraFiles.batoceraBins[system.config['emulator']], "-L", retroarchCore, "--config", system.config['configfile'], exe]
                 dontAppendROM = True
             else:

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/libretro-dosbox-pure.mk
@@ -3,8 +3,8 @@
 # libretro-dosbox-pure
 #
 ################################################################################
-# Version: Commits on Nov 30, 2023
-LIBRETRO_DOSBOX_PURE_VERSION = 89a4fdbf962dd0ee6f6130b4bb6549073235a621
+# Version: Commits on Dec 6, 2023
+LIBRETRO_DOSBOX_PURE_VERSION = 210b39d8604cc27843500c41789f0487f50617bd
 LIBRETRO_DOSBOX_PURE_SITE = $(call github,schellingb,dosbox-pure,$(LIBRETRO_DOSBOX_PURE_VERSION))
 LIBRETRO_DOSBOX_PURE_LICENSE = GPLv2
 


### PR DESCRIPTION
* Bump libretro-dosbox-pure to 0.9.8
* Remove workaround from #7351, because it was fixed in https://github.com/schellingb/dosbox-pure/commit/00495dd91dc4e471f6bff64befac211ee1ad0531 (related to https://github.com/schellingb/dosbox-pure/pull/382).

CC: @jdeath @lbrpdx