### PR TITLE
Update shGenerator.py

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/sh/shGenerator.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command
-from ...controller import generate_sdl_game_controller_config
+from ...controller import generate_sdl_game_controller_config, write_sdl_controller_db
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -25,6 +25,10 @@ class ShGenerator(Generator):
         # in case of squashfs, the root directory is passed
         runsh = rom_path / "run.sh"
         shrom = runsh if runsh.exists() else rom_path
+
+        # PortMaster uses this.
+        dbfile = "/tmp/gamecontrollerdb.txt"
+        write_sdl_controller_db(playersControllers, dbfile)
 
         commandArray = ["/bin/bash", shrom]
         return Command.Command(array=commandArray,env={


### PR DESCRIPTION
shGenerator.py dumps a fresh `gamecontrollerdb.txt` into `/tmp/gamecontrollerdb.txt` for PortMaster ports to use.

This saves us the hassle of reinventing the wheel on Batocera where controller support is mostly solved problem for our use case.