### PR TITLE
fix bugs with fpinball generator

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
@@ -60,11 +60,10 @@ class FpinballGenerator(Generator):
         src_file = Path("/usr/fpinball/BAM/FPLoader.exe")
         dest_file = emupath / "BAM" / "FPLoader.exe"
         if src_file.stat().st_mtime > dest_file.stat().st_mtime:
-            shutil.copytree('/usr/fpinball', emupath)
+            shutil.copytree('/usr/fpinball', emupath, dirs_exist_ok=True)
 
         # convert rom path
         rompath = PureWindowsPath(rom)
-        rom = f"Z:{rompath}"
 
         if rom == 'config':
             commandArray = [
@@ -80,7 +79,7 @@ class FpinballGenerator(Generator):
                 "/desktop=Wine,{}x{}".format(gameResolution["width"],
                 gameResolution["height"]),
                 emupath / "BAM" / "FPLoader.exe",
-                "/open", rom, "/play", "/exit" ]
+                "/open", f"Z:{rompath}", "/play", "/exit" ]
 
         # config
         mkdir_if_not_exists(_FPINBALL_CONFIG)
@@ -173,6 +172,7 @@ class FpinballGenerator(Generator):
                         f.write("\"JoypadVolumeDown\"=dword:ffffffff\r\n")
                         f.write("\"JoypadVolumeUp\"=dword:ffffffff\r\n")
                         f.write("\r\n")
+                    nplayer += 1
 
         cmd = ["wine", "regedit", _FPINBALL_CONFIG_REG]
         env = {"LD_LIBRARY_PATH": "/lib32:/usr/wine/wine-tkg/lib/wine", "WINEPREFIX": wineprefix }


### PR DESCRIPTION
Three issues found while adding unit tests:

- If `fpinball` exists in `wineprefix`, copying newer files from `/usr/fpinball` fails
- Setting the `rom` variable to a string with the `Z:` prefix makes it so the comparison to `'config'` never happens
- The player controller loop doesn't increase `nplayer`, so it adds all of the controllers every time (which the comments say we don't want to do)