### PR TITLE
coco autoload .dsk and .cas support

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -29,6 +29,11 @@ Support for Nvidia cards requiring the legacy 340.108 driver.
   - Thrustmaster T150RS
   - Thrustmaster T80 (gamepad mode only)
   - Driving Wheel SV200
+- Color Computer (coco) now autoloads cassettes and disks based on MAME software lists with default fallbacks
+  - uses "usage" info field in MAME software list
+  - .cas/.dsk default autoload behaviors (.bas in rom basename uses CLOAD/RUN)
+  - user overrides declarable in `system/configs/mame/autoload/coco_{cass,flop}_autoload.csv`
+- "Tandy Radio Shack Color Computer cassettes" softList added to coco Advanced Game Options
 ### Fixed
 - RG552 Splash-screen rotation
 - RG552 Vibrator enabled
@@ -46,6 +51,7 @@ Support for Nvidia cards requiring the legacy 340.108 driver.
 - Vulkan driver version via System Information whne using a multi-GPU systems was sometimes wrong
 - Fix SteamDeck LCD mono audio which snuck in with the v39 release.
 - ScummVM configuration file location & ensure native file system is turned off
+- Color Computer .dsk floppy images accepted in ES. "Disk" altRomType added in Advanced Game Options
 ### Changed
 - RK3326 Replaced the mali-G31 driver with mesa3d
 - Amiga BIOS files now go into the bios/amiga/ subfolder

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -506,7 +506,7 @@ class MameGenerator(Generator):
                     with openARFile:
                         autoRunList = csv.reader(openARFile, delimiter=';', quotechar="'")
                         for row in autoRunList:
-                            if row:
+                            if row and not row[0].startswith('#'):
                                 if row[0].casefold() == romName.casefold():
                                     autoRunCmd = row[1] + "\\n"
             else:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2966,6 +2966,7 @@ libretro:
                       description: Use MAME software lists to identify ROM
                       choices:
                           "Don't Use (Default)":                          none
+                          "Tandy Radio Shack Color Computer cassettes":   coco_cass
                           "Tandy Radio Shack Color Computer cartridges":  coco_cart
                           "Tandy Radio Shack Color Computer disk images": coco_flop
                   altmodel:
@@ -2982,8 +2983,9 @@ libretro:
                       prompt:      MEDIA TYPE
                       description: Type of ROM file to load.
                       choices:
-                          "Cassette":    cass
-                          "Cartridge":   cart
+                          "Cassette":       cass
+                          "Cartridge":      cart
+                          "Disk (Drive 1)": flop1
                   enableui:
                       group: ADVANCED OPTIONS
                       prompt:      UI KEYS
@@ -10146,6 +10148,7 @@ mame:
                     description: Use MAME software lists to identify ROM
                     choices:
                         "Don't Use (Default)":                          none
+                        "Tandy Radio Shack Color Computer cassettes":   coco_cass
                         "Tandy Radio Shack Color Computer cartridges":  coco_cart
                         "Tandy Radio Shack Color Computer disk images": coco_flop
                 altmodel:
@@ -10162,8 +10165,9 @@ mame:
                     prompt:      MEDIA TYPE
                     description: Type of ROM file to load.
                     choices:
-                        "Cassette":    cass
-                        "Cartridge":   cart
+                        "Cassette":       cass
+                        "Cartridge":      cart
+                        "Disk (Drive 1)": flop1
                 enableui:
                     group: ADVANCED OPTIONS
                     prompt:      UI KEYS

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3506,14 +3506,24 @@ coco:
   manufacturer: Tandy Radio Shack
   release: 1980
   hardware: computer
-  extensions: [wav, cas, ccc, rom, zip, 7z]
+  extensions: [wav, cas, dsk, ccc, rom, zip, 7z]
   emulators:
     libretro:
       mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
     mame:
       mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
   comment_en: |
