### PR TITLE
fix & update `upgrade` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,12 +205,17 @@ endif
 %-upgrade: %-supported
 	$(if $(DEV),,$(error "DEV not specified!"))
 	-@sudo umount /tmp/mount
-	-@mkdir /tmp/mount
+	-@mkdir -p /tmp/mount
 	@sudo mount $(DEV)1 /tmp/mount
+	@lsblk
+	@ls /tmp/mount
+	@echo "continue BATOCERA upgrade $(DEV)1 with $* build? [y/N]"
+	@read line; if [ "$$line" != "y" ]; then echo aborting; exit 1 ; fi
 	-@sudo rm /tmp/mount/boot/batocera
-	@sudo tar xvf $(OUTPUT_DIR)/$*/images/batocera/boot.tar.xz -C /tmp/mount --no-same-owner
+	@sudo tar xvf $(OUTPUT_DIR)/$*/images/batocera/images/$*/boot.tar.xz -C /tmp/mount --no-same-owner --exclude=batocera-boot.conf --exclude=config.txt
 	@sudo umount /tmp/mount
 	-@rmdir /tmp/mount
+	@sudo fatlabel $(DEV)1 BATOCERA
 
 %-toolchain: %-supported
 	$(if $(shell which btrfs 2>/dev/null),, $(error "btrfs not found!"))


### PR DESCRIPTION
The `%-upgrade` target was out-of-date.

1. Changed to correct path to boot.tar.xz
2. Output `lsblk` and list contents of partition (`ls`) and ask for confirmation. (only `y` is accepted)
3. Preserve `batocera-boot.conf` and `config.txt` (assumes this is an **upgrade** and these 2 files exist as extraction of these 2 files is intentionally suppressed)
4. label partition with `BATOCERA` (system will hang on boot in the event label got lost)

tested using last v41-dev build of bcm2836 to a micro SD with the following command:
```
make bcm2836-upgrade DEV=/dev/sdb
```
new build booted on Pi Zero 2W 🚀