### PR TITLE
fix libretro generator after relative import refactor

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1,6 +1,9 @@
 import os
 import configparser
 
+from ... import batoceraFiles
+from ... import controllersConfig
+
 def generateCoreSettings(coreSettings, system, rom, guns, wheels):
 
     # Amstrad CPC / GX4000


### PR DESCRIPTION
I mistakenly removed these imports because `generateCoreSettings()` is too complex for pyright to analyze. I checked all of the imports I removed in the relative import refactor and these were the only ones referenced in the file.

- [X] Builds
- [X] Tested