### PR TITLE
automap-inputs-genesisplusgx-picodrive

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -329,6 +329,47 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
         else:
             retroarchConfig['input_libretro_device_p2'] = '513' # 6 button
 
+    ## Sega Megadrive style controller remap
+    if system.config['core'] in ['genesisplusgx', 'picodrive']:
+        
+        valid_megadrive_controller_guids = [
+        # 8bitdo m30
+        "05000000c82d00005106000000010000",
+        "03000000c82d00000650000011010000",
+        "050000005e0400008e02000030110000",
+        # 8bitdo m30 modkit
+        "03000000c82d00000150000011010000",
+        "05000000c82d00000151000000010000",
+        ]
+        
+        valid_megadrive_controller_names = [
+        "8BitDo M30 gamepad",
+        "8Bitdo  8BitDo M30 gamepad",
+        "8BitDo M30 Modkit",
+        "8Bitdo  8BitDo M30 Modkit",
+        ]
+        
+        def update_megadrive_controller_config(controller_number):
+            # Remaps for Megadrive style controllers
+            remap_values = {
+                'btn_a': '0', 'btn_b': '1', 'btn_x': '9', 'btn_y': '10', 
+                'btn_l': '11', 'btn_r': '8',             
+            }           
+            
+            for btn, value in remap_values.items():
+                retroarchConfig[f'input_player{controller_number}_{btn}'] = value                      
+            
+        if system.config['core'] == 'genesisplusgx':
+            option = 'gx'
+        if system.config['core'] == 'picodrive':
+            option = 'pd'   
+            
+        controller_list = sorted(controllers.items())
+        for i in range(1, min(5, len(controller_list) + 1)):
+            controller, pad = controller_list[i - 1]
+            if (pad.guid in valid_megadrive_controller_guids and pad.configName in valid_megadrive_controller_names) or (system.isOptSet(f'{option}_controller{i}_mapping') and system.config[f'{option}_controller{i}_mapping'] != 'retropad'):
+                update_megadrive_controller_config(i)
+
     ## Sega Mastersystem controller
     if system.config['core'] == 'genesisplusgx' and system.name == 'mastersystem':
         if system.isOptSet('controller1_ms'):

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4700,4 +4700,21 @@
 		<input name="y" type="button" id="3" value="1" code="291" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="050000005e0400008e02000030110000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="l2" type="button" id="4" value="1" code="310" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="axis" id="5" value="1" code="5" />
+		<input name="pageup" type="button" id="5" value="1" code="311" />
+		<input name="r2" type="axis" id="2" value="1" code="2" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="3" value="1" code="308" />
+		<input name="y" type="button" id="2" value="1" code="307" />
+	</inputConfig>
 </inputList>

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1812,6 +1812,35 @@ libretro:
                 choices:
                     "Off":                disabled
                     "On":                 enabled
+            gx_controller1_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 1 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            gx_controller2_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 2 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            gx_controller3_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 3 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            gx_controller4_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 4 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive            
+            
       systems:
             megadrive:
                 shared: [use_guns]
@@ -1832,6 +1861,7 @@ libretro:
                             "Off":        disabled
                             "On":         enabled
                     controller1_md:
+                        submenu:     CONTROLLERS
                         prompt:      CONTROLLER 1 TYPE
                         choices:
                             #"None":                          0
@@ -1845,6 +1875,7 @@ libretro:
                             #"XE-1AP":                        773
                             "Mouse":                         2
                     controller2_md:
+                        submenu:     CONTROLLERS
                         prompt:      CONTROLLER 2 TYPE
                         description: Light guns can only be used in port 2.
                         choices:
@@ -4394,12 +4425,42 @@ libretro:
                 choices:
                     "Off":             disabled
                     "On":              enabled
+            pd_controller1_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 1 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            pd_controller2_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 2 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            pd_controller3_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 3 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive
+            pd_controller4_mapping:
+                submenu:     CONTROLLERS   
+                prompt:      CONTROLLER 4 INPUT MAPPING
+                description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
+                choices:
+                    "Retropad (Default)": retropad
+                    "Megadrive":          megadrive              
             picodrive_controller1:
+                submenu:     CONTROLLERS  
                 prompt:      CONTROLLER 1 TYPE
                 choices:
                     "Joypad 3 Button": 3 button pad
                     "Joypad 6 Button": 6 button pad
             picodrive_controller2:
+                submenu:     CONTROLLERS  
                 prompt:      CONTROLLER 2 TYPE
                 choices:
                     "Joypad 3 Button": 3 button pad


### PR DESCRIPTION
Added ES settings for controller input mapping for genesisplusgx + picodrive libretro cores. (Could be added for genesisplusgx-wide core but there are NO es settings for this core currently so I assume it's mostly unused)

For use when using a megadrive style controller with 6 face buttons. Controllers can be mapped in ES with recommended mappings then select new ES setting to automap correct inputs in-game.

retropad = default PS/Xbox style controller
megadrive = any megadrive style controller with 6 face buttons.

Recommended mappings for megadrive style controller in ES:
A = SOUTH
B = EAST
C = R
X = WEST
Y = NORTH
Z = L