### PR TITLE
fix typo in variable use in lightgun reload option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -361,7 +361,7 @@ def generateMAMEConfigs(playersControllers, system, rom, guns):
 
     # Lightgun reload option
     if system.isOptSet('offscreenreload') and system.getOptBoolean('offscreenreload'):
-        commandArray += [ "-offscreen_reload" ]
+        commandLine += [ "-offscreen_reload" ]
 
     # Art paths - lr-mame displays artwork in the game area and not in the bezel area, so using regular MAME artwork + shaders is not recommended.
     # By default, will ignore standalone MAME's art paths.


### PR DESCRIPTION
While trying to debug #11545, I turned on the newly implemented offscreen reload option in ES (#6704) and configgen craps out:

```

evmapy: no process found
2024-05-01 19:12:00,060 ERROR (emulatorlauncher:609):<module> configgen exception: 
Traceback (most recent call last):
  File "/usr/bin/emulatorlauncher", line 607, in <module>
    exitcode = main(args, maxnbplayers)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/emulatorlauncher", line 99, in main
    return start_rom(args, maxnbplayers, args.rom, args.rom)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/emulatorlauncher", line 268, in start_rom
    cmd = generator.generate(system, rom, playersControllers, metadata, guns, wheels, gameResolution)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/configgen/generators/libretro/libretroGenerator.py", line 94, in generate
    libretroConfig.writeLibretroConfig(self, retroconfig, system, playersControllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend)
  File "/usr/lib/python3.11/site-packages/configgen/generators/libretro/libretroConfig.py", line 81, in writeLibretroConfig
    writeLibretroConfigToFile(retroconfig, createLibretroConfig(generator, system, controllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend))
                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/configgen/generators/libretro/libretroConfig.py", line 107, in createLibretroConfig
    libretroMAMEConfig.generateMAMEConfigs(controllers, system, rom, guns)
  File "/usr/lib/python3.11/site-packages/configgen/generators/libretro/libretroMAMEConfig.py", line 364, in generateMAMEConfigs
    commandArray += [ "-offscreen_reload" ]
    ^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'commandArray' where it is not associated with a value
```

this commit fixes the issue.