### PR TITLE
use path objects in configgen core

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Command.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Command.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
 class Command:
-    def __init__(self, array, env=dict()):
-        self.array = array
-        self.env = env
+    def __init__(self, array: Sequence[str | Path], env: Mapping[str, str | Path] = dict()):
+        self.array = list(array)
+        self.env = dict(env)
 
     def __str__(self):
-        str = list()
+        strings: list[str] = []
 
         for varName, varValue in self.env.items():
-            str.append("%s=%s" % (varName, varValue))
+            strings.append(f"{varName}={varValue}")
 
         for value in self.array:
-            str.append(value)
+            strings.append(str(value))
 
-        return " ".join(str)
+        return " ".join(strings)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/README.md
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/README.md
@@ -1,6 +1,6 @@
 ## Directory navigation
 
  - `generators` The infamous Python configuration generators, bane of the end-user who's used to modifying INI and XML files directly. These are what create the necessary configuration files, controller profiles and any other necessary INI/CFG file an emulator uses upon launching an emulator. Used in conjunction with [ES features](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/emulationstation/batocera-es-system/es_features.yml) to make these generated configs based on the options the user has set in ES. If creating a new one, don't forget to [define](https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py) it as well.
- - `batoceraFiles.py` The paths used by emulators for their configuration files, saves, etc.
+ - `batoceraPaths.py` The paths used by emulators for their configuration files, saves, etc.
  - `Emulator.py` How do we grab all the settings? And in what order?
  - `emulatorlauncher.py` The main launcher.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/batoceraPaths.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/batoceraPaths.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from typing import Final
+
+BATOCERA_SHARE_DIR: Final = Path('/usr/share/batocera')
+DATAINIT_DIR: Final = BATOCERA_SHARE_DIR / 'datainit'
+USERDATA: Final = Path('/userdata')
+
+HOME_INIT: Final = DATAINIT_DIR / 'system'
+CONF_INIT: Final = HOME_INIT / 'configs'
+
+HOME: Final = USERDATA / 'system'
+CONFIGS: Final = HOME / 'configs'
+EVMAPY: Final = CONFIGS / 'evmapy'
+SAVES: Final = USERDATA / 'saves'
+SCREENSHOTS: Final = USERDATA / 'screenshots'
+RECORDINGS: Final = USERDATA / 'recordings'
+BIOS: Final = USERDATA / 'bios'
+OVERLAYS: Final = USERDATA / 'overlays'
+CACHE: Final = HOME / 'cache'
+ROMS: Final = USERDATA / 'roms'
+LOGS: Final = HOME / 'logs'
+BATOCERA_CONF: Final = HOME / 'batocera.conf'
+
+USER_ES_DIR: Final = CONFIGS / 'emulationstation'
+BATOCERA_ES_DIR: Final = Path('/usr/share/emulationstation')
+
+_ES_RESOURCES_DIR: Final = BATOCERA_ES_DIR / 'resources'
+
+ES_SETTINGS: Final = USER_ES_DIR / 'es_settings.cfg'
+ES_GUNS_METADATA: Final = _ES_RESOURCES_DIR / 'gungames.xml'
+ES_WHEELS_METADATA: Final = _ES_RESOURCES_DIR / 'wheelgames.xml'
+ES_GAMES_METADATA: Final = _ES_RESOURCES_DIR / 'gamesdb.xml'
+
+DEFAULTS_DIR: Final = BATOCERA_SHARE_DIR / 'configgen'
+
+USER_SHADERS: Final = USERDATA / 'shaders'
+BATOCERA_SHADERS: Final = BATOCERA_SHARE_DIR / 'shaders'
+
+USER_DECORATIONS: Final = USERDATA / 'decorations'
+SYSTEM_DECORATIONS: Final = DATAINIT_DIR / 'decorations'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -1,10 +1,11 @@
+from pathlib import Path
 import xml.etree.ElementTree as ET
 import os
 import pyudev
 import evdev
 import re
 
-from . import batoceraFiles
+from .batoceraPaths import ES_GAMES_METADATA, BATOCERA_ES_DIR, USER_ES_DIR
 from .utils.logger import get_logger
 
 eslog = get_logger(__name__)
@@ -55,8 +56,8 @@ class Controller:
 # Load all controllers from the es_input.cfg
 def loadAllControllersConfig():
     controllers = dict()
