### PR TITLE
[WIP] psvita.vita3k_prefpath option to reduce /userdata/saves bloat

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
@@ -19,6 +19,10 @@ class Vita3kGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
         
+        # Fetch user-defined prefpath if it exists
+        if system.isOptSet("vita3k_prefpath"):
+            vitaConfig = system.config["vita3k_prefpath"]
+
         # Create config folder
         if not path.isdir(vitaConfig):
             os.mkdir(vitaConfig)
@@ -30,13 +34,14 @@ class Vita3kGenerator(Generator):
             os.mkdir(vitaSaves)
         
         # Move saves if necessary
-        if os.path.isdir(os.path.join(vitaConfig, 'ux0')):
-            # Move all folders from vitaConfig to vitaSaves except "data", "lang", and "shaders-builtin"
-            for item in os.listdir(vitaConfig):
-                if item not in ['data', 'lang', 'shaders-builtin']:
-                    item_path = os.path.join(vitaConfig, item)
-                    if os.path.isdir(item_path):
-                        shutil.move(item_path, vitaSaves)
+        if vitaSaves == vitaConfig:
+            if os.path.isdir(os.path.join(vitaConfig, 'ux0')):
+                # Move all folders from vitaConfig to vitaSaves except "data", "lang", and "shaders-builtin"
+                for item in os.listdir(vitaConfig):
+                    if item not in ['data', 'lang', 'shaders-builtin']:
+                        item_path = os.path.join(vitaConfig, item)
+                        if os.path.isdir(item_path):
+                            shutil.move(item_path, vitaSaves)
         
         # Create the config.yml file if it doesn't exist
         vita3kymlconfig = {}
@@ -48,7 +53,7 @@ class Vita3kGenerator(Generator):
             vita3kymlconfig = {}
         
         # ensure the correct path is set
-        vita3kymlconfig["pref-path"] = vitaSaves
+        vita3kymlconfig["pref-path"] = vitaConfig
 
         # Set the renderer
         if system.isOptSet("vita3k_gfxbackend"):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vita3k/vita3kGenerator.py
@@ -21,20 +21,16 @@ class Vita3kGenerator(Generator):
         
         # Fetch user-defined prefpath if it exists
         if system.isOptSet("vita3k_prefpath"):
-            vitaConfig = system.config["vita3k_prefpath"]
-
-        # Create config folder
-        if not path.isdir(vitaConfig):
-            os.mkdir(vitaConfig)
-            # copy /usr/bin/vita3k contents here
-            copy_tree("/usr/bin/vita3k", vitaConfig)
+            vitaPrefPath = system.config["vita3k_prefpath"]
+        else:
+            vitaPrefPath = vitaSaves
 
         # Create save folder
         if not path.isdir(vitaSaves):
             os.mkdir(vitaSaves)
         
-        # Move saves if necessary
-        if vitaSaves == vitaConfig:
+        if vitaPrefPath == vitaSaves:
+            # Move saves if necessary
             if os.path.isdir(os.path.join(vitaConfig, 'ux0')):
                 # Move all folders from vitaConfig to vitaSaves except "data", "lang", and "shaders-builtin"
                 for item in os.listdir(vitaConfig):
@@ -42,6 +38,9 @@ class Vita3kGenerator(Generator):
                         item_path = os.path.join(vitaConfig, item)
                         if os.path.isdir(item_path):
                             shutil.move(item_path, vitaSaves)
+            xdgData = batoceraFiles.SAVES
+        else:
+            xdgData = batoceraFiles.CONF
         
         # Create the config.yml file if it doesn't exist
         vita3kymlconfig = {}
@@ -53,11 +52,13 @@ class Vita3kGenerator(Generator):
             vita3kymlconfig = {}
         
         # ensure the correct path is set
-        vita3kymlconfig["pref-path"] = vitaConfig
+        vita3kymlconfig["pref-path"] = vitaPrefPath
 
         # Set the renderer
         if system.isOptSet("vita3k_gfxbackend"):
