### PR TITLE
[v40] vpinball: update libdmdutil, libpinmame, libaltsound, libzedmd, and vpinball

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Jan 28, 2024
+# Version: Commits on Mar 1, 2024
 # uses standalone tree for now
-VPINBALL_VERSION = 0d0dcff884f71eecab96111b63db6b5586ae4b2c
+VPINBALL_VERSION = 030566e09dea5ff0fd383ad91141f07b5ab5459a 
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE
@@ -14,20 +14,22 @@ VPINBALL_SUPPORTS_IN_SOURCE_BUILD = NO
 
 # handle supported target platforms
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3588),y)
-    SOURCE = CMakeLists_gl-rk3588-aarch64.txt
-    SOURCE_DIR = rk3588
+    SOURCE = CMakeLists_gl-linux-aarch64.txt
+    SOURCE_DIR = linux-aarch64
     ARCH = aarch64
+    VPINBALL_CONF_OPTS += "-DBUILD_RK3588=ON"
 endif
 
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_BCM2711)$(BR2_PACKAGE_BATOCERA_TARGET_BCM2712),y)
-    SOURCE = CMakeLists_gl-rpi-aarch64.txt
-    SOURCE_DIR = rpi
+    SOURCE = CMakeLists_gl-linux-aarch64.txt
+    SOURCE_DIR = linux-aarch64
     ARCH = aarch64
+    VPINBALL_CONF_OPTS += "-DBUILD_RPI=ON"
 endif
 
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY),y)
     SOURCE = CMakeLists_gl-linux-x64.txt
-    SOURCE_DIR = linux
+    SOURCE_DIR = linux-x64
     ARCH = x86_64
 endif
 

--- a/package/batocera/libraries/libaltsound/libaltsound.mk
+++ b/package/batocera/libraries/libaltsound/libaltsound.mk
@@ -3,8 +3,8 @@
 # libaltsound
 #
 ################################################################################
-# Version: Commits on Jan 27, 2024
-LIBALTSOUND_VERSION = 676ebcde7802ffdbd84c9a275213754a4ebf5e8f
+# Version: Commits on Feb 24, 2024
+LIBALTSOUND_VERSION = 9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
 LIBALTSOUND_SITE = $(call github,vpinball,libaltsound,$(LIBALTSOUND_VERSION))
 LIBALTSOUND_LICENSE = BSD-3-Clause
 LIBALTSOUND_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on Jan 27, 2024
-LIBDMDUTIL_VERSION = 0a7e81f64c32b02596f11c969a07207bea48a8cc
+# Version: Commits on Feb 28, 2024
+LIBDMDUTIL_VERSION = aa9891badb82ced609460f914e85966ce75df7a6
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE
@@ -15,6 +15,7 @@ LIBDMDUTIL_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
 LIBDMDUTIL_CONF_OPTS += -DBUILD_STATIC=OFF
 LIBDMDUTIL_CONF_OPTS += -DPLATFORM=linux
 LIBDMDUTIL_CONF_OPTS += -DARCH=$(BUILD_ARCH)
+LIBDMDUTIL_CONF_OPTS += -DPOST_BUILD_COPY_EXT_LIBS=OFF
 
 # handle supported target platforms
 ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3588),y)

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Jan 27, 2024
-LIBPINMAME_VERSION = a157ac7dc5a4020f7b4af6353b5809f4220ec3d3
+# Version: Commits on Mar 1, 2024
+LIBPINMAME_VERSION = dbe4f64738d680e9572c2afc30ba6bb10176d07d
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libzedmd/libzedmd.mk
+++ b/package/batocera/libraries/libzedmd/libzedmd.mk
@@ -3,8 +3,8 @@
 # libzedmd
 #
 ################################################################################
-# Version: Commits on Jan 27, 2024
-LIBZEDMD_VERSION = b2190a3efaa52d705c9a5c62f00b418376a2604d
+# Version: Commits on Feb 28, 2024
+LIBZEDMD_VERSION = 08e98a858eb6e1394b4844bec7dd27c7c0d9a845
 LIBZEDMD_SITE = $(call github,PPUC,libzedmd,$(LIBZEDMD_VERSION))
 LIBZEDMD_LICENSE = GPLv3
 LIBZEDMD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
- new libdmdutil which makes multiple copies of the dmd buffer needed for in game dmd and external windows.
- new pinmame that supports pwm lights and modulated solenoids
- new vpx that's is based on 10.8.0 rc 1 with some memory leak fixes
- support for reordering external windows so pinmame and flex external windows are above b2s external windows.

can wait until v40.