### PR TITLE
N64 libretro + mupen code cleanup and added n64 controller auto config 

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -473,27 +473,43 @@ def createLibretroConfig(generator, system, controllers, guns, rom, bezel, shade
         retroarchConfig['wswan_rotate_display'] = wswanOrientation
 
     ## N64 Controller Remap
-    def update_controller_config(controller_number, option):
-        # Remaps for N64 style controllers
-        remap_values = {
-            'btn_a': '1', 'btn_b': '0', 'btn_x': '23', 'btn_y': '21', 
-            'btn_l2': '22', 'btn_r2': '20', 'btn_select': '12',             
-        }
-            
-        for btn, value in remap_values.items():
-            retroarchConfig[f'input_player{controller_number}_{btn}'] = value
-            
-            
-    if system.config['core'] == 'mupen64plus-next':
-        option = 'mupen64plus-controller'
-    elif system.config['core'] == 'parallel_n64':
-        option = 'parallel-n64-controller'
-    else:
-        option = None
+    if system.config['core'] in ['mupen64plus-next', 'parallel_n64']:    
         
-    for i in range(1, 5):
-        if option and system.isOptSet(f'{option}{i}') and system.config[f'{option}{i}'] != 'retropad':
-            update_controller_config(i, option)
+        valid_n64_controller_guids = [
+            # official nintendo switch n64 controller
+            "050000007e0500001920000001800000",
+            # 8bitdo n64 modkit
+            "05000000c82d00006928000000010000",
+            "030000007e0500001920000011810000",
+        ]
+        
+        valid_n64_controller_names = [
+            "N64 Controller",
+            "Nintendo Co., Ltd. N64 Controller",
+            "8BitDo N64 Modkit",
+        ]
+        
+        def update_n64_controller_config(controller_number):
+            # Remaps for N64 style controllers
+            remap_values = {
+                'btn_a': '1', 'btn_b': '0', 'btn_x': '23', 'btn_y': '21', 
+                'btn_l2': '22', 'btn_r2': '20', 'btn_select': '12',             
+            }
+                
+            for btn, value in remap_values.items():
+                retroarchConfig[f'input_player{controller_number}_{btn}'] = value
+                
+                
+        if system.config['core'] == 'mupen64plus-next':
+            option = 'mupen64plus'
+        elif system.config['core'] == 'parallel_n64':
+            option = 'parallel-n64'
+        
+        controller_list = sorted(controllers.items())
+        for i in range(1, min(5, len(controller_list) + 1)):    
+            controller, pad = controller_list[i - 1]
+            if (pad.guid in valid_n64_controller_guids and pad.configName in valid_n64_controller_names) or (system.isOptSet(f'{option}-controller{i}') and system.config[f'{option}-controller{i}'] != 'retropad'):
+                update_n64_controller_config(i)
                       
     ## PORTS
     ## Quake

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenControllers.py
@@ -15,6 +15,20 @@ mupenHatToAxis        = {'1': 'Up',   '2': 'Right', '4': 'Down', '8': 'Left'}
 mupenHatToReverseAxis = {'1': 'Down', '2': 'Left',  '4': 'Up',   '8': 'Right'}
 mupenDoubleAxis = {0:'X Axis', 1:'Y Axis'}
 
+valid_n64_controller_guids = [
+    # official nintendo switch n64 controller
+    "050000007e0500001920000001800000",
+    # 8bitdo n64 modkit
+    "05000000c82d00006928000000010000",
+    "030000007e0500001920000011810000",
+]
+        
+valid_n64_controller_names = [
+    "N64 Controller",
+    "Nintendo Co., Ltd. N64 Controller",
+    "8BitDo N64 Modkit",
+]
+
 def getMupenMapping(use_n64_inputs):
     # load system values and override by user values in case some user values are missing
     map = dict()
@@ -78,7 +92,8 @@ def getJoystickDeadzone(default_peak, config_value, system):
     return f"{deadzone},{deadzone}"
     
 def defineControllerKeys(nplayer, controller, system):
-        if f"mupen64-controller{nplayer}" in system.config and system.config[f"mupen64-controller{nplayer}"] != "retropad":
+        # check for auto-config inputs by guid and name, or es settings
+        if (controller.guid in valid_n64_controller_guids and controller.configName in valid_n64_controller_names) or (f"mupen64-controller{nplayer}" in system.config and system.config[f"mupen64-controller{nplayer}"] != "retropad"):
             mupenmapping = getMupenMapping(True)
         else:    
             mupenmapping = getMupenMapping(False)


### PR DESCRIPTION
General code cleanup and added ability to auto config based on controller guid/name, increasing plug-and-play-ability.

Currently only the official nintendo switch n64 controller and the 8bitdo n64 modkit are included but others can be added later. Note that any user using a controller that does NOT have a dedicated hotkey button should still use the es setting for limited hotkeys as controller type and at least currently should not have the controllers guid added to auto config. 