### PR TITLE
Minor improvement in batocera.conf comment

### DIFF
--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -153,7 +153,7 @@ controllers.bluetooth.enabled=1
 
 # -------------- D1 - PS3 Controllers ------------ #
 
-## Enable PS3 controller support
+## Enable support for PS3 controllers (and likely some other Bluetooth controllers too)
 ## PS3 controller support enables CVE-2023-45866 security vulnerability. Disable if not needed.
 controllers.ps3.enabled=1
 ## Choose a Bluetooth driver.


### PR DESCRIPTION
Mention that PS3 controller support might also be needed for some other controllers.