### PR TITLE
v41 bump vpinball, libdmdutil, and libpinmame

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Jul 2, 2024
+# Version: Commits on Aug 6, 2024
 # uses standalone tree for now
-VPINBALL_VERSION = db7519688c9b9dde004db38d7a4488c81a144996
+VPINBALL_VERSION = 62cc433880a7dda9a22096ede441c77ce7249d2f
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on Jul 9, 2024
-LIBDMDUTIL_VERSION = 71378daabb9a66bde3d88bcda8738c540aacf7f2
+# Version: Commits on Aug 6, 2024
+LIBDMDUTIL_VERSION = 2f507682e4e44669b916031091d7e89dd2391824
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Jul 2, 2024
-LIBPINMAME_VERSION = 2c4116642c1c15644e47c0054e3268af47559f9a
+# Version: Commits on Aug 6, 2024
+LIBPINMAME_VERSION = 4b9b96153a8131452830691ea6426f97353e9150
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE


### PR DESCRIPTION
TimeFence support added to libpinmame and vpinball (and integrated b2s)

Tested under 40 but missed cutoff.