-          Requires MAME BIOS file coco.zip
+          Requires MAME BIOS file coco.zip and coco3.zip
+
+          Default Autoload Behaviors
+          1. "usage" info field when using MAME software lists (if declared)
+          2. Cassette (.cas) files autoload as binary (CLOADM:EXEC)
+          3. Disk (.dsk) files autoload based on basename (eg. ZONX.dsk autoloads as LOADM “ZONX”:EXEC)
+          4. BASIC programs autorun if file basename ends with .bas
+              3a. ALPHAII.BAS.dsk autoloads using RUN “ALPHAII”
+              3b. GROVER.bas.cas  autoloads using CLOAD:RUN
+
+          user definable autoload overrides in: `system/configs/mame/autoload/coco_{cass,flop}_autoload.csv`
   comment_br: |
           Requer o arquivo coco.zip da BIOS do MAME
 

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3524,6 +3524,7 @@ coco:
               3b. GROVER.bas.cas  autoloads using CLOAD:RUN
 
           user definable autoload overrides in: `system/configs/mame/autoload/coco_{cass,flop}_autoload.csv`
+          syntax: <romBasename>;<autoload command> (see comments in .csv files for detailed help & examples)
   comment_br: |
           Requer o arquivo coco.zip da BIOS do MAME
 

--- a/package/batocera/emulators/mame/autoload/coco_cass_autoload.csv
+++ b/package/batocera/emulators/mame/autoload/coco_cass_autoload.csv
@@ -1,0 +1,13 @@
+# coco_cass autoload (mame -autoboot_command) override file
+#  https://github.com/batocera-linux/batocera.linux/pull/11706
+#
+# one rom override per line using ";" as delimiter:
+# <romBasename>;<autoload command override>
+#
+# it is *not* necessary to escape quotes or ampersands (&) (as required in MAME software list XML)
+#
+# example: coco/roms/Grover's Number Rover (CCW).cas
+# result:  loads BASIC (not binary) bootloader from cassette
+#
+# Grover's Number Rover (CCW);CLOAD:RUN
+

--- a/package/batocera/emulators/mame/autoload/coco_flop_autoload.csv
+++ b/package/batocera/emulators/mame/autoload/coco_flop_autoload.csv
@@ -1,0 +1,14 @@
+# coco_flop autoload (mame -autoboot_command) override file
+#  https://github.com/batocera-linux/batocera.linux/pull/11706
+#
+# one rom override per line using ";" as delimiter
+# <romBasename>;<autoload command override>
+#
+# it is *not* necessary to escape quotes or ampersands (&) (as required in MAME software list XML)
+#
+# example: coco/roms/Sam Sleuth.dsk
+# result:  loads & executes machine language in "SLUTHIGH" into high memory,
+#          then starts execution at address 0x073F after loading "SLUTHLOW" into low memory
+#
+# Sam Sleuth;LOADM "SLUTHIGH":EXEC:LOADM "SLUTHLOW":EXEC &H073F
+

--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -128,6 +128,8 @@ define MAME_BUILD_CMDS
 	TOOLS=1
 endef
 
+MAME_CONF_INIT = $(TARGET_DIR)/usr/share/batocera/datainit/system/configs/mame/
+
 define MAME_INSTALL_TARGET_CMDS
 	# Create specific directories on target to store MAME distro
 	mkdir -p $(TARGET_DIR)/usr/bin/mame/
@@ -200,6 +202,10 @@ define MAME_INSTALL_TARGET_CMDS
 	# gameStop script when exiting a rotated screen
 	mkdir -p $(TARGET_DIR)/usr/share/batocera/configgen/scripts
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/rotation_fix.sh $(TARGET_DIR)/usr/share/batocera/configgen/scripts/rotation_fix.sh
+
+	# Copy user -autoboot_command overrides (batocera.linux/batocera.linux#11706)
+	mkdir -p $(MAME_CONF_INIT)/autoload
+	cp -R $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/mame/autoload			$(MAME_CONF_INIT)
 endef
 
 define MAME_EVMAPY


