### PR TITLE
es_systems: thextech : add .squashfs support

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2282,7 +2282,7 @@ thextech:
   manufacturer: Wohlstand
   release: 2020
   hardware: port
-  extensions: [smbx]
+  extensions: [smbx, squashfs]
   emulators:
     thextech:
       thextech:  { requireAnyOf: [BR2_PACKAGE_THEXTECH] }


### PR DESCRIPTION
xtech games directories are readonly (and saves are already done in /userdata/saves).

They can have a lot of small files (around 60000 for supermario X).

compression is around 25%

du -sh "Super Mario Bros X.smbx"
2.1G	Super Mario Bros X.smbx

du -sh "Super Mario Bros X.squashfs"
1.6G	Super Mario Bros X.squashfs