### PR TITLE
Allow LVM partitions to be used for storage

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -279,6 +279,15 @@ else
     MODE=${RMODE}
 fi
 
+VGSCAN=/usr/sbin/vgscan
+VGCHANGE=/usr/sbin/vgchange
+
+if [ -x ${VGSCAN} -a -x ${VGCHANGE} ]
+then
+    ${VGSCAN}
+    ${VGCHANGE} -ay
+fi
+
 case "${MODE}" in
     "DEV")
         LDEVICE=$(blkid | grep " UUID=\"${UUID}\"" | head -1)

--- a/package/batocera/core/batocera-scripts/scripts/batocera-config
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-config
@@ -251,8 +251,8 @@ if [ "$command" = "storage" ]; then
 	INTERNAL_DEVICE=$(batocera-part share_internal)
 	PARTPREFIX=$(batocera-part prefix "${INTERNAL_DEVICE}")
 	lsblk -n -P -o NAME,FSTYPE,LABEL,UUID,SIZE,TYPE |
-	    grep 'TYPE="part"' |
-	    grep -v "FSTYPE=\"swap\"" |
+	    grep -E "TYPE=\"(part|lvm)\"" |
+	    grep -vE "FSTYPE=\"(swap|LVM2_member)\"" |
 	    sed -e s+'^NAME="'+'NAME="/dev/'+ -e s+'LABEL=""'+'LABEL="NO_NAME"'+ |
 	    grep -vE "^NAME=\"${PARTPREFIX}" |
 	    sed -e s+'^NAME="[^"]*" FSTYPE="[^"]*" LABEL="\([^"]*\)" UUID="\([^"]*\)" SIZE="\([^"]*\)" TYPE="[^"]*"$'+'DEV \2 \1 - \3'+


### PR DESCRIPTION
1. filter LVM partitions from "batocera-config storage list" as they aren't mountable
2. activate available logical volumes ~~that match a prefix~~ before mounting /userdata in S11share

These two changes are interrelated. Logical volumes need to be activated so that are visible to `lsblk` and can be presented in the ES system settings storage menu. Once the partitions are activated (TYPE="lvm") they need to be added to the output of `batocera-config storage list` and the partition the LVs reside on (FSTYPE="LVM2_member") should be excluded from the list.

I'm creating as a draft because I'd like comments on the decision to use a prefix to limit the LVs available to for mounting, as well as entertain any questions on the implementation. All feedback is welcome.