### PR TITLE
don't give Steam full access to the Nintendo Pro controller

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-steam-controller.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-steam-controller.rules
@@ -6,3 +6,5 @@ KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input"
 KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0666"
 # Valve HID devices over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*28DE:*", MODE="0666"
+# Nintendo Pro controller - don't give full access
+KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="", TAG:=""


### PR DESCRIPTION
- fixes Steam locking access to the controller on exit