-            vita3kymlconfig["backend-renderer"] = system.config["vita3k_gfxbackend"]
+            # disabled until vulkan fixed upstream
+            #vita3kymlconfig["backend-renderer"] = system.config["vita3k_gfxbackend"]
+            vita3kymlconfig["backend-renderer"] = "OpenGL" # use opengl manually for now
         else:
             vita3kymlconfig["backend-renderer"] = "OpenGL"
         # Set the resolution multiplier
@@ -66,13 +67,13 @@ class Vita3kGenerator(Generator):
         else:
             vita3kymlconfig["resolution-multiplier"] = 1
         # Set FXAA
-        if system.isOptSet("vita3k_fxaa"):
-            vita3kymlconfig["enable-fxaa"] = system.config["vita3k_fxaa"]
+        if system.isOptSet("vita3k_fxaa") and system.getOptBoolean("vita3k_surface") == True:
+            vita3kymlconfig["enable-fxaa"] = "true"
         else:
             vita3kymlconfig["enable-fxaa"] = "false"
         # Set VSync
-        if system.isOptSet("vita3k_vsync"):
-            vita3kymlconfig["v-sync"] = system.config["vita3k_vsync"]
+        if system.isOptSet("vita3k_vsync") and system.getOptBoolean("vita3k_surface") == False:
+            vita3kymlconfig["v-sync"] = "false"
         else:
             vita3kymlconfig["v-sync"] = "true"
         # Set the anisotropic filtering
@@ -81,15 +82,15 @@ class Vita3kGenerator(Generator):
         else:
             vita3kymlconfig["anisotropic-filtering"] = 1
         # Set the linear filtering option
-        if system.isOptSet("vita3k_linear"):
-            vita3kymlconfig["enable-linear-filter"] = int(system.config["vita3k_linear"])
+        if system.isOptSet("vita3k_linear") and system.getOptBoolean("vita3k_surface") == True:
+            vita3kymlconfig["enable-linear-filter"] = "true"
         else:
             vita3kymlconfig["enable-linear-filter"] = "false"
         # Surface Sync
-        if system.isOptSet("vita3k_surface"):
-            vita3kymlconfig["disable-surface-sync"] = int(system.config["vita3k_surface"])
+        if system.isOptSet("vita3k_surface") and system.getOptBoolean("vita3k_surface") == False:
+            vita3kymlconfig["disable-surface-sync"] = "false"
         else:
-            vita3kymlconfig["enable-linear-filter"] = "true"
+            vita3kymlconfig["disable-surface-sync"] = "true"
         
         # Vita3k is fussy over its yml file
         # We try to match it as close as possible, but the 'vectors' cause yml formatting issues
@@ -104,18 +105,33 @@ class Vita3kGenerator(Generator):
         # Simplify the rom name (strip the directory & extension)
         begin, end = rom.find('['), rom.rfind(']')
         smplromname = rom[begin+1: end]
-        # becuase of the yml formatting, we don't allow Vita3k to modify it
-        # using the -w & -f options prevents Vuta3k from re-writing & prompting the user in GUI
-        # we wwant to avoid that so roms load staright away
-        commandArray = ["/usr/bin/vita3k/Vita3K", "-F", "-w", "-f", "-c", vitaConfigFile, "-r", smplromname]
+        # because of the yml formatting, we don't allow Vita3k to modify it
+        # using the -w & -f options prevents Vita3k from re-writing & prompting the user in GUI
+        # we want to avoid that so roms load straight away
+        if path.isdir(vitaPrefPath + '/ux0/app/' + smplromname):
+            commandArray = ["/usr/bin/vita3k/Vita3K", "-F", "-w", "-f", "-c", vitaConfigFile, "-r", smplromname]
+        else:
+            # Game not installed yet, let's open the menu
+            commandArray = ["/usr/bin/vita3k/Vita3K", "-F", "-w", "-f", "-c", vitaConfigFile, rom]
 
         return Command.Command(
             array=commandArray,
             env={
-                'SDL_GAMECONTROLLERCONFIG': controllersConfig.generateSdlGameControllerConfig(playersControllers)
+                "SDL_GAMECONTROLLERCONFIG": controllersConfig.generateSdlGameControllerConfig(playersControllers),
+                "SDL_JOYSTICK_HIDAPI": "0",
+                "XDG_CONFIG_HOME": batoceraFiles.CONF,
+                "XDG_DATA_HOME": xdgData,
+                "XDG_CACHE_HOME": batoceraFiles.CACHE,
+                "XDG_DATA_DIRS": xdgData
             }
         )
     
     # Show mouse for touchscreen actions
     def getMouseMode(self, config, rom):
