### PR TITLE
fix pcsx2 cross-compile

### DIFF
--- a/package/batocera/emulators/pcsx2/013-fix-cross-compile.patch
+++ b/package/batocera/emulators/pcsx2/013-fix-cross-compile.patch
@@ -1,0 +1,39 @@
+diff --git a/cmake/BuildParameters.cmake b/cmake/BuildParameters.cmake
+index 21d9940..1858019 100644
+--- a/cmake/BuildParameters.cmake
++++ b/cmake/BuildParameters.cmake
+@@ -72,8 +72,8 @@ mark_as_advanced(CMAKE_C_FLAGS_DEVEL CMAKE_CXX_FLAGS_DEVEL CMAKE_LINKER_FLAGS_DE
+ #-------------------------------------------------------------------------------
+ # Select the architecture
+ #-------------------------------------------------------------------------------
+-if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "amd64" OR
+-   "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "AMD64" OR "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64")
++if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "amd64" OR
++   "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "AMD64" OR "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "x86_64")
+ 	# Multi-ISA only exists on x86.
+ 	option(DISABLE_ADVANCE_SIMD "Disable advance use of SIMD (SSE2+ & AVX)" OFF)
+ 
+@@ -99,12 +99,12 @@ if("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64" OR "${CMAKE_HOST_SYSTEM_PR
+ 			add_compile_options("-msse" "-msse2" "-msse4.1" "-mfxsr")
+ 		else()
+ 			# Can't use march=native on Apple Silicon.
+-			if(NOT APPLE OR "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
++			if(NOT APPLE OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
+ 				add_compile_options("-march=native")
+ 			endif()
+ 		endif()
+ 	endif()
+-elseif("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64" OR "${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR
++elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "aarch64" OR
+        "${CMAKE_OSX_ARCHITECTURES}" STREQUAL "arm64")
+ 	message(STATUS "Building for Apple Silicon (ARM64).")
+ 	list(APPEND PCSX2_DEFS _M_ARM64=1)
+@@ -127,7 +127,7 @@ elseif("${CMAKE_HOST_SYSTEM_PROCESSOR}" STREQUAL "arm64" OR "${CMAKE_HOST_SYSTEM
+ 		list(APPEND PCSX2_DEFS OVERRIDE_HOST_CACHE_LINE_SIZE=64)
+ 	endif()
+ else()
+-	message(FATAL_ERROR "Unsupported architecture: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
++	message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+ endif()
+ 
+ # Require C++20.


### PR DESCRIPTION
Currently, the pcsx2 build decides the build flags to use based on the *host* architecture rather than the *target* architecture. This means building pcsx2 on aarch64 for x86_64 results in aarch64 build flags being used. The buildroot cmake package infrastructure sets `CMAKE_SYSTEM_PROCESSOR` to `BR2_ARCH` (as outlined in [cmake's docs](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_PROCESSOR.html)), so using `CMAKE_SYSTEM_PROCESSOR` to determine build flags is the correct choice.

- [x] Compiles
- [x] Tested