### PR TITLE
es_systems.yml: Update DevilutionX instructions

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -828,7 +828,7 @@ devilutionx:
 
     Place diabdat.mpq from your CD or GoG installation into:
 
-        /userdata/roms/devilution/
+        /userdata/roms/devilutionx/
 
     For Hellfire, also copy hellfire.mpq, hfmonk.mpq, hfmusic.mpq, and hfvoice.mpq.
 
@@ -844,15 +844,18 @@ devilutionx:
 
     Coloque o arquivo diabdat.mpq do seu CD ou instalação do GoG em:
 
-        /userdata/roms/devilution/
+        /userdata/roms/devilutionx/
 
     Para Hellfire, copie também hellfire.mpq, hfmonk.mpq, hfmusic.mpq e hfvoice.mpq.
 
     Para cópia de suporte de texto em chinês, japonês e coreano:
-    https://github.com/diasurgical/devilutionx-assets/releases/download/v1/fonts.mpq
+    https://github.com/diasurgical/devilutionx-assets/releases/download/v4/fonts.mpq
 
-    Para a cópia do pacote de voz em polonês:
-    https://github.com/diasurgical/devilutionx-assets/releases/download/v1/pl.mpq
+    Pacotes de voz:
+    * Polonês: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/pl.mpq
+    * Russo: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/ru.mpq
+    * Espanhol: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/es.mpq
+
 
 fbneo:
   name:       Final Burn Neo

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -833,10 +833,12 @@ devilutionx:
     For Hellfire, also copy hellfire.mpq, hfmonk.mpq, hfmusic.mpq, and hfvoice.mpq.
 
     For Chinese, Japanese, and Korean text support copy:
-    https://github.com/diasurgical/devilutionx-assets/releases/download/v1/fonts.mpq
+    https://github.com/diasurgical/devilutionx-assets/releases/download/v4/fonts.mpq
 
-    For the Polish voice pack copy:
-    https://github.com/diasurgical/devilutionx-assets/releases/download/v1/pl.mpq
+    Voice packs:
+    * Polish: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/pl.mpq
+    * Russian: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/ru.mpq
+    * Spanish: https://github.com/diasurgical/devilutionx-assets/releases/download/v4/es.mpq
   comment_br: |
     Diablo 1.
 


### PR DESCRIPTION
1. Updates the assets version number to v4, which is the correct assets version for v1.5.1+.
2. Adds links to the new Russian and Spanish voice packs.
3. `/userdata/roms/devilution` -> `/userdata/roms/devilutionx`, per:
   https://github.com/batocera-linux/batocera.linux/blob/d3da6abdf56a835f49fe85e06dbfcf6ec6fa2dc3/package/batocera/core/batocera-configgen/configgen/configgen/generators/devilutionx/devilutionxGenerator.py#L22