### PR TITLE
Save random seed on startup [v42]

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S03urandom
+++ b/board/batocera/fsoverlay/etc/init.d/S03urandom
@@ -3,21 +3,30 @@
 # Preserve random seed across reboot. See urandom(4).
 #
 
+load() {
+  if seed="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf randomseed)"
+  then
+    printf "Restoring random seed: "
+    echo $seed | xxd -r -ps > /dev/urandom
+    echo "done."
+  fi
+}
+
+save() {
+  printf "Saving random seed: "
+  mount -o remount,rw /boot
+  /usr/bin/batocera-settings-set -f /boot/batocera-boot.conf randomseed `xxd -ps -l 512 -c 512 /dev/urandom`
+  mount -o remount,ro /boot
+  echo "done."
+}
+
 case "$1" in
   start)
-    if seed="$(/usr/bin/batocera-settings-get -f /boot/batocera-boot.conf randomseed)"
-    then
-      printf "Restoring random seed: "
-      echo $seed | xxd -r -ps > /dev/urandom
-      echo "done."
-    fi
+    load
+    save
     ;;
   stop)
-    printf "Saving random seed: "
-    mount -o remount,rw /boot
-    /usr/bin/batocera-settings-set -f /boot/batocera-boot.conf randomseed `xxd -ps -l 512 -c 512 /dev/urandom`
-    mount -o remount,ro /boot
-    echo "done."
+    save
     ;;
   *)
     echo "usage: $0 {start|stop}"


### PR DESCRIPTION
This is a small security fix/improvement. I think it should wait for v42.

Currently the random seed is saved only on clean shutdown. This leads to no entropy being accumulated and the same seed reused if the device is not shut down properly.

Saving random seed on startup (immediately after using the previously saved seed) is the behavior of most distros.