### PR TITLE
set governor to `powersave` for fallback in "balanced" mode

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-power-mode
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-power-mode
@@ -87,7 +87,7 @@ handle_powermode() {
                     set_epp "balance_performance"
                 fi
             else
-                set_governor "performance"
+                set_governor "powersave"
                 if epp_available; then
                     set_epp "balance_performance"
                 fi


### PR DESCRIPTION
For both the [Intel](https://github.com/torvalds/linux/blob/94ede2a3e9135764736221c080ac7c0ad993dc2d/drivers/cpufreq/intel_pstate.c#L791-L792) and [AMD](https://github.com/torvalds/linux/blob/94ede2a3e9135764736221c080ac7c0ad993dc2d/drivers/cpufreq/amd-pstate.c#L305-L308) p-state drivers, the only option available for `energy_performance_preference` using the `performance` governor is `performance` and setting it to anything else will result in an error. In order to set `energy_performance_preference` to `balance_performance`, the governor needs to be set to a governor like `powersave`.

I have tested this on my ROG Ally.
