### PR TITLE
xemu configgen network part

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xemu/xemuConfig.py
@@ -46,6 +46,9 @@ def createXemuConfig(iniConfig, system, rom, playersControllers, gameResolution)
         iniConfig.add_section("input.bindings")
     if not iniConfig.has_section("net"):
         iniConfig.add_section("net")
+    if not iniConfig.has_section("net.udp"):
+        iniConfig.add_section("net.udp")
+        
 
     # Boot Animation Skip
     if system.isOptSet("xemu_bootanim"):
@@ -57,7 +60,7 @@ def createXemuConfig(iniConfig, system, rom, playersControllers, gameResolution)
     iniConfig.set("general", "show_welcome", "false")
 
     # Set Screenshot directory
-    iniConfig.set("general", "screenshot_dir", '"/userdata/screenshots"') 
+    iniConfig.set("general", "screenshot_dir", '"/userdata/screenshots"')
 
     # Fill sys sections
     if system.isOptSet("xemu_memory"):
@@ -82,17 +85,17 @@ def createXemuConfig(iniConfig, system, rom, playersControllers, gameResolution)
         iniConfig.set("display.quality", "surface_scale", system.config["xemu_render"])
     else:
         iniConfig.set("display.quality", "surface_scale", "1") #render scale by default
-    
+
     # start fullscreen
     iniConfig.set("display.window", "fullscreen_on_startup", "true")
-    
+
     # Window size
     window_res = format(gameResolution["width"]) + "x" + format(gameResolution["height"])
     iniConfig.set("display.window", "startup_size", '"' + window_res + '"')
-    
+
     # turn vsync on, doesn't improve framerate when off
     iniConfig.set("display.window", "vsync", "true")
-    
+
     # don't show the menubar
     iniConfig.set("display.ui", "show_menubar", "false")
 
@@ -101,13 +104,13 @@ def createXemuConfig(iniConfig, system, rom, playersControllers, gameResolution)
         iniConfig.set("display.ui", "fit", '"' + system.config["xemu_scaling"] + '"')
     else:
         iniConfig.set("display.ui", "fit", '"scale"')
-    
+
     # Aspect ratio
     if system.isOptSet("xemu_aspect"):
         iniConfig.set("display.ui", "aspect_ratio", '"' + system.config["xemu_aspect"] + '"')
     else:
         iniConfig.set("display.ui", "aspect_ratio", '"auto"')
-    
+
     # Fill input section
     # first, clear
     for i in range(1,5):
@@ -118,39 +121,15 @@ def createXemuConfig(iniConfig, system, rom, playersControllers, gameResolution)
             iniConfig.set("input.bindings", f"port{nplayer}", '"' + pad.guid + '"')
         nplayer = nplayer + 1
 
