### PR TITLE
V39-fix-rpcs3-configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -153,16 +153,19 @@ class Rpcs3Generator(Generator):
         else:
             rpcs3ymlconfig["Video"]["Stretch To Display Area"] = False
         # Frame Limit
+        # Frame limit checks for specific values("Auto", "Off", "30", "50", "59.94", "60")
+        # Second Frame Limit can be any float/integer. 0 = disabled.
         if system.isOptSet("rpcs3_framelimit"):
-            if system.config["rpcs3_framelimit"] in ["30", "50", "59.94", "60"]:
+            # Check for valid Frame Limit value, if it's not a Frame Limit value apply to Second Frame Limit
+            if system.config["rpcs3_framelimit"] in ["Off", "30", "50", "59.94", "60"]:
                 rpcs3ymlconfig["Video"]["Frame limit"] = system.config["rpcs3_framelimit"]
-                rpcs3ymlconfig["Video"]["Second Frame Limit"] = False
+                rpcs3ymlconfig["Video"]["Second Frame Limit"] = 0
             else:
                 rpcs3ymlconfig["Video"]["Second Frame Limit"] = system.config["rpcs3_framelimit"]
-                rpcs3ymlconfig["Video"]["Frame limit"] = False
+                rpcs3ymlconfig["Video"]["Frame limit"] = "Off"
         else:
             rpcs3ymlconfig["Video"]["Frame limit"] = "Auto"
-            rpcs3ymlconfig["Video"]["Second Frame Limit"] = False
+            rpcs3ymlconfig["Video"]["Second Frame Limit"] = 0
         # Write Color Buffers
         if system.isOptSet("rpcs3_colorbuffers"):
             rpcs3ymlconfig["Video"]["Write Color Buffers"] = system.config["rpcs3_colorbuffers"]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8977,8 +8977,14 @@ rpcs3:
             description: Most games already have an internal framelimit. Minor performance cost.
             choices:
                 "Off (faster, unstable)": Off
+                "20":                     20
+                "25":                     25    
                 "30":                     30
+                "35":                     35
+                "40":                     40
+                "45":                     45
                 "50":                     50
+                "55":                     55 
                 "59.94":                  59.94
                 "60":                     60
         rpcs3_anisotropic:


### PR DESCRIPTION
Fixes invalid values error in the rpcs3 configgen for frame limits.

Frame limit only accepts specific values: Off, 30, 50, 59.94, and 60.
Second Frame Limit can accept any float/integer value, so the configgen checks if the setting equals accepted values for the primary frame limit first, if not than applies to the secondary frame limit.

Default/Auto frame limit value of "Auto" for primary and 0 for seconday.