### PR TITLE
Yabasanshiro-InputFix

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -121,6 +121,11 @@ def generateControllerConfig(controller, retroarchspecials, system, lightgun, mo
             retroarchbtns["pageup"] = "l2"
             retroarchbtns["l2"] = "l"
 
+    # Fix for reversed inputs in Yabasanshiro core which is unmaintained by retroarch
+    if (system.config['core'] == 'yabasanshiro'):
+        retroarchbtns["pageup"] = "r"
+        retroarchbtns["pagedown"] = "l"
+
     config = dict()
     # config['input_device'] = '"%s"' % controller.realName
     for btnkey in retroarchbtns:


### PR DESCRIPTION
Yabasanshiro core has the Saturn pad C and Z inputs reversed. This fix corrects the default retroarch mapping to be in line with both Kronos and Beetle cores.

Also of note is that the Yabasanshiro core is unmaintained so issue is unlikely to be fixed upstream.