### PR TITLE
ensure nvidia scripts use utilities in host directory

### DIFF
--- a/package/batocera/gpu/nvidia-open-driver/nvidia-open-driver.mk
+++ b/package/batocera/gpu/nvidia-open-driver/nvidia-open-driver.mk
@@ -14,6 +14,7 @@ NVIDIA_OPEN_DRIVER_LICENSE = NVIDIA Software License
 NVIDIA_OPEN_DRIVER_LICENSE_FILES = LICENSE
 NVIDIA_OPEN_DRIVER_REDISTRIBUTE = NO
 NVIDIA_OPEN_DRIVER_INSTALL_STAGING = YES
+NVIDIA_OPEN_DRIVER_EXTRACT_DEPENDENCIES = host-zstd
 
 ifeq ($(BR2_PACKAGE_NVIDIA_OPEN_DRIVER_XORG),y)
 
@@ -166,8 +167,8 @@ endif # BR2_PACKAGE_NVIDIA_OPEN_DRIVER_MODULE == y
 # virtually everywhere, and it is fine enough to provide useful options.
 # Except it can't extract into an existing (even empty) directory.
 define NVIDIA_OPEN_DRIVER_EXTRACT_CMDS
-	$(SHELL) $(NVIDIA_OPEN_DRIVER_DL_DIR)/$(NVIDIA_OPEN_DRIVER_SOURCE) --extract-only --target \
-		$(@D)/tmp-extract
+	PATH="$(HOST_DIR)/bin:$(PATH)" $(SHELL) $(NVIDIA_OPEN_DRIVER_DL_DIR)/$(NVIDIA_OPEN_DRIVER_SOURCE) \
+		--extract-only --target $(@D)/tmp-extract
 	chmod u+w -R $(@D)
 	mv $(@D)/tmp-extract/* $(@D)/tmp-extract/.manifest $(@D)
 	rm -rf $(@D)/tmp-extract
@@ -322,7 +323,7 @@ define NVIDIA_OPEN_DRIVER_RENAME_KERNEL_MODULES
 	cp $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-modeset.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-modeset-production.ko
 	cp $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-drm.ko \
-	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-drm-production.ko	
+	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-drm-production.ko
 	cp $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-uvm.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-uvm-production.ko
 	# set the driver version file

--- a/package/batocera/gpu/nvidia-proprietary-driver/nvidia-proprietary-driver.mk
+++ b/package/batocera/gpu/nvidia-proprietary-driver/nvidia-proprietary-driver.mk
@@ -13,6 +13,7 @@ NVIDIA_PROPRIETARY_DRIVER_SOURCE = \
 NVIDIA_PROPRIETARY_DRIVER_LICENSE = NVIDIA Software License
 NVIDIA_PROPRIETARY_DRIVER_LICENSE_FILES = LICENSE
 NVIDIA_PROPRIETARY_DRIVER_REDISTRIBUTE = NO
+NVIDIA_PROPRIETARY_DRIVER_EXTRACT_DEPENDENCIES = host-zstd
 
 # Build and install the proprietary kernel modules if needed
 ifeq ($(BR2_PACKAGE_NVIDIA_PROPRIETARY_DRIVER_MODULE),y)
@@ -41,8 +42,8 @@ endif # BR2_PACKAGE_NVIDIA_PROPRIETARY_DRIVER_MODULE == y
 # virtually everywhere, and it is fine enough to provide useful options.
 # Except it can't extract into an existing (even empty) directory.
 define NVIDIA_PROPRIETARY_DRIVER_EXTRACT_CMDS
-	$(SHELL) $(NVIDIA_PROPRIETARY_DRIVER_DL_DIR)/$(NVIDIA_PROPRIETARY_DRIVER_SOURCE) --extract-only --target \
-		$(@D)/tmp-extract
+	PATH="$(HOST_DIR)/bin:$(PATH)" $(SHELL) $(NVIDIA_PROPRIETARY_DRIVER_DL_DIR)/$(NVIDIA_PROPRIETARY_DRIVER_SOURCE) \
+		--extract-only --target $(@D)/tmp-extract
 	chmod u+w -R $(@D)
 	mv $(@D)/tmp-extract/* $(@D)/tmp-extract/.manifest $(@D)
 	rm -rf $(@D)/tmp-extract
@@ -60,7 +61,7 @@ define NVIDIA_PROPRIETARY_DRIVER_RENAME_KERNEL_MODULES
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-modeset.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-modeset-proprietary.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-drm.ko \
-	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-drm-proprietary.ko	
+	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-drm-proprietary.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-uvm.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia-uvm-proprietary.ko
 endef

--- a/package/batocera/gpu/nvidia340-legacy-driver/nvidia340-legacy-driver.mk
+++ b/package/batocera/gpu/nvidia340-legacy-driver/nvidia340-legacy-driver.mk
@@ -14,6 +14,7 @@ NVIDIA340_LEGACY_DRIVER_LICENSE = NVIDIA Software License
 NVIDIA340_LEGACY_DRIVER_LICENSE_FILES = LICENSE
 NVIDIA340_LEGACY_DRIVER_REDISTRIBUTE = NO
 NVIDIA340_LEGACY_DRIVER_INSTALL_STAGING = YES
+NVIDIA340_LEGACY_DRIVER_EXTRACT_DEPENDENCIES = host-xz
 
 ifeq ($(BR2_PACKAGE_NVIDIA340_LEGACY_DRIVER_XORG),y)
 
@@ -143,8 +144,8 @@ endif # BR2_PACKAGE_NVIDIA340_LEGACY_DRIVER_MODULE == y
 # virtually everywhere, and it is fine enough to provide useful options.
 # Except it can't extract into an existing (even empty) directory.
 define NVIDIA340_LEGACY_DRIVER_EXTRACT_CMDS
-	$(SHELL) $(NVIDIA340_LEGACY_DRIVER_DL_DIR)/$(NVIDIA340_LEGACY_DRIVER_SOURCE) \
-	    --extract-only --target $(@D)/tmp-extract
+	PATH="$(HOST_DIR)/bin:$(PATH)" $(SHELL) $(NVIDIA340_LEGACY_DRIVER_DL_DIR)/$(NVIDIA340_LEGACY_DRIVER_SOURCE) \
+		--extract-only --target $(@D)/tmp-extract
 	chmod u+w -R $(@D)
 	mv $(@D)/tmp-extract/* $(@D)/tmp-extract/.manifest $(@D)
 	rm -rf $(@D)/tmp-extract

--- a/package/batocera/gpu/nvidia390-legacy-driver/nvidia390-legacy-driver.mk
+++ b/package/batocera/gpu/nvidia390-legacy-driver/nvidia390-legacy-driver.mk
@@ -12,6 +12,7 @@ NVIDIA390_LEGACY_DRIVER_LICENSE = NVIDIA Software License
 NVIDIA390_LEGACY_DRIVER_LICENSE_FILES = LICENSE
 NVIDIA390_LEGACY_DRIVER_REDISTRIBUTE = NO
 NVIDIA390_LEGACY_DRIVER_INSTALL_STAGING = YES
+NVIDIA390_LEGACY_DRIVER_EXTRACT_DEPENDENCIES = host-xz
 
 ifeq ($(BR2_PACKAGE_NVIDIA390_LEGACY_DRIVER_XORG),y)
 
@@ -102,8 +103,8 @@ endif # BR2_PACKAGE_NVIDIA390_LEGACY_DRIVER_MODULE == y
 # virtually everywhere, and it is fine enough to provide useful options.
 # Except it can't extract into an existing (even empty) directory.
 define NVIDIA390_LEGACY_DRIVER_EXTRACT_CMDS
-	$(SHELL) $(NVIDIA390_LEGACY_DRIVER_DL_DIR)/$(NVIDIA390_LEGACY_DRIVER_SOURCE) --extract-only --target \
-		$(@D)/tmp-extract
+	PATH="$(HOST_DIR)/bin:$(PATH)" $(SHELL) $(NVIDIA390_LEGACY_DRIVER_DL_DIR)/$(NVIDIA390_LEGACY_DRIVER_SOURCE) \
+		--extract-only --target $(@D)/tmp-extract
 	chmod u+w -R $(@D)
 	mv $(@D)/tmp-extract/* $(@D)/tmp-extract/.manifest $(@D)
 	rm -rf $(@D)/tmp-extract
@@ -139,7 +140,7 @@ define NVIDIA390_LEGACY_DRIVER_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0644 $(@D)/libglx.so.$(NVIDIA390_LEGACY_DRIVER_VERSION) \
 	        $(TARGET_DIR)/usr/lib/xorg/modules/extensions/libglx.so.$(NVIDIA390_LEGACY_DRIVER_VERSION)
 	$(NVIDIA390_LEGACY_DRIVER_INSTALL_KERNEL_MODULE)
-	
+
 	# batocera install files needed by libglvnd
 	$(INSTALL) -D -m 0644 $(@D)/10_nvidia.json \
 		$(TARGET_DIR)/usr/share/glvnd/egl_vendor.d/10_nvidia390_legacy.json
@@ -161,7 +162,7 @@ define NVIDIA390_LEGACY_DRIVER_RENAME_KERNEL_MODULES
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-modeset.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia390-modeset-legacy.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-drm.ko \
-	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia390-drm-legacy.ko	
+	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia390-drm-legacy.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-uvm.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia390-uvm-legacy.ko
 	mv -f $(TARGET_DIR)/usr/lib/xorg/modules/extensions/libglx.so.$(NVIDIA390_LEGACY_DRIVER_VERSION) \

--- a/package/batocera/gpu/nvidia470-legacy-driver/nvidia470-legacy-driver.mk
+++ b/package/batocera/gpu/nvidia470-legacy-driver/nvidia470-legacy-driver.mk
@@ -14,6 +14,7 @@ NVIDIA470_LEGACY_DRIVER_LICENSE = NVIDIA Software License
 NVIDIA470_LEGACY_DRIVER_LICENSE_FILES = LICENSE
 NVIDIA470_LEGACY_DRIVER_REDISTRIBUTE = NO
 NVIDIA470_LEGACY_DRIVER_INSTALL_STAGING = YES
+NVIDIA470_LEGACY_DRIVER_EXTRACT_DEPENDENCIES = host-xz
 
 ifeq ($(BR2_PACKAGE_NVIDIA470_LEGACY_DRIVER_XORG),y)
 
@@ -146,8 +147,8 @@ endif # NVIDIA470_LEGACY_DRIVER_MODULE == y
 # virtually everywhere, and it is fine enough to provide useful options.
 # Except it can't extract into an existing (even empty) directory.
 define NVIDIA470_LEGACY_DRIVER_EXTRACT_CMDS
-	$(SHELL) $(NVIDIA470_LEGACY_DRIVER_DL_DIR)/$(NVIDIA470_LEGACY_DRIVER_SOURCE) --extract-only --target \
-		$(@D)/tmp-extract
+	PATH="$(HOST_DIR)/bin:$(PATH)" $(SHELL) $(NVIDIA470_LEGACY_DRIVER_DL_DIR)/$(NVIDIA470_LEGACY_DRIVER_SOURCE) \
+		--extract-only --target $(@D)/tmp-extract
 	chmod u+w -R $(@D)
 	mv $(@D)/tmp-extract/* $(@D)/tmp-extract/.manifest $(@D)
 	rm -rf $(@D)/tmp-extract
@@ -246,7 +247,7 @@ define NVIDIA470_LEGACY_DRIVER_RENAME_KERNEL_MODULES
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-modeset.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia470-modeset-legacy.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-drm.ko \
-	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia470-drm-legacy.ko	
+	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia470-drm-legacy.ko
 	mv -f $(TARGET_DIR)/lib/modules/$(LINUX_VERSION_PROBED)/updates/nvidia-uvm.ko \
 	    $(TARGET_DIR)/usr/share/nvidia/modules/nvidia470-uvm-legacy.ko
 	# set the driver version file


### PR DESCRIPTION
The scripts that are used to compile the nvidia drivers check for `xz` or `zstd` and if they aren't found, use extract a binary that is contained within the script and use it. This isn't a problem when building on an x86_64 machine since the binary is x86. However when cross-compiling, `xz` or `zstd` need to be available to run on the host and in the `PATH` for the scripts to find them.

- [X] Compiles
- [ ] Tested (I don't own a machine that requires nvidia drivers)