### PR TITLE
retroarch, disable libdecor for wayland as workaround to fix boot on …

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -19,6 +19,10 @@ ifeq ($(BR2_ENABLE_DEBUG),y)
     RETROARCH_CONF_OPTS += --enable-debug
 endif
 
+# disable libdecor : A client-side decorations library for Wayland client
+# it makes retroarch unable to start on dual screen. It looks like a ra bug
+RETROARCH_CONF_OPTS += --disable-libdecor
+
 ifeq ($(BR2_PACKAGE_FFMPEG),y)
     RETROARCH_CONF_OPTS += --enable-ffmpeg
     RETROARCH_DEPENDENCIES += ffmpeg


### PR DESCRIPTION
…dual screen monitor