### PR TITLE
Update shim-signed mirror url

### DIFF
--- a/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.mk
+++ b/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_VERSION = 1+15.7+1
-BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_SITE = https://ftp.debian.org/debian/pool/main/s/shim-helpers-i386-signed
+BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_SITE = https://mirror.ufam.edu.br/debian/pool/main/s/shim-helpers-i386-signed
 BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_SOURCE = shim-helpers-i386-signed_$(BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_VERSION)_i386.deb
 
 define BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_EXTRACT_CMDS

--- a/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.mk
+++ b/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 BATOCERA_SHIM_SIGNED_EFI_IA32_VERSION = 1.39+15.7-1
-BATOCERA_SHIM_SIGNED_EFI_IA32_SITE = https://ftp.debian.org/debian/pool/main/s/shim-signed
+BATOCERA_SHIM_SIGNED_EFI_IA32_SITE = https://mirror.ufam.edu.br/debian/pool/main/s/shim-signed
 BATOCERA_SHIM_SIGNED_EFI_IA32_SOURCE = shim-signed_$(BATOCERA_SHIM_SIGNED_EFI_IA32_VERSION)_i386.deb
 
 define BATOCERA_SHIM_SIGNED_EFI_IA32_EXTRACT_CMDS


### PR DESCRIPTION
Current mirror was broken, it has 15.6 and 15.8 but not 15.7. Also, the mirror fallback urls are also broken. I'm not sure why most of the mirrors online are missing this version of the file, but this was one I found that works for now.

Example of error while building:

```
>>> batocera-shim-signed-efi-ia32 1.39+15.7-1 Downloading
wget -nd -t 3 -O '/x86_64/build/.shim-signed_1.39+15.7-1_i386.deb.rD3rh6/output' 'https://ftp.debian.org/debian/pool/main/s/shim-signed/shim-signed_1.39+15.7-1_i386.deb'
--2024-09-19 01:03:47--  https://ftp.debian.org/debian/pool/main/s/shim-signed/shim-signed_1.39+15.7-1_i386.deb
Resolving ftp.debian.org (ftp.debian.org)... 151.101.54.132, 2a04:4e42:4::644
Connecting to ftp.debian.org (ftp.debian.org)|151.101.54.132|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-09-19 01:03:47 ERROR 404: Not Found.

wget -nd -t 3 -O '/x86_64/build/.shim-signed_1.39+15.7-1_i386.deb.WBd1pE/output' 'https://sources.buildroot.net/batocera-shim-signed-efi-ia32/shim-signed_1.39+15.7-1_i386.deb'
--2024-09-19 01:03:47--  https://sources.buildroot.net/batocera-shim-signed-efi-ia32/shim-signed_1.39+15.7-1_i386.deb
Resolving sources.buildroot.net (sources.buildroot.net)... 104.26.0.37, 172.67.72.56, 104.26.1.37, ...
Connecting to sources.buildroot.net (sources.buildroot.net)|104.26.0.37|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-09-19 01:03:47 ERROR 404: Not Found.

wget -nd -t 3 -O '/x86_64/build/.shim-signed_1.39+15.7-1_i386.deb.qkA02C/output' 'https://sources.buildroot.net/shim-signed_1.39+15.7-1_i386.deb'
--2024-09-19 01:03:48--  https://sources.buildroot.net/shim-signed_1.39+15.7-1_i386.deb
Resolving sources.buildroot.net (sources.buildroot.net)... 104.26.0.37, 172.67.72.56, 104.26.1.37, ...
Connecting to sources.buildroot.net (sources.buildroot.net)|104.26.0.37|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2024-09-19 01:03:48 ERROR 404: Not Found.
```