### PR TITLE
In batocera.conf add CVE comment for controllers.ps3.enabled

### DIFF
--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -154,6 +154,7 @@ controllers.bluetooth.enabled=1
 # -------------- D1 - PS3 Controllers ------------ #
 
 ## Enable PS3 controller support
+## PS3 controller support enables CVE-2023-45866 security vulnerability. Disable if not needed.
 controllers.ps3.enabled=1
 ## Choose a Bluetooth driver.
 ## bluez -> bluez 5 + kernel drivers, supports official and Shanwan Sixaxis.


### PR DESCRIPTION
In `batocera.conf` for `controllers.ps3.enabled` add comment:
`## PS3 controller support enables CVE-2023-45866 security vulnerability. Disable if not needed.`

Idea is to inform users who manually edit `batocera.conf` that they might want to disable `controllers.ps3.enabled` if they are not planning to use PS3 controllers. 
Maybe the text can be improved.

@lbrpdx What do you think about this?