### PR TITLE
xash3d_fwgs improvements

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/gamepad.cfg
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/gamepad.cfg
@@ -25,6 +25,11 @@
 // SELECT + L1: Screenshot
 // SELECT + START: Quit
 
+joy_side_deadzone "4096"
+joy_forward_deadzone "4096"
+joy_pitch_deadzone "4096"
+joy_yaw_deadzone "4096"
+
 bind DPAD_UP "impulse 201"
 bind DPAD_DOWN "lastinv"
 bind DPAD_LEFT "invprev"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xash3d_fwgs/xash3dFwgsGenerator.py
@@ -111,10 +111,6 @@ class Xash3dFwgsGenerator(Generator):
         commandArray.append('+showfps')
         commandArray.append('1' if system.getOptBoolean('showFPS') == True else '0')
 
-        # https://github.com/FWGS/xash3d-fwgs/issues/307
-        commandArray.append('+sv_validate_changelevel')
-        commandArray.append('0')
-
         self._maybeInitConfig(game)
         self._maybeInitSaveDir(game)
 

--- a/package/batocera/ports/xash3d/xash3d-fwgs/0001-Enable-VSync-by-default.patch
+++ b/package/batocera/ports/xash3d/xash3d-fwgs/0001-Enable-VSync-by-default.patch
@@ -1,0 +1,25 @@
+From b5c8dc48569a833a6ffcf1faa51753edae58eef7 Mon Sep 17 00:00:00 2001
+From: Gleb Mazovetskiy <glex.spb@gmail.com>
+Date: Sun, 21 Jan 2024 16:21:44 +0000
+Subject: [PATCH] Enable VSync by default
+
+---
+ engine/client/ref_common.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/engine/client/ref_common.c b/engine/client/ref_common.c
+index 89f1211b..0e3a6674 100644
+--- a/engine/client/ref_common.c
++++ b/engine/client/ref_common.c
+@@ -8,7 +8,7 @@
+ struct ref_state_s ref;
+ ref_globals_t refState;
+ 
+-CVAR_DEFINE_AUTO( gl_vsync, "0", FCVAR_ARCHIVE,  "enable vertical syncronization" );
++CVAR_DEFINE_AUTO( gl_vsync, "1", FCVAR_ARCHIVE,  "enable vertical syncronization" );
+ CVAR_DEFINE_AUTO( r_showtextures, "0", FCVAR_CHEAT, "show all uploaded textures" );
+ CVAR_DEFINE_AUTO( r_adjust_fov, "1", FCVAR_ARCHIVE, "making FOV adjustment for wide-screens" );
+ CVAR_DEFINE_AUTO( r_decals, "4096", FCVAR_ARCHIVE, "sets the maximum number of decals" );
+-- 
+2.40.1
+


### PR DESCRIPTION
1. Enable vsync by default. Even an rk3326 can run Half-Life at 60 FPS, so on is a better default.
2. Set a default deadzone.