### PR TITLE
remove .squashfs support for ikemen

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2705,7 +2705,7 @@ ikemen:
   manufacturer: Elecbyte
   release: 2021
   hardware: port
-  extensions: [ikemen, pc, squashfs]
+  extensions: [ikemen, pc]
   emulators:
     ikemen:
       ikemen:  { requireAnyOf: [BR2_PACKAGE_IKEMEN] }


### PR DESCRIPTION
Just like mugen, it needs to write a file which is read-only on .squashfs format. Remove it.