### PR TITLE
Bluetooth: dynamically set ClassicBondedOnly

### DIFF
--- a/board/batocera/fsoverlay/etc/bluetooth/input.conf
+++ b/board/batocera/fsoverlay/etc/bluetooth/input.conf
@@ -1,2 +1,2 @@
 [General]
-ClassicBondedOnly=false
+ClassicBondedOnly=true

--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -42,8 +42,8 @@ rm -f "${TARGET_DIR}/etc/init.d/S40xorg" || exit 1
 # remove the S10triggerhappy
 rm -f "${TARGET_DIR}/etc/init.d/S10triggerhappy" || exit 1
 
-# remove the S40bluetooth
-rm -f "${TARGET_DIR}/etc/init.d/S40bluetooth" || exit 1
+# remove the S40bluetoothd
+rm -f "${TARGET_DIR}/etc/init.d/S40bluetoothd" || exit 1
 
 # we want an empty boot directory (grub installation copy some files in the target boot directory)
 rm -rf "${TARGET_DIR}/boot/grub" || exit 1

--- a/package/batocera/core/batocera-bluetooth/S32bluetooth.template
+++ b/package/batocera/core/batocera-bluetooth/S32bluetooth.template
@@ -10,6 +10,14 @@ case "$1" in
         # Restores old settings saved in userdata
         batocera-bluetooth restore
         enabled="$(/usr/bin/batocera-settings-get controllers.bluetooth.enabled)"
+        ps3_enabled="$(/usr/bin/batocera-settings-get controllers.ps3.enabled)"
+        if [ "$enabled" = "1" ] && [ "$ps3_enabled" = "1" ]
+        then 
+            /usr/bin/batocera-settings-set -f /etc/bluetooth/input.conf ClassicBondedOnly false
+        else
+            /usr/bin/batocera-settings-set -f /etc/bluetooth/input.conf ClassicBondedOnly true
+        fi
+
         [ "$enabled" = "1" ] || exit 0
         # soft unblock bluetooth
         rfkill unblock bluetooth
@@ -61,6 +69,11 @@ case "$1" in
             BLUETOOTHD_ARGS="--noplugin=sixaxis"
         else
             BLUETOOTHD_ARGS="--noplugin=sixaxispair"
+        fi
+
+        if [ "$ps3_enabled" != "1" ]
+        then 
+            BLUETOOTHD_ARGS="--noplugin=sixaxis,sixaxispair"
         fi
 
         debug="$(/usr/bin/batocera-settings-get controllers.bluetooth.debug)"


### PR DESCRIPTION
Set `ClassicBondedOnly=false` only when `controllers.bluetooth.enabled`=1 and `controllers.ps3.enabled`=1.

`ClassicBondedOnly=true` (which is default starting BlueZ 5.71) fixes [CVE-2023-45866](https://ubuntu.com/security/CVE-2023-45866), but also breaks compatibility with PS3 (and possibly some legacy other) controllers. 
Hence when PS3 controller support is enabled (when `controllers.bluetooth.enabled`=1 and `controllers.ps3.enabled`=1) `ClassicBondedOnly` is set to `false`.

Additionally this PR fixes removal of the file `/etc/init.d/S40bluetoothd` (which unsuccessfully tries to do a subset of what `S32bluetooth` does).