### PR TITLE
pseudo -rompath for mame0139 (bios/mame2010) & mame078plus (bios/mame2003-plus) using softDir

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -65,6 +65,7 @@ Add support for the Ayaneo Air Plus (6800U) model
 - Rpi4 udev rules when a gun is detected in Hypseus Singe
 - Scanlines not showing in Daphne/Singe
 - Supermodel persistent crash in some cases with light guns
+- libretro MAME0139 core no longer picks up BIOS files in bios or bios/mame2010 (#11650)
 ### Changed
 - RK3326 Replaced the mali-G31 driver with mesa3d
 - Amiga BIOS files now go into the bios/amiga/ subfolder

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -101,10 +101,10 @@ class LibretroGenerator(Generator):
 
                 linkedHash = {}
 
-                # link files in directory rom is found first
+                # link files in directory rom is located in first (and be sure to link CHD subdir)
                 romDir=path.dirname(rom)
                 for fileName in os.listdir(romDir):
-                    if fileName.endswith('.zip'):
+                    if fileName.endswith('.zip') or (fileName == os.path.splitext(path.basename(rom))[0]):
                         os.symlink(romDir + "/" + fileName, softDirRoms + fileName)
                         linkedHash[fileName] = 1
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -85,7 +85,7 @@ def generateRetroarchCustom():
 
     retroarchSettings.write()
 
-def generateRetroarchCustomPathes(retroarchSettings):
+def generateRetroarchCustomPathes(retroarchSettings, system_directory):
     # Path Retroarch
     retroarchSettings.save('core_options_path',             '"/userdata/system/configs/retroarch/cores/retroarch-core-options.cfg"')
     retroarchSettings.save('assets_directory',              '"/usr/share/libretro/assets"')
@@ -96,7 +96,7 @@ def generateRetroarchCustomPathes(retroarchSettings):
     retroarchSettings.save('extraction_directory',          '"/userdata/extractions/"')
     retroarchSettings.save('cheat_database_path',           '"/userdata/cheats/cht/"')
     retroarchSettings.save('cheat_settings_path',           '"/userdata/cheats/saves/"')
-    retroarchSettings.save('system_directory',              '"/userdata/bios/"')
+    retroarchSettings.save('system_directory',              '"{}"'.format(system_directory))
     retroarchSettings.save('joypad_autoconfig_dir',         '"/userdata/system/configs/retroarch/inputs/"')
     retroarchSettings.save('video_shader_dir',              '"/usr/share/batocera/shaders/"')
     retroarchSettings.save('video_font_path',               '"/usr/share/fonts/dejavu/DejaVuSansMono.ttf"')


### PR DESCRIPTION
## Summary

fixes bug #11650 by creating a runtime flat rom directory structure by symlinking all ROM & bios files found in an emulated -rompath (and CHD directory) into `/var/run/mame_software/roms`. This eliminates a rom search path requirement at MAME2010 runtime as all files required are in a single "virtual" directory.

This is done because:
1. MAME2010 does not use RA's `system_directory`
2. RA does not support multiple bios paths
3. MAME2010 does not accept a generated command file containing `-rompath`
4. MAME2010 does not process a "rompath" or "bios" option in a default `mame.ini`
5. MAME2010 does not appear to support `-rompath`

- tested in v40-dev & patched v39 & patched v35.
- tested with 3300+ item 0.139 rom set. focused on ~100 ROMs that depend on bios files and/or CHDs
- performance hit creating ~3400 symlinks on rom boot is **unnoticeable** on a old 2015 MBP. Any modern system will be fine.

This is a niche enhancement as most gamers are using lr-mame & standalone MAME.  It brings consistency & stability to the preservation of the MAME2010 Reference Set as all 0.139 bios files can reside in `bios/mame2010` & safe from clobbering.

## Details

Took at stab at fixing bug #11650 implementing [possible solution 3](https://github.com/batocera-linux/batocera.linux/issues/11650#issuecomment-2148703550)

> Use `system_directory=/var/run/mame_software` and symlink expected bios files (for MAME0139) in `bios/mame2010` and `bios` (using this search order) in this temp run directory
> 
> This is similar to how standalone MAME deals with software lists:
> 
> ```
> [root@BATOCERA /var/run/mame_software]# ls -l coco_flop hash/coco_flop.xml 
> lrwxrwxrwx 1 root root 19 Jun  4 19:06 coco_flop -> /userdata/roms/coco
> lrwxrwxrwx 1 root root 32 Jun  4 19:06 hash/coco_flop.xml -> /usr/bin/mame/hash/coco_flop.xml

I’d love someone to review the code as it’s a bit kludgey in that it links **all** .zip files to get something working sooner than later:
```
[root@BATOCERA]# ls -l /var/run/mame_software/bios/
lrwxrwxrwx 1 root root  33 Jun  5 00:09 cheat.zip -> /userdata/bios/mame2010/cheat.zip
lrwxrwxrwx 1 root root  24 Jun  5 00:09 coco3.zip -> /userdata/bios/coco3.zip
lrwxrwxrwx 1 root root  23 Jun  5 00:09 coco.zip -> /userdata/bios/coco.zip
drwxr-x--- 6 root root 120 Jun  5 00:09 mame2010
lrwxrwxrwx 1 root root  35 Jun  5 00:09 stvbios.zip -> /userdata/bios/mame2010/stvbios.zip
```

It could use more testing with complete MAME2010 and MAME2003+ rom sets with bios files put in `/userdata/bios/mame2010` and `/userdata/bios/mame2003-plus` respectively.

An assumption I’m also making is with the way Batocera executes the MAME2010 core, bios files cannot be in the same directory as the rom (like standalone MAME or lr-mame) (eg. `/userdata/roms`) as there can only be one `system_directory` specified in RetroArch (previously hardcoded to `/userdata/bios`)