### PR TITLE
Bump linux-firmware to 20240220

### DIFF
--- a/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
+++ b/package/batocera/firmwares/alllinuxfirmwares/alllinuxfirmwares.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-ALLLINUXFIRMWARES_VERSION = 20240115
+ALLLINUXFIRMWARES_VERSION = 20240220
 ALLLINUXFIRMWARES_SOURCE = linux-firmware-$(ALLLINUXFIRMWARES_VERSION).tar.gz
 ALLLINUXFIRMWARES_SITE = https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot
 


### PR DESCRIPTION
Bump linux-firmware to [20240220](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20240220).