### PR TITLE
batocera-wine : dxvk_install: always create windows systems directory

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -328,8 +328,8 @@ dxvk_install() {
 	    export DXVK_HUD=1
     fi
 
+    mkdir -p "${WINEPREFIX}/drive_c/windows/system32" "${WINEPREFIX}/drive_c/windows/syswow64" || return 1
     if test "${DXVK}" = 1; then
-        mkdir -p "${WINEPREFIX}/drive_c/windows/system32" "${WINEPREFIX}/drive_c/windows/syswow64" || return 1
         if test -e "/userdata/system/wine/dxvk"; then
             echo "Creating links using /userdata, Linux File System required !!!"
             ln -sf "/userdata/system/wine/dxvk/x64/"{d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi64.dll} "${WINEPREFIX}/drive_c/windows/system32" || return 1


### PR DESCRIPTION
Currently, if a game in wsquashfs format don't have the windows directory,

+ dxvk is not enabled, the symlinks in dvxk_install are not working because the windows/system32 && windows/syswow64 don't exist.

Always create theses dictories before symlink.

After, the game will  deploy the structure at first run, without overriding theses symlink.


fix: https://github.com/batocera-linux/batocera.linux/issues/11091