### PR TITLE
pcsx-rearmed-add-enhanced-resolution

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -2667,9 +2667,16 @@ def generateCoreSettings(coreSettings, system, rom, guns, wheels):
         else:
             coreSettings.save('pcsx_rearmed_frameskip', '"0"')
         # Enhanced resolution at the cost of lower performance
-        # Speed hack causes game glitches - turn it off.
-        coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"disabled"')
-        coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"disabled"')
+        if system.isOptSet('neon_enhancement') and system.config['neon_enhancement'] != 'disabled':
+            if system.config['neon_enhancement'] == 'enabled':
+                coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"enabled"')
+                coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"disabled"')
+            elif system.config['neon_enhancement'] == 'enabled_with_speedhack':
+                coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"enabled"')
+                coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"enabled"')
+        else:
+            coreSettings.save('pcsx_rearmed_neon_enhancement_enable',  '"disabled"')
+            coreSettings.save('pcsx_rearmed_neon_enhancement_no_main', '"disabled"')
         # Multitap
         if system.isOptSet('pcsx_rearmed_multitap'):
             coreSettings.save('pcsx_rearmed_multitap', '"' + system.config['pcsx_rearmed_multitap'] + '"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -4810,6 +4810,13 @@ libretro:
                     "1":                1
                     "2":                2
                     "3":                3
+            neon_enhancement:
+                prompt:      ENHANCED RENDERING RESOLUTION
+                description: Double the rendering resolution.
+                choices:
+                    "Off":              disabled
+                    "On":               enabled
+                    "On (Speed hack)":  enabled_with_speedhack
             pcsx_rearmed_multitap:
                 prompt:      MULTITAP
                 description: Allows up to 5 or 8 controllers in supported games.


### PR DESCRIPTION
Add back in enhanced resolution es-settings. Previously removed due to "some games having glitches" but I think it's ok to add back in now. Testing with several games has not had any problems. 