### PR DESCRIPTION
Color Computer (coco) .cas and .dsk files previously did not autoload like other systems (eg. apple2)

Drivers coco & coco3 as of MAME v0.261 have support for .dsk:
```
[root@BATOCERA]# /usr/bin/mame/mame -listmedia coco
SYSTEM           MEDIA NAME       (brief)    IMAGE FILE EXTENSIONS SUPPORTED
---------------- --------------------------- -------------------------------
coco             floppydisk1      (flop1)    .mfi  .dfi  .hfe  .mfm  .td0  .imd  .d77  .d88  .1dd  .cqm  .cqi  .dsk  .dmk  .sdf  .jvc  .vdk  .os9  

[root@BATOCERA]# /usr/bin/mame/mame -listmedia coco3
SYSTEM           MEDIA NAME       (brief)    IMAGE FILE EXTENSIONS SUPPORTED
---------------- --------------------------- -------------------------------
coco3             floppydisk1      (flop1)    .mfi  .dfi  .hfe  .mfm  .td0  .imd  .d77  .d88  .1dd  .cqm  .cqi  .dsk  .dmk  .sdf  .jvc  .vdk  .os9  
```

### Commit Summary
1. allow ES to accept .dsk extension. Add “Disk” to coco altRomType choice 
2. add "Tandy Radio Shack Color Computer cassettes" to coco softList choice in Advanced Game Options (lr-mame, standalone MAME)
3. implement autoload behavior to use “usage” info in coco MAME software lists
4. implement autoload behavior for .cas and .dsk (.bas in rom basename uses CLOAD/RUN)
5. implement autoRunCmd override for cass and flop

### Default Autoload Behavior (top to bottom)
1. "usage" info field when using coco MAME software lists (if declared)
2. Cassette (.cas) files autoload as binary - verified and tested Zaxxon (Datasoft).cas, Zonx (The Rainbow).cas autoload using `CLOADM:EXEC` (F10 is useful to unthrottle and speed up loading :)
6. Disk (.dsk) files autoload based on basename (eg. ZONX.dsk autoloads as `LOADM “ZONX”:EXEC`)
7. BASIC programs autorun if file basename ends with .bas - examples:
4a. ALPHAII.BAS.dsk autoloads using `RUN “ALPHAII”`
4b. GROVER.bas.cas  autoloads using `CLOAD:RUN`
5. user defined override (section below)

