### PR TITLE
wheelsUtil.py: fix bug where wheelsUtils crashes if pad.dev happens to be None

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
@@ -99,7 +99,7 @@ def reconfigureControllers(playersControllers, system, rom, metadata, deviceList
 
     eslog.info("before wheel reconfiguration :")
     for playercontroller, pad in sorted(playersControllers.items()):
-        eslog.info("  " + playercontroller + ". index:" + str(pad.index) + " dev:" + pad.dev + " name:" + pad.realName)
+        eslog.info("  {}. index:{} dev:{} name:{}".format(playercontroller, str(pad.index), pad.dev,pad.realName))
 
     # reconfigure wheel buttons
     # no need to sort, but i like keeping the same loop (sorted by players)
@@ -223,7 +223,7 @@ def reconfigureControllers(playersControllers, system, rom, metadata, deviceList
 
     eslog.info("after wheel reconfiguration :")
     for playercontroller, pad in sorted(playersControllersNew.items()):
-        eslog.info("  " + playercontroller + ". index:" + str(pad.index) + " dev:" + pad.dev + " name:" + pad.realName)
+        eslog.info("  {}. index:{} dev:{} name:{}".format(playercontroller, str(pad.index), pad.dev,pad.realName))
 
     return (procs, playersControllersNew, deviceList)
 


### PR DESCRIPTION
got into a situation where pad.dev was None

using format() ensures it is converted to a null string before being passed to print()
