### PR TITLE
Correct scrapping for namco2x6 platform

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -4917,7 +4917,7 @@ namco2x6:
   release: 2000
   hardware: arcade
   extensions: [zip]
-  platform: namco2x6, arcade
+  platform: namco, sega, arcade
   emulators:
     play:
       play: { requireAnyOf: [BR2_PACKAGE_PLAY] }


### PR DESCRIPTION
There's no namco2x6 platform in https://github.com/batocera-linux/batocera-emulationstation/blob/master/es-app/src/PlatformId.cpp On screenscrapper, id are 147 for sega classics (Sega released some games on namco's 2x6 system) and 155 for namco classics. Not sure if we should keep "arcade" as a platform, so let's keep it for now, just in case.