-    for conffile in ["/usr/share/emulationstation/es_input.cfg", batoceraFiles.CONF + '/emulationstation/es_input.cfg']:
-      if os.path.exists(conffile):
+    for conffile in [BATOCERA_ES_DIR / "es_input.cfg", USER_ES_DIR / 'es_input.cfg']:
+      if conffile.exists():
           tree = ET.parse(conffile)
           root = tree.getroot()
           for controller in root.findall(".//inputConfig"):
@@ -73,8 +74,8 @@ def loadAllControllersConfig():
 # Load all controllers from the es_input.cfg
 def loadAllControllersByNameConfig():
     controllers = dict()
-    for conffile in ["/usr/share/emulationstation/es_input.cfg", batoceraFiles.CONF + '/emulationstation/es_input.cfg']:
-        if os.path.exists(conffile):
+    for conffile in [BATOCERA_ES_DIR / "es_input.cfg", USER_ES_DIR / 'es_input.cfg']:
+        if conffile.exists():
             tree = ET.parse(conffile)
             root = tree.getroot()
             for controller in root.findall(".//inputConfig"):
@@ -208,7 +209,7 @@ def generateSdlGameControllerConfig(controllers):
     return "\n".join(configs)
 
 
-def writeSDLGameDBAllControllers(controllers, outputFile = "/tmp/gamecontrollerdb.txt"):
+def writeSDLGameDBAllControllers(controllers, outputFile: str | Path = "/tmp/gamecontrollerdb.txt"):
     with open(outputFile, "w") as text_file:
         text_file.write(generateSdlGameControllerConfig(controllers))
     return outputFile
@@ -378,7 +379,7 @@ def shortNameFromPath(path):
 
 def getGamesMetaData(system, rom):
     # load the database
-    tree = ET.parse(batoceraFiles.esGamesMetadata)
+    tree = ET.parse(ES_GAMES_METADATA)
     root = tree.getroot()
     game = shortNameFromPath(rom)
     res = {}

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+from pathlib import Path
+
 profiler = None
 
 # 1) touch /var/run/emulatorlauncher.perf
@@ -21,9 +23,9 @@ import time
 from sys import exit
 import subprocess
 
-from . import batoceraFiles
 from . import controllersConfig as controllers
 from . import GeneratorImporter
+from .batoceraPaths import SAVES
 from .Emulator import Emulator
 from .utils import bezels as bezelsUtil
 from .utils import videoMode
@@ -206,9 +208,9 @@ def start_rom(args, maxnbplayers, rom, romConfiguration):
         eslog.debug("resolution: {}x{}".format(str(gameResolution["width"]), str(gameResolution["height"])))
 
         # savedir: create the save directory if not already done
-        dirname = os.path.join(batoceraFiles.savesDir, system.name)
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
+        dirname = SAVES / system.name
+        if not dirname.exists():
+            dirname.mkdir(parents=True)
 
         # core
         effectiveCore = ""

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -2,13 +2,13 @@ import os
 import struct
 from PIL import Image, ImageOps
 
-from .. import batoceraFiles
+from ..batoceraPaths import SYSTEM_DECORATIONS, USER_DECORATIONS
 from .videoMode import getAltDecoration
 from .logger import get_logger
 
 eslog = get_logger(__name__)
 
-def getBezelInfos(rom, bezel, systemName, emulator):
+def getBezelInfos(rom: str, bezel: str, systemName: str, emulator: str):
     # by order choose :
     # rom name in the system subfolder of the user directory (gb/mario.png)
     # rom name in the system subfolder of the system directory (gb/mario.png)
@@ -23,82 +23,82 @@ def getBezelInfos(rom, bezel, systemName, emulator):
     # mamezip files are for MAME-specific advanced artwork (bezels with overlays and backdrops, animated LEDs, etc)
     altDecoration = getAltDecoration(systemName, rom, emulator)
     romBase = os.path.splitext(os.path.basename(rom))[0] # filename without extension
-    overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".info"
-    overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".png"
-    overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".lay"
-    overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".zip"
+    overlay_info_file = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.info"
+    overlay_png_file  = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.png"
+    overlay_layout_file  = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.lay"
+    overlay_mamezip_file  = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.zip"
     bezel_game = True
