### PR TITLE
Update batocera-wine

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -252,7 +252,7 @@ redist_install() {
                 ;;
 
             "${USER_DIR}/exe/vcredist_x64_2008.exe" | "${USER_DIR}/exe/vcredist_x86_2008.exe")
-                WINEPREFIX=${WINEPOINT} "${WINE}" "${file}" /quiet /qn /norestart &>/dev/null || return 1
+                WINEPREFIX=${WINEPOINT} "${WINE}" "${file}" /q &>/dev/null || return 1
                 "${WINESERVER}" -w
                 ;;
 


### PR DESCRIPTION
VC redist 2008 does not have /quiet option. It uses /q option like the 2005 version.