### PR TITLE
ports/devilutionx: Always enable ZeroTier

### DIFF
--- a/package/batocera/ports/devilutionx/devilutionx.mk
+++ b/package/batocera/ports/devilutionx/devilutionx.mk
@@ -15,21 +15,10 @@ DEVILUTIONX_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
 DEVILUTIONX_CONF_OPTS += -DBUILD_TESTING=OFF
 # Prefill the player name when creating a new character,
 # in case the device does not have a keyboard.
-DEVILUTIONX_CONF_OPTS += -DPREFILL_PLAYER_NAME=ON                         
+DEVILUTIONX_CONF_OPTS += -DPREFILL_PLAYER_NAME=ON
 # Ensure that DevilutionX's vendored dependencies are not accidentally fetched from network.
 # They should all be present in the source package.
 DEVILUTIONX_CONF_OPTS += -DFETCHCONTENT_FULLY_DISCONNECTED=ON
-
-# ZeroTier on aarch64 uses ARMv8 Cryptography Extensions.
-# These extension are optional and only certain Armv8-A CPUs support them.
-# Disables ZeroTier if the CPU compilation flags do not specify the "+crypto" extension.
-ifeq ($(BR2_aarch64)$(BR2_ARM_CPU_ARMV8A),yy)
-    ifneq ($(findstring +crypto,$(BR2_TARGET_OPTIMIZATION)),+crypto)
-        DEVILUTIONX_CONF_OPTS += -DDISABLE_ZERO_TIER=ON
-    endif
-else ifeq ($(BR2_arm),y)
-    DEVILUTIONX_CONF_OPTS += -DDISABLE_ZERO_TIER=ON
-endif
 
 # ugly hack becuase the is no version in the source file
 # and using the git tag doesn't download the submodules properly


### PR DESCRIPTION
The ZeroTier version used in DevilutionX 1.5+ no longer requires ARM cryptography extensions (as of
https://github.com/diasurgical/ZeroTierOne/commit/b0b342579adf6cec3ee26ec7c6148ec66d01709f)

Allow building ZeroTier for online multiplayer on any platform.

Refs https://github.com/diasurgical/devilutionX/issues/7545