### PR TITLE
Enable configgen to parse unique config entries based on relative path

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -76,7 +76,9 @@ class Emulator():
 
     def game_settings_name(self,rom):
 
-        rom = os.path.basename(rom)
+        # $$$ if users have roms in subdirs previously, batocera.conf needs updating (could script upgrade)
+        # https://stackoverflow.com/a/19856910/9983389
+        rom = os.path.relpath(rom, batoceraFiles.ROMS + "/" + self.name)
 
         # sanitize rule by EmulationStation 
         # see FileData::getConfigurationName() on batocera-emulationstation 


### PR DESCRIPTION
### Summary
Enables configgen to parse relative paths in `batocera.conf` and handle 2 cases:

1. Media with multiple media formats (eg. disk and cassette): #11781
2. Multiple MAME rom sets (MAME and MAME2010)

PR is paired with [Enable ES to save unique config entries based on relative path ](batocera-linux/batocera-emulationstation#1750)

Both PRs will be pull out of draft when more thoroughly tested (esp the ES side of the fence)
### Testing
`game_settings_name` in es_log is correct:
```
2024-06-30 02:59:27,707 INFO (Emulator.py:87):game_settings_name game settings name: cas/zonx.zip
```
and it successfully parses the following options in `batocera.conf`:
```
coco["cas/grover.zip"]=coco_cass
coco["cas/ssleuth.zip"]=coco_cass
coco["cas/zaxxon.zip"]=coco_cass
coco["cas/zonx.zip"]=coco_cass
```
