### PR TITLE
fix 4:3 sinden ratio values

### DIFF
--- a/package/batocera/controllers/guns/sinden-guns/virtual-sindenlightgun-add
+++ b/package/batocera/controllers/guns/sinden-guns/virtual-sindenlightgun-add
@@ -164,15 +164,11 @@ then
 	OPT_RATIO=$(batocera-settings-get controllers.guns.bordersratio)
 	if test "${OPT_RATIO}" = "4:3"
 	then
-	    sed -i -e s+'\(key="OffsetX"[ ]*value="\)[^"]*"'+'\1012.5"'+     "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetXRatio"[ ]*value="\)[^"]*"'+'\10.75"'+ "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetY"[ ]*value="\)[^"]*"'+'\100"'+        "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetYRatio"[ ]*value="\)[^"]*"'+'\101"'+   "${CONFIGFILE}" || unlockAndExit 1
+	    sed -i -e s+'\(key="OffsetX"[ ]*value="\)[^"]*"'+'\1012.5"'+        "${CONFIGFILE}" || unlockAndExit 1
+	    sed -i -e s+'\(key="OffsetXRatio"[ ]*value="\)[^"]*"'+'\10.75"'+    "${CONFIGFILE}" || unlockAndExit 1
 	else # full
-	    sed -i -e s+'\(key="OffsetX"[ ]*value="\)[^"]*"'+'\100"'+      "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetXRatio"[ ]*value="\)[^"]*"'+'\101"'+ "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetY"[ ]*value="\)[^"]*"'+'\100"'+      "${CONFIGFILE}" || unlockAndExit 1
-	    sed -i -e s+'\(key="OffsetYRatio"[ ]*value="\)[^"]*"'+'\101"'+ "${CONFIGFILE}" || unlockAndExit 1
+	    sed -i -e s+'\(key="OffsetX"[ ]*value="\)[^"]*"'+'\100"'+           "${CONFIGFILE}" || unlockAndExit 1
+	    sed -i -e s+'\(key="OffsetXRatio"[ ]*value="\)[^"]*"'+'\101"'+      "${CONFIGFILE}" || unlockAndExit 1
 	fi
 
 	sed -i -e s+'\(key="SerialPortWrite"[ ]*value="\)[^"]*"'+'\1'${ACMDEV}'"'+ "${CONFIGFILE}" || unlockAndExit 1


### PR DESCRIPTION
~~Current parameters are the ones used by older driver. Newer driver currently used changed the parameter names.~~

We are still using 1.09 parameters for some reason.