### PR TITLE
Update es_input.cfg - M30 cleanup

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -1498,23 +1498,6 @@
 		<input name="x" type="button" id="4" value="1" code="308" />
 		<input name="y" type="button" id="3" value="1" code="307" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="05000000c82d00005106000000010000">
-		<input name="a" type="button" id="7" value="1" code="311" />
-		<input name="b" type="button" id="1" value="1" code="305" />
-		<input name="down" type="axis" id="1" value="1" code="1" />
-		<input name="hotkey" type="button" id="2" value="1" code="306" />
-		<input name="l2" type="button" id="8" value="1" code="312" />
-		<input name="left" type="axis" id="0" value="-1" code="0" />
-		<input name="pagedown" type="button" id="6" value="1" code="310" />
-		<input name="pageup" type="button" id="3" value="1" code="307" />
-		<input name="r2" type="button" id="9" value="1" code="313" />
-		<input name="right" type="axis" id="0" value="1" code="0" />
-		<input name="select" type="button" id="10" value="1" code="314" />
-		<input name="start" type="button" id="11" value="1" code="315" />
-		<input name="up" type="axis" id="1" value="-1" code="1" />
-		<input name="x" type="button" id="4" value="1" code="308" />
-		<input name="y" type="button" id="0" value="1" code="304" />
-	</inputConfig>
 	<inputConfig type="joystick" deviceName="8Bitdo  8BitDo M30 Modkit" deviceGUID="03000000c82d00000150000011010000">
 		<input name="a" type="button" id="0" value="1" code="304" />
 		<input name="b" type="button" id="1" value="1" code="305" />
@@ -4271,21 +4254,6 @@
 		<input name="x" type="button" id="9" value="1" code="544" />
 		<input name="y" type="button" id="11" value="1" code="546" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="05000000c82d00005106000000010000">
-		<input name="a" type="button" id="7" value="1" code="311" />
-		<input name="b" type="button" id="1" value="1" code="305" />
-		<input name="down" type="axis" id="1" value="1" code="1" />
-		<input name="hotkey" type="button" id="2" value="1" code="306" />
-		<input name="left" type="axis" id="0" value="-1" code="0" />
-		<input name="pagedown" type="button" id="6" value="1" code="310" />
-		<input name="pageup" type="button" id="3" value="1" code="307" />
-		<input name="right" type="axis" id="0" value="1" code="0" />
-		<input name="select" type="button" id="10" value="1" code="314" />
-		<input name="start" type="button" id="11" value="1" code="315" />
-		<input name="up" type="axis" id="1" value="-1" code="1" />
-		<input name="x" type="button" id="4" value="1" code="308" />
-		<input name="y" type="button" id="0" value="1" code="304" />
-	</inputConfig>
 	<inputConfig type="joystick" deviceName=" Trooper V2     Trooper V2   " deviceGUID="03000000242e00006a38000010010000">
 		<input name="a" type="button" id="1" value="1" code="289" />
 		<input name="b" type="button" id="0" value="1" code="288" />
@@ -4698,23 +4666,6 @@
 		<input name="y" type="button" id="3" value="1" code="291" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="050000005e0400008e02000030110000">
-		<input name="a" type="button" id="1" value="1" code="305" />
-		<input name="b" type="button" id="0" value="1" code="304" />
-		<input name="down" type="hat" id="0" value="4" />
-		<input name="hotkey" type="button" id="8" value="1" code="316" />
-		<input name="l2" type="button" id="4" value="1" code="310" />
-		<input name="left" type="hat" id="0" value="8" />
-		<input name="pagedown" type="axis" id="5" value="1" code="5" />
-		<input name="pageup" type="button" id="5" value="1" code="311" />
-		<input name="r2" type="axis" id="2" value="1" code="2" />
-		<input name="right" type="hat" id="0" value="2" />
-		<input name="select" type="button" id="6" value="1" code="314" />
-		<input name="start" type="button" id="7" value="1" code="315" />
-		<input name="up" type="hat" id="0" value="1" />
-		<input name="x" type="button" id="3" value="1" code="308" />
-		<input name="y" type="button" id="2" value="1" code="307" />
-	</inputConfig>
 	<inputConfig type="joystick" deviceName="SNES30             SNES30 Joy    " deviceGUID="03000000c82d000020ab000010010000">
 		<input name="a" type="button" id="0" value="1" code="288" />
 		<input name="b" type="button" id="1" value="1" code="289" />
@@ -4804,6 +4755,40 @@
 		<input name="select" type="button" id="7" value="1" code="315" />
 		<input name="start" type="button" id="6" value="1" code="314" />
 		<input name="up" type="axis" id="1" value="-1" code="1" />
+		<input name="x" type="button" id="3" value="1" code="308" />
+		<input name="y" type="button" id="2" value="1" code="307" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="05000000c82d00005106000000010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="2" value="1" code="306" />
+		<input name="l2" type="axis" id="5" value="1" code="10" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="axis" id="4" value="1" code="9" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="10" value="1" code="314" />
+		<input name="start" type="button" id="11" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="4" value="1" code="308" />
+		<input name="y" type="button" id="3" value="1" code="307" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo M30 gamepad" deviceGUID="050000005e0400008e02000030110000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="l2" type="button" id="4" value="1" code="310" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="axis" id="5" value="1" code="5" />
+		<input name="pageup" type="button" id="5" value="1" code="311" />
+		<input name="r2" type="axis" id="2" value="1" code="2" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>


### PR DESCRIPTION
Cleans up duplicate M30 entry. Also maps according to new recommended default mapping in edition to using the following info from 8bitdo using the dpad as HAT and not a joystick.

```
LEFT + Select : set Dpad as left analogue stick.
Up + Select : reset Dpad.
Right + Select : set Dpad as right analogue stick.
Down + Select : Swap A/B and X/Y mapping (on Switch mode only).
*Press and hold any of the key combinations above for 5 seconds to map the buttons.
*LED will blink in red to indicate the success of each button mapping.
*You need to reset the buttons manually.
```

should resolve https://github.com/batocera-linux/batocera.linux/issues/10869