### PR TITLE
Bump ia32 EFI shim boot to latest

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -117,6 +117,7 @@
 - Mesa3D to 24.2.1
 - Buildroot to the 2024.05.2 release base
 - GStreamer codecs to 1.24.7
+- shim-signed ia32 EFI bootloader to 1.44~1+deb12u1+15.8-1~deb12u1
 
 # 2024/08/11 - batocera.linux 40 - Swallowtail
 ### Special Notes

--- a/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.hash
+++ b/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.hash
@@ -1,2 +1,2 @@
 # From https://packages.debian.org/bookworm/i386/shim-helpers-i386-signed/download :
-sha256	d22b5b9db03ce3e52404dc4afa2a61398bfe4e3b18d292ae8f2461c2176fa9e0  shim-helpers-i386-signed_1+15.7+1_i386.deb
+sha256	f7f20896b122cf7bbb19804a07b1cb5eec4aa099be51c778a51d2cb3c08511a4  shim-helpers-i386-signed_1+15.8+1~deb12u1_i386.deb

--- a/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.mk
+++ b/package/batocera/boot/batocera-shim-signed-efi-helpers-ia32/batocera-shim-signed-efi-helpers-ia32.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_VERSION = 1+15.7+1
+BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_VERSION = 1+15.8+1~deb12u1
 BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_SITE = https://ftp.debian.org/debian/pool/main/s/shim-helpers-i386-signed
 BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_SOURCE = shim-helpers-i386-signed_$(BATOCERA_SHIM_SIGNED_EFI_HELPERS_IA32_VERSION)_i386.deb
 

--- a/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.hash
+++ b/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.hash
@@ -1,2 +1,2 @@
 # From https://packages.debian.org/bookworm/i386/shim-signed/download :
-sha256	34f2583a129cb4c6e48387e77f0fd3bc60c40c660d5c560585f9b940e2c49a3b  shim-signed_1.39+15.7-1_i386.deb
+sha256	4ed64ef758a5d9a023bce832f615447ebea7b0f6124c3f3c2832e3f03d08954b  shim-signed_1.44~1+deb12u1+15.8-1~deb12u1_i386.deb

--- a/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.mk
+++ b/package/batocera/boot/batocera-shim-signed-efi-ia32/batocera-shim-signed-efi-ia32.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-BATOCERA_SHIM_SIGNED_EFI_IA32_VERSION = 1.39+15.7-1
+BATOCERA_SHIM_SIGNED_EFI_IA32_VERSION = 1.44~1+deb12u1+15.8-1~deb12u1
 BATOCERA_SHIM_SIGNED_EFI_IA32_SITE = https://ftp.debian.org/debian/pool/main/s/shim-signed
 BATOCERA_SHIM_SIGNED_EFI_IA32_SOURCE = shim-signed_$(BATOCERA_SHIM_SIGNED_EFI_IA32_VERSION)_i386.deb
 


### PR DESCRIPTION
Bump ia32 EFI shim boot to latest version from Debian.
Replaces #12501 
