### PR TITLE
wifi-update [V42]

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -86,13 +86,13 @@ wifi_configure_all() {
 wifi_enable() {
     settingsCountry="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi.country)"
     [ -n "$settingsCountry" ] && /usr/sbin/iw reg set "$settingsCountry"
-    if [ "$settingsWlan" != "1" ]; then
-	    connmanctl disable wifi 2>/dev/null
-	    return
-    fi
 
     connmanctl enable wifi 2>/dev/null
     connmanctl scan   wifi 2>/dev/null
+}
+
+wifi_disable() {
+    connmanctl disable wifi 2>/dev/null
 }
 
 case "$1" in
@@ -100,56 +100,58 @@ case "$1" in
 	    batocera_hostname
 	    wifi_configure_all
 	    printf "Starting connman: "
-		start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r
+        start-stop-daemon -S -q -m -b -p /var/run/connmand.pid --exec /usr/sbin/connmand -- -n -r
 
-		# wait connmann is started. otherwise, S10wifi is unable to execute connmanctl commands
-		N=0
-		connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-		while test $? -ne 0 -a $N -lt 5; do # 5 tries
-		    N=$((N+1))
-		    sleep 1
-		    connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='
-		done
-		sleep 0.5
+        # wait connmann is started. otherwise, S10wifi is unable to execute connmanctl commands
+        for i in $(seq 1 20); do
+            if connmanctl state 2>/dev/null | grep -qE '^[ ]*State[ ]='; then
+                break
+            fi
+            sleep 0.25
+        done
 
-		# Check if device is a Retroid Pocket model,
-		# We generate a MAC address based on the serial number.
-		MAC=""
-		info_output=$(batocera-info)
+        # Check if device is a Retroid Pocket model,
+        # We generate a MAC address based on the serial number.
+        MAC=""
+        info_output=$(batocera-info)
 
-		if echo "$info_output" | grep -qE "Model: Retroid_Pocket_(Mini|5)"; then
-			WLAN=$(ls /sys/class/net | grep -E '^wlan' | head -n 1)
-			SERIAL="$(cat /sys/devices/soc0/serial_number)"
-			MAC="00:03:7F:${SERIAL:4:2}:${SERIAL:6:2}:${SERIAL:8:2}"
+        if echo "$info_output" | grep -qE "Model: Retroid_Pocket_(Mini|5)"; then
+            WLAN=$(ls /sys/class/net | grep -E '^wlan' | head -n 1)
+            SERIAL="$(cat /sys/devices/soc0/serial_number)"
+            MAC="00:03:7F:${SERIAL:4:2}:${SERIAL:6:2}:${SERIAL:8:2}"
 			
-			if [ -n "$WLAN" ]; then  # Check if a wlan interface was found
-				# Restart the link with the new MAC address
-				ip link set "$WLAN" down
-				ip link set "$WLAN" address "$MAC"
-				ip link set "$WLAN" up
-				echo "Custom MAC address $MAC set for wifi on interface $WLAN"
-				echo "Based on serial number $SERIAL"
-			else
-				echo "No wireless interface found."
-			fi
-		fi
+            if [ -n "$WLAN" ]; then  # Check if a wlan interface was found
+                # Restart the link with the new MAC address
+                ip link set "$WLAN" down
+                ip link set "$WLAN" address "$MAC"
+                ip link set "$WLAN" up
+                echo "Custom MAC address $MAC set for wifi on interface $WLAN"
+                echo "Based on serial number $SERIAL"
+            else
+                echo "No wireless interface found."
+            fi
+        fi
 
-		# can be done detached
-		wifi_enable &
+        if [ "$settingsWlan" = "1" ];then
+            # Detach the wifi enable process
+            wifi_enable &
+        else
+            wifi_disable
+        fi
 
-		echo "done."
-		;;
+        echo "done."
+        ;;
 	stop)
-		printf "Stopping connman: "
-		start-stop-daemon -K -q -p /var/run/connmand.pid
-		echo "done."
-		;;
+        printf "Stopping connman: "
+        start-stop-daemon -K -q -p /var/run/connmand.pid
+        echo "done."
+        ;;
 	restart | reload)
