### PR TITLE
Allow overriding webserver directory for a specific BOARD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,13 @@ dl-dir:
 %-webserver: output-dir-%
 	$(if $(wildcard $(OUTPUT_DIR)/$*/images/batocera/*),,$(error "$* not built!"))
 	$(if $(shell which python 2>/dev/null),,$(error "python not found!"))
-	@python3 -m http.server --directory $(OUTPUT_DIR)/$*/images/batocera/images/$*/
+ifeq ($(strip $(BOARD)),)
+	$(if $(wildcard $(OUTPUT_DIR)/$*/images/batocera/images/$*/.*),,$(error "Directory not found: $(OUTPUT_DIR)/$*/images/batocera/images/$*"))
+	python3 -m http.server --directory $(OUTPUT_DIR)/$*/images/batocera/images/$*/
+else
+	$(if $(wildcard $(OUTPUT_DIR)/$*/images/batocera/images/$(BOARD)/.*),,$(error "Directory not found: $(OUTPUT_DIR)/$*/images/batocera/images/$(BOARD)"))
+	python3 -m http.server --directory $(OUTPUT_DIR)/$*/images/batocera/images/$(BOARD)/
+endif
 
 %-rsync: output-dir-%
 	$(eval TMP := $(call UC, $*)_IP)


### PR DESCRIPTION
Allow overriding webserver directory for a specific BOARD. Don't hide web server command, to provide information on what's being served.

Replaces and closes #8809

Example:

```
(bugfix/webserver-board)entropy@katarina:~/batocera.linux$ make riscv-webserver
Makefile:193: *** "Directory not found: /home/entropy/batocera.linux/output/riscv/images/batocera/images/riscv".  Stop.
(bugfix/webserver-board)entropy@katarina:~/batocera.linux$ make riscv-webserver BOARD=visionfive2
python3 -m http.server --directory /home/entropy/batocera.linux/output/riscv/images/batocera/images/visionfive2/
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
```