### PR TITLE
update-rotate-mappings-dolphin [V41]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -464,23 +464,15 @@ def get_AltMapping(system, nplayer, anyMapping):
         mapping['a'] = 'Buttons/B'
         mapping['b'] = 'Buttons/A'
         
-    # Only apply alt inputs for standard controller type
+    # Only rotate inputs for standard controller type so it doesn't effect other controller types.
     if not system.isOptSet(f"dolphin_port_{nplayer}_type") or system.config.get(f'dolphin_port_{nplayer}_type') == '6a':
-        # Check for alternative mappings settings and adjust
-        if system.isOptSet(f"alt_mappings_{nplayer}"): 
-            alt_mapping_type = system.config.get(f'alt_mappings_{nplayer}')
-            
-            if alt_mapping_type == 'buttons_ccw':
-                mapping['a'] = 'Buttons/B'
-                mapping['b'] = 'Buttons/Y'
-                mapping['y'] = 'Buttons/X'
-                mapping['x'] = 'Buttons/A'
-                
-            elif alt_mapping_type == 'buttons_cw':
-                mapping['a'] = 'Buttons/X'
-                mapping['b'] = 'Buttons/A'
-                mapping['y'] = 'Buttons/B'
-                mapping['x'] = 'Buttons/Y'
+        # Check for rotate mappings settings and adjust
+        if system.isOptSet(f"alt_mappings_{nplayer}") and system.getOptBoolean(f"alt_mappings_{nplayer}") == True:
+
+            mapping['a'] = 'Buttons/X'
+            mapping['b'] = 'Buttons/A'
+            mapping['y'] = 'Buttons/B'
+            mapping['x'] = 'Buttons/Y'
     
     return mapping
 
@@ -555,7 +547,7 @@ def generateControllerConfig_any_auto(f, pad, anyMapping, anyReverseAxes, anyRep
     for opt in extraOptions:
         f.write(opt + " = " + extraOptions[opt] + "\n")
     
-    # Get alt input mappings and recompute the mapping according to available buttons on the pads and the available replacements
+    # Check for alt input mappings
     currentMapping = get_AltMapping(system, nplayer, anyMapping)
     # Apply replacements
     if anyReplacements is not None:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7357,35 +7357,27 @@ dolphin:
         alt_mappings_1:
             group: CONTROLS
             submenu: GAMECUBE CONTROLLER 1
-            prompt: ALT INPUT MAPPING
-            description: Use alternative input mappings. Only applies to Standard Controller type.
-            choices:
-                "Face Buttons (CW)":         buttons_cw
-                "Face Buttons (CCW)":        buttons_ccw
+            prompt: ROTATE FACE BUTTONS
+            description: Moves South to West, West to North, etc. Standard controller type only.
+            preset: switchoff
         alt_mappings_2:
             group: CONTROLS
             submenu: GAMECUBE CONTROLLER 2
-            prompt: ALT INPUT MAPPING
-            description: Use alternative input mappings. Only applies to Standard Controller type.
-            choices:
-                "Face Buttons (CW)":         buttons_cw
-                "Face Buttons (CCW)":        buttons_ccw
+            prompt: ROTATE FACE BUTTONS
+            description: Moves South to West, West to North, etc. Standard controller type only.
+            preset: switchoff
         alt_mappings_3:
             group: CONTROLS
             submenu: GAMECUBE CONTROLLER 3
-            prompt: ALT INPUT MAPPING
-            description: Use alternative input mappings. Only applies to Standard Controller type.
-            choices:
-                "Face Buttons (CW)":         buttons_cw
-                "Face Buttons (CCW)":        buttons_ccw
+            prompt: ROTATE FACE BUTTONS
+            description: Moves South to West, West to North, etc. Standard controller type only.
+            preset: switchoff
         alt_mappings_4:
             group: CONTROLS
             submenu: GAMECUBE CONTROLLER 4
-            prompt: ALT INPUT MAPPING
-            description: Use alternative input mappings. Only applies to Standard Controller type.
-            choices:
-                "Face Buttons (CW)":         buttons_cw
-                "Face Buttons (CCW)":        buttons_ccw
+            prompt: ROTATE FACE BUTTONS
+            description: Moves South to West, West to North, etc. Standard controller type only.
+            preset: switchoff
         deadzone_1:
             group: CONTROLS
             submenu: GAMECUBE CONTROLLER 1


### PR DESCRIPTION
Removes unused rotate face buttons counter-clockwise and changes to simple switch toggle. Updated setting name and description for better clarity.