### PR TITLE
CriticalFix-V39-duplicate-folders

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -108,14 +108,14 @@ do
         if [ ! -e "${OUT}/${FILE}" ]; then
             mkdir -p "$(dirname "${OUT}/${FILE}")"
             echo "Creating $OUT/$FILE"
-            cp -rf "${IN}/${FILE}" "${OUT}/${FILE}"
+            cp -rf "${IN}/${FILE}" "$(dirname "${OUT}/${FILE}")"/
         fi
     else
         # Update if newer
         if [ -e "${IN}/${FILE}" ] && { [ ! -e "${OUT}/${FILE}" ] || [ "${IN}/${FILE}" -nt "${OUT}/${FILE}" ]; }; then
             mkdir -p "$(dirname "${OUT}/${FILE}")"
             echo "Updating $OUT/$FILE"
-            cp -rf "${IN}/${FILE}" "${OUT}/${FILE}"
+            cp -rf "${IN}/${FILE}" "$(dirname "${OUT}/${FILE}")"/
         fi
     fi
 done


### PR DESCRIPTION
Submitted PR on behalf of another user:

cjom:
"Hi! I found a bug in /etc/init.d/S12populateshare but I can't do a PR because I can't find the package where it comes from (I had deleted my entire "dl" folder after building, to save some space...
The problem is in lines 111 and 118. This is supposed to copy newer files and folders after a system update, but when copying a folder over an existing folder it will create a new folder with the same name inside the older one. For example, instead of updating /userdata/bios it will create the new folder /userdata/bios/bios

Please change the lines 111 and 118 from: cp -rf "${IN}/${FILE}" "${OUT}/${FILE}"
to: cp -rf "${IN}/${FILE}" "$(dirname "${OUT}/${FILE}")"/
This will work as intended, either with files or folders."

I have experienced this bug myself in V39 and has been reported by several other users also.