### PR TITLE
hatari: fix ACSI hdd controller type

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
@@ -83,8 +83,8 @@ class HatariGenerator(Generator):
 
         rom_extension = rom_path.suffix.lower()
         if rom_extension == ".hd":
-            if system.isOptSet("hatari_drive") and system.config["hatari_drive"] == "ASCI":
-                commandArray += ["--asci", rom_path]
+            if system.isOptSet("hatari_drive") and system.config["hatari_drive"] == "ACSI":
+                commandArray += ["--acsi", rom_path]
             else:
                 commandArray += ["--ide-master", rom_path]
         elif rom_extension == ".gemdos":

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -2839,7 +2839,7 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
             coreSettings.save('hatarib_hardimg', '"hatarib/hdd"')
             coreSettings.save('hatarib_hardboot', '"1"')
             coreSettings.save('hatarib_hard_readonly', '"1"')
-            if system.isOptSet("hatarib_drive") and system.config["hatarib_drive"] == "ASCI":
+            if system.isOptSet("hatarib_drive") and system.config["hatarib_drive"] == "ACSI":
                 coreSettings.save('hatarib_hardtype', '"2"')
             elif system.isOptSet("hatarib_drive") and system.config["hatarib_drive"] == "SCSI":
                 coreSettings.save('hatarib_hardtype', '"3"')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2450,7 +2450,7 @@ libretro:
                description: Choose your Atari hard drive type for the .hd extension file.
                choices:
                   "IDE (Default)": IDE
-                  "ASCI":          ASCI
+                  "ACSI":          ACSI
     imame4all:
       features: [netplay]
       shared: [rewind, autosave]
@@ -8290,7 +8290,7 @@ hatari:
             description: Choose your Atari hard drive type for the .hd extension file.
             choices:
                 "IDE (Default)": IDE
-                "ASCI":          ASCI
+                "ACSI":          ACSI
 
 melonds:
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]


### PR DESCRIPTION
this is ACSI,  not ASCI.  Hatari is not starting currently with --asci.