### PR TITLE
pcsx2 add shaders and force 32bit dithering

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -435,6 +435,11 @@ def configureINI(config_directory, bios_directory, system, rom, controllers, met
         pcsx2INIConfig.set("EmuCore/GS", "OsdShowMessages", system.config["pcsx2_osd_messages"])
     else:
         pcsx2INIConfig.set("EmuCore/GS", "OsdShowMessages", "true")
+    # TV Shader
+    if system.isOptSet('pcsx2_shaderset'):
+        pcsx2INIConfig.set("EmuCore", "TVShader", system.config["pcsx2_shaderset"])
+    else:
+        pcsx2INIConfig.set("EmuCore", "TVShader", "0")    
 
     ## [InputSources]
     if not pcsx2INIConfig.has_section("InputSources"):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8698,6 +8698,18 @@ pcsx2:
       shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
       features: [cheevos]
       cfeatures:
+        pcsx2_shaderset:
+            submenu: RENDERING
+            prompt: SHADER SET
+            description:
+            choices:
+               "scanlines":         1
+               "diagonal filter":   2
+               "triangular filter": 3
+               "wave filter":       4
+               "lottes crt":        5
+               "4xrgss":            6
+               "nxagss":            7
         pcsx2_osd_messages:
             submenu: DISPLAY
             prompt: OSD MESSAGES
@@ -8850,7 +8862,8 @@ pcsx2:
             choices:
                 "Off":                 0
                 "Unscaled (Default)":  1
-                "Basic (Recommended)": 2
+                "Scaled":              2
+                "Force 32bit":         3
         pcsx2_blending:
             submenu: RENDERING
             prompt: BLENDING ACCURACY


### PR DESCRIPTION
Add ES setting for pcsx2 shaders under rendering submenu.
Add force 32 bit dithering setting, as well as update dithering "basic" setting to "scaled" which is what pcsx2 refers to it as internally. 