### PR TITLE
Apply game specific powermode

### DIFF
--- a/package/batocera/core/batocera-configgen/scripts/powermode_launch_hooks.sh
+++ b/package/batocera/core/batocera-configgen/scripts/powermode_launch_hooks.sh
@@ -73,6 +73,8 @@ is_power_connected() {
 # Check for events
 EVENT=$1
 SYSTEM_NAME=$2
+GAME_NAME=$5
+GAME_NAME="${GAME_NAME##*/}"
 
 # Exit if the event is neither gameStart nor gameStop
 if [ "$EVENT" != "gameStart" ] && [ "$EVENT" != "gameStop" ]; then
@@ -101,8 +103,13 @@ if [ "$EVENT" == "gameStop" ]; then
     exit 0
 fi
 
-# Check for user set system specific setting
-if [ -n "${SYSTEM_NAME}" ]; then
+# Check for user set game specific setting
+if  [ -n "${GAME_NAME}" ]; then
+    POWER_MODE_SETTING="${SYSTEM_NAME}[\"${GAME_NAME}\"].powermode"
+    POWER_MODE="$(/usr/bin/batocera-settings-get-master "${POWER_MODE_SETTING}")"
+fi
+# If no user set game specific setting check for user set system specific setting
+if [ -z "${POWER_MODE}" ] && [ -n "${SYSTEM_NAME}" ]; then
     POWER_MODE_SETTING="${SYSTEM_NAME}.powermode"
     POWER_MODE="$(/usr/bin/batocera-settings-get-master "${POWER_MODE_SETTING}")"
 fi


### PR DESCRIPTION
The UI saves the game specific powermode to batocera.conf but is not applied by the powermode launcher hook