### PR TITLE
rpcs3-AdditionalFrameLimits-UpdateDepreciatedSetting

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -101,7 +101,8 @@ class Rpcs3Generator(Generator):
                 rpcs3ymlconfig["Core"]["Accurate xfloat"] = False
                 rpcs3ymlconfig["Core"]["Approximate xfloat"] = False
         # Set the Default Core Values we need
-        rpcs3ymlconfig["Core"]["SPU Cache"] = False # When SPU Cache is True, game performance decreases signficantly. Force it to off.
+        # Force to True for now to account for updates where exiting config file present. (True results in less stutter when a SPU module is in cache)
+        rpcs3ymlconfig["Core"]["SPU Cache"] = True # When SPU Cache is True, game performance decreases signficantly. Force it to off. (Depreciated)
         # Preferred SPU Threads
         if system.isOptSet("rpcs3_sputhreads"):
             rpcs3ymlconfig["Core"]["Preferred SPU Threads"] = system.config["rpcs3_sputhreads"]
@@ -153,9 +154,15 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Video"]["Stretch To Display Area"] = False
         # Frame Limit
         if system.isOptSet("rpcs3_framelimit"):
-            rpcs3ymlconfig["Video"]["Frame limit"] = system.config["rpcs3_framelimit"]
+            if system.config["rpcs3_framelimit"] in ["30", "50", "59.94", "60"]:
+                rpcs3ymlconfig["Video"]["Frame limit"] = system.config["rpcs3_framelimit"]
+                rpcs3ymlconfig["Video"]["Second Frame Limit"] = False
+            else:
+                rpcs3ymlconfig["Video"]["Second Frame Limit"] = system.config["rpcs3_framelimit"]
+                rpcs3ymlconfig["Video"]["Frame limit"] = False
         else:
             rpcs3ymlconfig["Video"]["Frame limit"] = "Auto"
+            rpcs3ymlconfig["Video"]["Second Frame Limit"] = False
         # Write Color Buffers
         if system.isOptSet("rpcs3_colorbuffers"):
             rpcs3ymlconfig["Video"]["Write Color Buffers"] = system.config["rpcs3_colorbuffers"]


### PR DESCRIPTION
Added additional frame limit settings for a more granular control over fps. Particularly useful in games with a variable fps where using a specific frame limit can result in an overall more consistent frame rate.

Changed SPU cache to True. RPCS3 Devs removed this setting from the GUI because they found no use case for disabling it as it would always result in a performance loss due to a SPU module having to be recompiled at every game launch vs loading from cache. RPCS3 devs have enabled by default. Eventually will probably be best to just remove the line but I thought it best for now to change to True to account for updates where existing config file is present.