### PR TITLE
reorganize-es-settings-dolphin

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -84,25 +84,25 @@ class DolphinGenerator(Generator):
         dolphinSettings.remove_option("Display", "Fullscreen")
 
         # Enable Cheats
-        if system.isOptSet("enable_cheats") and system.getOptBoolean("enable_cheats"):
+        if system.isOptSet("enable_cheats") and system.getOptBoolean("enable_cheats") == True:
             dolphinSettings.set("Core", "EnableCheats", "True")
         else:
             dolphinSettings.set("Core", "EnableCheats", "False")
 
         # Speed up disc transfer rate
-        if system.isOptSet("enable_fastdisc") and system.getOptBoolean("enable_fastdisc"):
+        if system.isOptSet("enable_fastdisc") and system.getOptBoolean("enable_fastdisc") == True:
             dolphinSettings.set("Core", "FastDiscSpeed", "True")
         else:
             dolphinSettings.set("Core", "FastDiscSpeed", "False")
 
         # Dual Core
-        if system.isOptSet("dual_core") and system.getOptBoolean("dual_core"):
+        if system.isOptSet("dual_core") and system.getOptBoolean("dual_core") == True:
             dolphinSettings.set("Core", "CPUThread", "True")
         else:
             dolphinSettings.set("Core", "CPUThread", "False")
 
         # Gpu Sync
-        if system.isOptSet("gpu_sync") and system.getOptBoolean("gpu_sync"):
+        if system.isOptSet("gpu_sync") and system.getOptBoolean("gpu_sync") == True:
             dolphinSettings.set("Core", "SyncGPU", "True")
         else:
             dolphinSettings.set("Core", "SyncGPU", "False")
@@ -114,7 +114,7 @@ class DolphinGenerator(Generator):
             dolphinSettings.set("Core", "SelectedLanguage", str(getGameCubeLangFromEnvironment()))
 
         # Enable MMU
-        if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu"):
+        if system.isOptSet("enable_mmu") and system.getOptBoolean("enable_mmu") == True:
             dolphinSettings.set("Core", "MMU", "True")
         else:
             dolphinSettings.set("Core", "MMU", "False")
@@ -163,7 +163,7 @@ class DolphinGenerator(Generator):
         dolphinSettings.set("Core", "AutoDiscChange", "True")
 
         # Skip Menu
-        if system.isOptSet("dolphin_SkipIPL") and system.getOptBoolean("dolphin_SkipIPL"):
+        if system.isOptSet("dolphin_SkipIPL") and system.getOptBoolean("dolphin_SkipIPL") == True:
             # check files exist to avoid crashes
             ipl_regions = ["USA", "EUR", "JAP"]
             base_path = "/userdata/bios/GC"
@@ -178,7 +178,8 @@ class DolphinGenerator(Generator):
         dolphinSettings.set("DSP", "Backend", "Cubeb")
         
         # Dolby Pro Logic II for surround sound
-        if system.isOptSet("dplii") and system.getOptBoolean("dplii"):
+        # DPL II requires DSPHLE to be disabled
+        if system.isOptSet("dplii") and system.getOptBoolean("dplii") == True:
             dolphinSettings.set("Core", "DPL2Decoder", "True")
             dolphinSettings.set("Core", "DSPHLE", "False")
             dolphinSettings.set("DSP", "EnableJIT", "True")
@@ -246,7 +247,7 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "ShowFPS", "False")
 
         # HiResTextures
-        if system.isOptSet('hires_textures') and system.getOptBoolean('hires_textures'):
+        if system.isOptSet('hires_textures') and system.getOptBoolean('hires_textures') == True:
             dolphinGFXSettings.set("Settings", "HiresTextures",      "True")
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
         else:
@@ -260,9 +261,9 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "CacheHiresTextures", "True")
 
         # Widescreen Hack
-        if system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack'):
+        if system.isOptSet('widescreen_hack') and system.getOptBoolean('widescreen_hack') == True:
             # Prefer Cheats than Hack
