### PR TITLE
Update-controllersConfig-Add-N64LibretroAutoRumblePak

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/batoceraFiles.py
@@ -16,6 +16,7 @@ esInputs = CONF + '/emulationstation/es_input.cfg'
 esSettings = CONF + '/emulationstation/es_settings.cfg'
 esGunsMetadata = "/usr/share/emulationstation/resources/gungames.xml"
 esWheelsMetadata = "/usr/share/emulationstation/resources/wheelgames.xml"
+esGamesMetadata = "/usr/share/emulationstation/resources/gamesdb.xml"
 batoceraConf = HOME + '/batocera.conf'
 logdir = HOME + '/logs/'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -407,6 +407,27 @@ def getGameWheelsMetaData(system, rom):
                     return res
     return res
 
+def getGamesMetaData(system, rom):
+    # load the database
+    tree = ET.parse(batoceraFiles.esGamesMetadata)
+    root = tree.getroot()
+    game = gunNameFromPath(rom)
+    res = {}
+    eslog.info("looking for game metadata ({}, {})".format(system, game))
+
+    for nodesystem in root.findall(".//system"):
+        if nodesystem.get("name") == system:
+            for nodegame in nodesystem.findall(".//game"):
+                if nodegame.get("name") in game:
+                    for child in nodegame:
+                        for attribute in child.attrib:
+                            key = "{}_{}".format(child.tag, attribute)
+                            res[key] = child.get(attribute)
+                            eslog.info("found game metadata {}={}".format(key, res[key]))
+                    return res
+
+    return res
+
 def dev2int(dev):
     matches = re.match(r"^/dev/input/event([0-9]*)$", dev)
     if matches is None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1045,7 +1045,7 @@ def generateCoreSettings(coreSettings, system, rom, guns, wheels):
             f.write("video_driver = \"glcore\"\n")
             f.close()
 
-    # Nintendo 64
+    # Nintendo 64   
     if (system.config['core'] == 'mupen64plus-next'):
         # Threaded Rendering
         coreSettings.save('mupen64plus-ThreadedRenderer', '"True"')
@@ -1088,24 +1088,60 @@ def generateCoreSettings(coreSettings, system, rom, guns, wheels):
             coreSettings.save('mupen64plus-txEnhancementMode', '"' + system.config['mupen64plus-txEnhancementMode'] + '"')
         else:
             coreSettings.save('mupen64plus-txEnhancementMode', '"None"')
+        
+        # Check if any controller packs are set to auto rumble
+        auto_rumble_pak = None
+        for pak in range(1, 5):
+            pak_value = f'mupen64plus-pak{pak}'
+            if system.isOptSet(pak_value) and system.config[pak_value] == 'auto_rumble':
+                auto_rumble_pak = pak_value
+                break
+                
+        if auto_rumble_pak:
+            metadata = controllersConfig.getGamesMetaData(system.name, rom)  
+        
         # Controller Pak 1
         if system.isOptSet('mupen64plus-pak1'):