-		$0 stop
-		sleep 1
-		$0 start
-		;;
+        $0 stop
+        sleep 0.5
+        $0 start
+        ;;
 	*)
-		echo "usage: $0 {start|stop|restart|reload}"
-		;;
+        echo "usage: $0 {start|stop|restart|reload}"
+        ;;
 esac

--- a/package/batocera/core/batocera-scripts/scripts/batocera-wifi
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-wifi
@@ -14,10 +14,26 @@ do_scanlist() {
     do_list
 }
 
+wait_for_ip() {
+    local mode=$1
+
+    for i in $(seq 1 20); do
+        if [ "$mode" = "up" ]; then
+            if ip -4 addr show | grep "inet " | grep -qv "127\.0\.0\.1"; then
+                break
+            fi
+        elif [ "$mode" = "down" ]; then
+            if ! ip -4 addr show | grep "inet " | grep -qv "127\.0\.0\.1"; then
+                break
+            fi
+        fi
+        sleep 0.5
+    done
+}
 
 if [ $# -eq 0 ]; then
-	do_help
-	exit 1
+    do_help
+    exit 1
 fi
 
 ACTION=$1
@@ -25,40 +41,41 @@ shift
 
 case "${ACTION}" in
     "list")
-	do_list
-	;;
+        do_list
+        ;;
     "scanlist")
-	do_scanlist
-	;;
+        do_scanlist
+        ;;
     "start")
-	/etc/init.d/S08connman restart
-	;;
+        /etc/init.d/S08connman restart
+        ;;
     "enable")
-	batocera-settings-set wifi.enabled 1
-	if [ "$#" -eq 2 ]; then
-		batocera-settings-set wifi.ssid "$1"
-		batocera-settings-set wifi.key "$2"
-	fi
-	/etc/init.d/S08connman reload
+        batocera-settings-set wifi.enabled 1
+        if [ $# -eq 2 ]; then
+            batocera-settings-set wifi.ssid "$1"
+            batocera-settings-set wifi.key "$2"
+        fi
+        /etc/init.d/S08connman reload
 
-	# wait up to 5 sec for an IP address
-	N=0
-	ifconfig | grep "inet addr" | grep -qv "127\.0\.0\.1"
-	while test $? -ne 0 -a $N -lt 10 # 10 tries
-	do
-		N=$((N+1))
-		sleep 0.5
-		ifconfig | grep "inet addr" | grep -qv "127\.0\.0\.1"
-	done
+        settings_ssid="$(batocera-settings-get wifi.ssid)"
 
-	;;
+        # We don't need to wait for an IP if no saved ssid
+        if [ -n "${settings_ssid}" ]; then
+            wait_for_ip up
+        else
+            sleep 1 # wait 1 second for connman to initialize and start scanning
+        fi
+        ;;
     "disable")
-	batocera-settings-set wifi.enabled 0
-	/etc/init.d/S08connman reload
-	;;
-	*)
-		do_help
-		>&2 echo "error: invalid command ${ACTION}"
-		exit 1
+        batocera-settings-set wifi.enabled 0
+        /etc/init.d/S08connman reload
+        wait_for_ip down
+        ;;
+    *)
+        do_help
+        >&2 echo "error: invalid command ${ACTION}"
+        exit 1
+        ;;
 esac
+
 exit 0


### PR DESCRIPTION
Refactor some code involved in batocera-wifi and S08connman

S08connman - splits the disable/enable into seperate functions instead of using "wifi_enable" to disable wifi. Refactor/optimize the wait loop. Reduce sleep time between stop and start in restart case(the only thing that is dependent on this is batocera-wifi setting wifi data before calling S08connman reload. There needs to be a brief wait period for batocera-settings-set to be applied, 0.5 is more than enough)

batocera-wifi - adds wait_for_ip function and optimizes the loop. wait_for_ip up is for when es wifi toggle is enabled, down is for when toggle is disabled, so wait time does not have to be the same. 