-            if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats'):
+            if system.isOptSet('enable_cheats') and system.getOptBoolean('enable_cheats') == True:
                 dolphinGFXSettings.set("Settings", "wideScreenHack", "False")
             else:
                 dolphinGFXSettings.set("Settings", "wideScreenHack", "True")
@@ -276,13 +277,13 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "ShaderCompilationMode", "0")
 
         # Shader pre-caching
-        if system.isOptSet('wait_for_shaders') and system.getOptBoolean('wait_for_shaders'):
+        if system.isOptSet('wait_for_shaders') and system.getOptBoolean('wait_for_shaders') == True:
             dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", "True")
         else:
             dolphinGFXSettings.set("Settings", "WaitForShadersBeforeStarting", "False")
 
         # Various performance hacks - Default Off
-        if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks'):
+        if system.isOptSet('perf_hacks') and system.getOptBoolean('perf_hacks') == True:
             dolphinGFXSettings.set("Hacks", "BBoxEnable", "False")
             dolphinGFXSettings.set("Hacks", "DeferEFBCopies", "True")
             dolphinGFXSettings.set("Hacks", "EFBEmulateFormatChanges", "False")
@@ -309,7 +310,7 @@ class DolphinGenerator(Generator):
                 dolphinGFXSettings.remove_option("Enhancements", "DisableCopyFilter")
                 dolphinGFXSettings.remove_option("Enhancements", "ForceTrueColor")
         
-        if system.isOptSet('vbi_hack'):
+        if system.isOptSet('vbi_hack') and system.getOptBoolean("vbi_hack") == True:
             dolphinGFXSettings.set("Hacks", "VISkip", system.config["vbi_hack"])
         else:
             dolphinGFXSettings.set("Hacks", "VISkip", "False")
@@ -321,10 +322,10 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "InternalResolution", "1")
 
         # VSync
-        if system.isOptSet('vsync'):
-            dolphinGFXSettings.set("Hardware", "VSync", str(system.getOptBoolean('vsync')))
-        else:
+        if system.isOptSet('vsync') and system.getOptBoolean("vsync") == True:
             dolphinGFXSettings.set("Hardware", "VSync", "True")
+        else:
+            dolphinGFXSettings.set("Hardware", "VSync", "False")
 
         # Anisotropic filtering
         if system.isOptSet('anisotropic_filtering'):
@@ -339,16 +340,16 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "MSAA", "0")
 
         # Anti aliasing mode
-        if system.isOptSet('use_ssaa') and system.getOptBoolean('use_ssaa'):
+        if system.isOptSet('use_ssaa') and system.getOptBoolean('use_ssaa') == True:
             dolphinGFXSettings.set("Settings", "SSAA", "True")
         else:
             dolphinGFXSettings.set("Settings", "SSAA", "False")
         
         # Manual texture sampling
-        if system.isOptSet('manual_texture_sampling') and system.getOptBoolean('manual_texture_sampling'):
-            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "False")
+        if system.isOptSet('manual_texture_sampling') and system.getOptBoolean('manual_texture_sampling') == True:
+            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "True")
         else:
-            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "True")        
+            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "False")        
 
         # Save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -224,21 +224,26 @@ shared:
         "On": 1
         "Off": 0
     use_guns:
-      group: LIGHT GUN
+      order: 99
+      group: CONTROLS
+      submenu: LIGHT GUNS
       prompt: USE LIGHT GUNS
       description: Use light guns instead of pads if light guns are connected.
       choices:
         "On":  1
         "Off": 0
     use_wheels:
-      group: WHEELS
+      order: 100
+      group: CONTROLS
+      submenu: WHEELS
       prompt: USE WHEELS
       description: Use wheels instead of pads if wheels are connected.
       choices:
         "On":  1
         "Off": 0
     wheel_rotation:
-      group: WHEELS
+      group: CONTROLS
+      submenu: WHEELS
       prompt: WHEEL ROTATION
       description: Maximum wheel rotation from left to right (in degrees)
       choices:
@@ -252,7 +257,8 @@ shared:
         "900": 900
         "1080": 1080
     wheel_deadzone:
-      group: WHEELS
+      group: CONTROLS
+      submenu: WHEELS
       prompt: WHEEL DEADZONE
       description: Zone for which the game doesn't react to the wheel (in degrees)
       choices:
