### PR TITLE
replace commas with dots in controller.realName fixing non-working controller configurations

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -120,7 +120,7 @@ def _generateSdlGameControllerConfig(controller, sdlMapping=_DEFAULT_SDL_MAPPING
     """Returns an SDL_GAMECONTROLLERCONFIG-formatted string for the given configuration."""
     config = []
     config.append(controller.guid)
-    config.append(controller.realName)
+    config.append(controller.realName.replace(",", "."))
     config.append("platform:Linux")
 
     def add_mapping(input):


### PR DESCRIPTION
Controllers with device names that contain a comma refuse to load properly when emulators such as pcsx2 are used.  The game_controller_db.txt appears to parse a comma delimited file and fails because of said erroneous comma placements.  This patch will simply replace said commas with dots.

Tested and working after this simple change.

Refer to https://github.com/batocera-linux/batocera.linux/issues/8568 with the poster who made the discovery.  They had the same issue with the ppsspp emulator.