-    # Determine the current default network connection
-    #currentDefaultNetwork = defaultNetworkInterface()
-
-    #if currentDefaultNetwork:
-        ## Fill network section
-        #iniConfig.set("network", "enabled", "true")
-        #iniConfig.set("network", "backend", "pcap")
-        #iniConfig.set("network", "local_addr", "0.0.0.0:9368")
-        #iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
-        #iniConfig.set("network", "pcap_iface", currentDefaultNetwork)
-    #else:
-        #iniConfig.set("network", "enabled", "false")
-        #iniConfig.set("network", "backend", "user")
-        #iniConfig.set("network", "local_addr", "0.0.0.0:9368")
-        #iniConfig.set("network", "remote_addr", "1.2.3.4:9368")
-
-    # Fill misc section
-    #iniConfig.set("misc", "user_token", "")
-
-#def defaultNetworkInterface():
-    ## This function returns the name of the first interface that routes to the "default" destination. If there is no such interface, return None instead.
-
-    #n = 0
-    ## Open the route network information.
-    #with open("/proc/net/route") as f:
-        #for line in f:
-            #n += 1
-            ## Check to make sure we are skipping over the first line (as it is just the header).
-            #if n > 1:
-                #words = line.split("\t")
-                ## If the "Destination" of the route is the default "00000000":
-                #if words[1] == "00000000":
-                    ## Return the name of that "Iface" and immediately exit this function:
-                    #return words[0]
-    ## Otherwise, this loop repeats for all the remaining routes. If none are found, return None.
-    #return None
+    # Network
+    # Documentation: https://github.com/xemu-project/xemu/blob/master/config_spec.yml
+    if system.isOptSet("xemu_networktype"):
+        iniConfig.set("net", "enable", "true")
+        iniConfig.set("net", "backend", '"' + system.config["xemu_networktype"] + '"')
+    else:
+        iniConfig.set("net", "enable", "false")
+    # Additionnal settings for udp: if nothing is entered in these fields, the xemu.toml is untouched
+    if system.isOptSet("xemu_udpremote"):
+        iniConfig.set("net.udp", "remote_addr", '"' + system.config["xemu_udpremote"] + '"')
+    if system.isOptSet("xemu_udpbind"):
+        iniConfig.set("net.udp", "bind_addr", '"' + system.config["xemu_udpbind"] + '"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -343,7 +343,7 @@ libretro:
         "ALSAThread":      alsathread
         "TinyALSA":        tinyalsa
         "SDL2":            sdl2
-        "Pulse (Default)": pulse    
+        "Pulse (Default)": pulse
     audio_latency:
       group: ADVANCED OPTIONS
       prompt:      AUDIO LATENCY
@@ -1847,34 +1847,34 @@ libretro:
                     "Off":                disabled
                     "On":                 enabled
             gx_controller1_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 1 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             gx_controller2_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 2 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             gx_controller3_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 3 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             gx_controller4_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 4 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
-                    "Megadrive":          megadrive            
-            
+                    "Megadrive":          megadrive
+
       systems:
             megadrive:
                 shared: [use_guns]
@@ -1934,7 +1934,7 @@ libretro:
                             "MAME (ASIC YM3438)":       mame (asic ym3438)
                             "MAME (Enhanced YM3438)":   mame (enhanced ym3438)
                             "Nuked (YM2612)":           nuked (ym2612)
-                            "Nuked (YM3438)":           nuked (ym3438)        
+                            "Nuked (YM3438)":           nuked (ym3438)
             segacd:
                 cfeatures:
                     gpgx_cd_add_on:
@@ -1967,7 +1967,7 @@ libretro:
                             "MAME (ASIC YM3438)":       mame (asic ym3438)
                             "MAME (Enhanced YM3438)":   mame (enhanced ym3438)
                             "Nuked (YM2612)":           nuked (ym2612)
-                            "Nuked (YM3438)":           nuked (ym3438)    
+                            "Nuked (YM3438)":           nuked (ym3438)
             msu-md:
                 cfeatures:
                     gpgx_cd_add_on:
@@ -2165,13 +2165,13 @@ libretro:
             prompt: IMPROVED MESH
             description: Replace meshed transparency by real transparency.
             choices:
-                "Disabled": disabled 
+                "Disabled": disabled
                 "Enabled":  enabled
         kronos_bandingmode:
             prompt: IMPROVED BANDING
             description: Apply gouraud shading instead of flat shading.
             choices:
-                "Disabled": disabled 
+                "Disabled": disabled
                 "Enabled":  enabled
         kronos_multitap:
             prompt: MULTITAP
@@ -2185,7 +2185,7 @@ libretro:
             prompt: BIOS Language
             description: Choose system BIOS language.
             choices:
-                "English":  English 
+                "English":  English
                 "German":   German
                 "French":   French
                 "Spanish":  Spanish
@@ -3836,7 +3836,7 @@ libretro:
                     "Cached Interpreter":               cached_interpreter
                     "Pure Interpreter (Most Accurate)": pure_interpreter
             mupen64plus-controller1:
-                submenu:     CONTROLLER 1    
+                submenu:     CONTROLLER 1
                 prompt:      CONTROLLER TYPE
                 description: Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey.
                 choices:
@@ -3844,7 +3844,7 @@ libretro:
                     "N64": n64
                     "N64 (Limited Hotkeys)": n64limited
             mupen64plus-controller2:
-                submenu:     CONTROLLER 2 
+                submenu:     CONTROLLER 2
                 prompt:      CONTROLLER TYPE
                 description: Useful for N64 style controllers.
                 choices:
@@ -3858,12 +3858,12 @@ libretro:
                     "RetroPad (Default)": retropad
                     "N64": n64
             mupen64plus-controller4:
-                submenu:     CONTROLLER 4 
+                submenu:     CONTROLLER 4
                 prompt:      CONTROLLER TYPE
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
-                    "N64": n64                   
+                    "N64": n64
             mupen64plus-pak1:
                 submenu:     CONTROLLER 1
                 prompt:      CONTROLLER PAK
@@ -3873,7 +3873,7 @@ libretro:
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
             mupen64plus-pak2:
-                submenu:     CONTROLLER 2 
+                submenu:     CONTROLLER 2
                 prompt:      CONTROLLER PAK
                 description: Emulate a pak in the controller expansion port.
                 choices:
@@ -3881,7 +3881,7 @@ libretro:
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
             mupen64plus-pak3:
-                submenu:     CONTROLLER 3 
+                submenu:     CONTROLLER 3
                 prompt:      CONTROLLER PAK
                 description: Emulate a pak in the controller expansion port.
                 choices:
@@ -3889,7 +3889,7 @@ libretro:
                     "Memory Pak":  memory
                     "Rumble Pak":  rumble
             mupen64plus-pak4:
-                submenu:     CONTROLLER 4 
+                submenu:     CONTROLLER 4
                 prompt:      CONTROLLER PAK
                 description: Emulate a pak in the controller expansion port.
                 choices:
@@ -3903,7 +3903,7 @@ libretro:
                     "0%":               0
                     "5%":               5
                     "15% (Default)":    15
-                    "20%":              20 
+                    "20%":              20
                     "25%":              25
                     "30%":              30
             mupen64plus-sensitivity:
@@ -3913,13 +3913,13 @@ libretro:
                     "50%":              50
                     "55%":              55
                     "60%":              60
-                    "65%":              65 
+                    "65%":              65
                     "70%":              70
                     "75%":              75
                     "80%":              80
                     "85%":              85
                     "90%":              90
-                    "95%":              95 
+                    "95%":              95
                     "100% (Default)":   100
                     "105%":             105
                     "110%":             110
@@ -3930,7 +3930,7 @@ libretro:
                     "135%":             135
                     "140%":             140
                     "145%":             145
-                    "150%":             150  
+                    "150%":             150
             mupen64plus-Framerate:
                 group: ADVANCED OPTIONS
                 prompt: FRAME RATE
@@ -4330,7 +4330,7 @@ libretro:
                     "Gln64":     gln64
                     "Rice":      rice
                     "Angrylion": angrylion
-                    "Parallel":  parallel            
+                    "Parallel":  parallel
             parallel-n64-screensize:
                 prompt:      RENDERING RESOLUTION
                 description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.
@@ -4395,7 +4395,7 @@ libretro:
                 description: Useful for N64 style controllers.
                 choices:
                     "RetroPad (Default)": retropad
-                    "N64": n64               
+                    "N64": n64
             parallel-n64-pak1:
                 submenu:     CONTROLLER 1
                 prompt:      CONTROLLER PAK
@@ -4435,7 +4435,7 @@ libretro:
                     "0%":               0
                     "5%":               5
                     "15% (Default)":    15
-                    "20%":              20 
+                    "20%":              20
                     "25%":              25
                     "30%":              30
             parallel-n64-sensitivity:
@@ -4445,13 +4445,13 @@ libretro:
                     "50%":              50
                     "55%":              55
                     "60%":              60
-                    "65%":              65 
+                    "65%":              65
                     "70%":              70
                     "75%":              75
                     "80%":              80
                     "85%":              85
                     "90%":              90
-                    "95%":              95 
+                    "95%":              95
                     "100% (Default)":   100
                     "105%":             105
                     "110%":             110
@@ -4462,7 +4462,7 @@ libretro:
                     "135%":             135
                     "140%":             140
                     "145%":             145
-                    "150%":             150          
+                    "150%":             150
     pce:
       features: [netplay, cheevos]
       shared: [rewind, autosave]
@@ -4591,41 +4591,41 @@ libretro:
                     "Off":             disabled
                     "On":              enabled
             pd_controller1_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 1 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             pd_controller2_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 2 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             pd_controller3_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 3 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
                     "Megadrive":          megadrive
             pd_controller4_mapping:
-                submenu:     CONTROLLERS   
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 4 INPUT MAPPING
                 description: Use Megadrive to automap inputs for a Megadrive style controller with a 6 button layout.
                 choices:
                     "Retropad (Default)": retropad
-                    "Megadrive":          megadrive              
+                    "Megadrive":          megadrive
             picodrive_controller1:
-                submenu:     CONTROLLERS  
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 1 TYPE
                 choices:
                     "Joypad 3 Button": 3 button pad
                     "Joypad 6 Button": 6 button pad
             picodrive_controller2:
-                submenu:     CONTROLLERS  
+                submenu:     CONTROLLERS
                 prompt:      CONTROLLER 2 TYPE
                 choices:
                     "Joypad 3 Button": 3 button pad
@@ -4717,7 +4717,7 @@ libretro:
                     "3360x1904":         3360x1904
                     "3840x2176":         3840x2176
                     "4320x2448":         4320x2448
-                    "4800x2720":         4800x2720      
+                    "4800x2720":         4800x2720
     prboom:
       shared: [rewind, autosave]
       cfeatures:
@@ -5454,7 +5454,7 @@ libretro:
                     "RGB":        "rgb"
                     "S-Video":    "s-video"
                     "Composite":  "composite"
-                
+
     snes9x_next:
       features: [netplay, cheevos]
       shared: [rewind, autosave, use_guns]
@@ -5522,7 +5522,7 @@ libretro:
                     "RGB":        "rgb"
                     "S-Video":    "s-video"
                     "Composite":  "composite"
-    
+
     stella:
       features: [netplay, cheevos]
       shared: [rewind, autosave, use_guns]
@@ -6664,7 +6664,7 @@ citra:
             prompt: GRAPHICS API
             description: Choose which graphics API library to use.
             choices:
-                "Software":         0 
+                "Software":         0
                 "OpenGL (Default)": 1
                 "Vulkan":           2
         citra_use_vsync_new:
@@ -6694,7 +6694,7 @@ citra:
             description: Compile shaders using background threads to avoid shader compilation stutter. May cause graphical glitches.
             choices:
                 "Off": 0
-                "On":  1            
+                "On":  1
         citra_custom_textures:
             submenu: GRAPHICS
             prompt: LOAD CUSTOM TEXTURES
@@ -6914,7 +6914,7 @@ dolphin:
             choices:
                 "None":                       0
                 "Standard Controller":        6a
-                "GameCube Controller":        6b 
+                "GameCube Controller":        6b
                 "GameCube Adapter for Wii U": 12
                 "Steering Wheel":             8
                 "Dance Mat":                  9
@@ -6948,7 +6948,7 @@ dolphin:
             description: Use alternative input mappings. Only applies to Standard Controller type.
             choices:
                 "Face Buttons (CW)":         buttons_cw
-                "Face Buttons (CCW)":        buttons_ccw        
+                "Face Buttons (CCW)":        buttons_ccw
         anisotropic_filtering:
             submenu: RENDERING
             prompt: ANISOTROPIC FILTERING
@@ -7050,7 +7050,7 @@ dolphin:
             description: Set joystick deadzone.
             choices:
                 "0%":            0.0
-                "5% (Default)":  5.0        
+                "5% (Default)":  5.0
                 "10%":           10.0
                 "15%":           15.0
                 "20%":           20.0
@@ -7062,7 +7062,7 @@ dolphin:
             description: Set joystick deadzone.
             choices:
                 "0%":            0.0
-                "5% (Default)":  5.0        
+                "5% (Default)":  5.0
                 "10%":           10.0
                 "15%":           15.0
                 "20%":           20.0
@@ -7074,7 +7074,7 @@ dolphin:
             description: Set joystick deadzone.
             choices:
                 "0%":            0.0
-                "5% (Default)":  5.0        
+                "5% (Default)":  5.0
                 "10%":           10.0
                 "15%":           15.0
                 "20%":           20.0
@@ -7086,7 +7086,7 @@ dolphin:
             description: Set joystick deadzone.
             choices:
                 "0%":            0.0
-                "5% (Default)":  5.0        
+                "5% (Default)":  5.0
                 "10%":           10.0
                 "15%":           15.0
                 "20%":           20.0
@@ -7098,7 +7098,7 @@ dolphin:
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
                 "Smaller":          smaller
-                "Normal (Default)": normal        
+                "Normal (Default)": normal
                 "Larger":           larger
         jsgate_size_2:
             submenu: CONTROLLER 2
@@ -7106,23 +7106,23 @@ dolphin:
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
                 "Smaller":          smaller
-                "Normal (Default)": normal        
-                "Larger":           larger 
+                "Normal (Default)": normal
+                "Larger":           larger
         jsgate_size_3:
             submenu: CONTROLLER 3
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
                 "Smaller":          smaller
-                "Normal (Default)": normal        
-                "Larger":           larger 
+                "Normal (Default)": normal
+                "Larger":           larger
         jsgate_size_4:
             submenu: CONTROLLER 4
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
                 "Smaller":          smaller
-                "Normal (Default)": normal        
+                "Normal (Default)": normal
                 "Larger":           larger
         dplii:
             group: ADVANCED OPTIONS
@@ -7130,7 +7130,7 @@ dolphin:
             description: Enables Dolby Pro Logic II for surround sound. May impact performance.
             choices:
                 "Off": 0
-                "On":  1        
+                "On":  1
   systems:
     gamecube:
         cfeatures:
@@ -7383,7 +7383,7 @@ duckstation:
             choices:
                 "Vulkan":   Vulkan
                 "OpenGL":   OpenGL
-                "Software": Software                
+                "Software": Software
         duckstation_vsync:
             submenu: DISPLAY
             prompt: VSYNC
@@ -7558,7 +7558,7 @@ duckstation:
                 "DualShock / Xbox Type":  AnalogController
                 "Namco GunCon (Rumble)":  NamcoGunCon
                 "PlayStation Mouse":      PlayStationMouse
-                "NeGcon (Rumble)":        NeGcon  
+                "NeGcon (Rumble)":        NeGcon
         duckstation_pgxp:
             group: ADVANCED OPTIONS
             prompt: ENABLE PGXP CORRECTIONS
@@ -7979,7 +7979,7 @@ moonlight:
             description: Enables surround sound if your audio card supports it (Consumes more bandwidth).
             choices:
                 "5.1": "5.1"
-                "7.1": "7.1"       
+                "7.1": "7.1"
 
 mupen64plus:
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation_angle, wheel_deadzone, wheel_midzone]
@@ -8084,7 +8084,7 @@ mupen64plus:
                 "Enable":       1
         mupen64-controller1:
             submenu: CONTROLLER 1
