### PR TITLE
Send hostname in DHCP request, fixes #7502

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -150,6 +150,8 @@
 - QT 6.6.1
 - Support x86_64 build on systems with x64 cpu but only ia32 UEFI
 - Add wsdd for system discovery in "Network" panel on Windows without legacy SMB1 protocols
+- Send hostname to DHCP server, and allow for dynamically configured
+  hostname from DHCP
 
 # 2023/10/16 - batocera.linux 38 - Blue Moon
 ### Hardware

--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -14,6 +14,33 @@ fi
 # WLAN enabled?
 settingsWlan="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.enabled)"
 
+# Set initial hostname, to be sent in connman DHCP Request
+#
+# Note that if the DHCP server sends back a hostname, connman will set
+# that as the system hostname.
+#
+# Later in the boot process, /etc/init.d/S26system will then reset the
+# hostname to the value specified in the system.hostname setting
+# ("BATOCERA" by default), but will do so *only* if the
+# system.hostname setting is absent or blank.
+#
+# This leaves the user in control of the hostname to be set, and also
+# lets the user allow for dynamic hostname configuration from DHCP, by
+# setting the system.hostname setting to a blank empty string.
+batocera_hostname() {
+    echo "$(date -u): starting initial hostname configuraton" > /tmp/hostname.log
+    settings_hostname="$(/usr/bin/batocera-settings-get -f "$BATOCONF" system.hostname)"
+    if [ -n "$settings_hostname" ]; then
+        echo "Setting initial hostname from system.hostname: ${settings_hostname}" >> /tmp/hostname.log
+        hostname="$settings_hostname"
+    else
+        echo "Setting default initial hostname BATOCERA" >> /tmp/hostname.log
+        hostname="BATOCERA"
+    fi
+
+    hostname "${hostname}"
+}
+
 # configure wifi files, always
 batocera_wifi_configure() {
     X=$1
@@ -65,6 +92,7 @@ wifi_enable() {
 
 case "$1" in
 	start)
+	        batocera_hostname
 	        wifi_configure_all
 	        printf "Starting connman: "
 		start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r

--- a/board/batocera/fsoverlay/etc/init.d/S26system
+++ b/board/batocera/fsoverlay/etc/init.d/S26system
@@ -25,11 +25,21 @@ ba_timezone() {
 
 ba_hostname() {
     settings_hostname="$(/usr/bin/batocera-settings-get system.hostname)"
+    hostname="$(hostname)"
+    echo "Hostname after DHCP setup is: ${hostname}" >> /tmp/hostname.log
     if [ "$settings_hostname" != "" ]; then
+        echo "Setting hostname from system.hostname: ${settings_hostname}" >> /tmp/hostname.log
+        hostname="${settings_hostname}"
         hostname "${settings_hostname}"
-        echo "127.0.0.1	localhost"             > /etc/hosts
-        echo "127.0.1.1	${settings_hostname}" >> /etc/hosts
+    else
+        echo "No system.hostname value is set, leaving hostname unchanged" >> /tmp/hostname.log
     fi
+    if [ "$hostname" != "" ]; then
+        echo "Creating /etc/hosts" >> /tmp/hostname.log
+        echo "127.0.0.1	localhost"             > /etc/hosts
+        echo "127.0.1.1	${hostname}"          >> /etc/hosts
+    fi
+    cp /tmp/hostname.log /userdata/system/logs/hostname.log
 }
 
 ba_xarcade2jstick() {

--- a/board/batocera/fsoverlay/etc/init.d/S65values4boot
+++ b/board/batocera/fsoverlay/etc/init.d/S65values4boot
@@ -8,7 +8,7 @@
 [ "$1" = "stop" ] || exit 0
 
 set --
-for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled system.timezone es.resolution
+for key in wifi.enabled wifi.ssid wifi.key wifi2.ssid wifi2.key wifi3.ssid wifi3.key wifi.hidden.ssid wifi.hidden.key splash.screen.enabled system.timezone es.resolution system.hostname
 do
     value="$(/usr/bin/batocera-settings-get "$key")" # in case it is empty, it must be set in the batocera-boot.conf file to erase any existing value
     if [ "$value" != "$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf "$key")" ]

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -169,6 +169,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_CONNMAN                              # network manager
     select BR2_PACKAGE_CONNMAN_WIFI                         # network manager
     select BR2_PACKAGE_CONNMAN_CLIENT                       # network manager
+    select BR2_PACKAGE_CONNMAN_LOOPBACK                     # network manager
     select BR2_PACKAGE_BATOCERA_WPA                         # wireless tools
     select BR2_PACKAGE_WIRELESS_REGDB                       # wireless regulatory DB
     select BR2_PACKAGE_IW                                   # wireless country config for regulatoryDB


### PR DESCRIPTION
- save system.hostname to batocera-boot.conf
- set hostname before starting connman
- configure connman to send hostname (BR2_PACKAGE_CONNMAN_LOOPBACK)
- set default hostname for first boot
- allow for both static and dynamic hostname configuration
- fixes #7502