### PR TITLE
Add batocera-resetsystem

### DIFF
--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -71,6 +71,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-spinner-calibrator        $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-vulkan                    $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-power-mode                $(TARGET_DIR)/usr/bin/
+    install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-resetsystem               $(TARGET_DIR)/usr/bin/
 endef
 
 define BATOCERA_SCRIPTS_INSTALL_MOUSE

--- a/package/batocera/core/batocera-scripts/scripts/batocera-resetsystem
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-resetsystem
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+SYSTEM="/userdata/system"
+OLD_SYSTEM="${SYSTEM}.old"
+
+kill_es() {
+	killall emulationstation 2>/dev/null
+	killall touchegg 2>/dev/null
+	if [ $? -eq 0 ]; then
+		sleep 20 &
+		watchdog=$!
+		while ! [ -z $(pidof emulationstation) ]; do
+			sleep 0.25
+			$(kill -0 $watchdog) || exit
+		done
+		kill -9 $watchdog
+	fi
+}
+
+kill_es
+
+if [ -d "$SYSTEM" ]; then
+    if [ -d "$OLD_SYSTEM" ]; then
+        rm -rf "$OLD_SYSTEM"
+        echo "Existing directory '$OLD_SYSTEM' found and has been deleted."
+    fi
+    
+    mv "$SYSTEM" "$OLD_SYSTEM"
+    echo "Directory '$SYSTEM' has been renamed to '$OLD_SYSTEM'."
+else
+    echo "Directory '$SYSTEM' does not exist."
+fi
+
+sync
+
+reboot


### PR DESCRIPTION
Adds functionality to restore system configs to defaults from within the ES GUI.

Sister PR here: https://github.com/batocera-linux/batocera-emulationstation/pull/1768

ES PR adds GUI front end dev setting which upon confirmation calls batocera-resetsystem

batocera-resetsystem kills ES and then renames system directory to system.old, and in the instance of a previous backup it is deleted so that a single backup is always kept.