### PR TITLE
Bump LEDSpicer to 0.6.3.1, with dependency update

### DIFF
--- a/package/batocera/utils/ledspicer/ledspicer.mk
+++ b/package/batocera/utils/ledspicer/ledspicer.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-LEDSPICER_VERSION = 0.6.0
+LEDSPICER_VERSION = 0.6.3.1
 LEDSPICER_SITE = $(call github,meduzapat,LEDSpicer,$(LEDSPICER_VERSION))
 LEDSPICER_LICENSE = GPLv3
 LEDSPICER_DEPENDENCIES = tinyxml2 libusb libtool udev libpthread-stubs

--- a/package/batocera/utils/ledspicer/ledspicer.mk
+++ b/package/batocera/utils/ledspicer/ledspicer.mk
@@ -4,10 +4,10 @@
 #
 ################################################################################
 
-LEDSPICER_VERSION = 7e8957edebe9fd6e209ac824dfe109edb3de36d9
+LEDSPICER_VERSION = 0.6.0
 LEDSPICER_SITE = $(call github,meduzapat,LEDSpicer,$(LEDSPICER_VERSION))
 LEDSPICER_LICENSE = GPLv3
-LEDSPICER_DEPENDENCIES = tinyxml2 libusb libtool udev
+LEDSPICER_DEPENDENCIES = tinyxml2 libusb libtool udev libpthread-stubs
 LEDSPICER_AUTORECONF = YES
 LEDSPICER_CONF_OPTS = CXXFLAGS='-g0 -O3' --enable-nanoled --enable-pacdrive --enable-pacled64
 LEDSPICER_CONF_OPTS += --enable-ultimateio --enable-ledwiz32 --enable-howler --enable-adalight


### PR DESCRIPTION
Resolves #11313