### PR TITLE
libliftoff: bump to 0.4.1

### DIFF
--- a/package/batocera/libraries/libliftoff/libliftoff.hash
+++ b/package/batocera/libraries/libliftoff/libliftoff.hash
@@ -1,2 +1,2 @@
 # Generated locally
-sha256  ec689e36855ad50db04064dd9c603d35fb62fbd465bc729a826672674e313205  libliftoff-0.4.0.tar.gz
+sha256  9f16e3168234d63ad636224061bc88b0e5f0e43a5b4edfa24b61bf9d57a3eb3b  libliftoff-0.4.1.tar.gz

--- a/package/batocera/libraries/libliftoff/libliftoff.mk
+++ b/package/batocera/libraries/libliftoff/libliftoff.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LIBLIFTOFF_VERSION = 0.4.0
+LIBLIFTOFF_VERSION = 0.4.1
 LIBLIFTOFF_SITE = https://gitlab.freedesktop.org/emersion/libliftoff/-/releases/v$(LIBLIFTOFF_VERSION)/downloads
 LIBLIFTOFF_LICENSE = MIT
 LIBLIFTOFF_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Fix -Wsign-conversion on 32-bit