@@ -267,7 +273,8 @@ shared:
         "45": 45
         "50": 50
     wheel_midzone:
-      group: WHEELS
+      group: CONTROLS
+      submenu: WHEELS
       prompt: WHEEL MIDZONE
       description: Reserve a non dead zone at the center of the wheel to go straight ahead (in degrees)
       choices:
@@ -7153,6 +7160,11 @@ dolphin:
                 "Force 16:9":        1
                 "Force 4:3":         2
                 "Stretch to window": 3
+        vsync:
+            submenu: DISPLAY
+            prompt: VSYNC
+            description: Fix screen tearing. CPU heavy.
+            preset: switchon       
         gfxbackend:
             archs_include: [x86, x86_64, bcm2711, bcm2712]
             submenu: RENDERING
@@ -7187,25 +7199,88 @@ dolphin:
             submenu: RENDERING
             prompt: PRE-CACHE SHADERS
             description: Compile shaders on next launch of game (one time). Reduces micro-freezes.
+            preset: switchoff
+        anisotropic_filtering:
+            submenu: RENDERING
+            prompt: ANISOTROPIC FILTERING
+            description: Improves clarity of distant textures.
             choices:
-                "Off (default)": 0
-                "On":            1
+                "Off": 0
+                "2x":  1
+                "4x":  2
+                "8x":  3
+                "16x": 4
+        antialiasing:
+            submenu: RENDERING
+            prompt: ANTI-ALIASING
+            description: Enhancement. Smooth out jagged edges on 3D object polygons.
+            choices:
+                "Off": 0
+                "2x":  2
+                "4x":  4
+                "8x":  8
+        use_ssaa:
+            submenu: RENDERING
+            prompt: ANTI-ALIASING MODE
+            description: Use SSAA instead of MSAA for anti-aliasing. SSAA may look better but has a higher performance cost.
+            preset: switchoff
+        hires_textures:
+            submenu: RENDERING
+            prompt: LOAD CUSTOM TEXTURES
+            preset: switchoff
+        manual_texture_sampling:
+            submenu: RENDERING
+            prompt: MANUAL TEXTURE SAMPLING
+            description: Enabling will allow for correct emulation of texture wrapping. This comes at a cost of potential worse performance.
+            preset: switchoff           
+        dual_core:
+            submenu: EMULATION
+            prompt: DUAL CORE MODE
+            description: Usually not much faster than single core mode.
+            preset: switchoff
+        gpu_sync:
+            submenu: EMULATION
+            prompt: GPU SYNC
+            description: Speed hack for dual core mode to fix some glitches.
+            preset: switchoff
         perf_hacks:
-            group: ADVANCED OPTIONS
+            submenu: EMULATION
             prompt: PERFORMANCE HACKS
             description: Increase emulator performance, at the cost of accuracy/stability.
-            choices:
-                "Off": 0
-                "On":  1
+            preset: switchoff             
+        enable_cheats:
+            submenu: EMULATION
+            prompt: ENABLE CHEATS
+            description: To use game cheats or 16/9 Aspect Ratio Fix codes.
+            preset: switchoff
+        enable_mmu:
+            submenu: EMULATION
+            prompt: MEMORY MANAGEMENT UNIT
+            description: Required by some games.
+            preset: switchoff
+        enable_fastdisc:
+            submenu: EMULATION
+            prompt: FAST DISK TRANSFER RATE
+            description: Enhancement. Removes disc loading.
+            preset: switchoff             
+        vbi_hack:
+            submenu: EMULATION
+            prompt: VBI SKIP
+            description: Skips Vertical Blank Interrupts when lag is detected, allowing for smooth audio playback when emulation speed is not 100%.
+            preset: switchoff      
         use_pad_profiles:
-            group: ADVANCED OPTIONS
+            group: CONTROLS
             prompt: USE PAD PROFILES
             description: Search for custom configured joystick profiles.
