### PR TITLE
Update batocera-Changelog.md

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -4,6 +4,7 @@
 - Add Blamcon Gun support
 - Khadis VIM4 optimizations and enhancements
 ### Added
+- Exit game with light gun (hold `TRIGGER`, `ACTION` and `START` buttons for 2 seconds) 
 ### Fixed
 ### Changed / Improved
 ### Updated
@@ -124,7 +125,7 @@ Add support for the Pironman 5 case with RPi5 devices.
 - RPCS3 upscaling now outputs properly
 - GunCon3 default mapping (visit light gun page on official wiki)
   - Calibration now on C2 (press and hold it few seconds)
-- Sinden Lightgun firmware updated to 1.9
+- Sinden Lightgun drivers updated to 2.05 (firmware v1.9 now compatible)
 - Preferred vulkan driver name now listed in System Information
 - Start advisiong people on Vulkan GPU driver capabilities for Emualtors
 - Added additional Atari Lynx extensions for Beetle Lynx & Handy


### PR DESCRIPTION
- add exit functionality on lightguns
- proper wording about sinden light gun drivers (linux version of the driver is 2.05; windows is 2.07; firmware 1.9 of the hardware is now compatible with latest drivers)