### PR TITLE
improve atarist launchers

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
@@ -29,27 +29,38 @@ class HatariGenerator(Generator):
         rom_path = Path(rom)
 
         model_mapping = {
-            "520st_auto":   { "machine": "st",      "tos": "auto" },
-            "520st_100":    { "machine": "st",      "tos": "100"  },
-            "520st_102":    { "machine": "st",      "tos": "102"  },
-            "520st_104":    { "machine": "st",      "tos": "104"  },
-            "1040ste_auto": { "machine": "ste",     "tos": "auto" },
-            "1040ste_106":  { "machine": "ste",     "tos": "106"  },
-            "1040ste_162":  { "machine": "ste",     "tos": "162"  },
-            "megaste_auto": { "machine": "megaste", "tos": "auto" },
-            "megaste_205":  { "machine": "megaste", "tos": "205"  },
-            "megaste_206":  { "machine": "megaste", "tos": "206"  },
+            "520st_auto":       { "machine": "st",      "tos": "auto" },
+            "520st_100":        { "machine": "st",      "tos": "100"  },
+            "520st_102":        { "machine": "st",      "tos": "102"  },
+            "520st_104":        { "machine": "st",      "tos": "104"  },
+            "520st_etos256":    { "machine": "st",      "tos": "etos256"  },
+            "1040ste_auto":     { "machine": "ste",     "tos": "auto" },
+            "1040ste_106":      { "machine": "ste",     "tos": "106"  },
+            "1040ste_162":      { "machine": "ste",     "tos": "162"  },
+            "1040ste_etos256":  { "machine": "ste",     "tos": "etos256"  },
+            "megaste_auto":     { "machine": "megaste", "tos": "auto" },
+            "megaste_205":      { "machine": "megaste", "tos": "205"  },
+            "megaste_206":      { "machine": "megaste", "tos": "206"  },
+            "megaste_etos256":  { "machine": "megaste", "tos": "etos256"  },
+            "tt_auto":          { "machine": "tt",      "tos": "auto" },
+            "tt_306":           { "machine": "tt",      "tos": "306"  },
+            "tt_etos512":       { "machine": "tt",      "tos": "etos512"  },
+            "falcon_auto":      { "machine": "falcon",  "tos": "auto" },
+            "falcon_400":       { "machine": "falcon",  "tos": "400"  },
+            "falcon_402":       { "machine": "falcon",  "tos": "402"  },
+            "falcon_404":       { "machine": "falcon",  "tos": "404"  },
+            "falcon_etos512":   { "machine": "falcon",  "tos": "etos512"  },
         }
 
         # Start emulator fullscreen
         commandArray: list[str | Path] = ["hatari", "--fullscreen"]
 
         # Machine can be st (default), ste, megaste, tt, falcon
-        # st should use TOS 1.00 to TOS 1.04 (tos100 / tos102 / tos104)
-        # ste should use TOS 1.06 at least (tos106 / tos162 / tos206)
-        # megaste should use TOS 2.XX series (tos206)
-        # tt should use tos 3.XX
-        # falcon should use tos 4.XX
+        # st should use TOS 1.00 to TOS 1.04 (tos100 / tos102 / tos104 / emutos192k)
+        # ste should use TOS 1.06 at least (tos106 / tos162 / tos206 / emutos192K)
+        # megaste should use TOS 2.XX series (tos206 / emutos256k)
+        # tt should use tos 3.XX / emutos512k
+        # falcon should use tos 4.XX / emutos512k
 
         machine = "st"
         tosversion = "auto"
@@ -162,9 +173,11 @@ class HatariGenerator(Generator):
 
         # machine bioses by prefered orders, when value is "auto"
         all_machines_bios = {
-            "st":      ["104", "102", "100"],
-            "ste":     ["162", "106"],
-            "megaste": ["206", "205"]
+            "st":      ["etos256", "104", "102", "100"],
+            "ste":     ["etos256", "162", "106"],
+            "megaste": ["etos256", "206", "205"],
+            "tt":      ["etos512", "306"],
+            "falcon":  ["etos512", "404", "402", "400"]
         }
 
         if machine in all_machines_bios:
@@ -178,8 +191,12 @@ class HatariGenerator(Generator):
                     l_lang = [language]
                 l_lang.extend(all_languages)
                 for v_language in l_lang:
-                    filename = f"tos{v_tos_version}{v_language}.img"
-                    if (biosdir / filename).exists():
+                    if "etos" in v_tos_version:
+                        biosversion = v_tos_version
+                    else:
+                        biosversion = f"tos{v_tos_version}"
+                    filename = f"{biosversion}{v_language}.img"
+                    if os.path.exists(f"{biosdir}/{filename}"):
                         eslog.debug(f"tos filename: {filename}")
                         return filename
                     else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -366,6 +366,20 @@ class LibretroGenerator(Generator):
                 corePath = system.config['core']
             commandArray.append(f'/var/run/cmdfiles/{rom_path.stem}.cmd')
 