-    if not os.path.exists(overlay_png_file):
-        overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/games/" + systemName + "/" + romBase + ".info"
-        overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/games/" + systemName + "/" + romBase + ".png"
-        overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".lay"
-        overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + systemName + "/" + romBase + ".zip"
+    if not overlay_png_file.exists():
+        overlay_info_file = SYSTEM_DECORATIONS / bezel / "games" / systemName / f"{romBase}.info"
+        overlay_png_file  = SYSTEM_DECORATIONS / bezel / "games" / systemName / f"{romBase}.png"
+        overlay_layout_file  = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.lay"
+        overlay_mamezip_file  = USER_DECORATIONS / bezel / "games" / systemName / f"{romBase}.zip"
         bezel_game = True
-        if not os.path.exists(overlay_png_file):
-            overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".info"
-            overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".png"
-            overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".lay"
-            overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".zip"
+        if not overlay_png_file.exists():
+            overlay_info_file = USER_DECORATIONS / bezel / "games" / f"{romBase}.info"
+            overlay_png_file  = USER_DECORATIONS / bezel / "games" / f"{romBase}.png"
+            overlay_layout_file  = USER_DECORATIONS / bezel / "games" / f"{romBase}.lay"
+            overlay_mamezip_file  = USER_DECORATIONS / bezel / "games" / f"{romBase}.zip"
             bezel_game = True
-            if not os.path.exists(overlay_png_file):
-                overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/games/" + romBase + ".info"
-                overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/games/" + romBase + ".png"
-                overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".lay"
-                overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/games/" + romBase + ".zip"
+            if not overlay_png_file.exists():
+                overlay_info_file = SYSTEM_DECORATIONS / bezel / "games" / f"{romBase}.info"
+                overlay_png_file  = SYSTEM_DECORATIONS / bezel / "games" / f"{romBase}.png"
+                overlay_layout_file  = USER_DECORATIONS / bezel / "games" / f"{romBase}.lay"
+                overlay_mamezip_file  = USER_DECORATIONS / bezel / "games" / f"{romBase}.zip"
                 bezel_game = True
-                if not os.path.exists(overlay_png_file):
+                if not overlay_png_file.exists():
                     if altDecoration != 0:
-                      overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".info"
-                      overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".png"
-                      overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".lay"
-                      overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".zip"
+                      overlay_info_file = USER_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.info"
+                      overlay_png_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.png"
+                      overlay_layout_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.lay"
+                      overlay_mamezip_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.zip"
                       bezel_game = False
-                    if not os.path.exists(overlay_png_file):
-                        overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + ".info"
-                        overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + ".png"
-                        overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + ".lay"
-                        overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/systems/" + systemName + ".zip"
+                    if not overlay_png_file.exists():
+                        overlay_info_file = USER_DECORATIONS / bezel / "systems" / f"{systemName}.info"
+                        overlay_png_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}.png"
+                        overlay_layout_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}.lay"
+                        overlay_mamezip_file  = USER_DECORATIONS / bezel / "systems" / f"{systemName}.zip"
                         bezel_game = False
-                        if not os.path.exists(overlay_png_file):
+                        if not overlay_png_file.exists():
                             if altDecoration != 0:
-                              overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".info"
-                              overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".png"
-                              overlay_layout_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".lay"
-                              overlay_mamezip_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + "-" + str(altDecoration) + ".zip"
+                              overlay_info_file = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.info"
+                              overlay_png_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.png"
+                              overlay_layout_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.lay"
+                              overlay_mamezip_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}-{altDecoration!s}.zip"
                               bezel_game = False
-                            if not os.path.exists(overlay_png_file):
-                                overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + ".info"
-                                overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + ".png"
-                                overlay_layout_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + ".lay"
-                                overlay_mamezip_file  = batoceraFiles.overlaySystem + "/" + bezel + "/systems/" + systemName + ".zip"
+                            if not overlay_png_file.exists():
+                                overlay_info_file = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}.info"
+                                overlay_png_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}.png"
+                                overlay_layout_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}.lay"
+                                overlay_mamezip_file  = SYSTEM_DECORATIONS / bezel / "systems" / f"{systemName}.zip"
                                 bezel_game = False
