### PR TITLE
Removed a buggy duplicate XArcade Tankstick mapping.

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -2911,30 +2911,6 @@
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Xarcade-to-Gamepad Device 1" deviceGUID="03000000010000000100000004000000">
-		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
-		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-		<input name="a" type="button" id="3" value="1" code="307" />
-		<input name="b" type="button" id="4" value="1" code="308" />
-		<input name="hotkey" type="button" id="7" value="1" code="314" />
-		<input name="pagedown" type="button" id="6" value="1" code="311" />
-		<input name="pageup" type="button" id="2" value="1" code="305" />
-		<input name="select" type="button" id="7" value="1" code="314" />
-		<input name="start" type="button" id="8" value="1" code="315" />
-		<input name="x" type="button" id="1" value="1" code="304" />
-		<input name="y" type="button" id="5" value="1" code="310" />
-	</inputConfig>
-	<inputConfig type="joystick" deviceName="Xarcade-to-Gamepad Device 2" deviceGUID="03000000010000000100000004000000">
-		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
-		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
-		<input name="a" type="button" id="3" value="1" code="307" />
-		<input name="b" type="button" id="4" value="1" code="308" />
-		<input name="pagedown" type="button" id="6" value="1" code="311" />
-		<input name="pageup" type="button" id="2" value="1" code="305" />
-		<input name="start" type="button" id="8" value="1" code="315" />
-		<input name="x" type="button" id="1" value="1" code="304" />
-		<input name="y" type="button" id="5" value="1" code="310" />
-	</inputConfig>
 	<inputConfig type="joystick" deviceName="PS3/PC Gamepad" deviceGUID="03000000100800000300000010010000">
 		<input name="a" type="button" id="1" value="1" code="289" />
 		<input name="b" type="button" id="2" value="1" code="290" />


### PR DESCRIPTION
Don't try to map an analog stick to a d-pad (i.e. 4x buttons).