### PR TITLE
fix-nso-n64-calibration [V41]

### DIFF
--- a/package/batocera/controllers/nso-n64/99-nso-n64-joystick.rules
+++ b/package/batocera/controllers/nso-n64/99-nso-n64-joystick.rules
@@ -1,0 +1,5 @@
+# Wired
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="Nintendo Co., Ltd. N64 Controller", RUN+="/usr/bin/nso-n64-calibration.sh"
+
+# Bluetooth
+ACTION=="add", SUBSYSTEM=="input", ATTRS{name}=="N64 Controller", RUN+="/usr/bin/nso-n64-calibration.sh"

--- a/package/batocera/controllers/nso-n64/Config.in
+++ b/package/batocera/controllers/nso-n64/Config.in
@@ -1,0 +1,5 @@
+config BR2_PACKAGE_NSO_N64
+    bool "nso-n64"
+
+    help
+	  fixes nso n64 calibration

--- a/package/batocera/controllers/nso-n64/nso-n64-calibration.sh
+++ b/package/batocera/controllers/nso-n64/nso-n64-calibration.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This is needed because the default calibration data for the NSO N64 controller is incorrect
+
+# VID AND PID for NSO N64 controller
+TARGET_VENDOR="057E"
+TARGET_PRODUCT="2019"
+
+find_event_device() {
+    for device in /dev/input/event*; do
+        udev_info=$(udevadm info --query=all --name="$device")        
+        devpath=$(echo "$udev_info" | grep 'DEVPATH' | cut -d'=' -f2)
+        
+        if [[ "$devpath" == *"$TARGET_VENDOR"* ]] && [[ "$devpath" == *"$TARGET_PRODUCT"* ]]; then
+            EVENT_PATH=$device
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+find_event_device
+
+if [ -z "$EVENT_PATH" ]; then
+    echo "Device not found, exiting."
+    exit 1
+fi
+
+# Apply calibration for X-axis (axis 0)
+evdev-joystick --e "$EVENT_PATH" --minimum -27767 --maximum 32767 --a 0 --d 500 --f 25
+
+# Apply calibration for Y-axis (axis 1)
+evdev-joystick --e "$EVENT_PATH" --minimum -32767 --maximum 27767 --a 1 --d 500 --f 25
+
+exit 0

--- a/package/batocera/controllers/nso-n64/nso-n64.mk
+++ b/package/batocera/controllers/nso-n64/nso-n64.mk
@@ -1,0 +1,19 @@
+################################################################################
+#
+# nso-n64-calibration
+#
+################################################################################
+NSO_N64_VERSION = 1
+NSO_N64_LICENSE = GPL
+NSO_N64_SOURCE=
+
+define NSO_N64_INSTALL_TARGET_CMDS
+    $(INSTALL) -m 0755 -D \
+    $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/nso-n64/99-nso-n64-joystick.rules \
+    $(TARGET_DIR)/etc/udev/rules.d/99-nso-n64-joystick.rules
+    $(INSTALL) -m 0755 -D \
+    $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/nso-n64/nso-n64-calibration.sh \
+    $(TARGET_DIR)/usr/bin/nso-n64-calibration.sh
+endef
+
+$(eval $(generic-package))

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -287,6 +287,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_HID_NX				if !BR2_PACKAGE_HOST_LINUX_HEADERS_CUSTOM_4_4 && !BR2_PACKAGE_BATOCERA_TARGET_BCM2835 && !BR2_PACKAGE_BATOCERA_TARGET_RK3326 # updated nintendo switch controller driver, requires kernel > 4.4
 	select BR2_PACKAGE_JOYCOND				if BR2_PACKAGE_HID_NX # nintendo switch joycon daemon (requires hid-nx)
 	select BR2_PACKAGE_JAMMASD
+	select BR2_PACKAGE_NSO_N64
 
 	select BR2_PACKAGE_UPOWER # required by some cemuhook servers
 


### PR DESCRIPTION
The default calibration data is incorrect for the NSO N64 controller. Known issue for several releases now. This aims to automatically calibrate to more correct values. I have 4 NSO N64 controllers, this is a universal issue and not related to any one specific controller.

Example of incorrect calibration:
Super Mario 64: Cannot jump out of water (down axis never reaches max value)
Star Fox 64: Unable to do loop (down axis never reaches max value)

After better calibration values are used issues resolve.