### PR TITLE
add T80 steering wheel support

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -17,7 +17,7 @@ Initial support for the Lenovo Legion Go
 - DMD server (handling any dmd supported by libdmd) integrated with vpinball
 - Support for multi screens (for pincab, mame multi games)
 - Evmapy keys file to help exit running flatpak app
-- Steering wheel support for Thrustmaster T150RS
+- Steering wheel support for Thrustmaster T150RS and T80 (gamepad mode only)
 ### Fixed
 - RG552 Splash-screen rotation
 - RG552 Vibrator enabled

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -15,6 +15,7 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech Logitech Driving Fo
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech G923 Racing Wheel for PlayStation 4 and PC", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="ThrustMaster, Inc. Ferrari 458 Spider",               MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T150RS",                    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="1080"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T80",                       MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 
 # for ThrustMaster, Inc. Ferrari 458 Spider, cause xpad driver is blacklisted for the prefered xone
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b671", RUN+="/sbin/modprobe xpad"

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5033,4 +5033,24 @@
         <input name="x" type="button" id="2" value="1" code="290" />
         <input name="y" type="button" id="3" value="1" code="291" />
     </inputConfig>
+	<inputConfig type="joystick" deviceName="Thrustmaster Thrustmaster T80" deviceGUID="030000004f0400006ab6000010010000">
+		<input name="a" type="button" id="2" value="1" code="306" />
+		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="l2" type="axis" id="3" value="1" code="3" />
+		<input name="l3" type="button" id="6" value="1" code="310" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="309" />
+		<input name="pageup" type="button" id="4" value="1" code="308" />
+		<input name="r2" type="axis" id="4" value="1" code="4" />
+		<input name="r3" type="button" id="7" value="1" code="311" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="8" value="1" code="312" />
+		<input name="start" type="button" id="9" value="1" code="313" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="3" value="1" code="307" />
+		<input name="y" type="button" id="0" value="1" code="304" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Gamepad mode only. It won't work in wheel mode (not supported by Linux kernel).

How to:
![T80_WHEEL_GAMEPAD_MODES](https://github.com/batocera-linux/batocera.linux/assets/32983607/4341d0d2-9584-407e-9fcd-208d338b4cb7)


(Waiting for feedback...)