### PR TITLE
fix: on steamdeck, audio profile output of pactl has spaces in name...

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -72,7 +72,7 @@ case "${ACTION}" in
 
     list-profiles)
         echo "auto auto"
-        LANG=C pactl list cards-profiles-raw | grep "available=1" | sed -e s+"^card=[0-9]* name=\([^ ]*\) profile=\([^ ]*\) available=[01] active=[01] description=\(.*\)$"+"\2@\1 \3"+
+        LANG=C pactl list cards-profiles-raw | grep "available=1" | sed -e s+"^card=[0-9]* name=\([^ ]*\) profile=\(.*\) available=[01] active=[01] description=\(.*\)$"+"\2@\1 \3"+
         ;;
 
     get-profile)


### PR DESCRIPTION
i hesitate to patch pactl to have something with "xxx" it would make more sens for names etc, but maybe used