### PR TITLE
add t248 steering wheel

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -17,8 +17,9 @@
 - Exit game with light gun (hold `TRIGGER`, `ACTION` and `START` buttons for 2 seconds)
 - Enhanced Bluetooth AD2P codec support for LDAC & aptX supported headphones or speakers
   - The supported AD2P codec may need to be selected under SYSTEM SETTINGS -> AUDIO PROFILES
-- Steering wheel support for Microsoft SideWinder Precision Racing Wheel
-- Thrustmaster T150 and TMX Force Feedback Wheel Linux drivers
+- Steering wheel support added for :
+  - Thurstmaster T150, TMX and T248 with force Feedback (new driver)
+  - Microsoft SideWinder Precision Racing Wheel
 - Display reflection for x86_64 boards (display.reflection=x or y or xy in batocera.conf to enable it)
 - Emulationstation now supports savestates for standalones (dolphin, pcsx2, mupen, ppsspp)
 - Add Raspberry Pi patches for hardware accelerated HEVC decoding (RPi4 & RPi5 boards)

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -19,6 +19,7 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T1
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T80",                       MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="FGT Rumble Wheel",                                    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Microsoft SideWinder Precision Racing Wheel USB version 1.0",    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster Racing Wheel FFB",                     MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
 
 # for ThrustMaster, Inc. Ferrari 458 Spider, cause xpad driver is blacklisted for the prefered xone
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b671", RUN+="/sbin/modprobe xpad"

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5359,4 +5359,24 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="4" value="1" code="308" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Thrustmaster Thrustmaster Racing Wheel FFB" deviceGUID="030000004f04000096b6000011010000">
+		<input name="a" type="button" id="4" value="1" code="292" />
+		<input name="b" type="button" id="5" value="1" code="293" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="300" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="l2" type="axis" id="1" value="-1" code="1" />
+		<input name="l3" type="button" id="21" value="1" code="709" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="1" value="1" code="289" />
+		<input name="pageup" type="button" id="0" value="1" code="288" />
+		<input name="r2" type="axis" id="5" value="-1" code="5" />
+		<input name="r3" type="button" id="22" value="1" code="710" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="294" />
+		<input name="start" type="button" id="7" value="1" code="295" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="2" value="1" code="290" />
+		<input name="y" type="button" id="3" value="1" code="291" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
(PS version of the wheel)

Firmware must be updated to v2.00 to gain FFB feature.

https://support.thrustmaster.com/en/product/t248-ps-en/

PC MODE only.