### PR TITLE
Fix potential bug with batocera-es-system.py

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
+++ b/package/batocera/emulationstation/batocera-es-system/batocera-es-system.py
@@ -120,7 +120,7 @@ class EsSystemConf:
         with open(configFile) as fp:
             line = fp.readline()
             while line:
-                m = re.search("^([^ ]+)=y$", line)
+                m = re.search("^([^#][^ ]*)=y$", line)
                 if m:
                     config[m.group(1)] = 1
                 line = fp.readline()


### PR DESCRIPTION
The regex was potentially matching commented out lines such as:

```
#BR2_PACKAGE_LIBRETRO_ATARI800=y
```