### PR TITLE
batocera-wine : fix waitwineserver

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -121,7 +121,7 @@ usage() {
 }
 
 waitWineServer() {
-    while pgrep "${WINESERVER}"
+    while pgrep -f "${WINESERVER}"
     do
 	echo "waiting wineserver" >&2
 	sleep 1


### PR DESCRIPTION
egrep need to use -f flag to match a full path

```
-f, --full
     The pattern is normally only matched against the process name.
     When -f is set, the full command line is used.
```

Currently, it's skipping loop directly.
For wsquashfs, that mean that's it's trying to do cleanup and umount of overlays directly after the start, and can't do it

```
batocera-wine windows play /userdata/roms/windows/game.squashfs
.....
.....
....
+ cd '/var/run/wine/game.wsquashfs/'
+ WINEPREFIX='/var/run/wine/game.wsquashfs'
+ eval '' '/usr/wine/wine-tkg/bin/wine  "game.exe"'
++ /usr/wine/wine-tkg/bin/wine game.exe
wineserver: using server-side synchronization.
+ waitWineServer
+ sleep 2
+ /bin/pgrep /usr/wine/wine-tkg/bin/wineserver
+ sleep 1
+ umount -f -R '/var/run/wine/game.wsquashfs'
umount: /var/run/wine/game.wsquashfs: target is busy.
+ umount -f -R '/var/run/wine/game.wsquashfs'
+ sleep 1
+ rm -rf '/var/run/wine/squashfs_game.wsquashfs'
+ rm -rf '/userdata/system/wine-bottles/windows/game.wsquashfs.work'
+ rm -rf '/var/run/wine/game.wsquashfs'
rm: cannot remove '/var/run/wine/game.wsquashfs/dosdevices': Directory not empty
rm: cannot remove '/var/run/wine/game.wsquashfs/drive_c/Program Files/Common Files/Microsoft Shared': Directory not empty
rm: cannot remove '/var/run/wine/game.wsquashfs/drive_c/Program Files/Common Files/System/ADO': Directory not empty
....
....
```