### PR TITLE
add HORI Racing Wheel Overdrive support

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -37,6 +37,7 @@ Add support for the Rock 5c
   - Driving Wheel SV200
   - PNX-V10 (x-input only)
   - Logitech Driving Force Pro
+  - HORI Racing Wheel Overdrive (mode 2 only)
 - Dolphin: support for Retroachievements (when they are enabled)
 - Color Computer (coco) now autoloads cassettes and disks based on MAME software lists with default fallbacks
   - uses "usage" info field in MAME software list

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -32,10 +32,13 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTR{idV
 # DRIVING WHEEL SV200 (GAMEPAD MODE ONLY)
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTR{idVendor}=="0079", ATTR{idProduct}=="189c", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="180"
 
+# HORI RACING WHEEL OVERDRIVE (MODE 2 ONLY)
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Microsoft X-Box One pad", ATTR{idVendor}=="0f0d", ATTR{idProduct}=="0121", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
+
 # PXN-V10 (X-INPUT MODE ONLY, HARDWARE SWITCH TO 270 DEGREES)
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTR{idVendor}=="llff", ATTR{idProduct}=="f201", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
 
-#
+# MOZA R9 BASE STEERING WHEEL WITH CUSTOM PEDALS GUDSEN SRP
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Gudsen MOZA R9 Base", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0", RUN+="/usr/bin/evsieve-merge-devices --by-names 'MOZA R9 wheels' 'Gudsen MOZA R9 Base' 'Gudsen MOZA SRP pedals'"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Gudsen MOZA SRP pedals", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0", RUN+="/usr/bin/evsieve-merge-devices --by-names 'MOZA R9 wheels' 'Gudsen MOZA R9 Base' 'Gudsen MOZA SRP pedals'"
 KERNEL=="event*", SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="MOZA R9 wheels", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1" , ENV{ID_INPUT_WHEEL}="1" , ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", ENV{ID_INPUT_MOUSE}="0"

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5126,4 +5126,24 @@
         <input name="x" type="button" id="3" value="1" code="291" />
         <input name="y" type="button" id="1" value="1" code="289" />
     </inputConfig>
+	<inputConfig type="joystick" deviceName="Microsoft X-Box One pad" deviceGUID="060000000d0f00002101000001010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="axis" id="4" value="1" code="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="l3" type="button" id="9" value="1" code="317" />
+		<input name="left" type="axis" id="3" value="-1" code="3" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
+		<input name="r3" type="button" id="10" value="1" code="318" />
+		<input name="right" type="axis" id="3" value="1" code="3" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="axis" id="4" value="-1" code="4" />
+		<input name="x" type="button" id="3" value="1" code="308" />
+		<input name="y" type="button" id="2" value="1" code="307" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Waiting for feedback...

Must be set on `MODE 2` (gamepad).

![image](https://github.com/batocera-linux/batocera.linux/assets/32983607/61a40cb8-93b3-4265-b5ab-902f42527927)

This wheel has no FFB.
Xbox logo is HOTKEY.