### PR TITLE
improve ruffle build and add dependencies

### DIFF
--- a/package/batocera/emulators/ruffle/Config.in
+++ b/package/batocera/emulators/ruffle/Config.in
@@ -1,9 +1,12 @@
 config BR2_PACKAGE_RUFFLE
 	bool "ruffle"
-    depends on BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS
+	depends on BR2_PACKAGE_HOST_RUSTC_TARGET_ARCH_SUPPORTS
+	depends on BR2_PACKAGE_HAS_UDEV
 	select BR2_PACKAGE_HOST_RUSTC
-    select BR2_PACKAGE_OPENSSL
+	select BR2_PACKAGE_OPENSSL
+	select BR2_PACKAGE_NGHTTP2
+	select BR2_PACKAGE_ALSA_LIB
 	help
-        ruffle is a Flash Player emulator built in the Rust programming language.
+	  ruffle is a Flash Player emulator built in the Rust programming language.
 
-        https://ruffle.rs/
+	  https://ruffle.rs/

--- a/package/batocera/emulators/ruffle/ruffle.mk
+++ b/package/batocera/emulators/ruffle/ruffle.mk
@@ -7,25 +7,23 @@
 RUFFLE_VERSION = nightly-2024-03-28
 RUFFLE_SITE = $(call github,ruffle-rs,ruffle,$(RUFFLE_VERSION))
 RUFFLE_LICENSE = GPLv2
-RUFFLE_DEPENDENCIES = host-rustc host-rust-bin openssl
+RUFFLE_DEPENDENCIES = host-rustc host-rust-bin openssl udev nghttp2 alsa-lib
 
-RUFFLE_ARGS_FOR_BUILD = -L $(STAGING_DIR) -Wl,-rpath,$(STAGING_DIR)
-
-RUFFLE_CARGO_ENV = CARGO_HOME=$(HOST_DIR)/usr/share/cargo \
-    RUSTFLAGS='$(addprefix -C linker=$(TARGET_CC) -C link-args=,$(RUFFLE_ARGS_FOR_BUILD))' \
+RUFFLE_CARGO_ENV = CARGO_HOME=$(DL_DIR)/br-cargo-home \
+    CARGO_BUILD_TARGET="$(RUSTC_TARGET_NAME)" \
+    CARGO_HOST_RUSTFLAGS="$(addprefix -C link-args=,$(HOST_LDFLAGS))" \
+    CARGO_TARGET_$(call UPPERCASE,$(RUSTC_TARGET_NAME))_LINKER=$(notdir $(TARGET_CROSS))gcc \
     PKG_CONFIG="$(PKG_CONFIG_HOST_BINARY)"
-
 
 RUFFLE_CARGO_MODE = $(if $(BR2_ENABLE_DEBUG),,release)
 RUFFLE_BIN_DIR = target/$(RUSTC_TARGET_NAME)/$(RUFFLE_CARGO_MODE)
 
 RUFFLE_CARGO_OPTS = \
     --$(RUFFLE_CARGO_MODE) \
-        --target=$(RUSTC_TARGET_NAME) \
-        --manifest-path=$(@D)/Cargo.toml
+    --manifest-path=$(@D)/Cargo.toml
 
 define RUFFLE_BUILD_CMDS
-    $(TARGET_MAKE_ENV) $(RUFFLE_CARGO_ENV) \
+    $(TARGET_MAKE_ENV) $(TARGET_CONFIGURE_OPTS) $(RUFFLE_CARGO_ENV) \
             cargo build $(RUFFLE_CARGO_OPTS)
 endef
 


### PR DESCRIPTION
I ran into an issue doing a clean build where the dependencies weren't ready in the target when buildroot started compiling ruffle. I also updated the makefile to be closer to what `cargo-package` does to make sure the buildroot toolchain is being used.