+        if system.config['core'] == 'hatarib':
+            rom_extension = os.path.splitext(romName)[1].lower()
+            biosdir = "/userdata/bios/hatarib"
+            if not os.path.exists(biosdir):
+                os.mkdir(biosdir)
+            targetlink = biosdir + "/hdd"
+            #retroarch can't use hdd files outside his system directory (/userdata/bios)
+            if os.path.exists(targetlink):
+                os.unlink(targetlink)
+            if rom_extension in [ '.hd', '.gemdos'] :
+                #don't pass hd drive as parameter, it need to be added in configuration
+                dontAppendROM = True
+                os.symlink(rom, targetlink)
+
         if dontAppendROM == False:
             commandArray.append(rom_path)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -2788,11 +2788,20 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
         coreSettings.save('hatarib_statusbar', '"0"')
         coreSettings.save('hatarib_fast_floppy', '"1"')
         coreSettings.save('hatarib_show_welcome', '"0"')
+        coreSettings.save('hatarib_tos', '"<etos1024k>"')
+
         # Machine Type
         if system.isOptSet('hatarib_machine'):
             coreSettings.save('hatarib_machine', '"' + system.config['hatarib_machine'] + '"')
         else:
             coreSettings.save('hatarib_machine', '"0"')
+
+        # Language/Region
+        if system.isOptSet("hatarib_language"):
+            coreSettings.save('hatarib_region', '"' + system.config['hatarib_language'] + '"')
+        else:
+            coreSettings.save('hatarib_region', '"127"')
+
         # CPU
         if system.isOptSet('hatarib_cpu'):
             coreSettings.save('hatarib_cpu', '"' + system.config['hatarib_cpu'] + '"')
@@ -2807,7 +2816,7 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
         if system.isOptSet('hatarib_memory'):
             coreSettings.save('hatarib_memory', '"' + system.config['hatarib_memory'] + '"')
         else:
-            coreSettings.save('hatarib_memory', '"0"')
+            coreSettings.save('hatarib_memory', '"1024"')
         # Pause Screen
         if system.isOptSet('hatarib_pause'):
             coreSettings.save('hatarib_pause_osk', '"' + system.config['hatarib_pause'] + '"')
@@ -2823,6 +2832,29 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
             coreSettings.save('hatarib_borders', '"' + system.config['hatarib_borders'] + '"')
         else:
             coreSettings.save('hatarib_borders', '"0"')
+
+        # Harddrive image support
+        rom_extension = os.path.splitext(os.path.basename(rom))[1].lower()
+        if rom_extension == '.hd':
+            coreSettings.save('hatarib_hardimg', '"hatarib/hdd"')
+            coreSettings.save('hatarib_hardboot', '"1"')
+            coreSettings.save('hatarib_hard_readonly', '"1"')
+            if system.isOptSet("hatarib_drive") and system.config["hatarib_drive"] == "ASCI":
+                coreSettings.save('hatarib_hardtype', '"2"')
+            elif system.isOptSet("hatarib_drive") and system.config["hatarib_drive"] == "SCSI":
+                coreSettings.save('hatarib_hardtype', '"3"')
+            else:
+                coreSettings.save('hatarib_hardtype', '"4"')
+        elif rom_extension == '.gemdos':
+            coreSettings.save('hatarib_hardimg', '"hatarib/hdd"')
+            coreSettings.save('hatarib_hardboot', '"1"')
+            coreSettings.save('hatarib_hardtype', '"0"')
+            coreSettings.save('hatarib_hard_readonly', '"0"')
+        else:
+            coreSettings.save('hatarib_hardimg', '')
+            coreSettings.save('hatarib_hardtype', '"0"')
+            coreSettings.save('hatarib_hardboot', '"0"')
+            coreSettings.save('hatarib_hard_readonly', '"1"')
 
     # Custom : Allow the user to configure directly retroarchcore.cfg via batocera.conf via lines like : snes.retroarchcore.opt=val
     for user_config in system.config:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2380,8 +2380,6 @@ libretro:
               prompt: ATARI ST MEMORY SIZE
               description: Choose your desired Atari ST memory size.
               choices:
-                  "256 KB": "256"
-                  "512 KB": "512"
                   "1 MB":   "1024"
                   "2 MB":   "2048"
                   "2.5 MB": "2560"
@@ -2423,6 +2421,36 @@ libretro:
                   "Snow":                 "5"
                   "Darken":               "1"
                   "No Indicator":         "0"
