### PR TITLE
Fix batocera-info

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -156,7 +156,7 @@ fi
 DISPLAYRES=$(batocera-resolution currentResolution)
 if [ ! -z "$WAYLAND_DISPLAY" ]; then # wayland
     DISPLAYRATE=$(batocera-resolution currentMode | awk -F'[x.]' '{printf "%.3f", $3 / 1000}')
-elif test -f /var/run/drmMode; then  # drm
+elif test -f /var/run/drmMode; then  # drm
     DISPLAYRATE=$(batocera-resolution currentMode | awk -F'\\.' '{print $4}')
 else # xorg
     DISPLAYRATE=$(batocera-resolution currentMode | awk -F'\\.' '{print $2"."$3}')


### PR DESCRIPTION
Replace space-like UTF-8 character (0xC2, 0xA0) with a space (0x20).
This fixes the "command not found" error on line 159 of `batocera-info` on systems with DRM display.