### PR TITLE
VPinballX: add option for multiaudio (backglass + ball)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballOptions.py
@@ -97,3 +97,14 @@ def configureOptions(vpinballSettings, system):
         vpinballSettings.set("Standalone", "AltSound", "0")
     else:
         vpinballSettings.set("Standalone", "AltSound","1")
+
+    # select which ID for sounddevices by running:
+    # /usr/bin/vpinball/VPinballX_GL -listsnd
+    if system.isOptSet("vpinball_sounddevice"):
+        vpinballSettings.set("Player", "SoundDevice", system.config["vpinball_sounddevice"])
+    else:
+        vpinballSettings.set("Player", "SoundDevice", "")
+    if system.isOptSet("vpinball_sounddevicebg"):
+        vpinballSettings.set("Player", "SoundDeviceBG", system.config["vpinball_sounddevicebg"])
+    else:
+        vpinballSettings.set("Player", "SoundDeviceBG", "")


### PR DESCRIPTION
UI might be tricky in ES with the current menu, and I must be the only one with multiple audio outputs in my Batocera pincab right now, so if you want to use it:
 - connect through SSH and run `/usr/bin/vpinball/VPinballX_GL -listsnd`
 - select from the list you get the `<id>`s you want for your table audio output (ball sounds) and the one for your backglass (music and sound effects).
 - add `vpinball.vpinball_sounddevice=<id>` (table) and  `vpinball.vpinball_sounddevicebg=<id>` (backglass) in your `batocera.conf`