### PR TITLE
add support for SideWinder Precision Racing Wheel

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -10,6 +10,7 @@
 - Exit game with light gun (hold `TRIGGER`, `ACTION` and `START` buttons for 2 seconds)
 - Enhanced Bluetooth AD2P codec support for LDAC & aptX supported headphones or speakers
   - The supported AD2P codec may need to be selected under SYSTEM SETTINGS -> AUDIO PROFILES
+- Steering wheel support for Microsoft SideWinder Precision Racing Wheel
 ### Fixed
 - Steam loading on a NAS drive
 - ScummVM forcing English which can prevent some non-english games from starting

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -18,6 +18,7 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="ThrustMaster, Inc. Ferrari 4
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T150RS",                    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="1080"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T80",                       MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="FGT Rumble Wheel",                                    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Microsoft SideWinder Precision Racing Wheel USB version 1.0",    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="220"
 
 # for ThrustMaster, Inc. Ferrari 458 Spider, cause xpad driver is blacklisted for the prefered xone
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b671", RUN+="/sbin/modprobe xpad"

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5247,4 +5247,18 @@
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Microsoft SideWinder Precision Racing Wheel USB version 1.0" deviceGUID="030000005e0400001a00000000010000">
+		<input name="a" type="button" id="0" value="1" code="288" />
+		<input name="b" type="button" id="1" value="1" code="289" />
+		<input name="hotkey" type="button" id="5" value="1" code="293" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="l2" type="axis" id="1" value="1" code="1" />
+		<input name="pagedown" type="button" id="7" value="1" code="295" />
+		<input name="pageup" type="button" id="6" value="1" code="294" />
+		<input name="r2" type="axis" id="2" value="1" code="5" />
+		<input name="select" type="button" id="5" value="1" code="293" />
+		<input name="start" type="button" id="2" value="1" code="290" />
+		<input name="x" type="button" id="3" value="1" code="291" />
+		<input name="y" type="button" id="4" value="1" code="292" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Works out of the box, mapping is limited. Select (bottom left button) is also hotkey. Bottom right button is start. No dpad.