### PR TITLE
3ds: add support for .squashfs

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2114,7 +2114,7 @@ x1:
   manufacturer: Nintendo
   release: 2011
   hardware: portable
-  extensions: [3ds, 3dsx, cxi, axf, elf, app]
+  extensions: [3ds, 3dsx, cxi, axf, elf, app, squashfs]
   emulators:
     citra:
       citra: { requireAnyOf: [BR2_PACKAGE_CITRA]          }


### PR DESCRIPTION
3ds games can use a lot of space,  
citra emulator don't support compression format currently.

squashfs compression ratio is around 60% of original size


```
-rw-rw-r-- 1 root root 4.0G Jun 22 09:04 'Pokemon Ultra Moon.3ds'
-rw-r--r-- 1 root root 2.4G Jun 22 09:12 'Pokemon Ultra Moon.3ds.squashfs'
```