### PR TITLE
Enable swap on rpi through rpi3

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -165,6 +165,8 @@
 - QT 6.6.1
 - Vulkan stack to support 1.3.275
 - Added zramswap service
+- Enable swap on rpi through rpi3 to improve suppport for low-memory
+  variants e.g. Zero 2W
 
 # 2023/10/16 - batocera.linux 38 - Blue Moon
 ### Hardware

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -286,7 +286,11 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
     select BR2_PACKAGE_PIXELCADE		if !BR2_riscv
 
     # swap
-    select BR2_PACKAGE_SWAPIT if BR2_PACKAGE_BATOCERA_TARGET_RK3128 || BR2_PACKAGE_BATOCERA_TARGET_RK3326
+    select BR2_PACKAGE_SWAPIT                  if BR2_PACKAGE_BATOCERA_TARGET_RK3128  || \
+                                                  BR2_PACKAGE_BATOCERA_TARGET_RK3326  || \
+                                                  BR2_PACKAGE_BATOCERA_TARGET_BCM2835 || \
+                                                  BR2_PACKAGE_BATOCERA_TARGET_BCM2836 || \
+                                                  BR2_PACKAGE_BATOCERA_TARGET_BCM2837
     select BR2_PACKAGE_ZRAMSWAP                # swap on zram, optional user-enabled service
 
     # irq balancing


### PR DESCRIPTION
Enable swap on rpi through rpi3 to improve suppport for low-memory variants e.g. Zero 2W