### PR TITLE
name the bluetooth adapter

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -56,6 +56,7 @@ Support for Nvidia cards requiring the legacy 340.108 driver.
 - Preferred vulkan driver name now listed in System Information
 - Start advisiong people on Vulkan GPU driver capabilities for Emualtors
 - Added additional Atari Lynx extensions for Beetle Lynx & Handy
+- Name the Bluetooth connection based on the host system hardware name.
 ### Updated
 - Retroarch to 1.18.0
 - Libretro cores for retroarch 1.17.0 [#11113](https://github.com/batocera-linux/batocera.linux/pull/11113/files)

--- a/package/batocera/core/batocera-bluetooth/S29namebluetooth
+++ b/package/batocera/core/batocera-bluetooth/S29namebluetooth
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MAIN_CONF_FILE="/etc/bluetooth/main.conf"
+
+# run this command to get the desired adapter name
+info_output=$(batocera-info | grep "Model:" | awk -F": " '{print $2}' | head -n 1)
+
+if [ -n "$info_output" ]; then
+    sed -i '/^\[General\]/a Name = '"$info_output" "$MAIN_CONF_FILE"
+
+    echo "Bluetooth adapter name has been set to: $info_output"
+else
+    # fallback to a default naming scheme
+    sed -i '/^\[General\]/a Name = %h-%d' "$MAIN_CONF_FILE"
+
+    echo "Falling back to hostname & adapter"
+fi

--- a/package/batocera/core/batocera-bluetooth/batocera-bluetooth.mk
+++ b/package/batocera/core/batocera-bluetooth/batocera-bluetooth.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_BLUETOOTH_VERSION = 2.1
+BATOCERA_BLUETOOTH_VERSION = 2.2
 BATOCERA_BLUETOOTH_LICENSE = GPL
 BATOCERA_BLUETOOTH_SOURCE=
 
@@ -22,8 +22,12 @@ endif
 
 define BATOCERA_BLUETOOTH_INSTALL_TARGET_CMDS
     mkdir -p $(TARGET_DIR)/etc/init.d/
-    cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-bluetooth/S32bluetooth.template $(TARGET_DIR)/etc/init.d/S32bluetooth
-    sed -i -e s+"@INTERNAL_BLUETOOTH_STACK@"+"$(BATOCERA_BLUETOOTH_STACK)"+ $(TARGET_DIR)/etc/init.d/S32bluetooth
+    cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-bluetooth/S29namebluetooth \
+        $(TARGET_DIR)/etc/init.d/S29namebluetooth
+    cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-bluetooth/S32bluetooth.template \
+        $(TARGET_DIR)/etc/init.d/S32bluetooth
+    sed -i -e s+"@INTERNAL_BLUETOOTH_STACK@"+"$(BATOCERA_BLUETOOTH_STACK)"+ \
+        $(TARGET_DIR)/etc/init.d/S32bluetooth
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
- prevents multiple devices sharing the same generic Bluez name
- improves discovery / identification in 3rd-party apps