-            choices:
-                "Off": 0
-                "On":  1
+            preset: switchoff
+        rumble:
+            group: CONTROLS
+            prompt: RUMBLE
+            description: Enable controller rumble capabilities if supported by the controller.
+            preset: switchon       
         dolphin_port_1_type:
-            submenu: CONTROLLER 1
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 1
             prompt: GAMECUBE PORT 1 TYPE
             description: Change what's plugged into the virtual GameCube ports.
             choices:
@@ -7219,7 +7294,8 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_2_type:
-            submenu: CONTROLLER 2
+           group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 2
             prompt: GAMECUBE PORT 2 TYPE
             description: Change what's plugged into the virtual GameCube ports.
             choices:
@@ -7233,7 +7309,8 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_3_type:
-            submenu: CONTROLLER 3
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 3
             prompt: GAMECUBE PORT 3 TYPE
             description: Change what's plugged into the virtual GameCube ports.
             choices:
@@ -7247,7 +7324,8 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         dolphin_port_4_type:
-            submenu: CONTROLLER 4
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 4
             prompt: GAMECUBE PORT 4 TYPE
             description: Change what's plugged into the virtual GameCube ports.
             choices:
@@ -7261,130 +7339,40 @@ dolphin:
                 #"GBA (TCP)":                  5
                 "Keyboard":                   7
         alt_mappings_1:
-            submenu: CONTROLLER 1
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 1
             prompt: ALT INPUT MAPPING
             description: Use alternative input mappings. Only applies to Standard Controller type.
             choices:
                 "Face Buttons (CW)":         buttons_cw
                 "Face Buttons (CCW)":        buttons_ccw
         alt_mappings_2:
-            submenu: CONTROLLER 2
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 2
             prompt: ALT INPUT MAPPING
             description: Use alternative input mappings. Only applies to Standard Controller type.
             choices:
                 "Face Buttons (CW)":         buttons_cw
                 "Face Buttons (CCW)":        buttons_ccw
         alt_mappings_3:
-            submenu: CONTROLLER 3
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 3
             prompt: ALT INPUT MAPPING
             description: Use alternative input mappings. Only applies to Standard Controller type.
             choices:
                 "Face Buttons (CW)":         buttons_cw
                 "Face Buttons (CCW)":        buttons_ccw
         alt_mappings_4:
-            submenu: CONTROLLER 4
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 4
             prompt: ALT INPUT MAPPING
             description: Use alternative input mappings. Only applies to Standard Controller type.
             choices:
                 "Face Buttons (CW)":         buttons_cw
                 "Face Buttons (CCW)":        buttons_ccw
-        anisotropic_filtering:
-            submenu: RENDERING
-            prompt: ANISOTROPIC FILTERING
-            description: Improves clarity of distant textures.
-            choices:
-                "Off": 0
-                "2x":  1
-                "4x":  2
-                "8x":  3
-                "16x": 4
-        dual_core:
-            group: ADVANCED OPTIONS
-            prompt: DUAL CORE MODE
-            description: Usually not much faster than single core mode.
-            choices:
-                "Off": 0
-                "On":  1
-        gpu_sync:
-            group: ADVANCED OPTIONS
-            prompt: GPU SYNC
-            description: Speed hack for dual core mode to fix some glitches.
-            choices:
-                "Off": 0
-                "On":  1
-        antialiasing:
-            submenu: RENDERING
-            prompt: ANTI-ALIASING
-            description: Enhancement. Smooth out jagged edges on 3D object polygons.
-            choices:
-                "Off": 0
-                "2x":  2
-                "4x":  4
-                "8x":  8
-        use_ssaa:
-            submenu: RENDERING
-            prompt: ANTI-ALIASING MODE
-            description: Toggle MSAA/SSAA. Depends on anti-aliasing being enabled.
-            choices:
-                "MSAA (default)": 0
-                "SSAA":           1
-        hires_textures:
-            submenu: RENDERING
-            prompt: LOAD CUSTOM TEXTURES
-            choices:
-                "Off": 0
-                "On":  1
-        manual_texture_sampling:
-            submenu: RENDERING
-            prompt: MANUAL TEXTURE SAMPLING
-            description: Enabling will allow for correct emulation of texture wrapping. This comes at a cost of potential worse performance.
-            choices:
-                "Off": 0
-                "On":  1
-        enable_cheats:
-            group: ADVANCED OPTIONS
-            prompt: ENABLE CHEATS
-            description: To use game cheats or 16/9 Aspect Ratio Fix codes.
-            choices:
-                "Off": 0
-                "On":  1
-        enable_mmu:
-            group: ADVANCED OPTIONS
-            prompt: MEMORY MANAGEMENT UNIT
-            description: Required by some games.
-            choices:
-                "Off": 0
-                "On":  1
-        enable_fastdisc:
-            group: ADVANCED OPTIONS
-            prompt: FAST DISK TRANSFER RATE
-            description: Enhancement. Removes disc loading.
-            choices:
-                "Off": 0
-                "On":  1
-        vsync:
-            submenu: DISPLAY
-            prompt: VSYNC
-            description: Fix screen tearing. CPU heavy.
-            choices:
-                "Off": 0
-                "On":  1
-        ShowDpMsg:
-            submenu: DISPLAY
-            prompt: SHOW ON-SCREEN DISPLAY MESSAGES
-            description: Show on screen display messages (memory card saves..).
-            choices:
-                "Off": 0
-                "On":  1
-        vbi_hack:
-            group: ADVANCED OPTIONS
-            prompt: VBI SKIP
-            description: Skips Vertical Blank Interrupts when lag is detected, allowing for smooth audio playback when emulation speed is not 100%.
-            choices:
-                "Off": "False"
-                "On":  "True"
         deadzone_1:
