### PR TITLE
propagate coco autoload behavior from standalone MAME to lr-mame

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from settings.unixSettings import UnixSettings
 from utils.logger import get_logger
 from xml.dom import minidom
+import xml.etree.ElementTree as ET
 import Command
 import batoceraFiles
 import codecs
@@ -48,7 +49,7 @@ def generateMAMEConfigs(playersControllers, system, rom, guns):
     commandLine = []
     romBasename = os.path.basename(rom)
     romDirname  = os.path.dirname(rom)
-    romDrivername = os.path.splitext(romBasename)[0]
+    (romDrivername, romExt) = os.path.splitext(romBasename)
     specialController = 'none'
 
     if system.config['core'] in [ 'mame', 'mess', 'mamevirtual' ]:
@@ -221,6 +222,13 @@ def generateMAMEConfigs(playersControllers, system, rom, guns):
                             commandLine += [ "-flop1" ]
                         else:
                             commandLine += [ "-cart1" ]
+                    elif system.name == "coco":
+                        if romExt.casefold() == ".cas":
+                            commandLine += [ "-cass" ]
+                        elif romExt.casefold() == ".dsk":
+                            commandLine += [ "-flop1" ]
+                        else:
+                            commandLine += [ "-cart" ]
                     # try to choose the right floppy for Apple2gs
                     elif system.name == "apple2gs":
                         rom_extension = os.path.splitext(rom)[1].lower()
@@ -328,6 +336,47 @@ def generateMAMEConfigs(playersControllers, system, rom, guns):
                     if (system.isOptSet("altromtype") and system.config["altromtype"] == "cass") or softList[-4:] == "cass":
                         autoRunCmd = 'LOADM”“,,R\\n'
                         autoRunDelay = 5
+            elif system.name == "coco":
+                romType = 'cart'
+                autoRunDelay = 2
+
+                # if using software list, use "usage" for autoRunCmd (if provided)
+                if softList != "":
+                    softListFile = '/usr/bin/mame/hash/{}.xml'.format(softList)
+                    if os.path.exists(softListFile):
+                        softwarelist = ET.parse(softListFile)
+                        for software in softwarelist.findall('software'):
+                            if software.attrib != {}:
+                                if software.get('name') == romDrivername:
+                                    for info in software.iter('info'):
+                                        if info.get('name') == 'usage':
+                                            autoRunCmd = info.get('value') + '\\n'
+
+                # if still undefined, default autoRunCmd based on media type
+                if autoRunCmd == "":
+                    if (system.isOptSet('altromtype') and system.config["altromtype"] == "cass") or (softList != "" and softList.endswith("cass")) or romExt.casefold() == ".cas":
+                        romType = 'cass'
+                        if romDrivername.casefold().endswith(".bas"):
+                            autoRunCmd = 'CLOAD:RUN\\n'
+                        else:
+                            autoRunCmd = 'CLOADM:EXEC\\n'
+                    if (system.isOptSet('altromtype') and system.config["altromtype"] == "flop1") or (softList != "" and softList.endswith("flop")) or romExt.casefold() == ".dsk":
+                        romType = 'flop'
+                        if romDrivername.casefold().endswith(".bas"):
+                            autoRunCmd = 'RUN \"{}\"\\n'.format(romDrivername)
+                        else:
+                            autoRunCmd = 'LOADM \"{}\":EXEC\\n'.format(romDrivername)
+
+                # check for a user override
+                autoRunFile = 'system/configs/mame/autoload/{}_{}_autoload.csv'.format(system.name, romType)
+                if os.path.exists(autoRunFile):
+                    openARFile = open(autoRunFile, 'r')
+                    with openARFile:
+                        autoRunList = csv.reader(openARFile, delimiter=';', quotechar="'")
+                        for row in autoRunList:
+                            if row and not row[0].startswith('#'):
+                                if row[0].casefold() == romDrivername.casefold():
+                                    autoRunCmd = row[1] + "\\n"
             else:
                 # Check for an override file, otherwise use generic (if it exists)
                 autoRunCmd = messAutoRun[messMode]
@@ -432,7 +481,7 @@ def prepSoftwareList(subdirSoftList, softList, softDir, hashDir, romDirname):
         if file.endswith(".xml"):
             os.remove(os.path.join(hashDir, file))
     # Copy hashfile
-    shutil.copy2("/usr/share/lr-mame/hash/" + softList + ".xml", hashDir + "/" + softList + ".xml")
+    shutil.copy2("/usr/bin/mame/hash/" + softList + ".xml", hashDir + "/" + softList + ".xml")
     # Link ROM's parent folder if needed, ROM's folder otherwise
     if softList in subdirSoftList:
         romPath = Path(romDirname)


### PR DESCRIPTION
## Summary
lr-mame inherits coco autoload behavior (#11706) with known issues:
1. lr-mame is sensitive to long filenames and/or filenames with spaces and symbols (workaround: create a symlink to original file with a shortened name removing all spaces and non-alphanumeric chars)
2. plugins not supported in lr-mame MESS - coco hiscore is only available in standalone MAME
3. Can’t access File Manager - swapping disks or changing cassettes (aka. flipping sides) is only available in standalone MAME

## Details
ok - that was a bit of an adventure discovering that standalone MAME and lr-mame are not 100% functionally equivalent (at least when it comes to MESS).

I got through all my coco test cases & made sure to boot non-MESS roms in lr-mame and MAME2010.

What doesn’t work in `lr-mame` is relatively minor (see below).  All in all, I’m satisfied and it was good to review the code and see how different libretroMAMEConfig is from mameGenerator.

I’m don’t know if using software lists in `/usr/share/lr-mame/hash` is legacy but I changed it to use `/usr/bin/mame/hash` (what standalone MAME uses) (and I also notice that for non-MESS ROMs, plugins come out of `/usr/bin/mame/plugins` - so better to get these in sync to save some headaches)

I’ve concluded since `lr-mame` appears to have a subset of the functionality of standalone MAME (so it’s a subpar experience IMHO), that we should direct people to use standalone MAME for MESS systems and we should consider deleting MESS-related code entirely from `libretroMAMEConfig.py` (after propagating any fixes that didn’t make it to mameGenerator) to simplify maintenance.  Just a thought.

Ok if you’re good with all of the above, this commit is good to go - it replaces #11913 and makes #11706 complete as can be.

### lr-mame is sensitive to long filenames and/or filenames with spaces and symbols
workaround is simple - just shorten the file name without spaces or symbols
1. disk: Castle of Death (The Rainbow).dsk —> `CASTLE.bas.dsk`
4. cart: Color Computer Disk BASIC V1.1 (1982) (26-3022) (Tandy).ccc —> `disk11.ccc`
5. cass: Grover's Number Rover (CCW).bas.cas —> `GROVER.bas.cas`

I thought it was using spaces but of course, there is a test cart that did boot **without** renaming: `'JDOS v1.23 (1985) (J&M Systems).ccc` - go figure.

### plugins not supported in lr-mame MESS
in standalone MAME, I’ve implemented hi scores (hiscore.dat) for 2 coco titles (I love that it works!)

I notice we avoid enabling plugins for MESS systems in lr-mame

I tried to pass `-plugins -plugin hiscore` and lr-mame just craps out without reporting an error (so annoying!)

I don’t know if it’s because lr-mame doesn’t support these options or something else.

So the coco system on lr-mame doesn’t support hi scores.

### Can’t access File Manager
You can hit Tab to bring up the MAME menu in lr-mame and select “File Manager” but no matter what you do, you can’t hit Enter to go into it to swap disks or “turn over” a cassette.

Is this a known issue with lr-mame?