### PR TITLE
Create retroarch directories at boot time

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -19,7 +19,8 @@ for DIR in cheats \
            system/.cache \
            system/.config/lirc \
            system/bluetooth \
-           system/configs \
+           system/configs/retroarch/config/remaps \
+           system/configs/retroarch/inputs \
            system/pacman \
            system/pacman/db \
            system/pacman/pkg \


### PR DESCRIPTION
Fixes bug documented on wiki:
https://wiki.batocera.org/remapping_controls_per_emulator#libretro_cores:~:text=cannot%20save%20remap%20file