### PR TITLE
Fix dosbox-staging tests for NEON on AArch32 and SSE2/SSSE3 on x86

### DIFF
--- a/package/batocera/emulators/dosbox-staging/002-disable-neon-sse2-ssse3-testing.patch
+++ b/package/batocera/emulators/dosbox-staging/002-disable-neon-sse2-ssse3-testing.patch
@@ -1,0 +1,96 @@
+--- a/meson.build	2024-03-14 15:58:49.003699790 +0100
++++ b/meson.build	2024-03-14 16:01:26.431251165 +0100
+@@ -299,37 +299,11 @@
+ 
+ # NEON on Aarch32
+ # ~~~~~~~~~~~~~~~
+-if (
+-    target_machine.cpu_family() == 'arm'
+-    and (zlib_ng_is_native
+-    or zlib_ng_wants_native
+-    or 'neon' in zlib_ng_options)
+-)
+-    neon_test_code = '''
+-                #include <arm_neon.h>
+-                int main() {
+-                uint8x16_t a = vdupq_n_u8(0);
+-                uint8x16_t b = vdupq_n_u8(0);
+-                uint8x16_t result = vaddq_u8(a, b);
+-                return 0;
+-                }
+-            '''
+-    neon_cflag = '-mfpu=neon-vfpv4'
+-    neon_test = cc.run(
+-        neon_test_code,
+-        args: neon_cflag,
+-        name: 'ARM NEON instruction set test',
+-    )
+-    if (neon_test.compiled() and neon_test.returncode() == 0)
+-        zlib_ng_options += 'neon'
+-        extra_flags += neon_cflag
+-        simd_instruction_sets += 'NEON'
+-        message('Enabling the ARM NEON instruction set')
+-    endif
+-endif
++# Disabled for batocera
+ 
+ # SSE2 and SSSE3 on x86
+ # ~~~~~~~~~~~~~~~~~~~~~
++# Force SSE2 on x86 (always true for x86_64), disable SSSE3 no way to run tests
+ if (
+     target_machine.cpu_family().startswith('x86')
+     and (
+@@ -339,49 +313,11 @@
+         or 'ssse3' in zlib_ng_options
+     )
+ )
+-    sse2_test_code = '''
+-                #include <emmintrin.h>
+-                int main() {
+-                __m128i a = _mm_setzero_si128();
+-                __m128i b = _mm_setzero_si128();
+-                __m128i result = _mm_add_epi32(a, b);
+-                return 0;
+-                }
+-            '''
++    zlib_ng_options += 'sse2'
++    extra_flags += sse2_cflags
++    simd_instruction_sets += 'SSE2'
+     sse2_cflags = '-msse2'
+-    sse2_test = cc.run(
+-        sse2_test_code,
+-        args: sse2_cflags,
+-        name: 'SSE2 instruction set test',
+-    )
+-    if (sse2_test.compiled() and sse2_test.returncode() == 0)
+-        zlib_ng_options += 'sse2'
+-        extra_flags += sse2_cflags
+-        simd_instruction_sets += 'SSE2'
+-        message('Enabling the SSE2 instruction set')
+-    endif
+-
+-    ssse3_test_code = '''
+-                #include <tmmintrin.h>
+-                int main() {
+-                __m128i a = _mm_setzero_si128();
+-                __m128i b = _mm_setzero_si128();
+-                __m128i result = _mm_hadd_epi16(a, b);
+-                return 0;
+-                }
+-            '''
+-    ssse3_cflag = '-mssse3'
+-    ssse3_test = cc.run(
+-        ssse3_test_code,
+-        args: ssse3_cflag,
+-        name: 'SSSE3 instruction set test',
+-    )
+-    if (ssse3_test.compiled() and ssse3_test.returncode() == 0)
+-        zlib_ng_options += 'ssse3'
+-        extra_flags += ssse3_cflag
+-        simd_instruction_sets += 'SSSE3'
+-        message('Enabling the SSSE3 instruction set')
+-    endif
++    message('Enabling the SSE2 instruction set')
+ endif
+ 
+ if simd_instruction_sets.length() == 0

--- a/package/batocera/emulators/dosbox-staging/dosbox-staging.mk
+++ b/package/batocera/emulators/dosbox-staging/dosbox-staging.mk
@@ -24,8 +24,8 @@ DOSBOX_STAGING_CXXFLAGS += -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard
 endif
 
 ifeq ($(BR2_cortex_a7),y)
-DOSBOX_STAGING_CFLAGS   += -marm -march=armv7-a -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-DOSBOX_STAGING_CXXFLAGS += -marm -march=armv7-a -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+DOSBOX_STAGING_CFLAGS   += -marm -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
+DOSBOX_STAGING_CXXFLAGS += -marm -march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard
 endif
 
 ifeq ($(BR2_cortex_a9),y)


### PR DESCRIPTION
Disables NEON for AArch32 (no guarantee)
Enables SSE2 for x86_64 (part of the spec), disables SSSE3