### PR TITLE
fix libretro-bsnes-hd cross-compile

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/libretro-bsnes-hd.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/libretro-bsnes-hd.mk
@@ -9,7 +9,7 @@ LIBRETRO_BSNES_HD_SITE = $(call github,DerKoun,bsnes-hd,$(LIBRETRO_BSNES_HD_VERS
 LIBRETRO_BSNES_HD_LICENSE = GPLv3
 
 define LIBRETRO_BSNES_HD_BUILD_CMDS
-	$(TARGET_CONFIGURE_OPTS) $(MAKE) CXX="$(TARGET_CXX)" CC="$(TARGET_CC)" -C $(@D)/bsnes -f GNUmakefile target="libretro" platform=linux local=false
+	$(TARGET_CONFIGURE_OPTS) $(MAKE) -C $(@D)/bsnes -f GNUmakefile target="libretro" platform=linux compiler="$(TARGET_CXX)" local=false
 endef
 
 define LIBRETRO_BSNES_HD_INSTALL_TARGET_CMDS


### PR DESCRIPTION
`libretro-bsnes-hd` ignores `CC` and `CXX`. When `platform` is set to `linux` without setting `compiler`, [it uses `g++`](https://github.com/DerKoun/bsnes-hd/blob/f46b6d6368ea93943a30b5d4e79e8ed51c2da5e8/nall/GNUmakefile#L70). This only works in the amd64 container because `/usr/bin/g++` produces x86_64 binaries (which could create problems, but doesn't in this case), but to support cross-compiling `compiler` needs to be overridden with `TARGET_CXX`.

- [X] Compiles
- [X] Tested (ROG Ally)