### PR TITLE
Fix serial console on rockchip boards

### DIFF
--- a/board/batocera/rockchip/rk3588/fsoverlay/etc/inittab
+++ b/board/batocera/rockchip/rk3588/fsoverlay/etc/inittab
@@ -12,8 +12,8 @@ si4::sysinit:/bin/mount -a
 si5::sysinit:/bin/hostname -F /etc/hostname
 si6::sysinit:/etc/init.d/rcS
 
-S0::respawn:/sbin/getty   -n -L -l /usr/bin/batocera-autologin /dev/ttyS0   115200 vt220 # Some boards have a console here
-FIQ0::respawn:/sbin/getty -n -L -l /usr/bin/batocera-autologin /dev/ttyFIQ0 115200 vt220 # Others have a console here
+S0::respawn:/sbin/getty   -n -L -l /usr/bin/batocera-autologin 115200 ttyS0   vt100 # Some boards have a console here
+FIQ0::respawn:/sbin/getty -n -L -l /usr/bin/batocera-autologin 115200 ttyFIQ0 vt100 # Others have a console here
 # 2:3:respawn:/sbin/getty 38400 tty2
 # 3:3:respawn:/sbin/getty 38400 tty3
 4:3:respawn:/sbin/getty 38400 tty4 -n -l /usr/bin/batocera-mixer


### PR DESCRIPTION
- getty device name must not include /dev/ path
- use vt100 as a TERM baseline
- reorder parameters for consistency