### PR TITLE
Added squashfs for MSU-MD

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -333,13 +333,17 @@ class LibretroGenerator(Generator):
             if "squashfs" in rom:
                 romsInDir = glob.glob(glob.escape(rom) + '/*.sfc') + glob.glob(glob.escape(rom) + '/*.smc')
                 rom = romsInDir[0]
+        elif system.name == 'msu-md':
+            if "squashfs" in rom:
+                romsInDir = glob.glob(glob.escape(rom) + '/*.md')
+                rom = romsInDir[0]
 
         if system.name == 'scummvm':
             rom = os.path.dirname(rom) + '/' + romName
             if os.stat(rom).st_size == 0:
                 # File is empty, run game directly
                 rom = rom[0:-8]
-        
+
         if system.name == 'reminiscence':
             with open(rom, 'r') as file:
                 first_line = file.readline().strip()

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -532,7 +532,7 @@ msu-md:
   manufacturer: Sega
   release: 2020
   hardware: console
-  extensions: [md, zip, 7z]
+  extensions: [md, zip, 7z, squashfs]
   platform:   genesis, megadrive
   group:      megadrive
   emulators:


### PR DESCRIPTION
In the following PR squashfs was added for Snes MSU1 and Satellaview: https://github.com/batocera-linux/batocera.linux/pull/12142

This PR also adds squashfs for MSU-MD.