### PR TITLE
Remove squashfs from mugen extensions, closes #6968

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2593,7 +2593,7 @@ mugen:
   manufacturer: Elecbyte
   release: 1999
   hardware: port
-  extensions: [pc, squashfs]
+  extensions: [pc]
   emulators:
     mugen:
       lutris:  { requireAnyOf: [BR2_PACKAGE_WINE_LUTRIS] }


### PR DESCRIPTION
Remove squashfs from mugen extensions, closes #6968
