### PR TITLE
libretro: puae: add missing video_standard options

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -550,7 +550,7 @@ def generateCoreSettings(coreSettings, system, rom, guns):
         if system.isOptSet('video_standard'):
             coreSettings.save('puae_video_standard', '"' + system.config['video_standard'] + '"')
         else:
-            coreSettings.save('puae_video_standard', '"PAL"')
+            coreSettings.save('puae_video_standard', '"PAL auto"')
         # Video Resolution
         if system.isOptSet('video_resolution'):
             coreSettings.save('puae_video_resolution', '"' + system.config['video_resolution'] + '"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4660,8 +4660,10 @@ libretro:
             video_standard:
                 prompt:      VIDEO FORMAT STANDARD
                 choices:
+                    "PAL 288x576px 50Hz (auto)":  PAL auto
                     "PAL 288x576px 50Hz":  PAL
                     "NTSC 240x480px 60Hz": NTSC
+                    "NTSC 240x480px 60Hz (auto)": NTSC auto
             video_resolution:
                 prompt:      VIDEO RESOLUTION
                 description: Manually define which resolution to use.&#x0a;Auto defaults to High and switches to Super-High when needed.


### PR DESCRIPTION
puae have 2 missing video_standard options:

- PAL auto
- NTSC auto

(and "PAL auto" is the default in retroarch)

These auto formats, allow to switch to another video_standard if it's defined in romfile path. This is important to automatic correct aspect ratio.

for example:

with "PAL auto", for a game with romfile "mygame_NTSC.adf", It'll auto switch to NTSC.