-                                if not os.path.exists(overlay_png_file):
-                                    overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/default-" + str(altDecoration) + ".info"
-                                    overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/default-" + str(altDecoration) + ".png"
-                                    overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/default-" + str(altDecoration) + ".lay"
-                                    overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/default-" + str(altDecoration) + ".zip"
+                                if not overlay_png_file.exists():
+                                    overlay_info_file = USER_DECORATIONS / bezel / f"default-{altDecoration!s}.info"
+                                    overlay_png_file  = USER_DECORATIONS / bezel / f"default-{altDecoration!s}.png"
+                                    overlay_layout_file  = USER_DECORATIONS / bezel / f"default-{altDecoration!s}.lay"
+                                    overlay_mamezip_file  = USER_DECORATIONS / bezel / f"default-{altDecoration!s}.zip"
                                     bezel_game = True
-                                    if not os.path.exists(overlay_png_file):
-                                      overlay_info_file = batoceraFiles.overlayUser + "/" + bezel + "/default.info"
-                                      overlay_png_file  = batoceraFiles.overlayUser + "/" + bezel + "/default.png"
-                                      overlay_layout_file  = batoceraFiles.overlayUser + "/" + bezel + "/default.lay"
-                                      overlay_mamezip_file  = batoceraFiles.overlayUser + "/" + bezel + "/default.zip"
+                                    if not overlay_png_file.exists():
+                                      overlay_info_file = USER_DECORATIONS / bezel / "default.info"
+                                      overlay_png_file  = USER_DECORATIONS / bezel / "default.png"
+                                      overlay_layout_file  = USER_DECORATIONS / bezel / "default.lay"
+                                      overlay_mamezip_file  = USER_DECORATIONS / bezel / "default.zip"
                                       bezel_game = True
-                                      if not os.path.exists(overlay_png_file):
-                                          overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/default-" + str(altDecoration) + ".info"
-                                          overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default-" + str(altDecoration) + ".png"
-                                          overlay_layout_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default-" + str(altDecoration) + ".lay"
-                                          overlay_mamezip_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default-" + str(altDecoration) + ".zip"
+                                      if not overlay_png_file.exists():
+                                          overlay_info_file = SYSTEM_DECORATIONS / bezel / f"default-{altDecoration!s}.info"
+                                          overlay_png_file  = SYSTEM_DECORATIONS / bezel / f"default-{altDecoration!s}.png"
+                                          overlay_layout_file  = SYSTEM_DECORATIONS / bezel / f"default-{altDecoration!s}.lay"
+                                          overlay_mamezip_file  = SYSTEM_DECORATIONS / bezel / f"default-{altDecoration!s}.zip"
                                           bezel_game = True
-                                          if not os.path.exists(overlay_png_file):
-                                            overlay_info_file = batoceraFiles.overlaySystem + "/" + bezel + "/default.info"
-                                            overlay_png_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default.png"
-                                            overlay_layout_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default.lay"
-                                            overlay_mamezip_file  = batoceraFiles.overlaySystem + "/" + bezel + "/default.zip"
+                                          if not overlay_png_file.exists():
+                                            overlay_info_file = SYSTEM_DECORATIONS / bezel / "default.info"
+                                            overlay_png_file  = SYSTEM_DECORATIONS / bezel / "default.png"
+                                            overlay_layout_file  = SYSTEM_DECORATIONS / bezel / "default.lay"
+                                            overlay_mamezip_file  = SYSTEM_DECORATIONS / bezel / "default.zip"
                                             bezel_game = True
-                                            if not os.path.exists(overlay_png_file):
-                                              return None
-    eslog.debug(f"Original bezel file used: {overlay_png_file}")
+                                            if not overlay_png_file.exists():
+                                                return None
+    eslog.debug(f"Original bezel file used: {overlay_png_file!s}")
     return { "png": overlay_png_file, "info": overlay_info_file, "layout": overlay_layout_file, "mamezip": overlay_mamezip_file, "specific_to_game": bezel_game }
 
 # Much faster than PIL Image.size


### PR DESCRIPTION
I've refactored the core modules of configgen to use `pathlib.Path` instead of strings. There are a couple of advantages to using path objects over strings:

* No need to remember whether you need "/" at the beginning of the string you're concatenating
* Most `os.path` functions have equivalent methods on path objects

This is the first of several pull requests to refactor configgen to use path objects

- [x] Builds
- [x] Tested