### PR TITLE
fix scummvm build

### DIFF
--- a/package/batocera/emulators/scummvm/scummvm.mk
+++ b/package/batocera/emulators/scummvm/scummvm.mk
@@ -21,20 +21,20 @@ endif
 
 ifeq ($(BR2_aarch64)$(BR2_arm),y)
     SCUMMVM_CONF_OPTS += --host=arm-linux
-endif
-
-ifeq ($(BR2_riscv),y)
+else ifeq ($(BR2_riscv),y)
     SCUMMVM_CONF_OPTS += --host=riscv64-linux
+else
+    SCUMMVM_CONF_OPTS += --host=$(GNU_TARGET_NAME)
 endif
 
-SCUMMVM_CONF_ENV += RANLIB="$(TARGET_RANLIB)" STRIP="$(TARGET_STRIP)" 
+SCUMMVM_CONF_ENV += RANLIB="$(TARGET_RANLIB)" STRIP="$(TARGET_STRIP)"
 SCUMMVM_CONF_ENV += AR="$(TARGET_AR) cru" AS="$(TARGET_AS)"
 
 SCUMMVM_CONF_OPTS += --opengl-mode=auto --disable-debug --enable-optimizations \
     --enable-mt32emu --enable-flac --enable-mad --enable-vorbis --disable-tremor \
     --enable-all-engines --enable-fluidsynth --disable-taskbar --disable-timidity \
     --disable-alsa --enable-vkeybd --enable-release --disable-eventrecorder \
-    --prefix=/usr --with-sdl-prefix="$(STAGING_DIR)/usr/bin"
+    --prefix=/usr --with-sdl-prefix="$(STAGING_DIR)/usr"
 
 ifeq ($(BR2_PACKAGE_LIBMPEG2),y)
     SCUMMVM_CONF_OPTS += --enable-mpeg2 --with-mpeg2-prefix="$(STAGING_DIR)/usr/lib"


### PR DESCRIPTION
The `configure` script for `scummvm` defaults to using `uname` to get the default value for the `--host` option. For cross-compiling, this means cflags and ldflags are set based on the host architecture rather than the target. Passing buildroot's `GNU_TARGET_NAME` (which is the target triple) corrects the problem. This also updates the value passed to `--with-sdl-prefix` to follow the documentation in the configure script.

- [X] Compiles
- [X] Tested (ROG Ally)