### PR TITLE
improve steam scrapping results

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2701,7 +2701,7 @@ steam:
   release:
   hardware:
   extensions: [steam]
-  platform: pc
+  platform: windows
   emulators:
     steam:
       steam: { requireAnyOf: [BR2_PACKAGE_BATOCERA_STEAM] }


### PR DESCRIPTION
This is a following of my first attempt to fix the current bad situation
Currently, for the steam platform scrapping returns very poor results.
Eg, for this game (https://store.steampowered.com/app/1342260/SAMURAI_SHODOWN/): the scrapper returns way too many results which are not relevant at all (example here are games exclusive to xbox360 or neo geo pocket), so it's a mess.
![screenshot-2024 02 05-23h12 00](https://github.com/batocera-linux/batocera.linux/assets/7478580/2385f72c-d660-4748-b5bb-c9c21cc5bd8c)
![screenshot-2024 02 05-23h12 11](https://github.com/batocera-linux/batocera.linux/assets/7478580/10c4d974-bd3b-4c7b-89fe-ab69830fe85c)

With this fix, for the same game, it gives correct results:
![screenshot-2024 02 06-16h32 47](https://github.com/batocera-linux/batocera.linux/assets/7478580/6446c4b0-d24b-4703-a664-ee44dcde42bf)

The initial discussion is here:
https://github.com/batocera-linux/batocera-emulationstation/pull/1679

I followed the advice of @fabricecaruso, but I did this only for steam as I can't test for windows games (https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulationstation/batocera-es-system/es_systems.yml#L2299).

