### PR TITLE
modernize `UnixSettings`

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -26,14 +26,14 @@ class Emulator():
 
         # load configuration from batocera.conf
         recalSettings = UnixSettings(batoceraFiles.batoceraConf)
-        globalSettings = recalSettings.loadAll('global')
-        controllersSettings = recalSettings.loadAll('controllers', True)
-        systemSettings = recalSettings.loadAll(self.name)
-        folderSettings = recalSettings.loadAll(self.name + ".folder[\"" + os.path.dirname(rom) + "\"]")
-        gameSettings = recalSettings.loadAll(self.name + "[\"" + gsname + "\"]")
+        globalSettings = recalSettings.load_all('global')
+        controllersSettings = recalSettings.load_all('controllers', True)
+        systemSettings = recalSettings.load_all(self.name)
+        folderSettings = recalSettings.load_all(self.name + ".folder[\"" + os.path.dirname(rom) + "\"]")
+        gameSettings = recalSettings.load_all(self.name + "[\"" + gsname + "\"]")
 
         # add some other options
-        displaySettings = recalSettings.loadAll('display')
+        displaySettings = recalSettings.load_all('display')
         for opt in displaySettings:
             self.config["display." + opt] = displaySettings[opt]
 
@@ -68,8 +68,8 @@ class Emulator():
         # for compatibility with earlier Batocera versions, let's keep -renderer
         # but it should be reviewed when we refactor configgen (to Python3?)
         # so that we can fetch them from system.shader without -renderer
-        systemSettings = recalSettings.loadAll(self.name + "-renderer")
-        gameSettings = recalSettings.loadAll(self.name + "[\"" + gsname + "\"]" + "-renderer")
+        systemSettings = recalSettings.load_all(self.name + "-renderer")
+        gameSettings = recalSettings.load_all(self.name + "[\"" + gsname + "\"]" + "-renderer")
 
         # es only allow to update systemSettings and gameSettings in fact for the moment
         Emulator.updateConfiguration(self.renderconfig, systemSettings)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -89,7 +89,7 @@ def connected_to_internet():
             eslog.error("Not connected to the internet")
             return False
 
-def writeLibretroConfig(generator, retroconfig, system, controllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend):
+def writeLibretroConfig(generator, retroconfig: UnixSettings, system, controllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend):
     writeLibretroConfigToFile(retroconfig, createLibretroConfig(generator, system, controllers, metadata, guns, wheels, rom, bezel, shaderBezel, gameResolution, gfxBackend))
 
 # Take a system, and returns a dict of retroarch.cfg compatible parameters