-            submenu: CONTROLLER 1
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 1
             prompt: DEADZONE
             description: Set joystick deadzone.
             choices:
@@ -7396,7 +7384,8 @@ dolphin:
                 "25%":           25.0
                 "30%":           30.0
         deadzone_2:
-            submenu: CONTROLLER 2
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 2
             prompt: DEADZONE
             description: Set joystick deadzone.
             choices:
@@ -7408,7 +7397,8 @@ dolphin:
                 "25%":           25.0
                 "30%":           30.0
         deadzone_3:
-            submenu: CONTROLLER 3
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 3
             prompt: DEADZONE
             description: Set joystick deadzone.
             choices:
@@ -7420,7 +7410,8 @@ dolphin:
                 "25%":           25.0
                 "30%":           30.0
         deadzone_4:
-            submenu: CONTROLLER 4
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 4
             prompt: DEADZONE
             description: Set joystick deadzone.
             choices:
@@ -7432,7 +7423,8 @@ dolphin:
                 "25%":           25.0
                 "30%":           30.0
         jsgate_size_1:
-            submenu: CONTROLLER 1
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 1
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
@@ -7440,7 +7432,8 @@ dolphin:
                 "Normal (Default)": normal
                 "Larger":           larger
         jsgate_size_2:
-            submenu: CONTROLLER 2
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 2
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
@@ -7448,7 +7441,8 @@ dolphin:
                 "Normal (Default)": normal
                 "Larger":           larger
         jsgate_size_3:
-            submenu: CONTROLLER 3
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 3
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
@@ -7456,20 +7450,24 @@ dolphin:
                 "Normal (Default)": normal
                 "Larger":           larger
         jsgate_size_4:
-            submenu: CONTROLLER 4
+            group: CONTROLS
+            submenu: GAMECUBE CONTROLLER 4
             prompt: JOYSTICK GATE SIZE
             description: Set virtual joysticks gate size. Smaller increases sensitivity. Larger decreases it.
             choices:
                 "Smaller":          smaller
                 "Normal (Default)": normal
-                "Larger":           larger
+                "Larger":           larger                             
         dplii:
-            group: ADVANCED OPTIONS
+            submenu: AUDIO
             prompt: DOLBY PRO LOGIC II
             description: Enables Dolby Pro Logic II for surround sound. May impact performance.
-            choices:
-                "Off": 0
-                "On":  1
+            preset: switchoff
+        ShowDpMsg:
+            submenu: UI
+            prompt: SHOW ON-SCREEN DISPLAY MESSAGES
+            description: Show on screen display messages (memory card saves..).
+            preset: switchon              
   systems:
     gamecube:
         cfeatures:
