### PR TITLE
Use /userdata/system/iptables.conf in S35iptables

### DIFF
--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -29,6 +29,10 @@ rm -f "${TARGET_DIR}/etc/init.d/S50kodi" || exit 1
 # we have custom urandom scripts
 rm -f "${TARGET_DIR}/etc/init.d/S20urandom" || exit 1
 
+# use /userdata/system/iptables.conf for S35iptables
+rm -f "${TARGET_DIR}/etc/iptables.conf" || exit 1
+ln -sf "/userdata/system/iptables.conf" "${TARGET_DIR}/etc/iptables.conf" || exit 1
+
 # acpid requires /var/run, so, requires S03populate
 if test -e "${TARGET_DIR}/etc/init.d/S02acpid"
 then


### PR DESCRIPTION
In Batocera `/etc/iptables.conf` is on volatile file system, so there is not much use for saving iptables configuration to this file.

The best option is to put `iptables` commands in `/boot/boot-custom.sh` - then they will be invoked early in the startup, before any network services start.