-            prompt: CONTROLLER TYPE             
+            prompt: CONTROLLER TYPE
             description: Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey.
             choices:
                 "RetroPad (Default)": retropad
@@ -8222,7 +8222,7 @@ mupen64plus:
                 "10%": 0.1
                 "15%": 0.15
                 "20%": 0.2
-                "25%": 0.25    
+                "25%": 0.25
 openbor:
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
   cfeatures:
@@ -8262,13 +8262,13 @@ openbor:
           description: Limit FPS to reduce high CPU usage.
           choices:
             "Disabled": 0
-            "Enabled":  1        
+            "Enabled":  1
         openbor_rumble:
           prompt: RUMBLE
           description: Only some games feature rumble. Not compatible with all controllers.
           choices:
             "Disabled": 0
-            "Enabled":  1 
+            "Enabled":  1
 
 pcsx2:
   cores:
@@ -10761,6 +10761,26 @@ xemu:
             choices:
                 "64MiB (Default)": 64
                 "128MiB":          128
+        xemu_networktype:
+            group: NETWORK
+            submenu: NETWORK
+            prompt: NETWORK TYPE
+            description: Nat to access internet from xemu machine. Udp for System Link. Default (Auto) disables network access.
+            choices:
+                "NAT": "nat"
+                "UDP Tunnel": "udp"
+        xemu_udpremote:
+            group: NETWORK
+            submenu: NETWORK
+            prompt: UDP REMOTE ADDRESS
+            description: Destination address and port to forward packets to. Leave this empty if you want to enter it manually in the xemu.toml configuration file.
+            preset: input
+        xemu_udpbind:
+            group: NETWORK
+            submenu: NETWORK
+            prompt: UDP BIND ADDRESS
+            description: Local address and port to receive packets on. Leave this empty if you want to enter it manually in the xemu.toml configuration file.
+            preset: input
 
 lexaloffle:
   features: [padtokeyboard]
