### PR TITLE
Fix lr-mame autoboot

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -304,20 +304,19 @@ def generateMAMEConfigs(playersControllers, system, rom):
             # Autostart via ini file
             # Init variables, delete old ini if it exists, prepare ini path
             # lr-mame does NOT support multiple ini paths
-            # Using computer.ini since autorun only applies to computers, and this would be unlikely to be used otherwise
             autoRunCmd = ""
             autoRunDelay = 0
             if not os.path.exists('/userdata/saves/mame/mame/ini/'):
                      os.makedirs('/userdata/saves/mame/mame/ini/')
-            if os.path.exists('/userdata/saves/mame/mame/ini/computer.ini'):
-                os.remove('/userdata/saves/mame/mame/ini/computer.ini')
+            if os.path.exists('/userdata/saves/mame/mame/ini/batocera.ini'):
+                os.remove('/userdata/saves/mame/mame/ini/batocera.ini')
             # bbc has different boots for floppy & cassette, no special boot for carts
             if system.name == "bbc":
                 if system.isOptSet("altromtype") or softList != "":
                     if (system.isOptSet("altromtype") and system.config["altromtype"] == "cass") or softList[-4:] == "cass":
                         autoRunCmd = '*tape\\nchain""\\n'
                         autoRunDelay = 2
-                    elif (system.isOptSet("altromtype") and left(system.config["altromtype"], 4) == "flop") or softList[-4:] == "flop":
+                    elif (system.isOptSet("altromtype") and system.config["altromtype"].startswith("flop")) or "flop" in softList:
                         autoRunCmd = '*cat\\n\\n\\n\\n*exec !boot\\n'
                         autoRunDelay = 3
                 else:
@@ -345,7 +344,7 @@ def generateMAMEConfigs(playersControllers, system, rom):
             if autoRunCmd != "":
                 if autoRunCmd.startswith("'"):
                     autoRunCmd.replace("'", "")
-                iniFile = open('/userdata/saves/mame/mame/ini/computer.ini', "w")
+                iniFile = open('/userdata/saves/mame/mame/ini/batocera.ini', "w")
                 iniFile.write('autoboot_command          ' + autoRunCmd + "\n")
                 iniFile.write('autoboot_delay            ' + str(autoRunDelay))
                 iniFile.close()

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/004-batocera-ini.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/004-batocera-ini.patch
@@ -1,0 +1,14 @@
+diff --git a/src/frontend/mame/mameopts.cpp b/src/frontend/mame/mameopts.cpp
+index cd754fcb..c483157f 100644
+--- a/src/frontend/mame/mameopts.cpp
++++ b/src/frontend/mame/mameopts.cpp
+@@ -41,6 +41,9 @@ void mame_options::parse_standard_inis(emu_options &options, std::ostream &error
+ 	parse_one_ini(options, emulator_info::get_configname(), OPTION_PRIORITY_MAME_INI);
+ 	parse_one_ini(options, emulator_info::get_configname(), OPTION_PRIORITY_MAME_INI, &error_stream);
+ 
++	// parse Batocera-specific configuration
++	parse_one_ini(options, "batocera", OPTION_PRIORITY_MAXIMUM, &error_stream);
++
+ 	// debug mode: parse "debug.ini" as well
+ 	if (options.debug())
+ 		parse_one_ini(options, "debug", OPTION_PRIORITY_DEBUG_INI, &error_stream);


### PR DESCRIPTION
- lr-mame no longer parses computer.ini, add and use our own batocera.ini to restore autoboot functionality

- Correct autoboot configgen for bbc micro, fixes #10402