### PR TITLE
fix-dolphin-configgen

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -341,10 +341,11 @@ class DolphinGenerator(Generator):
             dolphinGFXSettings.set("Settings", "SSAA", "False")
         
         # Manual texture sampling
+        # Setting on = speed hack off. Setting off = speed hack on
         if system.isOptSet('manual_texture_sampling') and system.getOptBoolean('manual_texture_sampling'):
-            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "True")
+            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "False")
         else:
-            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "False")        
+            dolphinGFXSettings.set("Hacks", "FastTextureSampling", "True")        
 
         # Save gfx.ini
         with open(batoceraFiles.dolphinGfxIni, 'w') as configfile:


### PR DESCRIPTION
Manual texture sampling is a hack. So enabling setting should disable hack, while enabling setting should disable hack.