### PR TITLE
add start/select on guns (Hypseus Singe)

### DIFF
--- a/package/batocera/emulators/hypseus-singe/singe.hypseus-singe.keys
+++ b/package/batocera/emulators/hypseus-singe/singe.hypseus-singe.keys
@@ -13,4 +13,28 @@
             "description": "Service menu"
     }
     ]
+    ,"actions_gun1": [
+    {
+            "trigger": "middle",
+            "type": "key",
+            "target": "KEY_5"
+    },
+	{
+            "trigger": "1",
+            "type": "key",
+            "target": "KEY_1"
+    }
+    ]
+    ,"actions_gun2": [
+    {
+            "trigger": "middle",
+            "type": "key",
+            "target": "KEY_6"
+    },
+	{
+            "trigger": "1",
+            "type": "key",
+            "target": "KEY_2"
+    }
+    ]
 }


### PR DESCRIPTION
Player 1 light gun and player 2 light gun. Useful for Hypseus Singe multigun versions of gun games (e.g.: Crime Patrol & Drug Wars).