### PR TITLE
fix pad2key shortcut for switching TV/Gamepad screen on WiiU

### DIFF
--- a/package/batocera/emulators/cemu/wiiu.keys
+++ b/package/batocera/emulators/cemu/wiiu.keys
@@ -9,7 +9,7 @@
         {
            "trigger": ["hotkey", "r2"],
             "type": "key", 
-            "target": ["KEY_LEFTALT", "KEY_TAB"],
+            "target": ["KEY_LEFTCTRL", "KEY_TAB"],
             "description": "Display the controller screen"
         }
     ]


### PR DESCRIPTION
On Cemu the default shortcut listen CTRL+TAB
but the Batocera config targets ALT+TAB. 