@@ -1129,7 +1129,7 @@ def configureGunInputsForPlayer(n, gun, controllers, retroarchConfig, core, meta
                         retroarchConfig['input_player{}_{}_axis'.format(n, m)] = aval + pad.inputs[mapping[m]].id
         nplayer += 1
 
-def writeLibretroConfigToFile(retroconfig, config):
+def writeLibretroConfigToFile(retroconfig: UnixSettings, config):
     for setting in config:
         retroconfig.save(setting, config[setting])
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -3,6 +3,7 @@ import os
 
 from ...controllersConfig import getDevicesInformation
 from ...controllersConfig import getAssociatedMouse
+from ...settings.unixSettings import UnixSettings
 
 sys.path.append(
     os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
@@ -26,7 +27,7 @@ systemToSwapDisable = {'amigacd32', 'amigacdtv', 'naomi', 'atomiswave', 'megadri
 
 # Write a configuration for a specified controller
 # Warning, function used by amiberry because it reads the same retroarch formatting
-def writeControllersConfig(retroconfig, system, controllers, lightgun):
+def writeControllersConfig(retroconfig: UnixSettings, system, controllers, lightgun):
     # Map buttons to the corresponding retroarch specials keys
     retroarchspecials = {'x': 'load_state', 'y': 'save_state', 'a': 'reset', 'start': 'exit_emulator', \
                          'up': 'state_slot_increase', 'down': 'state_slot_decrease', 'left': 'rewind', 'right': 'hold_fast_forward', \
@@ -77,21 +78,21 @@ def writeControllersConfig(retroconfig, system, controllers, lightgun):
     writeHotKeyConfig(retroconfig, controllers)
 
 # Remove all controller configurations
-def cleanControllerConfig(retroconfig, controllers, retroarchspecials):
-    retroconfig.disableAll('input_player')
+def cleanControllerConfig(retroconfig: UnixSettings, controllers, retroarchspecials):
+    retroconfig.disable_all('input_player')
     for specialkey in retroarchspecials:
-        retroconfig.disableAll(f'input_{retroarchspecials[specialkey]}')
+        retroconfig.disable_all(f'input_{retroarchspecials[specialkey]}')
 
 
 # Write the hotkey for player 1
-def writeHotKeyConfig(retroconfig, controllers):
+def writeHotKeyConfig(retroconfig: UnixSettings, controllers):
     if '1' in controllers:
         if 'hotkey' in controllers['1'].inputs and controllers['1'].inputs['hotkey'].type == 'button':
             retroconfig.save('input_enable_hotkey_btn', controllers['1'].inputs['hotkey'].id)
 
 
 # Write a configuration for a specified controller
-def writeControllerConfig(retroconfig, controller, playerIndex, system, retroarchspecials, lightgun, mouseIndex=0):
+def writeControllerConfig(retroconfig: UnixSettings, controller, playerIndex, system, retroarchspecials, lightgun, mouseIndex=0):
     generatedConfig = generateControllerConfig(controller, retroarchspecials, system, lightgun, mouseIndex)
     for key in generatedConfig:
         retroconfig.save(key, generatedConfig[key])

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroRetroarchCustom.py
@@ -3,7 +3,7 @@ import os
 from ... import batoceraFiles
 from ...settings.unixSettings import UnixSettings
 
-def generateRetroarchCustom():
+def generateRetroarchCustom() -> None:
     # retroarchcustom.cfg
     if not os.path.exists(os.path.dirname(batoceraFiles.retroarchCustom)):
         os.makedirs(os.path.dirname(batoceraFiles.retroarchCustom))
@@ -83,7 +83,7 @@ def generateRetroarchCustom():
 
     retroarchSettings.write()
 
-def generateRetroarchCustomPathes(retroarchSettings):
+def generateRetroarchCustomPathes(retroarchSettings: UnixSettings) -> None:
     # Path Retroarch
     retroarchSettings.save('core_options_path',             '"/userdata/system/configs/retroarch/cores/retroarch-core-options.cfg"')
     retroarchSettings.save('assets_directory',              '"/usr/share/libretro/assets"')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
@@ -1,8 +1,9 @@
+from ...settings.unixSettings import UnixSettings
 from ...utils.logger import get_logger
 
 eslog = get_logger(__name__)
 
-def generateControllerConfig(config, playersControllers, core):
+def generateControllerConfig(config: UnixSettings, playersControllers, core):
     if core == "openbor4432":
         setupControllers(config, playersControllers, 32, False)
     elif core == "openbor7142":
@@ -53,7 +54,7 @@ def JoystickValue(key, pad, joy_max_inputs, new_axis_vals, invertAxis = False):
     #eslog.debug("input.type={} input.id={} input.value={} => result={}".format(input.type, input.id, input.value, value))
     return value
 
-def setupControllers(config, playersControllers, joy_max_inputs, new_axis_vals):
+def setupControllers(config: UnixSettings, playersControllers, joy_max_inputs, new_axis_vals):
     idx = 0
     for playercontroller, pad in sorted(playersControllers.items()):
         config.save("keys." + str(idx) + ".0" , JoystickValue("up",       pad, joy_max_inputs, new_axis_vals)) # MOVEUP


### PR DESCRIPTION
The following changes are incorporated:

* Use `dataclass` to define the shape of the object
* Use slots to keep the size of the objects as small as possible
* Updated the names of properties and methods to follow PEP-8 guidelines
* Added type hints
* Updated to allow passing either a string or a `pathlib.Path` for the path to the settings file
* Updated `write()` to use `Path.open()` as a context manager which always closes the file at the end of the `with` block

- [X] Builds
- [X] Tested