### PR TITLE
add controller support RetroUSB SNES/NES/N64, MayFlash F500 and PS3 Dualshock 3

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5158,4 +5158,93 @@
 		<input name="up" type="hat" id="0" value="1" />
 		<input name="y" type="button" id="0" value="1" code="304" />
 	</inputConfig>
+		<inputConfig type="joystick" deviceName="RetroUSB.com SNES RetroPort" deviceGUID="0300000000f00000f100000000010000">
+		<input name="a" type="button" id="5" value="1" code="309" />
+		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="down" type="axis" id="1" value="1" code="1" />
+		<input name="hotkey" type="button" id="2" value="1" code="306" />
+		<input name="left" type="axis" id="0" value="-1" code="0" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="right" type="axis" id="0" value="1" code="0" />
+		<input name="select" type="button" id="2" value="1" code="306" />
+		<input name="start" type="button" id="3" value="1" code="307" />
+		<input name="up" type="axis" id="1" value="-1" code="1" />
+		<input name="x" type="button" id="4" value="1" code="308" />
+		<input name="y" type="button" id="0" value="1" code="304" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName=". MAYFLASH Arcade Fightstick F500 V2" deviceGUID="03000000790000001c18000011010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="2" value="-1" code="2" />
+		<input name="joystick2up" type="axis" id="3" value="-1" code="5" />
+		<input name="l2" type="button" id="8" value="1" code="312" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="9" value="1" code="313" />
+		<input name="r2" type="button" id="6" value="1" code="310" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="10" value="1" code="314" />
+		<input name="start" type="button" id="11" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="4" value="1" code="308" />
+		<input name="y" type="button" id="3" value="1" code="307" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="PS3 Controller" deviceGUID="030000004c0500006802000011810000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="button" id="14" value="1" code="545" />
+		<input name="hotkey" type="button" id="10" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />
+		<input name="joystick2up" type="axis" id="4" value="-1" code="4" />
+		<input name="l2" type="button" id="6" value="1" code="312" />
+		<input name="l3" type="button" id="11" value="1" code="317" />
+		<input name="left" type="button" id="15" value="1" code="546" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="button" id="7" value="1" code="313" />
+		<input name="r3" type="button" id="12" value="1" code="318" />
+		<input name="right" type="button" id="16" value="1" code="547" />
+		<input name="select" type="button" id="8" value="1" code="314" />
+		<input name="start" type="button" id="9" value="1" code="315" />
+		<input name="up" type="button" id="13" value="1" code="544" />
+		<input name="x" type="button" id="2" value="1" code="307" />
+		<input name="y" type="button" id="3" value="1" code="308" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="retroUSB NES RetroPort" deviceGUID="03000000d804000064f0000011010000">
+		<input name="a" type="button" id="0" value="1" code="304" />
+		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="hotkey" type="button" id="2" value="1" code="306" />
+		<input name="up" type="axis" id="1" value="-1" code="1" />
+		<input name="down" type="axis" id="1" value="1" code="1" />
+		<input name="left" type="axis" id="0" value="-1" code="0" />
+		<input name="right" type="axis" id="0" value="1" code="0" />
+		<input name="select" type="button" id="2" value="1" code="306" />
+		<input name="start" type="button" id="3" value="1" code="307" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="SealieComputing N64 RetroPort" deviceGUID="03000000341200000400000000010000">
+		<input name="b" type="button" id="7" value="1" code="311" />
+		<input name="a" type="button" id="6" value="1" code="310" />
+		<input name="down" type="button" id="2" value="1" code="306" />
+		<input name="hotkey" type="button" id="13" value="1" code="317" />
+		<input name="l2" type="button" id="10" value="1" code="314" />
+		<input name="left" type="button" id="1" value="1" code="305" />
+		<input name="pagedown" type="button" id="12" value="1" code="316" />
+		<input name="pageup" type="button" id="13" value="1" code="317" />
+		<input name="r2" type="button" id="8" value="1" code="312" />
+		<input name="right" type="button" id="0" value="1" code="304" />
+		<input name="select" type="button" id="5" value="1" code="309" />
+		<input name="start" type="button" id="4" value="1" code="308" />
+		<input name="up" type="button" id="3" value="1" code="307" />
+		<input name="x" type="button" id="11" value="1" code="315" />
+		<input name="y" type="button" id="9" value="1" code="313" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Additional input configs for the following controllers. 

From the makers of the AVS,
[SNES RetroPort](https://www.retrousb.com/product/snes-retroport/25?cp=true&sa=false&sbp=false&q=false&category_id=XMUPJ4I27NZEHIOGMV3JUCBH), [NES RetroPort](https://www.retrousb.com/product/nes-retroport/24?cp=true&sa=false&sbp=false&q=false&category_id=XMUPJ4I27NZEHIOGMV3JUCBH) and [N64 RetroPort](https://www.retrousb.com/product/n64-retroport/34?cp=true&sa=false&sbp=false&q=false&category_id=XMUPJ4I27NZEHIOGMV3JUCBH)

The N64 controller was mapped to the recommended control layout here -> https://wiki.batocera.org/systems:n64#controls

The [May Flash F500 V2](https://www.mayflash.com/product/mayflash_arcade_stick_f500_v2.html) arcade stick in controller mode 

The [Sony Dualshock 3](https://www.digitalgamemuseum.org/consolecontrollerevolution/modern/dualshock3/)

For retroport controllers the dpad/axis had to be manually edited in `es_input.cfg`. Configuration was unresponsive in the Batocera interface.