@@ -11024,7 +11044,7 @@ play:
           description: Only applicable when using OpenGL.
           choices:
               "Disabled": "false"
-              "Enabled":  "true"     
+              "Enabled":  "true"
       play_language:
           prompt: LANGUAGE
           description: Change the game's language.
@@ -11475,7 +11495,7 @@ xenia-canary:
             description: Enable or disable Xenia patches. These patches can fix graphics problems in some games.
             choices:
                 "Disabled (Default)": false
-                "Enabled": true            
+                "Enabled": true
 
 eka2l1:
   features: []
@@ -11594,7 +11614,7 @@ vita3k:
       description: Speed hack, enable to disable surface syncing between CPU and GPU. Surface syncing is needed by a few games.
       choices:
         "Disabled":          "false"
-        "Enabled (Default)": "true"    
+        "Enabled (Default)": "true"
     vita3k_linear:
       prompt: LINEAR FILTERING
       description: The image will be softer which could help with aliasing.
@@ -11766,7 +11786,7 @@ theforceengine:
       description: Enable 16-channel iMuse Digital Audio.
       choices:
         "Disabled (Default)": 0
-        "Enabled":            1    
+        "Enabled":            1
     force_fight_music:
       prompt: FIGHT MUSIC
       description: Enable / Disable fight music.
