### PR TITLE
fix ruffle build

### DIFF
--- a/package/batocera/emulators/ruffle/ruffle.mk
+++ b/package/batocera/emulators/ruffle/ruffle.mk
@@ -12,7 +12,9 @@ RUFFLE_DEPENDENCIES = host-rustc host-rust-bin openssl
 RUFFLE_ARGS_FOR_BUILD = -L $(STAGING_DIR) -Wl,-rpath,$(STAGING_DIR)
 
 RUFFLE_CARGO_ENV = CARGO_HOME=$(HOST_DIR)/usr/share/cargo \
-    RUSTFLAGS='$(addprefix -C linker=$(TARGET_CC) -C link-args=,$(RUFFLE_ARGS_FOR_BUILD))'
+    RUSTFLAGS='$(addprefix -C linker=$(TARGET_CC) -C link-args=,$(RUFFLE_ARGS_FOR_BUILD))' \
+    PKG_CONFIG="$(PKG_CONFIG_HOST_BINARY)"
+
 
 RUFFLE_CARGO_MODE = $(if $(BR2_ENABLE_DEBUG),,release)
 RUFFLE_BIN_DIR = target/$(RUSTC_TARGET_NAME)/$(RUFFLE_CARGO_MODE)
@@ -30,7 +32,7 @@ endef
 define RUFFLE_INSTALL_TARGET_CMDS
     $(INSTALL) -D -m 0755 $(@D)/$(RUFFLE_BIN_DIR)/ruffle_desktop \
              $(TARGET_DIR)/usr/bin/ruffle
-	
+
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/ruffle/flash.ruffle.keys \
         $(TARGET_DIR)/usr/share/evmapy


### PR DESCRIPTION
In order to find the libraries in the staging and target directories, `cargo` needs to be told which `pkg-config` to use.

- [X] Compiles
- [X] Tested