### PR TITLE
bump dolphin to 2407-76 (5.0 dev)

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -40,7 +40,7 @@ Add support for the Pironman 5 case with RPi5 devices.
   - PNX-V10 (x-input only)
   - Logitech Driving Force Pro
   - HORI Racing Wheel Overdrive (mode 2 only)
-- Dolphin: support for Retroachievements (when they are enabled)
+- Dolphin: support for Retroachievements
 - Color Computer (coco) now autoloads cassettes and disks based on MAME software lists with default fallbacks
   - uses "usage" info field in MAME software list
   - .cas/.dsk default autoload behaviors (.bas in rom basename uses CLOAD/RUN)
@@ -147,7 +147,7 @@ Add support for the Pironman 5 case with RPi5 devices.
 - Fheroes2 to 1.0.13
 - PCSX2 to v1.7.5913
 - Play! & Libretro Play! to 0.66
-- Dolphin to 5.0-21774
+- Dolphin to 2407-76 (5.0 development version)
 - Libretro-Hatarib: bump to v0.3
 - Hatari to v2.5.0
 - Citra to r64e3e9f

--- a/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
+++ b/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
@@ -3,8 +3,8 @@
 # dolphin-emu
 #
 ################################################################################
-# Version: 5.0-21774 - Commits on Jun 25, 2024
-DOLPHIN_EMU_VERSION = 10a95a4d5bb960d5df87ffbe1cdc8cdde34870a4
+# Version: 2407-76 (5.0 development) - Commits on Jul 19, 2024
+DOLPHIN_EMU_VERSION = 139e6f6f1b748211c0bd4d13d03e7ef433bee670
 DOLPHIN_EMU_SITE = https://github.com/dolphin-emu/dolphin
 DOLPHIN_EMU_SITE_METHOD = git
 DOLPHIN_EMU_LICENSE = GPLv2+


### PR DESCRIPTION
There have been quite a lot of recent fixes in dolphin development version, including one that should help preventing DDOS of retroachievements.org, thus older versions with achievement support [will be blacklisted](https://retroachievements.org/viewtopic.php?t=27292)

Not sure if you're ok to use the dev version, and not sure about naming convention for those versions (:

_Also it seems RA notifications for Dolphin aren't shown in Batocera, a user reported on discord that they work (he unlocked achievements) but no notification is ever shown, but that might need a new issue. EDIT: It's actually because on-screen display messages were disabled for this system. Maybe enabling achievements should enable them?_