@@ -11800,7 +11820,7 @@ theforceengine:
       prompt: SMOOTH VUES
       choices:
         "Disabled (Default)": 0
-        "Enabled":            1    
+        "Enabled":            1
     force_skip_cutscenes:
       group: ADVANCED OPTIONS
       prompt: SKIP CUTSCENES
@@ -11820,7 +11840,7 @@ iortcw:
       description: Choose your preferred renderer.
       choices:
         "Standard OpenGL (Default)": "opengl1"
-        "Enhanced OpenGL":           "rend2"    
+        "Enhanced OpenGL":           "rend2"
     iortcw_vsync:
       submenu: GRAPHICS
       prompt: VSYNC
@@ -11897,7 +11917,7 @@ fallout1-ce:
       choices:
         "None":             0
         "Minimal":          1
-        "Normal (Default)": 2  
+        "Normal (Default)": 2
         "Maximum Blood":    3
     fout1_subtitles:
       prompt: SUBTITLES
@@ -11938,7 +11958,7 @@ fallout2-ce:
       choices:
         "None":             0
         "Minimal":          1
-        "Normal (Default)": 2  
+        "Normal (Default)": 2
         "Maximum Blood":    3
     fout2_subtitles:
       prompt: SUBTITLES
@@ -11971,7 +11991,7 @@ dxx-rebirth:
       choices:
         "Classic (Default)": 0
         "Blocky Filtered":   1
