### PR TITLE
Fix multicast DNS name resolution, fixes #13028

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -62,6 +62,7 @@ We have migrated to a more modern WINE runner, using WINE-TKG.
 - Hotkey handling for Flycast
 - M.U.G.E.N controllers
 - Libretro-FBNeo crosshairs for light guns now showing
+- Fixed multicast DNS
 ### Changed / Improved
 - Splash screen now disabled by default
 - Added bezel & sinden border support for the RPi5 with Model 3 games

--- a/board/batocera/fsoverlay/etc/init.d/S04populate
+++ b/board/batocera/fsoverlay/etc/init.d/S04populate
@@ -25,9 +25,6 @@ mkdir -p /var/cache
 # dbus
 mkdir -p /var/lib/dbus
 
-# usbmount
-mkdir -p /var/run
-
 # Udev custom rules
 mkdir -p /run/udev/
 

--- a/board/batocera/fsoverlay/etc/init.d/rcS
+++ b/board/batocera/fsoverlay/etc/init.d/rcS
@@ -4,12 +4,12 @@
 # Start all init scripts in /etc/init.d
 # executing them in numerical order.
 #
+ln -s /run /var/run
 for i in /etc/init.d/S??* ;do
 
      # Ignore dangling symlinks (if any).
     [ ! -f "$i" ] && continue
 
-	mkdir -p /var/run/
     echo $(date +"%F %T,%3N")": ${i} - starting" >> /var/run/boot.log
 
      case "$i" in

--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -268,6 +268,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_AVAHI				# service discovery on local network
 	select BR2_PACKAGE_AVAHI_DAEMON				# ping batocera.local
 	select BR2_PACKAGE_AVAHI_LIBDNSSD_COMPATIBILITY		# bonjour
+	select BR2_PACKAGE_NSS_MDNS				# bonjour
 	select BR2_PACKAGE_WSDD					# service discovery on local network (windows network neighborhood)
 	select BR2_PACKAGE_NTP
 	select BR2_PACKAGE_RSYNC


### PR DESCRIPTION
Fix multicast DNS name resolution, fixes #13028

- Buildroot packages `nss-mdns` and `avahi` are currently misaligned in their default configuration regarding where the avahi socket belongs.  Make `/var/run` a symlink to `/run`, to conform with Filesystem Hierarchy Standard 3.0, and re-aligning these packages with each other.  https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s13.html
- Add package `nss-mdns` on all boards instead of only boards using Wine