### PR TITLE
batocera-wine: allow custom wine_versions

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -21,15 +21,17 @@ fi
 
 # Wine Folder
 wine_folder() {
-if test -e "/userdata/system/wine/ge-custom"; then
+if test -e "/userdata/system/wine/${WINE_VERSION}"; then
     echo "/userdata/system/wine"
-    else
+elif test -e "/usr/wine/${WINE_VERSION}"; then
     echo "/usr/wine"
+else
+    exit 1
 fi
 }
 
 ## Wine executables
-DIR="$(wine_folder)"
+DIR="$(wine_folder)" || { echo "can't find wine version ${WINE_VERSION} directory"; exit 1; }
 USER_DIR="/userdata/system/wine"
 WINE="${DIR}/${WINE_VERSION}/bin/wine"
 WINE64="${DIR}/${WINE_VERSION}/bin/wine64"


### PR DESCRIPTION
it could be usefull to use differents wine versions for specific games in case of regression.

simply but a specific version in /userdata/system/wine/<wineversion>

then use <system>.core=<winversion> ,  or windows["<gameid">].core=<winversion>