### PR TITLE
Add hash for devilutionx

### DIFF
--- a/package/batocera/ports/devilutionx/devilutionx.hash
+++ b/package/batocera/ports/devilutionx/devilutionx.hash
@@ -1,0 +1,2 @@
+# Computed locally
+sha256  ea948933eb5fbffb12d72743ef15b626e7004a88bd4f1415b26a9f45240f4a7e  devilutionx-src.tar.xz


### PR DESCRIPTION
The devilutionx-src.tar.xz is probably generated during DevilutionX release and its hash for a particular DevilutionX version shouldn't change over time.

This change has been tested in several full clean builds (`make rk3326-cleanbuild`).