### PR TITLE
configgen: emulatorlauncher: Support ".ROM" symlink in squashfs volumes.

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -70,6 +70,14 @@ def squashfs_begin(rom):
         eslog.debug(f"squashfs: single rom {romsingle}")
         return True, rommountpoint, romsingle
 
+    # If a .ROM symlink is present, use the linked file as the ROM.
+    try:
+        romlinked = os.path.realpath(os.path.join(rommountpoint, ".ROM"), strict=True)
+        eslog.debug(f"squashfs: linked rom {romlinked}")
+        return True, rommountpoint, romlinked
+    except:
+        pass
+
     return True, rommountpoint, rommountpoint
 
 def squashfs_end(rommountpoint):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -336,11 +336,11 @@ class LibretroGenerator(Generator):
         commandArray.extend(['--verbose'])
 
         if system.name == 'snes-msu1' or system.name == 'satellaview':
-            if "squashfs" in rom:
+            if "squashfs" in rom and os.path.isdir(rom):
                 romsInDir = glob.glob(glob.escape(rom) + '/*.sfc') + glob.glob(glob.escape(rom) + '/*.smc')
                 rom = romsInDir[0]
         elif system.name == 'msu-md':
-            if "squashfs" in rom:
+            if "squashfs" in rom and os.path.isdir(rom):
                 romsInDir = glob.glob(glob.escape(rom) + '/*.md')
                 rom = romsInDir[0]
 


### PR DESCRIPTION
In a squashfs volume with more than one file, a ".ROM" symlink may point to the ROM file that should be passed to the emulator.

Similar to https://github.com/batocera-linux/batocera.linux/pull/12142, this allows squashfs volumes to be used for snes-msu1 and other platforms where the emulator expects to be given a ROM file but will open additional files within the containing directory.

The advantage of this approach is that it makes squashfs volumes useful to platforms beyond snes-msu1, satellaview and msu-md without needing platform-specific code in configgen.  Or it may be beneficial where configgen makes incorrect assumptions about the location/name of the ROM file within a squashfs volume, or where the volume contains multiple ROM files.  It does, however, require that users include the symlink when generating their squashfs volumes.