### PR TITLE
LEDSpicer: Fix config locations & bump version

### DIFF
--- a/package/batocera/utils/ledspicer/001-userdata.patch
+++ b/package/batocera/utils/ledspicer/001-userdata.patch
@@ -12,7 +12,7 @@ index 374e18b..223ac48 100644
  			.append(".xml")
  	);
 diff --git a/src/Emitter.hpp b/src/Emitter.hpp
-index 1e47827..97a8e90 100644
+index 1e47827..a8a6b7c 100644
 --- a/src/Emitter.hpp
 +++ b/src/Emitter.hpp
 @@ -43,7 +43,7 @@ using std::endl;
@@ -33,6 +33,15 @@ index 1e47827..97a8e90 100644
  
  // Controllers
  #define MOUSE      "MOUSE"
+@@ -76,7 +76,7 @@ using std::endl;
+ #define POSITIONAL "POSITIONAL"
+ #define JOYSTICK   "JOYSTICK"
+ 
+-#define COLORINI_FILE PACKAGE_DATA_DIR "colors.ini"
++#define COLORINI_FILE "/userdata/system/configs/ledspicer/" "colors.ini"
+ 
+ struct PlayerData {
+ 
 diff --git a/src/Main.cpp b/src/Main.cpp
 index a95b594..74e7d31 100644
 --- a/src/Main.cpp

--- a/package/batocera/utils/ledspicer/ledspicer
+++ b/package/batocera/utils/ledspicer/ledspicer
@@ -2,7 +2,7 @@
 
 DAEMON="/usr/bin/ledspicerd"
 CONFIG_DIR="/userdata/system/configs/ledspicer"
-DAEMON_ARGS="--config $CONFIG_DIR/ledspicer.conf"
+DAEMON_ARGS=""
 
 start() {
         echo -n "Starting LEDSpicer: "

--- a/package/batocera/utils/ledspicer/ledspicer.mk
+++ b/package/batocera/utils/ledspicer/ledspicer.mk
@@ -4,13 +4,13 @@
 #
 ################################################################################
 
-LEDSPICER_VERSION = 7e8957edebe9fd6e209ac824dfe109edb3de36d9
+LEDSPICER_VERSION = 0.6.0
 LEDSPICER_SITE = $(call github,meduzapat,LEDSpicer,$(LEDSPICER_VERSION))
 LEDSPICER_LICENSE = GPLv3
 LEDSPICER_DEPENDENCIES = tinyxml2 libusb libtool udev
 LEDSPICER_AUTORECONF = YES
 LEDSPICER_CONF_OPTS = CXXFLAGS='-g0 -O3' --enable-nanoled --enable-pacdrive --enable-pacled64 --enable-ultimateio --enable-ledwiz32 --enable-howler --enable-adalight
-LEDSPICER_CONF_OPTS += --docdir=/usr/share/ledspicer/doc
+LEDSPICER_CONF_OPTS += --sysconfdir=/userdata/system/configs/ledspicer --docdir=/usr/share/ledspicer/doc
 
 ifeq ($(BR2_PACKAGE_PIGPIO),y)
     LEDSPICER_DEPENDENCIES += pigpio
@@ -37,6 +37,7 @@ else
 endif
 
 define LEDSPICER_UDEV_RULE
+    mkdir -p $(TARGET_DIR)/etc/udev/rules.d
     cp $(@D)/data/21-ledspicer.rules $(TARGET_DIR)/etc/udev/rules.d/99-ledspicer.rules
 endef
 


### PR DESCRIPTION
Contains the following changes:
- Version bump to 0.6.0 (latest release)
- Patch the location of `colors.ini` to `/userdata/system/configs/ledspicer/colors.ini`, consistent with other config files in the original Batocera release of LEDSpicer (#10388)
- Set the default location of `ledspicer.conf` to `/userdata/system/configs/ledspicer/ledspicer.conf`, eliminating the need to manually specify the path to this config when invoking `ledspicerd` and `emitter`. (#10388)