### PR TITLE
Fix fake-hwclock bugs discovered in testing

### DIFF
--- a/package/batocera/utils/fake-hwclock/0001-fix-load-force.patch
+++ b/package/batocera/utils/fake-hwclock/0001-fix-load-force.patch
@@ -1,0 +1,13 @@
+diff --git a/fake-hwclock b/fake-hwclock
+index 641c49f..d83afc8 100755
+--- a/fake-hwclock
++++ b/fake-hwclock
+@@ -56,7 +56,7 @@ case $COMMAND in
+             SAVED="$(cat $FILE)"
+             SAVED_SEC=$(date -u -d "$SAVED" '+%s')
+             NOW_SEC=$(date -u '+%s')
+-            if [ "$FORCE"x = "false"x ] || [ $NOW_SEC -le $SAVED_SEC ] ; then
++            if [ "$FORCE"x != "false"x ] || [ $NOW_SEC -le $SAVED_SEC ] ; then
+                 date -u -s "$SAVED"
+             else
+                 echo "Current system time: $(date -u '+%Y-%m-%d %H:%M:%S')"

--- a/package/batocera/utils/fake-hwclock/fake-hwclock.mk
+++ b/package/batocera/utils/fake-hwclock/fake-hwclock.mk
@@ -16,7 +16,7 @@ define FAKE_HWCLOCK_INSTALL_TARGET_CMDS
         $(INSTALL) -D -m 0750 $(@D)/debian/fake-hwclock.init $(TARGET_DIR)/etc/init.d/S47fake-hwclock
         mkdir -p $(TARGET_DIR)/etc/default
         echo 'FILE=/userdata/system/fake-hwclock.data' > $(TARGET_DIR)/etc/default/fake-hwclock
-        [ ! -f $(TARGET_DIR)/lib/lsb/init-functions ] && mkdir -p $(TARGET_DIR)/lib/lsb && echo '' > $(TARGET_DIR)/lib/lsb/init-functions
+        [ -f $(TARGET_DIR)/lib/lsb/init-functions ] || mkdir -p $(TARGET_DIR)/lib/lsb && echo '' > $(TARGET_DIR)/lib/lsb/init-functions
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
- Fix inverted logic in the script causing backwards time travel
- Ensure installation command returns success