### PR TITLE
Fix MAME config for apple2p, apple2e, apple2ee

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -437,16 +437,13 @@ def generateMAMEConfigs(playersControllers: ControllerMapping, system: Emulator,
         if system.getOptBoolean("artworkcrop"):
             commandLine += [ "-artwork_crop" ]
 
-    # Share plugins & samples with standalone MAME (except TI99 and apple2+/e/ee)
-    # FIXME: Not entirely sure why these paths cause parsing problems for apple2+/e/ee for retroarch
-    pluginspath = SAVES / 'mame' / 'plugins'
-    samplepath = BIOS / 'mame' / 'samples'
-    if not system.name in { "ti99", "apple2", "applep", "apple2e", "apple2ee" }:
-        commandLine += [ "-pluginspath", f'"/usr/bin/mame/plugins;{pluginspath}"' ]
-        commandLine += [ "-homepath", f'"{pluginspath}"' ]
-        commandLine += [ "-samplepath", f'"{samplepath}"' ]
-    mkdir_if_not_exists(pluginspath)
-    mkdir_if_not_exists(samplepath)
+    # Share plugins & samples with standalone MAME (except TI99)
+    if not system.name == "ti99":
+        commandLine += [ "-pluginspath", f"/usr/bin/mame/plugins/;{SAVES / 'mame' / 'plugins'}" ]
+        commandLine += [ "-homepath" , SAVES / 'mame' / 'plugins' ]
+        commandLine += [ "-samplepath", BIOS / "mame" / "samples" ]
+    mkdir_if_not_exists(SAVES / "mame" / "plugins")
+    mkdir_if_not_exists(BIOS / "mame" / "samples")
 
     # Delete old cmd files & prepare path
     cmdPath = Path("/var/run/cmdfiles")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -158,7 +158,10 @@ def generateMAMEConfigs(playersControllers: ControllerMapping, system: Emulator,
 
             # Apple II
             if system.name == "apple2":
-                commandLine += ["-sl7", "cffa202"]
+                rom_extension = rom.suffix.lower()
+                # only add SD/IDE control if provided a hard drive image
+                if rom_extension in {".hdv", ".2mg", ".chd", ".iso", ".bin", ".cue"}:
+                    commandLine += ["-sl7", "cffa202"]
                 if system.isOptSet('gameio') and system.config['gameio'] != 'none':
                     if system.config['gameio'] == 'joyport' and messModel != 'apple2p':
                         eslog.debug("Joyport is only compatible with Apple II +")
@@ -428,8 +431,8 @@ def generateMAMEConfigs(playersControllers: ControllerMapping, system: Emulator,
         if system.getOptBoolean("artworkcrop"):
             commandLine += [ "-artwork_crop" ]
 
-    # Share plugins & samples with standalone MAME (except TI99)
-    if not system.name == "ti99":
+    # Share plugins & samples with standalone MAME (except TI99 and apple2+/e/ee)
+    if system.name not in {"ti99", "apple2", "applep", "apple2e", "apple2ee"}:
         commandLine += [ "-pluginspath", f"/usr/bin/mame/plugins/;{SAVES / 'mame' / 'plugins'}" ]
         commandLine += [ "-homepath" , SAVES / 'mame' / 'plugins' ]
         commandLine += [ "-samplepath", BIOS / "mame" / "samples" ]


### PR DESCRIPTION
This PR fixes the following problems, which were discovered when trying to use libretro MAME for apple2+/e/ee.

1. For apple2+/e/ee, only add the SD/IDE card when a hard drive image is provided.
2. Many paths are not quoted; when there are special characters or spaces in the path/filenames, the produced CMD file will cause parsing problem.
3. Some path variables were set within `if` statements and unbound outside.
4. (see comment below) ~~Adding `pluginpath`, `homepath`, `samplepath` causes parsing problems as well. Not sure whether this is retroarch or MAME's parsing problem, but as a workaround, these are omit for now.~~