### PR TITLE
M30-add-leftjoystickmapping-xinputmodeonly

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4780,6 +4780,8 @@
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />
 		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 		<input name="l2" type="button" id="4" value="1" code="310" />
 		<input name="left" type="hat" id="0" value="8" />
 		<input name="pagedown" type="axis" id="5" value="1" code="5" />


### PR DESCRIPTION
I want to go ahead and map the "left joystick" so out of the box the controller will work regardless if dpad is in HAT mode or left joystick mode. But it's recommended to use HAT mode for the dpad. Note this is only for when the controller is in x-input mode. When in d-input mode using dpad as left joystick does not work. 