### PR TITLE
add image scaling to drastic [V42]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/drastic/drasticGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/drastic/drasticGenerator.py
@@ -42,6 +42,21 @@ class DrasticGenerator(Generator):
         f = drastic_conf.open("w", encoding="ascii")
 
         #Getting Values from ES
+        if system.isOptSet("drastic_scaling") and system.config["drastic_scaling"] == 'nearest':
+            subprocess.run(f"xxd {drastic_bin} > drastic.txt", shell=True)
+            if subprocess.run("grep -q '6c69 6e65 6172' drastic.txt", shell=True).returncode == 0:
+                # Swap to nearest neighbor
+                subprocess.run("sed -i 's/6c69 6e65 6172/3000 0000 0000/g' drastic.txt", shell=True)
+                subprocess.run(f"xxd -r drastic.txt > {drastic_bin}", shell=True)
+                os.remove("drastic.txt")
+        else:
+            subprocess.run(f"xxd {drastic_bin} > drastic.txt", shell=True)
+            if subprocess.run("grep -q '3000 0000 0000' drastic.txt", shell=True).returncode == 0:
+                # Swap to bilinear
+                subprocess.run("sed -i 's/3000 0000 0000/6c69 6e65 6172/g' drastic.txt", shell=True)
+                subprocess.run(f"xxd -r drastic.txt > {drastic_bin}", shell=True)
+                os.remove("drastic.txt")
+
         if system.isOptSet("drastic_hires") and system.config["drastic_hires"] == '1':
             esvaluedrastichires = 1
         else:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11316,6 +11316,13 @@ drastic:
             choices:
                 "Off": 0
                 "On":  1
+        drastic_scaling:
+            group: ADVANCED OPTIONS
+            prompt:      IMAGE SCALING
+            description: Switches between smooth (Bilinear) and sharp (Nearest Neighbor) image scaling.
+            choices:
+                "Bilinear": bilinear
+                "Nearest-neighbor":  nearest
         drastic_fix2d:
             group: ADVANCED OPTIONS
             prompt:      KEEP MAIN SCREEN ON TOP


### PR DESCRIPTION
Modifies drastic binary to use either bilinear or nearest-neighbor image scaling.

The specific binary data that's being searched for and changed was retrieved via projects that modify drastic for various linux based os's.

Tested working on a number of my handhelds.