### PR TITLE
Update sinden-guns.hash

### DIFF
--- a/package/batocera/controllers/sinden-guns/sinden-guns.hash
+++ b/package/batocera/controllers/sinden-guns/sinden-guns.hash
@@ -1,1 +1,1 @@
-sha256 9b993bc7264e23030bd26f30fb4dd39b7e424c0f95bf006f23b4318eb67af1ed  SindenLightgunSoftwareReleaseV1.09.zip
+sha256 d5e7caaf93daa24b349a9dd9565925c8e4a9bb151c030db732ce4e114bdd6728  SindenLightgunSoftwareReleaseV1.09.zip


### PR DESCRIPTION
Updated with the correct hash for the sinden software version 1.09