### PR TITLE
vpinball: bump libdmdutil, libdof, libpinmame, add ffmpeg

### DIFF
--- a/package/batocera/emulators/vpinball/Config.in
+++ b/package/batocera/emulators/vpinball/Config.in
@@ -8,6 +8,7 @@ config BR2_PACKAGE_VPINBALL
     select BR2_PACKAGE_SDL2
     select BR2_PACKAGE_SDL2_IMAGE
     select BR2_PACKAGE_SDL2_TTF
+    select BR2_PACKAGE_FFMPEG
     help
       Visual Pinball.
       

--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,13 +3,13 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Apr 3, 2024
+# Version: Commits on Apr 16, 2024
 # uses standalone tree for now
-VPINBALL_VERSION = c206e1214716b20c3fbe98073ed7b2ede8e58376 
+VPINBALL_VERSION = 9b49a0582b03af8a84e6086cf500d312366acfb2
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE
-VPINBALL_DEPENDENCIES = host-libcurl libfreeimage libpinmame libaltsound libdmdutil libdof sdl2 sdl2_image sdl2_ttf
+VPINBALL_DEPENDENCIES = host-libcurl libfreeimage libpinmame libaltsound libdmdutil libdof sdl2 sdl2_image sdl2_ttf ffmpeg
 VPINBALL_SUPPORTS_IN_SOURCE_BUILD = NO
 
 # handle supported target platforms

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on Apr 13, 2024
-LIBDMDUTIL_VERSION = 1d176946fb476d9c3b42f0fe9c3f585b7dd8d671
+# Version: Commits on Apr 16, 2024
+LIBDMDUTIL_VERSION = 0b58af9d2bb7886721ccfa3d3000b3d8f054a114
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdof/libdof.mk
+++ b/package/batocera/libraries/libdof/libdof.mk
@@ -3,8 +3,8 @@
 # libdof
 #
 ################################################################################
-# Version: Commits on Apr 3, 2024
-LIBDOF_VERSION = 3ea64f3f74cd3d676866c077eb9eb297f87b29b3
+# Version: Commits on Apr 15, 2024
+LIBDOF_VERSION = ac5d1e3487a4a6511953eb6aeef06ef5111510ea
 LIBDOF_SITE = $(call github,jsm174,libdof,$(LIBDOF_VERSION))
 LIBDOF_LICENSE = BSD-3-Clause
 LIBDOF_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Mar 23, 2024
-LIBPINMAME_VERSION = 788aa7af6eae8f777882e42abf44117f95a26bf4
+# Version: Commits on Apr 16, 2024
+LIBPINMAME_VERSION = f0722e0bfced46f3afb39d74e7ebb08e01495f35
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE


### PR DESCRIPTION
The PR adds initial support for [PUP Packs](https://www.nailbuster.com/wikipinup/doku.php?id=pup_capture).

It also bumps libdmdutil, libdof, and libpinmame.