### PR TITLE
no duckstation for the VIM1S

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -1123,7 +1123,11 @@ config BR2_PACKAGE_BATOCERA_CONSOLE_SYSTEMS
 	select BR2_PACKAGE_BATOCERA_SEGADC
 
 	# PSX
-	select BR2_PACKAGE_DUCKSTATION			if BR2_PACKAGE_BATOCERA_GLES3 && !BR2_PACKAGE_BATOCERA_TARGET_RK3326 # newer versions of duckstation are stricter on OpenGL 3.1
+	select BR2_PACKAGE_DUCKSTATION    if BR2_PACKAGE_BATOCERA_GLES3 && \
+	                                     !BR2_PACKAGE_BATOCERA_TARGET_RK3326 && \
+										 !BR2_PACKAGE_BATOCERA_TARGET_S9GEN4
+										 # newer versions of duckstation are stricter on OpenGL 3.1
+										 # requires X11 or Sway. 2GB boards aren't great.
 
 	select BR2_PACKAGE_DUCKSTATION_LEGACY		if !BR2_PACKAGE_BATOCERA_GLES3			&& \
 							   !BR2_riscv					&& \


### PR DESCRIPTION
- not enough memory for Wayland / Sway
- thus duckstation with QT6