+           hatarib_language:
+              prompt: LANGUAGE
+              description: Emutos language && region setting.
+              choices:
+                  "English (us)":         "0"
+                  "German (de)":          "1"
+                  "French (fr)":          "2"
+                  "British English (uk)": "3"
+                  "Spanish (es)":         "4"
+                  "Italian (it)":         "5"
+                  "Swedish (se)":         "6"
+                  "Swiss French (ch)":    "7"
+                  "Swiss German (ch)":    "8"
+                  "Turkish (tr)":         "9"
+                  "Finnish (fi)":         "10"
+                  "Norwegian (no)":       "11"
+                  "Danish (dk)":          "12"
+                  "Arabic (ar)":          "13"
+                  "Netherlands (nl)":     "14"
+                  "Czech (cz)":           "15"
+                  "Hungarian (hg)":       "16"
+                  "Poland (pl)":          "17"
+                  "Russian (ru)":         "18"
+                  "Greek (gk)":           "19"
+           hatarib_drive:
+              prompt: ATARI HARD DRIVE TYPE
+               description: Choose your Atari hard drive type for the .hd extension file.
+               choices:
+                  "IDE (Default)": IDE
+                  "ASCI":          ASCI
     imame4all:
       features: [netplay]
       shared: [rewind, autosave]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -8244,16 +8244,27 @@ hatari:
         model:
             prompt:      MODEL
             choices:
-                "520 ST AUTO":     520st_auto
-                "520 ST TOS 1.00": 520st_100
-                "520 ST TOS 1.02": 520st_102
-                "520 ST TOS 1.04": 520st_104
-                "1040 STE AUTO":   1040ste_auto
-                "1040 STE 1.06":   1040ste_106
-                "1040 STE 1.62":   1040ste_162
-                "Mega STE AUTO":   megaste_auto
-                "Mega STE 2.05":   megaste_205
-                "Mega STE 2.06":   megaste_206
+                "520 ST AUTO":        520st_auto
+                "520 ST TOS 1.00":    520st_100
+                "520 ST TOS 1.02":    520st_102
+                "520 ST TOS 1.04":    520st_104
+                "520 ST EMUTOS 256k": 520st_etos256
+                "1040 STE AUTO":      1040ste_auto
+                "1040 STE 1.06":      1040ste_106
+                "1040 STE 1.62":      1040ste_162
+                "1040 STE ETOS 256k": 1040ste_etos256
+                "Mega STE AUTO":      megaste_auto
+                "Mega STE 2.05":      megaste_205
+                "Mega STE 2.06":      megaste_206
+                "Mega STE ETOS 256k": megaste_etos256
+                "TT AUTO":            tt_auto
+                "TT 3.06":            tt_306
+                "TT ETOS 512k":       tt_etos512
+                "Falcon AUTO":        falcon_auto
+                "Falcon 4.0":         falcon_400
+                "Falcon 4.02":        falcon_402
+                "Falcon 4.04":        falcon_404
+                "Falcon ETOS 512k":   falcon_etos512
         language:
             prompt:      LANGUAGE
             description: TOS languages.

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1445,19 +1445,19 @@ atarist:
   manufacturer: Atari
   release: 1985
   hardware: computer
-  extensions: [st, msa, stx, dim, ipf, m3u, zip, 7z, hd, gemdos, vhd, gem, ide]
+  extensions: [st, msa, stx, dim, ipf, m3u, zip, 7z, hd, gemdos]
   emulators:
-    libretro:
-      hatari: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_HATARI], incompatible_extensions: [ hd, gemdos ] }
-      hatarib: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_HATARIB], incompatible_extensions: [ hd, gemdos ] }
     hatari:
       hatari: { requireAnyOf: [BR2_PACKAGE_HATARI] }
+    libretro:
+      hatarib: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_HATARIB] }
+      hatari: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_HATARI], incompatible_extensions: [ hd, gemdos ] }
   comment_en: |
-    To enable GEMDOS support within the non-libretro version of Hatari.
+    To enable GEMDOS support,
     Create a directory within the roms folder that has a .gemdos extension.
     i.e. /userdata/roms/atarist/<drive name>.gemdos
   comment_fr: |
-    Pour activer le support GEMDOS dans la version non libretro de Hatari.
+    Pour activer le support GEMDOS,
     Créez un répertoire dans le dossier roms portant une extension .gemdos.
     c'est-à-dire /userdata/roms/atarist/<nom du lecteur>.gemdos
 amstradcpc:


### PR DESCRIPTION
atarist: improve hatarib libretro core

- add support for .hd image && .gemos directory roms
- add ide|scsi|asci hdd controller
- use emutos 1024 by default (it's embedded inside the core).
  Currently, the default tos.img  don't work with all models, and don't support hard drives.
  emutos 1024k is embedded inside the core, so just use it. (and increase the min memory to 1MB)
- add language support (need emutos)
- systems: remove .vhd .gem .ide extensions, they are used internally by hatarib to detect the
          disk controller type. simply use the .hd extension + controller option if needed



atarist: harati : add TT & Falcon models and Emutos support

Default tos don't have hard drive support on ST.
use alternative emutos instead (opensource GPL)

I'm using 256k emutos for ST,STE,MEGASTE , and 512k for TT && Falcon

https://sourceforge.net/projects/emutos/files/emutos/1.3/emutos-256k-1.3.zip/download
https://sourceforge.net/projects/emutos/files/emutos/1.3/emutos-512k-1.3.zip/download

They are a 1024k multilang version, but we are not able to specify the lang command line,
