### PR TITLE
fix mugen generator config rewrite

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
@@ -16,10 +16,10 @@ class MugenGenerator(Generator):
         #clean up
         contents = re.sub(r'^[ ]*;', ';', contents, 0, re.MULTILINE)
         contents = re.sub(r'^[ ;]*FullScreen[ ]*=.*', 'FullScreen = 1', contents, 0, re.MULTILINE)
-        contents = re.sub(r'^[ ;]*GameWidth[ ]*=.*', 'Width = '+str(gameResolution["width"]), contents, 0, re.MULTILINE)
-        contents = re.sub(r'^[ ;]*GameHeight[ ]*=.*', 'Height = '+str(gameResolution["height"]), contents, 0, re.MULTILINE)
-        contents = re.sub(r'^[ ;]*Width[ ]*=.*', 'GameWidth = '+str(gameResolution["width"]), contents, 0, re.MULTILINE)
-        contents = re.sub(r'^[ ;]*Height[ ]*=.*', 'GameHeight = '+str(gameResolution["height"]), contents, 0, re.MULTILINE)
+        contents = re.sub(r'^[ ;]*GameWidth[ ]*=.*', 'GameWidth = '+str(gameResolution["width"]), contents, 0, re.MULTILINE)
+        contents = re.sub(r'^[ ;]*GameHeight[ ]*=.*', 'GameHeight = '+str(gameResolution["height"]), contents, 0, re.MULTILINE)
+        contents = re.sub(r'^[ ;]*Width[ ]*=.*', 'Width = '+str(gameResolution["width"]), contents, 0, re.MULTILINE)
+        contents = re.sub(r'^[ ;]*Height[ ]*=.*', 'Height = '+str(gameResolution["height"]), contents, 0, re.MULTILINE)
         contents = re.sub(r'^[ ;]*Language[ ]*=.*', 'Language = "en"', contents, 0, re.MULTILINE)
         with open(settings_path, 'w') as f:
             f.write(contents)


### PR DESCRIPTION
config rewrite for older mugen is broken since
https://github.com/batocera-linux/batocera.linux/commit/c97b6665669fc069c69954526b6d6839f74567b6

Width/Height are wrongly rewritten to GameWidth/GameHeight

newer version support both Width/Heigh  && newer GameWidth/GameHeight, so it was not breaking it

Older mugen support only Width= && Height=,  and crash at start with GameWidth/GameHeight, throwing a video config error.