### PR TITLE
Add exit function for light guns (v41)

### DIFF
--- a/package/batocera/emulators/dolphin-emu/wii.dolphin.keys
+++ b/package/batocera/emulators/dolphin-emu/wii.dolphin.keys
@@ -26,4 +26,13 @@
             "target": "KEY_F8"
         }
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit Dolphin"
+    }
+    ]
 }

--- a/package/batocera/emulators/duckstation/psx.duckstation.keys
+++ b/package/batocera/emulators/duckstation/psx.duckstation.keys
@@ -67,4 +67,13 @@
 	    "description": "Fast Forward"
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit Duckstation"
+    }
+	]
 }

--- a/package/batocera/emulators/flycast/atomiswave.flycast.keys
+++ b/package/batocera/emulators/flycast/atomiswave.flycast.keys
@@ -13,4 +13,13 @@
             "description": "Hide the bezel"
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "exec",
+            "hold": "2.0",
+            "target": "killall -15 flycast",
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/flycast/dreamcast.flycast.keys
+++ b/package/batocera/emulators/flycast/dreamcast.flycast.keys
@@ -13,4 +13,13 @@
             "description": "Hide the bezel"
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "exec",
+            "hold": "2.0",
+            "target": "killall -15 flycast",
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/flycast/naomi.flycast.keys
+++ b/package/batocera/emulators/flycast/naomi.flycast.keys
@@ -13,4 +13,13 @@
             "description": "Hide the bezel"
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "exec",
+            "hold": "2.0",
+            "target": "killall -15 flycast",
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/mame/mame.mame.keys
+++ b/package/batocera/emulators/mame/mame.mame.keys
@@ -36,4 +36,13 @@
             "target": [ "KEY_SCROLLLOCK" ]
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_ESC" ],
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/model2emu/model2.model2emu.keys
+++ b/package/batocera/emulators/model2emu/model2.model2emu.keys
@@ -27,7 +27,7 @@
             "type": "key",
             "target": "KEY_4"
 	}
-    ]		
+    ]
     ,"actions_gun1": [
 	{
             "trigger": "middle",
@@ -38,7 +38,14 @@
             "trigger": "1",
             "type": "key",
             "target": "KEY_1"
-	}
+	},
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit emulator"
+    }
     ]
     ,"actions_gun2": [
 	{
@@ -52,5 +59,4 @@
             "target": "KEY_2"
 	}
     ]
-
 }

--- a/package/batocera/emulators/pcsx2/ps2.pcsx2.keys
+++ b/package/batocera/emulators/pcsx2/ps2.pcsx2.keys
@@ -36,4 +36,13 @@
             "target": [ "KEY_F8" ]
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/retroarch/retroarch/libretro.keys
+++ b/package/batocera/emulators/retroarch/retroarch/libretro.keys
@@ -1,12 +1,7 @@
+# Player 1 light gun exit
+# Hold trigger, action and start for 2s.
 {
-    "actions_player1": [
-	{
-            "trigger": ["hotkey", "start"],
-            "type": "key",
-            "target": [ "KEY_LEFTALT", "KEY_F4" ]
-	}
-    ]
-    ,"actions_gun1": [
+    "actions_gun1": [
     {
             "trigger": ["left", "right", "middle"],
             "type": "key",
@@ -14,5 +9,5 @@
             "target": [ "KEY_LEFTALT", "KEY_F4" ],
             "description": "Exit emulator"
     }
-	]
+    ]
 }

--- a/package/batocera/emulators/rpcs3/evmapy.keys
+++ b/package/batocera/emulators/rpcs3/evmapy.keys
@@ -12,4 +12,13 @@
             ]
         }
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/supermodel/model3.supermodel.keys
+++ b/package/batocera/emulators/supermodel/model3.supermodel.keys
@@ -36,4 +36,13 @@
             "target": [ "KEY_LEFTALT", "KEY_S" ]
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_ESC" ],
+            "description": "Exit emulator"
+    }
+	]
 }

--- a/package/batocera/emulators/vice/c64.vice.keys
+++ b/package/batocera/emulators/vice/c64.vice.keys
@@ -6,4 +6,13 @@
             "target": [ "KEY_LEFTALT", "KEY_F4" ]
 	}
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": ["left", "right", "middle"],
+            "type": "key",
+            "hold": "2.0",
+            "target": [ "KEY_LEFTALT", "KEY_F4" ],
+            "description": "Exit emulator"
+    }
+	]
 }


### PR DESCRIPTION
This will add functionality to exit emulators with only the (first player) gun, making possible to play on Batocera without the need of a controller. To exit, hold `TRIGGER`, `ACTION` and `START` at the same time (left, right, middle mouse click).

Adding some mapping to Daphne standalone emulators too (coin, start).