### PR TITLE
add support for MAME (standalone, lr-mame) BIOS files in bios/mame

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -49,6 +49,8 @@ Add support for the Rock 5c
   - Bind key C for player 1; V for player 2; B for player 3; N for player 4
 - Nvidia cards using the latest production driver now has cuda hardware accelerated playback enabled for ffmpeg & mpv
 - Wireguard VPN tools to setup your PC for Wireguard VPN access. See the wiki here: https://wiki.batocera.org/vpn_client
+- Support for standalone MAME (MAME) and libretro-MAME (lr-mame) BIOS files in bios/mame/ subfolder
+  - BIOS files in /userdata/bios/mame have precendence over /userdata/bios (per MAME -rompath behavior)
 ### Fixed
 - RG552 Splash-screen rotation
 - RG552 Vibrator enabled

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -71,7 +71,7 @@ def generateMAMEConfigs(playersControllers, system, rom, guns):
         else:
             commandLine += [ romDrivername ]
         commandLine += [ '-cfg_directory', cfgPath ]
-        commandLine += [ '-rompath', romDirname + ';/userdata/bios/' ]
+        commandLine += [ '-rompath', romDirname + ';/userdata/bios/mame/;/userdata/bios/' ]
         pluginsToLoad = []
         if not (system.isOptSet("hiscoreplugin") and system.getOptBoolean("hiscoreplugin") == False):
             pluginsToLoad += [ "hiscore" ]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -85,12 +85,12 @@ class MameGenerator(Generator):
         # A lot more options can be configured, just run mame -showusage and have a look
         commandArray += [ "-skip_gameinfo" ]
         if messMode == -1:
-            commandArray += [ "-rompath",      romDirname ]
+            commandArray += [ "-rompath",      romDirname + ";/userdata/bios/mame/;/userdata/bios/" ]
         else:
             if softList in subdirSoftList:
-                commandArray += [ "-rompath",      romDirname + ";/userdata/bios/;/userdata/roms/mame/;/var/run/mame_software/" ]
+                commandArray += [ "-rompath",      romDirname + ";/userdata/bios/mame/;/userdata/bios/;/userdata/roms/mame/;/var/run/mame_software/" ]
             else:
-                commandArray += [ "-rompath",      romDirname + ";/userdata/bios/;/userdata/roms/mame/" ]
+                commandArray += [ "-rompath",      romDirname + ";/userdata/bios/mame/;/userdata/bios/;/userdata/roms/mame/" ]
 
         # MAME various paths we can probably do better
         commandArray += [ "-bgfx_path",    "/usr/bin/mame/bgfx/" ]          # Core bgfx files can be left on ROM filesystem


### PR DESCRIPTION
Putting MAME BIOS files in `/userdata/bios/mame` is totally optional and available for those who wish to reduce the clutter in `roms/mame` and `/userdata/bios`

This commit only adds `/userdata/bios/mame` to the `-rompath` for **non-MESS** roms.