### PR TITLE
add captain power bezel to configgen (Hypseus Singe)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
@@ -83,6 +83,7 @@ class HypseusSingeGenerator(Generator):
             "astron": ["astron", "astronp"],
             "badlands": ["badlands", "badlandsp"],
             "bega": ["bega", "begar1"],
+            "captainpower": ["cpower1", "cpower2", "cpower3", "cpower4", "cpowergh"],
             "cliff": ["cliffhanger", "cliff", "cliffalt", "cliffalt2"],
             "cobra": ["cobra", "cobraab", "cobraconv", "cobram3"],
             "conan": ["conan", "future_boy"],


### PR DESCRIPTION
Do NOT merge until Hypseus Singe is updated to 2.11.3, Batocera Hypseus Singe repository bezel bumped ~~and multi-games zipped ROMs is added to configgen~~.