### PR TITLE
Reduce compile-time Dropbear default receive window 

### DIFF
--- a/board/batocera/dropbear_localoptions.h
+++ b/board/batocera/dropbear_localoptions.h
@@ -1,4 +1,4 @@
-#define DEFAULT_RECV_WINDOW 10485760
+#define DEFAULT_RECV_WINDOW 204800
 
 #define DSS_PRIV_FILENAME "/userdata/system/ssh/dropbear_dss_host_key"
 #define RSA_PRIV_FILENAME "/userdata/system/ssh/dropbear_rsa_host_key"


### PR DESCRIPTION
Reduce compile-time Dropbear default receive window to match new value from #12463 for increased compatibility.

The /etc/default/dropbear file will only affect the server at runtime, and this patch will set the default for both server and client utilities.



