### PR TITLE
libretro-autowidescreen-n64-segasystems

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -100,6 +100,7 @@ def createLibretroConfig(generator, system, controllers, guns, wheels, rom, beze
     retroarchConfig = dict()
     systemConfig = system.config
     renderConfig = system.renderconfig
+    systemCore = system.config['core']
 
     # Basic configuration
     retroarchConfig['quit_press_twice'] = 'false'                 # not aligned behavior on other emus
@@ -572,17 +573,22 @@ def createLibretroConfig(generator, system, controllers, guns, wheels, rom, beze
     else:
         retroarchConfig['video_shader_enable'] = 'false'
 
-    # Ratio option
+     # Ratio option
     retroarchConfig['aspect_ratio_index'] = ''              # reset in case config was changed (or for overlays)
     if defined('ratio', systemConfig):
+        index = '22'    # default value (core)
         if systemConfig['ratio'] in ratioIndexes:
-            retroarchConfig['aspect_ratio_index'] = ratioIndexes.index(systemConfig['ratio'])
-            retroarchConfig['video_aspect_ratio_auto'] = 'false'
-        elif systemConfig['ratio'] == "custom":
-            retroarchConfig['video_aspect_ratio_auto'] = 'false'
-        else:
-            retroarchConfig['video_aspect_ratio_auto'] = 'false'
-            retroarchConfig['aspect_ratio_index'] = '22'
+            index = ratioIndexes.index(systemConfig['ratio'])
+        # Check if game natively supports widescreen from metadata (not widescreen hack) (for easy scalability ensure all values for respective systems start with core name and end with "-autowidescreen")
+        elif system.isOptSet(f"{systemCore}-autowidescreen") and system.config[f"{systemCore}-autowidescreen"] == "True": 
+            metadata = controllersConfig.getGamesMetaData(system.name, rom)
+            if metadata.get("video_widescreen") == "true":
+                index = str(ratioIndexes.index("16/9"))
+                # Easy way to disable bezels if setting to 16/9
+                bezel = None      
+        
+        retroarchConfig['video_aspect_ratio_auto'] = 'false'
+        retroarchConfig['aspect_ratio_index'] = index          
 
     # Rewind option
     retroarchConfig['rewind_enable'] = 'false'

--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -3,8 +3,8 @@
 # batocera-emulationstation
 #
 ################################################################################
-# Last update: Commits on Jan 12, 2024
-BATOCERA_EMULATIONSTATION_VERSION = c4dfa6104b5910d44aa6f0dee6d8e0192d557aa5
+# Last update: Commits on Jan 17, 2024
+BATOCERA_EMULATIONSTATION_VERSION = fc7808401abeee466e5154748e6c2726f1ed1a45
 BATOCERA_EMULATIONSTATION_SITE = https://github.com/batocera-linux/batocera-emulationstation
 BATOCERA_EMULATIONSTATION_SITE_METHOD = git
 BATOCERA_EMULATIONSTATION_LICENSE = MIT

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -463,6 +463,12 @@ libretro:
                     "Cross": "Cross"
                     "Dot": "Dot"
                     "Disabled": "Off"
+          beetle-saturn-autowidescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
           controller1_saturn:
                 prompt:      CONTROLLER 1 TYPE
                 description: Not all games support 3D pad.
@@ -1613,6 +1619,12 @@ libretro:
                 choices:
                     "Off": disabled
                     "On":  enabled
+            flycast-autowidescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
             reicast_widescreen_cheats:
                 prompt:      WIDESCREEN CHEAT (PRIORITY)
                 description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
@@ -2173,6 +2185,12 @@ libretro:
             choices:
                 "Disabled": disabled 
                 "Enabled":  enabled
+        kronos-autowidescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
         kronos_multitap:
             prompt: MULTITAP
             description: Allows up to 7 or 12 controllers in supported games.
@@ -3760,6 +3778,12 @@ libretro:
                     "2560x1440": 2560x1440
                     "3840x2160": 3840x2160
                     "7680x4320": 7680x4320
+            mupen64plus-next-autowidescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
             mupen64plus-aspect:
                 prompt:      WIDESCREEN HACK (GLITCHY)
                 description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
@@ -4349,6 +4373,12 @@ libretro:
                     "7x (2240x1680)":   2240x1680
                     "9x (2880x2160)":   2880x2160
                     "18x (5760x4320)":  5760x4320
+            parallel_n64-widescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
             parallel-n64-aspectratiohint:
                 prompt:      WIDESCREEN HACK (GLITCHY)
                 description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
@@ -4638,6 +4668,15 @@ libretro:
                 choices:
                     "Joypad 3 Button": 3 button pad
                     "Joypad 6 Button": 6 button pad
+      systems:
+            sega32x:
+                cfeatures:
+                    picodrive-autowidescreen:
+                        prompt:      AUTO WIDESCREEN
+                        description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                        choices:
+                            "Off":       "False"
+                            "On":        "True"
     pocketsnes:
       features: [netplay]
       shared: [rewind, autosave]
@@ -6412,6 +6451,12 @@ libretro:
                     "720p":          720p
                     "1080p":         1080p
                     "4K":            4k
+            yabasanshiro-autowidescreen:
+                prompt:      AUTO WIDESCREEN
+                description: Automatically sets aspect ratio to 16/9 for games that natively support it. 2D elements like HUD/UI may be stretched.
+                choices:
+                    "Off":       "False"
+                    "On":        "True"
             multitap_yabasanshiro:
                 prompt:      MULTITAP
                 description: Allows up to 7 or 12 controllers in supported games.


### PR DESCRIPTION
Add es feature for libretro cores(n64 and sega systems) that enable 16:9 aspect ratio for games that natively supported widescreen. 

Needs https://github.com/batocera-linux/batocera-emulationstation/pull/1660 to be merged first so that gamesdb.xml is updated. Once it's merged I can bump es and then this PR will be ready to merge.