### PR TITLE
Megadrive/SegaCD Add ES Sound Settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1984,7 +1984,12 @@ def generateCoreSettings(coreSettings, system, rom, guns):
             else:
                 status = '"disabled"'
             coreSettings.save('genesis_plus_gx_gun_cursor', status)
-
+        # Megadrive FM (YM2612)
+        if system.isOptSet('gpgx_fm'):
+            coreSettings.save('genesis_plus_gx_ym2612', '"' + system.config['gpgx_fm'] + '"')
+        else:
+            coreSettings.save('genesis_plus_gx_ym2612', '"mame (ym2612)"')       
+        
         # system.name == 'mastersystem'
         # Master System FM (YM2413)
         if system.isOptSet('ym2413') and system.config['ym2413'] != "automatic":

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1891,7 +1891,17 @@ libretro:
                             "Mouse":                         2
                             "Menacer Light Gun":             516
                             "Konami Justifiers":             772
-            megacd:
+                    gpgx_fm:
+                        group:       ADVANCED OPTIONS
+                        prompt:      FM SYNTHESIZER
+                        description: Sound generator. MAME is faster and Nuked is cycle accurate. Original model used YM2612 while later revisions used YM3438.
+                        choices:
+                            "MAME (YM2612)":            mame (ym2612)
+                            "MAME (ASIC YM3438)":       mame (asic ym3438)
+                            "MAME (Enhanced YM3438)":   mame (enhanced ym3438)
+                            "Nuked (YM2612)":           nuked (ym2612)
+                            "Nuked (YM3438)":           nuked (ym3438)        
+            segacd:
                 cfeatures:
                     gpgx_cd_add_on:
                         prompt:      CD ADD-ON
@@ -1914,6 +1924,16 @@ libretro:
                             "20":     20
                             "10":     10
                             "0":      0
+                    gpgx_fm:
+                        group:       ADVANCED OPTIONS
+                        prompt:      FM SYNTHESIZER
+                        description: Sound generator. MAME is faster and Nuked is cycle accurate. Original model used YM2612 while later revisions used YM3438.
+                        choices:
+                            "MAME (YM2612)":            mame (ym2612)
+                            "MAME (ASIC YM3438)":       mame (asic ym3438)
+                            "MAME (Enhanced YM3438)":   mame (enhanced ym3438)
+                            "Nuked (YM2612)":           nuked (ym2612)
+                            "Nuked (YM3438)":           nuked (ym3438)    
             msu-md:
                 cfeatures:
                     gpgx_cd_add_on:


### PR DESCRIPTION
Fixed es_features bug, there is no "megacd" system, which resulted in es features not showing. Fixed by changing to correct system name "segacd". 

Added FM Synthesizer ES settings for both mega drive and sega cd systems. They both share the same libretro core setting.