### PR TITLE
vpinball: bump deps and latest vpinball

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Apr 16, 2024
+# Version: Commits on Jul 2, 2024
 # uses standalone tree for now
-VPINBALL_VERSION = e32b3c666e074073018c11a392b1e6dc6f4daeaf
+VPINBALL_VERSION = db7519688c9b9dde004db38d7a4488c81a144996
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libaltsound/libaltsound.mk
+++ b/package/batocera/libraries/libaltsound/libaltsound.mk
@@ -3,8 +3,8 @@
 # libaltsound
 #
 ################################################################################
-# Version: Commits on Feb 24, 2024
-LIBALTSOUND_VERSION = 9ac08a76e2aabc1fba57d3e5a3b87e7f63c09e07
+# Version: Commits on Jul 2, 2024
+LIBALTSOUND_VERSION = b8f397858cbc7a879f7392c14a509f00c8bdc7dd
 LIBALTSOUND_SITE = $(call github,vpinball,libaltsound,$(LIBALTSOUND_VERSION))
 LIBALTSOUND_LICENSE = BSD-3-Clause
 LIBALTSOUND_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on May 10, 2024
-LIBDMDUTIL_VERSION = fc29cd7d8271c34999a125fbbc123a71ace571c9
+# Version: Commits on Jul 2, 2024
+LIBDMDUTIL_VERSION = 0eb20528c6ff8aa79d04d467a3c64029e070cdce
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdof/libdof.mk
+++ b/package/batocera/libraries/libdof/libdof.mk
@@ -3,8 +3,8 @@
 # libdof
 #
 ################################################################################
-# Version: Commits on Apr 15, 2024
-LIBDOF_VERSION = ac5d1e3487a4a6511953eb6aeef06ef5111510ea
+# Version: Commits on Jul 2, 2024
+LIBDOF_VERSION = 42160a6835ead9d64f101e687dc277a0fe766f25
 LIBDOF_SITE = $(call github,jsm174,libdof,$(LIBDOF_VERSION))
 LIBDOF_LICENSE = BSD-3-Clause
 LIBDOF_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Apr 16, 2024
-LIBPINMAME_VERSION = df7abda19dd67b71d45d2eba61b59983e6c2bbc9
+# Version: Commits on Jul 2, 2024
+LIBPINMAME_VERSION = 2c4116642c1c15644e47c0054e3268af47559f9a
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpupdmd/libpupdmd.mk
+++ b/package/batocera/libraries/libpupdmd/libpupdmd.mk
@@ -3,8 +3,8 @@
 # libpupdmd
 #
 ################################################################################
-# Version: Commits on Apr 3, 2024
-LIBPUPDMD_VERSION = c640ea2cec94097e8baefee9dab39266970e4405
+# Version: Commits on Jul 2, 2024
+LIBPUPDMD_VERSION = 124f45e5ddd59ceb339591de88fcca72f8c54612
 LIBPUPDMD_SITE = $(call github,ppuc,LIBPUPDMD,$(LIBPUPDMD_VERSION))
 LIBPUPDMD_LICENSE = GPL-3.0 license
 LIBPUPDMD_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libserum/libserum.mk
+++ b/package/batocera/libraries/libserum/libserum.mk
@@ -3,8 +3,8 @@
 # libserum
 #
 ################################################################################
-# Version: Commits on Jan 8, 2024
-LIBSERUM_VERSION = b69d2b436bc93570a2e7e78d0946cd3c43f7aed5
+# Version: Commits on Jul 3, 2024
+LIBSERUM_VERSION = 5329017fe093ecd46e382c3fd7f08da0c5b84797
 LIBSERUM_SITE = $(call github,zesinger,libserum,$(LIBSERUM_VERSION))
 LIBSERUM_LICENSE = GPLv2+
 LIBSERUM_LICENSE_FILES = LICENSE.md

--- a/package/batocera/libraries/libzedmd/libzedmd.mk
+++ b/package/batocera/libraries/libzedmd/libzedmd.mk
@@ -3,8 +3,8 @@
 # libzedmd
 #
 ################################################################################
-# Version: Commits on Jun 9, 2024
-LIBZEDMD_VERSION = 00f2e35a679969fbb508948054160b84aa76247e
+# Version: Commits on Jul 2, 2024
+LIBZEDMD_VERSION = 927a519efcff79f9876fecb9d5a04c9ba5fc2348
 LIBZEDMD_SITE = $(call github,PPUC,libzedmd,$(LIBZEDMD_VERSION))
 LIBZEDMD_LICENSE = GPLv3
 LIBZEDMD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
This PR brings VPinballX to all the latest work from the past few months.

- Serum2 colorization support
- VPinball 10.8 RC 4
- Initial support for PUP packs
- Tons of PWM updates to PinMAME