-        "Smooth":            2     
+        "Smooth":            2
     rebirth_anisotropy:
       prompt: ANISOTROPIC FILTERING
       description: Improves clarity of distant textures.


### PR DESCRIPTION
I wanted to have the possibility to use/configure system link from the couch.
So, this adds the ability to turn the network on, in order to:

1.  configure internet access (via nat) (to import save games for eg)
2. or to configure System Link for local (or remote with a public server) play (via udp) with another xemu computer.

Default settings are:

- network turned off to avoid an error message if the computer is disconnected from the wifi (for example)
- if the remote and bind fields are empty, then the values present in /userdata/system/config/xemu/xemu.toml are left untouched. This allows manual editing of the config file.

It's just  little improvement because these settings are accessible only by pressing the hotkey to overlay the xemu config window, and navigation inside this window is not gamepad friendly.
There was some obsolete (imo) code. For example, the "bridged adapter mode" ([https://xemu.app/docs/networking/]) doesn't work on batocera due to permission restrictions.

[https://wiki.batocera.org/systems:xbox]

![screenshot-2024 01 18-14h01 48](https://github.com/batocera-linux/batocera.linux/assets/7478580/805d0244-09e0-42d6-8c7c-ff50178f387f)
![screenshot-2024 01 18-14h01 37](https://github.com/batocera-linux/batocera.linux/assets/7478580/711a8fff-8a96-4114-8bcb-b75f15f45633)
