### PR TITLE
Add ROC-RK3588S-PC Support

### DIFF
--- a/board/batocera/rockchip/rk3588/firefly-station-m3/boot/extlinux.conf
+++ b/board/batocera/rockchip/rk3588/firefly-station-m3/boot/extlinux.conf
@@ -1,0 +1,4 @@
+LABEL batocera.linux
+  LINUX /boot/linux
+  FDT /boot/rk3588s-roc-pc.dtb
+  APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200n8 coherent_pool=2M

--- a/board/batocera/rockchip/rk3588/firefly-station-m3/create-boot-script.sh
+++ b/board/batocera/rockchip/rk3588/firefly-station-m3/create-boot-script.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# HOST_DIR = host dir
+# BOARD_DIR = board specific dir
+# BUILD_DIR = base dir/build
+# BINARIES_DIR = images dir
+# TARGET_DIR = target dir
+# BATOCERA_BINARIES_DIR = batocera binaries sub directory
+
+HOST_DIR=$1
+BOARD_DIR=$2
+BUILD_DIR=$3
+BINARIES_DIR=$4
+TARGET_DIR=$5
+BATOCERA_BINARIES_DIR=$6
+
+DTB="rk3588s-roc-pc.dtb"
+
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot"     || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux" || exit 1
+
+cp "${BINARIES_DIR}/Image"                 "${BATOCERA_BINARIES_DIR}/boot/boot/linux"                || exit 1
+cp "${BINARIES_DIR}/initrd.lz4"             "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"           || exit 1
+cp "${BINARIES_DIR}/rootfs.squashfs"       "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
+
+cp "${BINARIES_DIR}/${DTB}"                "${BATOCERA_BINARIES_DIR}/boot/boot/"     || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"       "${BATOCERA_BINARIES_DIR}/boot/extlinux/" || exit 1
+
+exit 0

--- a/board/batocera/rockchip/rk3588/firefly-station-m3/genimage.cfg
+++ b/board/batocera/rockchip/rk3588/firefly-station-m3/genimage.cfg
@@ -1,0 +1,48 @@
+image boot.vfat {
+	vfat {
+		extraargs = "-F 32 -n BATOCERA"
+		@files
+	}
+	size = 4G
+}
+
+image userdata.ext4 {
+	ext4 {
+		label = "SHARE"
+		use-mke2fs = "true"
+		extraargs = "-m 0"
+	}
+	size = "256M"
+	# include files from TARGET_DIR/userdata
+	mountpoint = "/userdata"
+}
+
+image batocera.img {
+	hdimage {
+		align = "1M"
+		partition-table-type = "gpt"
+	}
+
+        partition part_idbloader {
+                in-partition-table = "no"
+                image = "../../orangepi-5/idbloader.img"
+                offset = 32K
+        }
+
+        partition part_uboot {
+                in-partition-table = "no"
+                image = "../../orangepi-5/u-boot.itb"
+                offset = 8M
+        }
+
+	partition vfat {
+		partition-type-uuid = "F"
+		image = "boot.vfat"
+		offset = 16M
+	}
+
+	partition userdata {
+		partition-type-uuid = "L"
+		image = "userdata.ext4"
+	}
+}

--- a/configs/batocera-rk3588.board
+++ b/configs/batocera-rk3588.board
@@ -30,7 +30,7 @@ BR2_LINUX_KERNEL_NEEDS_HOST_OPENSSL=y
 
 # Build the DTB from the kernel sources
 BR2_LINUX_KERNEL_DTS_SUPPORT=y
-BR2_LINUX_KERNEL_INTREE_DTS_NAME="rockchip/rk3588-rock-5b rockchip/rk3588s-rock-5a rockchip/rk3588-evb1-lp4-v10-linux rockchip/rk3588s-orangepi-5 rockchip/rk3588s-orangepi-5b rockchip/rk3588-orangepi-5-plus rockchip/rk3588s-9tripod-linux rockchip/rk3588-blueberry-edge-v12-linux rockchip/rk3588s-khadas-edge2"
+BR2_LINUX_KERNEL_INTREE_DTS_NAME="rockchip/rk3588-rock-5b rockchip/rk3588s-rock-5a rockchip/rk3588-evb1-lp4-v10-linux rockchip/rk3588s-orangepi-5 rockchip/rk3588s-orangepi-5b rockchip/rk3588-orangepi-5-plus rockchip/rk3588s-9tripod-linux rockchip/rk3588-blueberry-edge-v12-linux rockchip/rk3588s-khadas-edge2 rockchip/rk3588s-roc-pc"
 
 # Use 'extreme' ZSTD compression for a smaller image, but a bit more CPU to decompress
 BR2_TARGET_ROOTFS_SQUASHFS4_ZSTD=y

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -468,7 +468,7 @@ config BR2_TARGET_BATOCERA_IMAGES_DEFINITIONS
                                                                                             if BR2_PACKAGE_BATOCERA_TARGET_S905
     default "rockchip/rk3399/rock960 rockchip/rk3399/rockpro64 rockchip/rk3399/rg552 rockchip/rk3399/orangepi4-lts rockchip/rk3399/rock-pi-4" \
                                                                                             if BR2_PACKAGE_BATOCERA_TARGET_RK3399
-    default "rockchip/rk3588/rock-5b rockchip/rk3588/rock-5a rockchip/rk3588/quartzpro64 rockchip/rk3588/orangepi-5 rockchip/rk3588/orangepi-5b rockchip/rk3588/orangepi-5-plus rockchip/rk3588/indiedroid-nova rockchip/rk3588/mekotronics-r58 rockchip/rk3588/khadas-edge-2" \
+    default "rockchip/rk3588/rock-5b rockchip/rk3588/rock-5a rockchip/rk3588/quartzpro64 rockchip/rk3588/orangepi-5 rockchip/rk3588/orangepi-5b rockchip/rk3588/orangepi-5-plus rockchip/rk3588/indiedroid-nova rockchip/rk3588/mekotronics-r58 rockchip/rk3588/khadas-edge-2 rockchip/rk3588/firefly-station-m3" \
                                                                                             if BR2_PACKAGE_BATOCERA_TARGET_RK3588
 
 choice


### PR DESCRIPTION
Add ROC-RK3588S-PC board Support.
[https://en.t-firefly.com/product/industry/rocrk3588spc](url)
Station M3 Mini PC is a consumer device based on this board.
[https://www.stationpc.com/product/stationm3](url)