-            coreSettings.save('mupen64plus-pak1', '"' + system.config['mupen64plus-pak1'] + '"')
+            if system.config['mupen64plus-pak1'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('mupen64plus-pak1', '"rumble"')
+                else:
+                    coreSettings.save('mupen64plus-pak1', '"memory"')     
+            else:
+                coreSettings.save('mupen64plus-pak1', '"' + system.config['mupen64plus-pak1'] + '"')                
         else:
             coreSettings.save('mupen64plus-pak1', '"memory"')
         # Controller Pak 2
         if system.isOptSet('mupen64plus-pak2'):
-            coreSettings.save('mupen64plus-pak2', '"' + system.config['mupen64plus-pak2'] + '"')
+            if system.config['mupen64plus-pak2'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('mupen64plus-pak2', '"rumble"')
+                else:
+                    coreSettings.save('mupen64plus-pak2', '"none"')     
+            else:
+                coreSettings.save('mupen64plus-pak2', '"' + system.config['mupen64plus-pak2'] + '"')                
         else:
             coreSettings.save('mupen64plus-pak2', '"none"')
         # Controller Pak 3
         if system.isOptSet('mupen64plus-pak3'):
-            coreSettings.save('mupen64plus-pak3', '"' + system.config['mupen64plus-pak3'] + '"')
+            if system.config['mupen64plus-pak3'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('mupen64plus-pak3', '"rumble"')
+                else:
+                    coreSettings.save('mupen64plus-pak3', '"none"')     
+            else:
+                coreSettings.save('mupen64plus-pak3', '"' + system.config['mupen64plus-pak3'] + '"')                
         else:
             coreSettings.save('mupen64plus-pak3', '"none"')
         # Controller Pak 4
         if system.isOptSet('mupen64plus-pak4'):
-            coreSettings.save('mupen64plus-pak4', '"' + system.config['mupen64plus-pak4'] + '"')
+            if system.config['mupen64plus-pak4'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('mupen64plus-pak4', '"rumble"')
+                else:
+                    coreSettings.save('mupen64plus-pak4', '"none"')     
+            else:
+                coreSettings.save('mupen64plus-pak4', '"' + system.config['mupen64plus-pak4'] + '"')                
         else:
             coreSettings.save('mupen64plus-pak4', '"none"')
         # RDP Plugin
@@ -1179,24 +1215,60 @@ def generateCoreSettings(coreSettings, system, rom, guns, wheels):
             coreSettings.save('parallel-n64-framerate', '"' + system.config['parallel-n64-framerate'] + '"')
         else:
             coreSettings.save('parallel-n64-framerate', '"automatic"')
+        
+        # Check if any controller packs are set to auto rumble
+        auto_rumble_pak = None
+        for pak in range(1, 5):
+            pak_value = f'parallel-n64-pak{pak}'
+            if system.isOptSet(pak_value) and system.config[pak_value] == 'auto_rumble':
+                auto_rumble_pak = pak_value
+                break
+                
+        if auto_rumble_pak:
+            metadata = controllersConfig.getGamesMetaData(system.name, rom) 
+        
         # Controller Pak 1
         if system.isOptSet('parallel-n64-pak1'):
-            coreSettings.save('parallel-n64-pak1', '"' + system.config['parallel-n64-pak1'] + '"')
+            if system.config['parallel-n64-pak1'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('parallel-n64-pak1', '"rumble"')
+                else:
+                    coreSettings.save('parallel-n64-pak1', '"memory"')     
+            else:
+                coreSettings.save('parallel-n64-pak1', '"' + system.config['parallel-n64-pak1'] + '"')                
         else:
             coreSettings.save('parallel-n64-pak1', '"memory"')
         # Controller Pak 2
         if system.isOptSet('parallel-n64-pak2'):
-            coreSettings.save('parallel-n64-pak2', '"' + system.config['parallel-n64-pak2'] + '"')
+            if system.config['parallel-n64-pak2'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('parallel-n64-pak2', '"rumble"')
+                else:
+                    coreSettings.save('parallel-n64-pak2', '"none"')     
+            else:
+                coreSettings.save('parallel-n64-pak2', '"' + system.config['parallel-n64-pak2'] + '"')                
         else:
             coreSettings.save('parallel-n64-pak2', '"none"')
         # Controller Pak 3
         if system.isOptSet('parallel-n64-pak3'):
-            coreSettings.save('parallel-n64-pak3', '"' + system.config['parallel-n64-pak3'] + '"')
+            if system.config['parallel-n64-pak3'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('parallel-n64-pak3', '"rumble"')
+                else:
+                    coreSettings.save('parallel-n64-pak3', '"none"')     
+            else:
+                coreSettings.save('parallel-n64-pak3', '"' + system.config['parallel-n64-pak3'] + '"')                
         else:
             coreSettings.save('parallel-n64-pak3', '"none"')
         # Controller Pak 4
         if system.isOptSet('parallel-n64-pak4'):
-            coreSettings.save('parallel-n64-pak4', '"' + system.config['parallel-n64-pak4'] + '"')
+            if system.config['parallel-n64-pak4'] == 'auto_rumble':
+                if metadata.get("controller_rumble") == "true":
+                    coreSettings.save('parallel-n64-pak4', '"rumble"')
+                else:
+                    coreSettings.save('parallel-n64-pak4', '"none"')     
+            else:
+                coreSettings.save('parallel-n64-pak4', '"' + system.config['parallel-n64-pak4'] + '"')                
         else:
             coreSettings.save('parallel-n64-pak4', '"none"')
         # Joystick deadzone

--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -3,8 +3,8 @@
 # batocera-emulationstation
 #
 ################################################################################
-# Last update: Commits on Jan 8, 2024
-BATOCERA_EMULATIONSTATION_VERSION = 0b82c0a51ae0860f2f227e48de98b0f9e4321840
+# Last update: Commits on Jan 12, 2024
+BATOCERA_EMULATIONSTATION_VERSION = c4dfa6104b5910d44aa6f0dee6d8e0192d557aa5
 BATOCERA_EMULATIONSTATION_SITE = https://github.com/batocera-linux/batocera-emulationstation
 BATOCERA_EMULATIONSTATION_SITE_METHOD = git
 BATOCERA_EMULATIONSTATION_LICENSE = MIT

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -3872,6 +3872,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             mupen64plus-pak2:
                 submenu:     CONTROLLER 2 
                 prompt:      CONTROLLER PAK
@@ -3880,6 +3881,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             mupen64plus-pak3:
                 submenu:     CONTROLLER 3 
                 prompt:      CONTROLLER PAK
@@ -3888,6 +3890,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             mupen64plus-pak4:
                 submenu:     CONTROLLER 4 
                 prompt:      CONTROLLER PAK
@@ -3896,6 +3899,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             mupen64plus-deadzone:
                 prompt:      JOYSTICK DEADZONE
                 description: Use to eliminate joystick drift/unwanted input. Effects all controllers.
@@ -4404,6 +4408,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             parallel-n64-pak2:
                 submenu:     CONTROLLER 2
                 prompt:      CONTROLLER PAK
@@ -4412,6 +4417,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             parallel-n64-pak3:
                 submenu:     CONTROLLER 3
                 prompt:      CONTROLLER PAK
@@ -4420,6 +4426,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             parallel-n64-pak4:
                 submenu:     CONTROLLER 4
                 prompt:      CONTROLLER PAK
@@ -4428,6 +4435,7 @@ libretro:
                     "Off":         none
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
+                    "Rumble Pak (Automatic)":  auto_rumble
             parallel-n64-deadzone:
                 prompt:      JOYSTICK DEADZONE
                 description: Use to eliminate joystick drift/unwanted input. Effects all controllers.


### PR DESCRIPTION
Updated controllersConfig to parse for generic game metadata. Added new controller pak value for N64 libretro cores. Setting this(Rumble (Automatic)) will parse metadata for games that are compatible with the N64 rumble pak and automatically assign that player controllers pak to rumble. Can be set independently per controller.

Companion PR for ES metadata xml file: https://github.com/batocera-linux/batocera-emulationstation/pull/1648