### PR TITLE
Cemu 2.0-66 (Experimental) - 2024-02-21 - https://github.com/cemu-pro…

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -124,7 +124,7 @@
 - Libretro-PCSX-ReARMed to Oct 9, 2023
 - Fheroes2 to 1.0.9
 - BigPEmu to 1.094
-- Cemu to 2.0-65
+- Cemu to 2.0-66
 - Citra to nightly-2054
 - Dolphin to 5.0-20840
 - Flycast to 17th Dec build

--- a/package/batocera/emulators/cemu/cemu.mk
+++ b/package/batocera/emulators/cemu/cemu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-CEMU_VERSION = v2.0-65
+CEMU_VERSION = v2.0-66
 CEMU_SITE = https://github.com/cemu-project/Cemu
 CEMU_LICENSE = GPLv2
 CEMU_SITE_METHOD=git


### PR DESCRIPTION
Please make sure your PR is ready to be merged !

- [x] You added the changes in CHANGELOG.md
- [x] You choose the right repository branch to make the PR
- [x] You described the PR as below

Changes :
- update Cemu from 2.0-65 to 2.0-66
source: https://github.com/cemu-project/Cemu/commits/v2.0-66

Summary from 2.0-65:
- Update SDL2 vcpkg port to 2.30.0
- Latte: Optimize uniform register array size for known shaders
- Latte: Avoid assert in texture view check
- BUILD.md: Mention Debian in the build-instructions for Ubuntu (#1096)
- Improve BUILD.md (#1093)
- Gamelist: Add right-click actions for copying title ID, name, and icon (#1089)
- Add support for portable directory without build flag (#1071)
- UI: Make Alt+F4/Ctrl+Q more reliable (#1035)
- Cubeb: Add a default device to the selection (#1017)
- Update issue templates
- CI: For the Windows build use as many cores as available
- Ignore Wii U pro controller
- Vulkan: Don't use glslang internal headers Signed-off-by: Mike Lothian <mike@fireburn.co.uk>
- Flatpak: Create shortcuts that launch flatpak
- Vulkan: Check for 0 size before wayland resize Fixes "Launching games directly with the --title-id argument doesn't work in Wayland" (#999)