@@ -7477,18 +7475,14 @@ dolphin:
                 submenu: DISPLAY
                 prompt: WIDESCREEN HACK (GLITCHY)
                 description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
             dolphin_SkipIPL:
-                group: ADVANCED OPTIONS
+                submenu: EMULATION
                 prompt: ENABLE BOOT ANIMATION
                 description: Enable Gamecube boot animation and BIOS access (requires IPL.bin BIOS in appropriate user directory).
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
             gamecube_language:
-                group: ADVANCED OPTIONS
+                submenu: UI
                 prompt: GAMECUBE LANGUAGE
                 description: Change the Gamecube system language.
                 choices:
@@ -7509,14 +7503,14 @@ dolphin:
                     "4:3":  0
                     "16:9": 1
             emulatedwiimotes:
-                submenu: CONTROLLERS
+                group: CONTROLS
+                submenu: WII CONTROLLERS
                 prompt: EMULATE WIIMOTE
                 description: Map your controller to an emulated Wiimote.
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
             controller_mode:
-                submenu: CONTROLLERS
+                group: CONTROLS
+                submenu: WII CONTROLLERS
                 prompt: CUSTOMIZE EMULATED WIIMOTE & GAMEPAD
                 description: Emulate a Wiimote Sideway with L2 for Shake and Nunchuk on R-stick.
                 choices:
@@ -7528,38 +7522,30 @@ dolphin:
                     "Wiimote Sideway + Tilt":    it
                     "Wiimote Sideway + Nunchuk": in
             sensorbar_position:
-                submenu: CONTROLLERS
+                group: CONTROLS
+                submenu: WII CONTROLLERS
                 prompt: SENSOR BAR POSITION
                 description: Position of wii sensor bar relative to the disaply for real wiimotes.
                 choices:
                     "Bottom (Default)": 0
                     "Top":  1
             dsmotion:
-                submenu: CONTROLLERS
+                group: CONTROLS
+                submenu: WII CONTROLLERS
                 prompt: DUALSHOCK MOTION CONTROL
                 description: Emulate the Wiimote pointer with a DS4's gyroscope.
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
             mouseir:
-                submenu: CONTROLLERS
+                group: CONTROLS
+                submenu: WII CONTROLLERS
                 prompt: MOUSE AS WIIMOTE POINTER
                 description: Emulate the Wiimote pointer with a mouse.
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
             dolphin-lightgun-hide-crosshair:
-                group: LIGHT GUN
+                group: CONTROLS
+                submenu: LIGHT GUNS
                 prompt: SHOW LIGHT GUN CROSSHAIRS
-                choices:
-                    "Off": 0
-                    "On":  1
-            rumble:
-                prompt: RUMBLE
-                description: Enable controller rumble capabilities if supported by the controller.
-                choices:
-                    "Off": 0
-                    "On":  1
+                preset: switchoff
 
 dolphin_triforce:
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]


### PR DESCRIPTION
Reorganizing ES settings. Starting with Dolphin stand alone. This will be a long process so doing one system at a time.

Actually fixed an issue where rumble es setting was under wii system but it's actually global between wii+gamecube, so moved it under general dolphin and not in wii system.

Categorized ES settings into:
DISPLAY
RENDERING
EMULATION
AUDIO
CONTROLS
UI

Set global videomode and aspect ratio submenu "DISPLAY".

I also gave global wheels and lightgun es settings submenus and CONTROLS group. Used order 99/100 to ensure they are always at the bottom of the list. Pad profiles and rumble are used for gamecube and wii. And since controls seem to be a more complicated matter over other settings I thought it best to make CONTROLS a group so additional submenus can be used and organized better that way.

For example for Wii system this PR CONTROLS group has:
--CONTROLS--
Use pad profiles
Rumble
Gamecube controller 1 (submenu)
Gamecube controller 2 (submenu)
Gamecube controller 3 (submenu)
Gamecube controller 4 (submenu)
Wii Controllers (submenu)
Light guns (submenu)
Wheels (submenu)