### PR TITLE
Fix amiberry CAPSimage library loading 

### DIFF
--- a/package/batocera/emulators/amiberry/003-fix-libcapsimage-dlopen.patch
+++ b/package/batocera/emulators/amiberry/003-fix-libcapsimage-dlopen.patch
@@ -1,0 +1,15 @@
+--- a/src/caps/caps_amiberry.cpp	2024-04-28 23:59:46.638426596 +0200
++++ b/src/caps/caps_amiberry.cpp	2024-04-29 00:00:16.911142575 +0200
+@@ -67,11 +67,7 @@
+ 
+ 	if (init)
+ 		return 1;
+-#ifdef ANDROID
+-	UAE_DLHANDLE h = uae_dlopen_plugin(_T("libcapsimage.so"));
+-#else
+-	UAE_DLHANDLE h = uae_dlopen_plugin(_T("capsimg"));
+-#endif
++	UAE_DLHANDLE h = uae_dlopen(_T("libcapsimage.so.5"));
+ 	if (!h) {
+ 		if (noticed)
+ 			return 0;


### PR DESCRIPTION
Force to dlopen() to our shared libcapimage.so.5 instead of their custom plugin system