### PR TITLE
fix: fix right stick on steam deck

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -3576,8 +3576,8 @@
 		<input name="hotkey" type="button" id="11" value="1" code="314" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-		<input name="joystick2left" type="axis" id="2" value="-1" code="3" />
-		<input name="joystick2up" type="axis" id="3" value="-1" code="4" />
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
 		<input name="l2" type="axis" id="2" value="1" code="2" />
 		<input name="left" type="button" id="18" value="1" code="546" />
 		<input name="pagedown" type="button" id="8" value="1" code="311" />


### PR DESCRIPTION
Previously my steam deck right stick would just rotate the camera on its own.  Tested this with `sdl2-jstest --test 0` command and saw that this would fix the proper defaults.  I only changed the config on this deviceGUID (wasn't sure if this was mine or the other one), but this worked for me.

I'm running Batocera v39 on the 256 GB Steam Deck LCD (first iteration).