### PR TITLE
improve configgen logging

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -3,12 +3,12 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import yaml
 import collections
+import logging
 
 from .batoceraPaths import BATOCERA_CONF, BATOCERA_SHADERS, DEFAULTS_DIR, ES_SETTINGS, USER_SHADERS
 from .settings.unixSettings import UnixSettings
-from .utils.logger import get_logger
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class Emulator():
     def __init__(self, name, rom):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/Evmapy.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Evmapy.py
@@ -1,12 +1,12 @@
 import subprocess
 import json
 import os
+import logging
 import evdev
 
 from . import controllersConfig as controllers
-from .utils.logger import get_logger
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class Evmapy():
     # evmapy is a process that map pads to keyboards (for pygame for example)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import xml.etree.ElementTree as ET
 from collections.abc import Iterable, Mapping
@@ -10,13 +11,12 @@ import evdev
 import pyudev
 
 from .batoceraPaths import BATOCERA_ES_DIR, ES_GAMES_METADATA, USER_ES_DIR
-from .utils.logger import get_logger
 
 if TYPE_CHECKING:
 
     from .types import DeviceInfoDict, DeviceInfoMapping, GunDict, GunMapping
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 
 """Default mapping of Batocera keys to SDL_GAMECONTROLLERCONFIG keys."""

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -7,14 +8,13 @@ from typing import TYPE_CHECKING, Final
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from ..libretro import libretroControllers
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _CONFIG_DIR: Final = CONFIGS / 'amiberry'
 _CONFIG: Final = _CONFIG_DIR / 'conf' / 'amiberry.conf'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/applewin/applewinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/applewin/applewinGenerator.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+import logging
 from typing import Final
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _CONFIG_DIR: Final = CONFIGS / 'applewin'
 _CONFIG_FILE: Final = _CONFIG_DIR / 'config.txt'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import HOME, mkdir_if_not_exists
 from ...utils import videoMode
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 bigPemuConfig = HOME / ".bigpemu_userdata" / "BigPEmuConfig.bigpcfg"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cdogs/cdogsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cdogs/cdogsGenerator.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ROMS
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class CdogsGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import codecs
+import logging
 import os
 import subprocess
 from os import environ
@@ -10,7 +11,6 @@ from xml.dom import minidom
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CACHE, CONFIGS, SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import cemuControllers
 from .cemuPaths import CEMU_BIOS, CEMU_CONFIG, CEMU_CONTROLLER_PROFILES, CEMU_ROMDIR, CEMU_SAVES
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class CemuGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import subprocess
 from os import environ
 from pathlib import Path
@@ -8,7 +9,6 @@ from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CACHE, CONFIGS, SAVES, ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class CitraGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/corsixth/corsixthGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/corsixth/corsixthGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 from pathlib import Path
@@ -7,7 +8,6 @@ from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, ROMS, SAVES, SCREENSHOTS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ corsixthSavesPath = SAVES / "corsixth"
 corsixthDataPath = ROMS / "corsixth"
 corsixthFontPath = Path("/usr/share/fonts/dejavu/DejaVuSans.ttf")
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class CorsixTHGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/demul/demulGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/demul/demulGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import os
 import shutil
 from distutils.dir_util import copy_tree
@@ -8,10 +9,9 @@ from pathlib import Path, PureWindowsPath
 
 from ... import Command
 from ...batoceraPaths import SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class DemulGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import codecs
 import configparser
+import logging
 import re
 from typing import TYPE_CHECKING
 
-from ...utils.logger import get_logger
 from .dolphinPaths import DOLPHIN_CONFIG
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import DeviceInfoMapping, GunMapping
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 # Create the controller configuration file
 def generateControllerConfig(system: Emulator, playersControllers: ControllerMapping, metadata: Mapping[str, str], wheels: DeviceInfoMapping, rom: Path, guns: GunMapping) -> None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import subprocess
 from os import environ
 from pathlib import Path
