### PR TITLE
fix broken pcsx2Generator.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -478,13 +478,16 @@ def configureINI(config_directory, bios_directory, system, rom, controllers, met
             if gun1onport2:
                 pcsx2INIConfig.set("USB2", "guncon2_numdevice", "0")
     # Gun crosshairs - one player only, PCSX2 can't distinguish both crosshair for some reason
-    if system.isOptSet('pcsx2_crosshairs') and system.config["pcsx2_crosshairs"] == "1":
-        pcsx2INIConfig.set("USB1", "guncon2_cursor_path", "/usr/pcsx2/bin/resources/crosshairs/Blue.png")
-        pcsx2INIConfig.set("USB2", "guncon2_cursor_path", "/usr/pcsx2/bin/resources/crosshairs/Red.png")
-    else:
-        pcsx2INIConfig.set("USB1", "guncon2_cursor_path", "")
-        pcsx2INIConfig.set("USB2", "guncon2_cursor_path", "")
-
+    if pcsx2INIConfig.has_section("USB1"):
+        if system.isOptSet('pcsx2_crosshairs') and system.config["pcsx2_crosshairs"] == "1":
+            pcsx2INIConfig.set("USB1", "guncon2_cursor_path", "/usr/pcsx2/bin/resources/crosshairs/Blue.png")
+        else:
+            pcsx2INIConfig.set("USB1", "guncon2_cursor_path", "")
+    if pcsx2INIConfig.has_section("USB2"):
+        if system.isOptSet('pcsx2_crosshairs') and system.config["pcsx2_crosshairs"] == "1":
+            pcsx2INIConfig.set("USB2", "guncon2_cursor_path", "/usr/pcsx2/bin/resources/crosshairs/Red.png")
+        else:
+            pcsx2INIConfig.set("USB2", "guncon2_cursor_path", "")
     # hack for the fog bug for guns (time crisis - crisis zone)
     fog_files = [
         "/usr/pcsx2/bin/resources/textures/SCES-52530/replacements/c321d53987f3986d-eadd4df7c9d76527-00005dd4.png",


### PR DESCRIPTION
Since https://github.com/batocera-linux/batocera.linux/pull/11329 pcsx2 (butterfly) crashes on launch with the error:

```
  File "/usr/lib/python3.11/site-packages/configgen/generators/pcsx2/pcsx2Generator.py", line 71, in generate
    configureINI(pcsx2ConfigDir, pcsx2BiosDir, system, rom, playersControllers, metadata, guns, wheels, playingWithWheel)
  File "/usr/lib/python3.11/site-packages/configgen/generators/pcsx2/pcsx2Generator.py", line 486, in configureINI
    pcsx2INIConfig.set("USB2", "guncon2_cursor_path", "")
  File "/usr/lib/python3.11/configparser.py", line 1220, in set
    super().set(section, option, value)
  File "/usr/lib/python3.11/configparser.py", line 918, in set
    raise NoSectionError(section) from None
configparser.NoSectionError: No section: 'USB2'
```
I'm not sure that setting it to `""` when `pcsx2_crosshairs` is disabled and `USB1/2` sections exists is actually useful, but at least that's a safe fix!