-        return True
+        if "vita3k_show_pointer" in config and config["vita3k_show_pointer"] == "0":
+             return False
+        else:
+             return True
+
+    def getInGameRatio(self, config, gameResolution, rom):
+        return 16/9

--- a/package/batocera/core/batocera-desktopapps/scripts/batocera-config-vita3k
+++ b/package/batocera/core/batocera-desktopapps/scripts/batocera-config-vita3k
@@ -5,22 +5,17 @@ then
     export DISPLAY=:0.0
 fi
 
+# $$ is this globally defined somewhere else?
 CFGDIR=/userdata/system/configs/vita3k
-CFGFILE=$CFGDIR/config.yml
 
-# check the config folder exosts, if not create it & copy files
-if [[ ! -e $CFGDIR ]]
-then
-    mkdir $CFGDIR
-    cp -R /usr/bin/vita3k/* $CFGDIR
-fi
+# $$ how to create a conditional for those who opt into moving app install data in /userdata/saves ?
+XDGDATA=$CFGDIR
+#XDGDATA=/userdata/saves
 
-# check a config files exists, if not make one
-if [[ ! -f $CFGFILE ]]
-then
-    mkdir -p $CFGDIR
-    touch $CFGFILE
-fi
-
+# set the environment variables
+XDG_CONFIG_HOME=$CFGDIR \
+XDG_CACHE_HOME=/userdata/system/cache \
+XDG_DATA_HOME=$XDGDATA \
+XDG_DATA_DIRS=$XDGDATA \
 # now run the emulator
-/usr/bin/vita3k/Vita3K -c $CFGFILE
+/usr/bin/vita3k/Vita3K -F

--- a/package/batocera/core/batocera-desktopapps/scripts/batocera-config-vita3k
+++ b/package/batocera/core/batocera-desktopapps/scripts/batocera-config-vita3k
@@ -8,6 +8,13 @@ fi
 # $$ is this globally defined somewhere else?
 CFGDIR=/userdata/system/configs/vita3k
 
+# check the config folder exists, if not create it & copy files
+if [[ ! -e $CFGDIR ]]
+then
+    mkdir $CFGDIR
+    cp -R /usr/bin/vita3k/* $CFGDIR
+fi
+
 # $$ how to create a conditional for those who opt into moving app install data in /userdata/saves ?
 XDGDATA=$CFGDIR
 #XDGDATA=/userdata/saves


### PR DESCRIPTION
Moving vita3k config to `/userdata/saves/vita3k` causes significant bloat by moving all app installation data (`ux0/app`), firmware (`os0`,`vs0`), and fonts (`sa0`) to `/userdata/saves` (#11517)

This commit implements an option in `batocera.conf` to specify and ability to restore the previous path:
```
psvita.vita3k_prefpath=/userdata/system/configs/vita3k
```
Alternatively (not yet implemented), this could be a Boolean to keep only two locations (`system/configs` or `saves/psvita`):
```
psvita.vita3k_system_prefpath=True
```
Due to hardcoded references to `saves`, I’ve merged commits 1941bd7, 47e2e5e, and 067b9de and verified Velocity Ultra boots in `40-dev-9a61198db7 2024/05/27 01:56` with files remaining under `/userdata/system/configs/vita3k`

I could use support in how to query `batocera.conf` options from bash to implement a conditional in `batocera-config-vita3k` so `XDG_DATA_HOME` and `XDG_DATA_DIRS` get assigned the correct path.

for the record: CFGDIR appears to be an undefined variable in `batocera-config-vita3k` (fixed)

This is a currently a work-in-progress and up for discussion as I would like to know what the main drive to move the config folder to `/userdata/saves` as I believe `ux0/user` (savedata and trophies) should be the only directory in `/userdata/saves/psvita`.