### PR TITLE
enable borders on the rpi5 for model3

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -7,6 +7,7 @@
 - Exit game with light gun (hold `TRIGGER`, `ACTION` and `START` buttons for 2 seconds) 
 ### Fixed
 ### Changed / Improved
+- Added bezel & sinden border support for the RPi5 with Model 3 games
 ### Updated
 - RetroArch to v1.19.1
   - Libretro-Melonds-Ds to v1.1.5

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -252,6 +252,18 @@ def gunsBordersSizeName(guns, config):
             return bordersSize
     return None
 
+# returns None to follow the bezel overlay size by default
+def gunsBorderRatioType(guns, config):
+    # add emulator specific configs here
+    if "m3_wideScreen" in config and config["m3_wideScreen"] == "1":
+        eslog.debug("Model 3 set to widescreen")
+        return None
+    else:
+        # check the display esolution is already 4:3
+        eslog.debug("Setting gun border ratio to 4:3")
+        return "4:3"
+    return None
+
 def getMouseButtons(device):
   caps = device.capabilities()
   caps_keys = caps[evdev.ecodes.EV_KEY]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -268,7 +268,7 @@ def start_rom(args, maxnbplayers, rom, romConfiguration):
             cmd = generator.generate(system, rom, playersControllers, metadata, guns, wheels, gameResolution)
 
             if system.isOptSet('hud_support') and system.getOptBoolean('hud_support') == True:
-                hud_bezel = getHudBezel(system, generator, rom, gameResolution, controllers.gunsBordersSizeName(guns, system.config))
+                hud_bezel = getHudBezel(system, generator, rom, gameResolution, controllers.gunsBordersSizeName(guns, system.config), controllers.gunsBorderRatioType(guns, system.config))
                 if (system.isOptSet('hud') and system.config['hud'] != "" and system.config['hud'] != "none") or hud_bezel is not None:
                     gameinfos = extractGameInfosFromXml(args.gameinfoxml)
                     cmd.env["MANGOHUD_DLSYM"] = "1"
@@ -314,7 +314,7 @@ def start_rom(args, maxnbplayers, rom, romConfiguration):
     # exit
     return exitCode
 
-def getHudBezel(system, generator, rom, gameResolution, bordersSize):
+def getHudBezel(system, generator, rom, gameResolution, bordersSize, bordersRatio):
     if generator.supportsInternalBezels():
         eslog.debug("skipping bezels for emulator {}".format(system.config['emulator']))
         return None
@@ -445,9 +445,9 @@ def getHudBezel(system, generator, rom, gameResolution, bordersSize):
     if bordersSize is not None:
         eslog.debug("Draw gun borders")
         output_png_file = "/tmp/bezel_gunborders.png"
-
         innerSize, outerSize = bezelsUtil.gunBordersSize(bordersSize)
-        borderSize = bezelsUtil.gunBorderImage(overlay_png_file, output_png_file, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
+        eslog.debug("Gun border ratio = {}".format(bordersRatio))
+        borderSize = bezelsUtil.gunBorderImage(overlay_png_file, output_png_file, bordersRatio, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
         overlay_png_file = output_png_file
 
     eslog.debug(f"applying bezel {overlay_png_file}")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -1345,7 +1345,7 @@ def writeBezelConfig(generator, bezel, shaderBezel, retroarchConfig, rom, gameRe
         eslog.debug("Draw gun borders")
         output_png_file = "/tmp/bezel_gunborders.png"
         innerSize, outerSize = bezelsUtil.gunBordersSize(gunsBordersSize)
-        borderSize = bezelsUtil.gunBorderImage(overlay_png_file, output_png_file, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
+        borderSize = bezelsUtil.gunBorderImage(overlay_png_file, output_png_file, None, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
         overlay_png_file = output_png_file
 
     eslog.debug(f"Bezel file set to {overlay_png_file}")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -748,7 +748,7 @@ class MameGenerator(Generator):
         if gunsBordersSize is not None:
             output_png_file = "/tmp/bezel_gunborders.png"
             innerSize, outerSize = bezelsUtil.gunBordersSize(gunsBordersSize)
-            borderSize = bezelsUtil.gunBorderImage(tmpZipDir + "/" + pngFile, output_png_file, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
+            borderSize = bezelsUtil.gunBorderImage(tmpZipDir + "/" + pngFile, None, output_png_file, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
             try:
                 os.remove(tmpZipDir + "/" + pngFile)
             except:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
@@ -22,9 +22,10 @@ class SupermodelGenerator(Generator):
              commandArray.extend(["-multi-texture", "-legacy-scsp", "-legacy3d"])
         
         # widescreen
-        if system.isOptSet("wideScreen") and system.getOptBoolean("wideScreen"):
+        if system.isOptSet("m3_wideScreen") and system.getOptBoolean("m3_wideScreen"):
             commandArray.append("-wide-screen")
             commandArray.append("-wide-bg")
+            system.config["bezel"] == "none"
 
         # quad rendering
         if system.isOptSet("quadRendering") and system.getOptBoolean("quadRendering"):

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2712.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2712.yml
@@ -16,8 +16,6 @@ model3:
   core:     supermodel-legacy
   options:
     videomode: max-1920x1080
-    decorations: none
-    hud_support: none
 scummvm:
   emulator: scummvm
   core:     scummvm

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -9579,7 +9579,7 @@ supermodel:
             choices:
                 "Off":      0
                 "On":       1
-        wideScreen:
+        m3_wideScreen:
             prompt:      WIDESCREEN HACK (GLITCHY)
             description: Enhancement. Only works with a 16/9 ratio and bezels disabled.
             choices:


### PR DESCRIPTION
add forced border ratio for emulators that need 4:3 sinden borders
- i.e. Model3