### PR TITLE
Add Tribute64 controller recommended input mappings

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4794,4 +4794,23 @@
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="SWITCH CO.,LTD. Controller (Dinput)" deviceGUID="03000000632500007505000011010000">
+		<input name="a" type="button" id="2" value="1" code="306" />
+		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="4" value="1" code="308" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="l2" type="button" id="0" value="1" code="304" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="309" />
+		<input name="pageup" type="button" id="4" value="1" code="308" />
+		<input name="r2" type="button" id="9" value="1" code="313" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="310" />
+		<input name="start" type="button" id="12" value="1" code="316" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="8" value="1" code="312" />
+		<input name="y" type="button" id="3" value="1" code="307" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Inputs are for both D-input and X-input modes. Note holding C-right and C-up for about 3 seconds switches between modes. This controller does not have a dedicated button for hotkey, or a select button so hotkey is mapped to L shoulder.

Recommended to use N64 ES setting controller type N64-Limited hotkeys with controller.