### PR TITLE
wineGenerator: allow custom system name

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -13,8 +13,8 @@ class WineGenerator(Generator):
         if system.name == "windows_installers":
             commandArray = ["batocera-wine", "windows", "install", rom]
             return Command.Command(array=commandArray)
-        elif system.name == "windows":
-            commandArray = ["batocera-wine", "windows", "play", rom]
+        else:
+            commandArray = ["batocera-wine", system.name, "play", rom]
             
             environment = {}
             #system.language
@@ -51,7 +51,6 @@ class WineGenerator(Generator):
             
             return Command.Command(array=commandArray, env=environment)
         
-        raise Exception("invalid system " + system.name)
 
     def getMouseMode(self, config, rom):
         if "force_mouse" in config and config["force_mouse"] == "0":


### PR DESCRIPTION
Currently, we can't define customs system using wine emulator.

currently not working custom system example:
es_systems_newsystem.cfg
```
<?xml version="1.0" encoding="UTF-8"?>
<systemList>
  <system>
        <fullname>newsystem</fullname>
        <name>newsystem</name>
        <path>/userdata/roms/newsystem</path>
        <extension>.pc .exe .wine .wsquashfs .wtgz</extension>
        <command>emulatorlauncher %CONTROLLERSCONFIG% -system newsystem -emulator %EMULATOR% -core %CORE% -rom %ROM% -gameinfoxml %GAMEINFOXML% -systemname %SYSTEMNAME%</command>
        <emulators>
            <emulator name="wine">
                <cores>
                    <core default="true">ge-custom</core>
                </cores>
            </emulator>
        </emulators>
  </system>
</systemList>
```
The batocera-wine command already support differents system name. like:

batocera-wine windows play game.pc
batocera-wine newsystem play game.pc

Without this, if we have 2 differents game with same name, in 2 differents custom system, it'll clash prefix in /userdata/system/wine-bottles/windows/ge-custom/game.pc.wine