@@ -8,7 +9,6 @@ from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import dolphinControllers, dolphinSYSCONF
 from .dolphinPaths import (
@@ -24,7 +24,7 @@ from .dolphinPaths import (
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class DolphinGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from os import environ
 from struct import pack, unpack
 from typing import TYPE_CHECKING, Any
 
-from ...utils.logger import get_logger
+from configgen.utils.logger import setup_logging
+
 from .dolphinPaths import DOLPHIN_SAVES
 
 if TYPE_CHECKING:
@@ -15,7 +17,7 @@ if TYPE_CHECKING:
     from ...types import Resolution
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 def readBEInt16(f):
     bytes = f.read(2)
@@ -146,4 +148,5 @@ def update(config: dict[str, Any], filepath: Path, gameResolution: Resolution) -
     readWriteFile(filepath, arg_setval)
 
 if __name__ == '__main__':
-    readWriteFile(DOLPHIN_SAVES / "Wii" / "shared2" / "sys" / "SYSCONF", {})
+    with setup_logging():
+        readWriteFile(DOLPHIN_SAVES / "Wii" / "shared2" / "sys" / "SYSCONF", {})

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import codecs
 import configparser
+import logging
 import re
 from typing import TYPE_CHECKING
 
-from ...utils.logger import get_logger
 from .dolphinTriforcePaths import DOLPHIN_TRIFORCE_CONFIG
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ...controllersConfig import Controller, ControllerMapping
     from ...Emulator import Emulator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 # Create the controller configuration file
 def generateControllerConfig(system: Emulator, playersControllers: ControllerMapping, rom: Path) -> None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import configparser
+import logging
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, CONFIGS, ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class DuckstationGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation_legacy/duckstationLegacyGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation_legacy/duckstationLegacyGenerator.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
 import configparser
+import logging
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, CONFIGS, ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class DuckstationLegacyGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import configparser
+import logging
 from typing import TYPE_CHECKING, Literal
 
 from ...batoceraPaths import mkdir_if_not_exists
-from ...utils.logger import get_logger
 from .flycastPaths import FLYCAST_MAPPING
 
 if TYPE_CHECKING:
     from ...controllersConfig import Controller
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 
 flycastMapping = { # Directions

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -8,13 +9,12 @@ from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import CONFIGS, HOME, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _FPINBALL_CONFIG: Final = CONFIGS / "fpinball"
 _FPINBALL_CONFIG_REG: Final = _FPINBALL_CONFIG / "batocera.confg.reg"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import logging
 import shutil
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import fsuaeControllers
 from .fsuaePaths import FSUAE_BIOS_DIR, FSUAE_CONFIG_DIR, FSUAE_SAVES
@@ -14,7 +14,7 @@ from .fsuaePaths import FSUAE_BIOS_DIR, FSUAE_CONFIG_DIR, FSUAE_SAVES
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class FsuaeGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, CONFIGS, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 _CONFIGDIR  = CONFIGS / 'GSplus'
 _CONFIGFILE = _CONFIGDIR / 'config.txt'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import configparser
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import BIOS, CONFIGS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 # libretro generator uses this, so it needs to be public
 HATARI_CONFIG: Final = CONFIGS / "hatari"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hcl/hclGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hcl/hclGenerator.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ROMS
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class HclGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hurrican/hurricanGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hurrican/hurricanGenerator.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ROMS
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class HurricanGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import filecmp
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -10,13 +11,12 @@ import ffmpeg
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, ROMS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _DATA_DIR: Final = CONFIGS / 'hypseus-singe'
 _CONFIG: Final = _DATA_DIR / 'hypinput.ini'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 Keymapping =[
         {

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lemonade/lemonadeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lemonade/lemonadeGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import subprocess
 from os import environ
 from pathlib import Path
@@ -8,13 +9,12 @@ from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CACHE, CONFIGS, SAVES, ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...Emulator import Emulator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class LemonadeGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, HOME, ROMS, SCREENSHOTS, ensure_parents_and_open
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 PICO8_BIN_PATH: Final = BIOS / "pico-8" / "pico8"
 PICO8_ROOT_PATH: Final = ROMS / "pico8"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -10,7 +11,6 @@ from ... import controllersConfig
 from ...batoceraPaths import DEFAULTS_DIR, ES_SETTINGS, SAVES, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
 from ...utils import bezels as bezelsUtil, videoMode as videoMode
-from ...utils.logger import get_logger
 from ..hatari.hatariGenerator import HATARI_CONFIG
 from . import libretroMAMEConfig, libretroOptions
 from .libretroPaths import (
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from ...generators.Generator import Generator
     from ...types import DeviceInfoMapping, GunMapping, Resolution
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 
 # Return value for es invertedbuttons

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -10,7 +11,6 @@ from ... import Command
 from ...batoceraPaths import BATOCERA_SHADERS, CONFIGS, HOME, OVERLAYS, ROMS, SAVES, USER_SHADERS, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
 from ...utils import videoMode as videoMode
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import libretroConfig, libretroControllers, libretroRetroarchCustom
 from .libretroPaths import (
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class LibretroGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import codecs
 import csv
+import logging
 import os
 import shutil
 import xml.etree.ElementTree as ET
@@ -11,7 +12,6 @@ from typing import TYPE_CHECKING
 from xml.dom import minidom
 
 from ...batoceraPaths import BIOS, CONFIGS, DEFAULTS_DIR, ROMS, SAVES, USER_DECORATIONS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import GunMapping
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 # Define RetroPad inputs for mapping
 retroPad = {

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import codecs
 import csv
+import logging
 import os
 from typing import TYPE_CHECKING
 from xml.dom import minidom
 
-from ...utils.logger import get_logger
 from .mamePaths import MAME_CONFIG, MAME_DEFAULT_DATA
 
 if TYPE_CHECKING:
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import DeviceInfoMapping, GunMapping
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 def generatePadsConfig(cfgPath: Path, playersControllers: ControllerMapping, sysName: str, altButtons: str, customCfg: bool, specialController: str, decorations: str | None, useGuns: bool, guns: GunMapping, useWheels: bool, wheels: DeviceInfoMapping, useMouse: bool, multiMouse: bool, system: Emulator) -> None:
     # config file

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import logging
 import os
 import shutil
 import subprocess
@@ -24,7 +25,6 @@ from ...batoceraPaths import (
     mkdir_if_not_exists,
 )
 from ...utils import bezels as bezelsUtil, videoMode as videoMode
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import mameControllers
 from .mamePaths import MAME_BIOS, MAME_CHEATS, MAME_CONFIG, MAME_DEFAULT_DATA, MAME_ROMS, MAME_SAVES
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext, Resolution
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 
 class MameGenerator(Generator):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/melonds/melondsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/melonds/melondsGenerator.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import codecs
+import logging
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import BIOS, CHEATS, CONFIGS, ROMS, SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _MELONDS_SAVES: Final = SAVES / "melonds"
 _MELONDS_ROMS: Final = ROMS / "nds"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import configparser
 import filecmp
+import logging
 import os
 import shutil
 import stat
@@ -11,14 +12,13 @@ from typing import TYPE_CHECKING, Final
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import HOME, ROMS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 MODEL2_ROMS: Final = ROMS / "model2"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
-
-from ...utils.logger import get_logger
 
 if TYPE_CHECKING:
     from ...controllersConfig import Controller, ControllerMapping
     from ...settings.unixSettings import UnixSettings
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 def generateControllerConfig(config: UnixSettings, playersControllers: ControllerMapping, core: str):
     if core == "openbor4432":

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -8,14 +9,13 @@ from typing import TYPE_CHECKING
 from ... import Command
 from ...batoceraPaths import CONFIGS, ROMS, SAVES, mkdir_if_not_exists
 from ...settings.unixSettings import UnixSettings
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import openborControllers
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class OpenborGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openjazz/openjazzGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openjazz/openjazzGenerator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ROMS
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 
 class OpenJazzGenerator(Generator):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openmsx/openmsxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openmsx/openmsxGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import shutil
 import xml.dom.minidom as minidom
@@ -11,13 +12,12 @@ from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import CONFIGS, SCREENSHOTS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 openMSX_Homedir: Final = CONFIGS / 'openmsx'
 openMSX_Config: Final = Path('/usr/share/openmsx')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import configparser
 import json
+import logging
 import re
 import shutil
 import subprocess
 import time
-from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
@@ -14,14 +14,15 @@ import httplib2
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, CACHE, CONFIGS, DATAINIT_DIR, ROMS, ensure_parents_and_open, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from ...Emulator import Emulator
     from ...types import DeviceInfoMapping, GunMapping, HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _PCSX2_BIN_DIR: Final = Path("/usr/pcsx2/bin")
 _PCSX2_RESOURCES_DIR: Final = _PCSX2_BIN_DIR / "resources"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import subprocess
 from typing import TYPE_CHECKING, Final
 
 from ...batoceraPaths import ensure_parents_and_open
-from ...utils.logger import get_logger
 from .ppssppPaths import PPSSPP_PSP_SYSTEM_DIR
 
 if TYPE_CHECKING:
     from ...Emulator import Emulator
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 ppssppConfig: Final   = PPSSPP_PSP_SYSTEM_DIR / 'ppsspp.ini'
 ppssppControls: Final = PPSSPP_PSP_SYSTEM_DIR / 'controls.ini'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
 import configparser
+import logging
 from typing import TYPE_CHECKING, Final
 
 from ...batoceraPaths import mkdir_if_not_exists
-from ...utils.logger import get_logger
 from .ppssppPaths import PPSSPP_CONFIG_INIT, PPSSPP_PSP_SYSTEM_DIR
 
 if TYPE_CHECKING:
     from ...controllersConfig import Controller
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 ppssppControlsIni: Final  = PPSSPP_PSP_SYSTEM_DIR / 'controls.ini'
 ppssppControlsInit: Final = PPSSPP_CONFIG_INIT / 'controls.ini'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/raze/razeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/raze/razeGenerator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import platform
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -7,13 +8,12 @@ from typing import TYPE_CHECKING
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, SAVES, mkdir_if_not_exists
 from ...utils.buildargs import parse_args
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class RazeGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import codecs
+import logging
 from typing import TYPE_CHECKING, Final
 
 from ...batoceraPaths import mkdir_if_not_exists
-from ...utils.logger import get_logger
 from .rpcs3Paths import RPCS3_CONFIG_DIR
 
 if TYPE_CHECKING:
     from ...controllersConfig import ControllerMapping
     from ...Emulator import Emulator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _RPCS3_INPUT_DIR: Final = RPCS3_CONFIG_DIR / "input_configs" / "global"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import re
 import shutil
 import subprocess
@@ -11,7 +12,6 @@ import ruamel.yaml as yaml
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import BIOS, CACHE, CONFIGS, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import rpcs3Controllers
 from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG
@@ -19,7 +19,7 @@ from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class Rpcs3Generator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/stella/stellaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/stella/stellaGenerator.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import logging
+
 from ... import Command, controllersConfig
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class StellaGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/suyu/suyuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/suyu/suyuGenerator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import subprocess
 from os import environ
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import CACHE, CONFIGS, SAVES, ensure_parents_and_open, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 SUYU_CONFIG: Final = CONFIGS / 'suyu'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
 from ...batoceraPaths import SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _THEXTECH_SAVES: Final = SAVES / "thextech"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/tyrian/tyrianGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/tyrian/tyrianGenerator.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
+import logging
 import os
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import ROMS
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class TyrianGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import configparser
+import logging
 import shutil
 from typing import TYPE_CHECKING
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CONFIGS, mkdir_if_not_exists
 from ...utils.batoceraServices import batoceraServices
-from ...utils.logger import get_logger
 from ..Generator import Generator
 from . import vpinballOptions, vpinballWindowing
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class VPinballGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import filecmp
+import logging
 import os
 import re
 import shutil
@@ -13,13 +14,12 @@ import toml
 
 from ... import Command, controllersConfig
 from ...batoceraPaths import CACHE, CONFIGS, HOME, SAVES, mkdir_if_not_exists
-from ...utils.logger import get_logger
 from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class XeniaGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
 import configparser
-from dataclasses import dataclass, InitVar, field
-from pathlib import Path
-import re
 import io
+import logging
+import re
 import typing
-
-from ..utils.logger import get_logger
+from dataclasses import InitVar, dataclass, field
+from pathlib import Path
 
 if typing.TYPE_CHECKING:
     from _typeshed import StrPath
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 def _protect_string(string: str) -> str:
     return re.sub(r'[^A-Za-z0-9-\.]+', '_', string)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/batoceraServices.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/batoceraServices.py
@@ -1,8 +1,7 @@
+import logging
 import subprocess
 
-from .logger import get_logger
-
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class batoceraServices:
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import struct
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
@@ -7,7 +8,6 @@ from typing import TYPE_CHECKING, TypedDict
 from PIL import Image, ImageOps
 
 from ..batoceraPaths import BATOCERA_SHARE_DIR, SYSTEM_DECORATIONS, USER_DECORATIONS
-from .logger import get_logger
 from .videoMode import getAltDecoration
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from ..Emulator import Emulator
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 class BezelInfos(TypedDict):
     png: Path

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/buildargs.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/buildargs.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
-from .logger import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 """Argument parsing helper functions for launching Build Engine source ports Eduke32 and Raze"""
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/logger.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/logger.py
@@ -1,24 +1,44 @@
+from __future__ import annotations
+
 import logging
 import sys
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
-def get_logger(module_name: str) -> logging.Logger:
-    # The logging level that separates stdout from stderr: stdout < error_level <= stderr
-    error_level = logging.WARNING
-    # Common formatter shared by handlers
-    formatter = logging.Formatter("%(asctime)s %(levelname)s (%(filename)s:%(lineno)d):%(funcName)s %(message)s")
-    # Configure stdout handler
-    stdout = logging.StreamHandler(sys.stdout)
-    stdout.setFormatter(formatter)
-    stdout.setLevel(logging.DEBUG)
-    stdout.addFilter(lambda record: record.levelno < error_level)  # Keep error logs out of stdout
-    # Configure stderr handler
-    stderr = logging.StreamHandler(sys.stderr)
-    stderr.setFormatter(formatter)
-    stderr.setLevel(error_level)
-    # Configure logger
-    logger = logging.getLogger(module_name)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(stdout)
-    logger.addHandler(stderr)
-    return logger
+@contextmanager
+def setup_logging() -> Iterator[None]:
+    logger = logging.getLogger(__name__.split('.')[0])
+
+    try:
+        # The logging level that separates stdout from stderr: stdout < error_level <= stderr
+        error_level = logging.WARNING
+
+        # Common formatter shared by handlers
+        formatter = logging.Formatter("%(asctime)s %(levelname)s (%(filename)s:%(lineno)d):%(funcName)s %(message)s")
+
+        # Configure stdout handler
+        stdout = logging.StreamHandler(sys.stdout)
+        stdout.setFormatter(formatter)
+        stdout.setLevel(logging.DEBUG)
+        stdout.addFilter(lambda record: record.levelno < error_level)  # Keep error logs out of stdout
+
+        # Configure stderr handler
+        stderr = logging.StreamHandler(sys.stderr)
+        stderr.setFormatter(formatter)
+        stderr.setLevel(error_level)
+
+        # Configure logger
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(stdout)
+        logger.addHandler(stderr)
+
+        yield
+    finally:
+        handlers = logger.handlers[:]
+        for handler in handlers:
+            handler.close()
+            logger.removeHandler(handler)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import logging
 import re
 import subprocess
 import sys
@@ -9,14 +10,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from ..batoceraPaths import DEFAULTS_DIR
-from .logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from ..types import Resolution, ScreenInfo
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 _ROTATION_FILE: Final = Path("/var/run/rk-rotation")
 _GLXINFO_BIN: Final = Path("/usr/bin/glxinfo")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 import os
 import re
@@ -10,7 +11,6 @@ from typing import TYPE_CHECKING, cast
 import evdev
 
 from .. import controllersConfig
-from .logger import get_logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ..Emulator import Emulator
     from ..types import DeviceInfoDict, DeviceInfoMapping
 
-eslog = get_logger(__name__)
+eslog = logging.getLogger(__name__)
 
 wheelMapping = {
     "wheel":      "joystick1left",


### PR DESCRIPTION
Rather than set up the logger every time a module needs it, I've added a context manager to set up logging once when the program runs and then each module uses `logging.getLogger()` directly