### PR TITLE
Be more selective about ANYEXTERNAL devices, fixes #3455

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -294,7 +294,7 @@ case "${MODE}" in
     ;;
     "ANYEXTERNAL")
         PARTPREFIX=$(batocera-part prefix "${INTERNALDEVICE}")
-        LDEVICE=$(blkid | grep -vE "^${PARTPREFIX}" | head -1)
+        LDEVICE=$(blkid | grep -F TYPE= | grep -F UUID= | grep -vE "^${PARTPREFIX}" | sort | head -1)
         while [ -z "${LDEVICE}" ] && [ "${NTRY}" -lt "${MAXTRY}" ] # wait the device that can take some seconds after udev started
         do
             NTRY=$((NTRY+1))


### PR DESCRIPTION
- Only include devices which have both TYPE and UUID tags to skip garbage like /dev/loop*
- Sort devices for slightly more consistency and predictability
- Fixes #3455