### PR TITLE
add initial light gun support namco 2x6

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -11,6 +11,7 @@
 - Enhanced Bluetooth AD2P codec support for LDAC & aptX supported headphones or speakers
   - The supported AD2P codec may need to be selected under SYSTEM SETTINGS -> AUDIO PROFILES
 - Steering wheel support for Microsoft SideWinder Precision Racing Wheel
+- Initial light gun support for Namco 2x6 (single light gun only)
 ### Fixed
 - Steam loading on a NAS drive
 - ScummVM forcing English which can prevent some non-english games from starting

--- a/package/batocera/emulators/play/namco2x6.keys
+++ b/package/batocera/emulators/play/namco2x6.keys
@@ -125,5 +125,27 @@
             "type": "key",
             "target": [ "KEY_0" ]
 	}
+        ]
+	,"actions_gun1": [
+	{
+            "trigger": "left",
+            "type": "key",
+            "target": "KEY_X"
+	},
+	{
+            "trigger": "right",
+            "type": "key",
+            "target": "KEY_S"
+	},
+	{
+            "trigger": "middle",
+            "type": "key",
+            "target": "KEY_BACKSPACE"
+	},
+	{
+            "trigger": "1",
+            "type": "key",
+            "target": "KEY_ENTER"
+	}
     ]
 }


### PR DESCRIPTION
This is a temporary solution. One gun only.