### PR TITLE
Dolphin standalone language selection from ES

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -103,9 +103,11 @@ class DolphinGenerator(Generator):
         else:
             dolphinSettings.set("Core", "SyncGPU", "False")
 
-        # Language
-        dolphinSettings.set("Core", "SelectedLanguage", str(getGameCubeLangFromEnvironment())) # Wii
-        dolphinSettings.set("Core", "GameCubeLanguage", str(getGameCubeLangFromEnvironment())) # GC
+        # Gamecube Language
+        if system.isOptSet("gamecube_language"):
+            dolphinSettings.set("Core", "SelectedLanguage", system.config["gamecube_language"])
+        else:
+            dolphinSettings.set("Core", "SelectedLanguage", str(getGameCubeLangFromEnvironment()))
 
         # Enable MMU
         if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu"):
@@ -435,6 +437,7 @@ class DolphinGenerator(Generator):
 
         return 4/3
 
+# Get the language from the environment if user didn't set it in ES.
 # Seem to be only for the gamecube. However, while this is not in a gamecube section
 # It may be used for something else, so set it anyway
 def getGameCubeLangFromEnvironment():

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7201,6 +7201,17 @@ dolphin:
                 choices:
                     "Off": 0
                     "On":  1
+            gamecube_language:
+                group: ADVANCED OPTIONS
+                prompt: GAMECUBE LANGUAGE
+                description: Change the Gamecube system language.
+                choices:
+                    "English/Japanese":     0
+                    "German":               1
+                    "French":               2
+                    "Spanish":              3
+                    "Italian":              4
+                    "Dutch":                5
     wii:
         shared: [use_guns]
         cfeatures:


### PR DESCRIPTION
Removed the old language selection behavior based on the batocera environment.
For example, if you want to play an Italian GC game, you have to set batocera to Italian.

Dolphin seems to only recognize the key=value `SelectedLanguage`,
and nothing else in Dolphin.ini for selecting the language.

Users can now select the desired Gamecube language in ES.

I only compiled `batocera-configgen` and `batocera-es-system`
Tested it on batocera butterfly and it works.