### Example Autoload Behavior Found in MAME Software Lists
1. run menu on disks that are a collection of programs (eg. Rainbow on Disk (eg. [rbwd0288](https://github.com/batocera-linux/batocera.linux/blob/6cfa2ca2f041cc7cd9872b62547e54fb94a3792d/package/batocera/core/batocera-configgen/data/mame/coco_flop_autoload.csv#L2)) autoruns `RUN “MENU”`)
3. roms that require a series of commands to autoload (eg. [Sam Sleuth](https://github.com/batocera-linux/batocera.linux/blob/6cfa2ca2f041cc7cd9872b62547e54fb94a3792d/package/batocera/core/batocera-configgen/data/mame/coco_flop_autoload.csv#L1) autoruns `LOADM "SLUTHIGH":EXEC:LOADM "SLUTHLOW":EXEC &H073F` (as specified by developer)
4. cassettes (or disks) that have BASIC bootloaders (eg. [Grover’s Number Rover (CCW).cas](https://github.com/batocera-linux/batocera.linux/blob/6cfa2ca2f041cc7cd9872b62547e54fb94a3792d/package/batocera/core/batocera-configgen/data/mame/coco_cass_autoload.csv#L1) requires `CLOAD:RUN` prior bootloader loading 2nd binary segment on tape into memory)

NOTE: A software list in “Advanced Game Options” **must** be selected to enable ES to search for your rom (and usage info, if available). This is not the default (unless you have set a software list for Color Computer in “Per System Advanced Configuration”)

### User definable overrides
define autoload overrides in: `system/configs/mame/autoload/coco_{cass,flop}_autoload.csv` - examples:
1. run a single BASIC program (able to symlink`1988_02a.dsk` to [Castle of Death (The Rainbow)](https://github.com/batocera-linux/batocera.linux/blob/6cfa2ca2f041cc7cd9872b62547e54fb94a3792d/package/batocera/core/batocera-configgen/data/mame/coco_flop_autoload.csv#L3) and autorun `RUN “CASTLE”`)

blank lines and lines starting with `#` (comments) are skipped in override file.

please consider contributing your overrides (and declaring new software) in our [MAME software lists](https://github.com/mamedev/mame/tree/master/hash)

### Not Implemented
1. tapes that require loading on both sides - user must attach 2nd .cas in MAME File Manager and continue CLOADM (eg. Sam Sleuth (part {1,2}) (Computerware).cas)) (possible future m3u implementation) (.dsk exists so not a high priority)

Verified carts continue to boot (eg. Personal Finance: `finance2.zip`)

If any other coco users want to pitch in and test their coco libraries, this would be great but I think I’ve covered most cases.

Let me know if you have any questions!

### Complete List of Titles Verified to Autoload
1. Rainbow on Disk (Feb 1988) (softList:coco_flop, rbwd0288.zip)
2. Rainbow on Disk (Feb 1988) (1988_02a.dsk, bas, coco_flop override)
2a. Castle of Death (The Rainbow, Feb 1988) (symlink, Castle of Death (The Rainbow).dsk, bas, coco_flop override)
2b The Controllers (The Rainbow) (symlink, CONTROL.bas.dsk)
3. Rainbow on Tape (Apr 1986) (ROT8604a.dsk, bas, coco_flop override)
3a. Maze of Moycullen (symlink, MOYCULEN.BAS.dsk)
4. CoCo Zone (cocozone.dsk, bas, override) (softList:coco_flop, cocozone.zip)
5. Rescue on Alpha II (The Rainbow) (softList:coco_flop, ralpha2.zip)
6. Rainbow Book of Adventures (softList:coco_flop, rnbadv1.zip)
7. Rainbow Book of Adventures (RNBADV1{a,b}.dsk, bas, coco_flop override)
7a. Deed of the York (symlink, DEEDYORK.BAS.dsk)
7b. Dungeon Adventure (symlink, DUNGEON.BAS.dsk)
7c. Escape from Sparta (symlink, ESSPARTA.BAS.dsk)
7d. Head of the Beast (symlink, HEAD.BAS.dsk)
7e. Lighthouse Adventure (symlink, LIGHTADV.BAS.dsk)
7f. Search for the Ruby Chalice (symlink, RCHALICE.BAS.dsk)
7g. An Unexplored Mansion (symlink, UMANSION.BAS.dsk)
8. Sir Randolf of the Moors (SRANDOLF.dsk, bas)
9. Second Rainbow Book of Adventures (softList:coco_flop, rnbadv2.zip)
10. CoCo Max III (v3.1) (softList:coco_flop, ccmax31.zip)
11. Grover’s Number Rover (softList:coco_flop, grover.zip)
12. Grover’s Number Rover (cas/grover.zip, coco_cass override) { prep for softList: coco_cass }
13. JDOS v1.23 (ccc)
14. Lansford Mansion (softList:coco_flop, lansford.zip)
15. Personal Finance II (softList:coco_cart, finance2.zip)
16. Sam Sleuth (Computerware) (softList:coco_flop, ssleuth.zip)
17. Zaxxon (Datasoft) (cas, bin)
18. Zaxxon (Datasoft) (wav, bin)
19. Zaxxon (Datasoft) (cas/zaxxon.zip) { prep for softLlist: coco_cass }
20. Zaxxon (Datasoft) (softList:coco_flop, zaxxon.zip)
21. Zonx (The Rainbow) (cas, bin) 
22. Zonx (The Rainbow) (cas/zonx.zip, coco_cass override) { prep for softList: coco_cass }
23. Zonx (The Rainbow) (softList:coco_flop, zonx.zip)