### PR TITLE
Handle NanoPI M6 DSI display automatically at boot

### DIFF
--- a/board/batocera/rockchip/rk3588/nanopi-m6/boot/extlinux.conf
+++ b/board/batocera/rockchip/rk3588/nanopi-m6/boot/extlinux.conf
@@ -1,5 +1,24 @@
-LABEL batocera.linux
+TIMEOUT 10
+DEFAULT batocera.linux.dsi1
+
+MENU TITLE boot menu
+
+LABEL batocera.linux.dsi1
+  MENU LABEL batocera.linux with display on dsi1
   LINUX /boot/linux
-  FDT /boot/dtbs/rk3588s-nanopi-m6.dtb
-  FDTOVERLAYS /boot/dtbs/nanopi-m6-display-dsi1-yx35.dtbo
+  FDTDIR /dtbs
+  FDTOVERLAYS /dtbs/rockchip/nanopi-m6-display-dsi1-yx35.dtbo
+  APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200n8 coherent_pool=2M
+
+LABEL batocera.linux.dsi0
+  MENU LABEL batocera.linux with display on dsi0
+  LINUX /boot/linux
+  FDTDIR /dtbs
+  FDTOVERLAYS /dtbs/rockchip/nanopi-m6-display-dsi0-yx35.dtbo
+  APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200n8 coherent_pool=2M
+
+LABEL batocera.linux
+  MENU LABEL batocera.linux
+  LINUX /boot/linux
+  FDTDIR /dtbs
   APPEND initrd=/boot/initrd.lz4 label=BATOCERA rootwait quiet loglevel=0 console=ttyS0,115200n8 coherent_pool=2M

--- a/board/batocera/rockchip/rk3588/nanopi-m6/create-boot-script.sh
+++ b/board/batocera/rockchip/rk3588/nanopi-m6/create-boot-script.sh
@@ -17,19 +17,20 @@ BATOCERA_BINARIES_DIR=$6
 DTB="rk3588s-nanopi-m6.dtb"
 DTBOVERLAYS="nanopi-m6-display-dsi0-yx35.dtbo nanopi-m6-display-dsi1-yx35.dtbo"
 
-mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot/dtbs" || exit 1
-mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux"  || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/boot" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/dtbs/rockchip" || exit 1
+mkdir -p "${BATOCERA_BINARIES_DIR}/boot/extlinux"      || exit 1
 
 cp "${BINARIES_DIR}/Image"                 "${BATOCERA_BINARIES_DIR}/boot/boot/linux"                || exit 1
 cp "${BINARIES_DIR}/initrd.lz4"            "${BATOCERA_BINARIES_DIR}/boot/boot/initrd.lz4"           || exit 1
 cp "${BINARIES_DIR}/rootfs.squashfs"       "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"      || exit 1
 
-cp "${BINARIES_DIR}/${DTB}"                "${BATOCERA_BINARIES_DIR}/boot/boot/dtbs/" || exit 1
-cp "${BOARD_DIR}/boot/extlinux.conf"       "${BATOCERA_BINARIES_DIR}/boot/extlinux/"  || exit 1
+cp "${BINARIES_DIR}/${DTB}"                "${BATOCERA_BINARIES_DIR}/boot/dtbs/rockchip/" || exit 1
+cp "${BOARD_DIR}/boot/extlinux.conf"       "${BATOCERA_BINARIES_DIR}/boot/extlinux/"      || exit 1
 
 for dtbo in $DTBOVERLAYS
 do
-	cp "${BINARIES_DIR}/dtbs/${dtbo}"  "${BATOCERA_BINARIES_DIR}/boot/boot/dtbs/" || exit 1
+	cp "${BINARIES_DIR}/dtbs/${dtbo}"  "${BATOCERA_BINARIES_DIR}/boot/dtbs/rockchip/" || exit 1
 done
 
 exit 0


### PR DESCRIPTION
- Add boot menu of configuration options, each will be tried in order
- Move .dtb and .dtbo to /boot/dtbs/rockchip
- Use FDTDIR instead of FDT, to find dtb chosen by u-boot