### PR TITLE
dolphin es setting name fix

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -7254,7 +7254,7 @@ dolphin:
                         "8x":  8
                 use_ssaa:
                     submenu: RENDERING
-                    prompt: ANTI-ALIASING MODE
+                    prompt: SSAA
                     description: Use SSAA instead of MSAA for anti-aliasing. SSAA may look better but has a higher performance cost.
                     preset: switchoff
                 hires_textures:


### PR DESCRIPTION
Changes es setting name to SSAA from ANTI-ALIASING MODE since it's just a toggle.