### PR TITLE
N64DD: add support for standalone .ndd (via lr-paralleln64)

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -18,6 +18,7 @@
 - Emulationstation now supports savestates for standalones (dolphin, pcsx2, mupen, ppsspp)
 - Add Raspberry Pi patches for hardware accelerated HEVC decoding (RPi4 & RPi5 boards)
 - Nvidia Encoding support with `batocera-record` for Production driver systems
+- N64DD: support for standalone .ndd disk format (with libretro-paralleln64)
 ### Fixed
 - Steam loading on a NAS drive
 - ScummVM forcing English which can prevent some non-english games from starting

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -788,6 +788,9 @@ systems = {
                                   { "md5": "758f8fec271fbf526bb22b36e88f154b", "zippedFile": "p513bk1b.bin", "file": "bios/vis.zip"} ] },
     
     # ---------- GameCube ---------- #
+    "n64dd":   { "name": "Nintendo 64DD", "biosFiles":  [ { "md5": "8d3d9f294b6e174bc7b1d2fd1c727530", "file": "bios/64DD_IPL.bin" } ] },
+
+    # ---------- GameCube ---------- #
     "gamecube":   { "name": "Nintendo GameCube", "biosFiles":  [ { "md5": "db92574caab77a7ec99d4605fd6f2450", "file": "bios/GC/EUR/IPL.bin" },
                                                                  { "md5": "b17148254a5799684c7d783206504926", "file": "bios/GC/JAP/IPL.bin" },
                                                                  { "md5": "b17148254a5799684c7d783206504926", "file": "bios/GC/USA/IPL.bin" } ] },

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -237,7 +237,7 @@ n64dd:
   manufacturer: Nintendo
   release: 1999
   hardware: console
-  extensions: [z64, n64, zip, 7z] # ndd, d64 : Not supported yet
+  extensions: [z64, n64, ndd, zip, 7z] # d64 : Not supported yet
   emulators:
     mupen64plus:
       gliden64:   { requireAnyOf: [BR2_PACKAGE_MUPEN64PLUS_GLIDEN64] }


### PR DESCRIPTION
Fix #12447 