### PR TITLE
Start sixad only if Bluetooth is enabled

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S31sixad
+++ b/board/batocera/fsoverlay/etc/init.d/S31sixad
@@ -3,7 +3,8 @@
 case "$1" in
     start)
         enabled="$(/usr/bin/batocera-settings-get controllers.ps3.enabled)"
-        if [ "$enabled" = "1" ]; then
+        bt_enabled="$(/usr/bin/batocera-settings-get controllers.bluetooth.enabled)"
+        if [ "$enabled" = "1" ] && [ "$bt_enabled" = "1" ]; then
             settings_version="$(/usr/bin/batocera-settings-get controllers.ps3.driver)"
             [ "$settings_version" = "bluez" ] && exit 0
             if [ "$settings_version" = "" ]; then


### PR DESCRIPTION
Currently sixad is started if `controllers.ps3.driver` is set to `official` or `shanwan`, and `controllers.ps3.enabled` is set to `1`.
This happens even if `controllers.bluetooth.enabled` is set to `0`.

With this PR sixad is started if `controllers.ps3.driver` is set to `official` or `shanwan`, and `controllers.ps3.enabled` is set to `1`, **and `controllers.bluetooth.enabled` is set to `1`**.

@dmanlfc 