### PR TITLE
Added SGB-MSU1 with squashfs

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -347,6 +347,9 @@ class LibretroGenerator(Generator):
         if system.name == 'snes-msu1' or system.name == 'satellaview':
             if "squashfs" in str(rom_path) and rom_path.is_dir():
                 rom_path = next(itertools.chain(rom_path.glob('*.sfc'), rom_path.glob('*.smc')))
+        elif system.name == 'sgb-msu1':
+            if "squashfs" in str(rom_path) and rom_path.is_dir():
+                rom_path = next(itertools.chain(rom_path.glob('*.gb'), rom_path.glob('*.gbc')))
         elif system.name == 'msu-md':
             if "squashfs" in str(rom_path) and rom_path.is_dir():
                 rom_path = next(rom_path.glob('*.md'))

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -549,6 +549,9 @@ sg1000:
 sgb:
   emulator: libretro
   core:     mgba
+sgb-msu1:
+  emulator: libretro
+  core:     bsnes
 singe:
   emulator: hypseus-singe
   core:     hypseus-singe

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -317,6 +317,18 @@ sgb:
       mgba:          { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MGBA] }
       mesen-s:       { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MESENS] }
 
+sgb-msu1:
+  name:       Super Game Boy MSU1
+  manufacturer: Nintendo
+  release: 1994
+  hardware: console
+  extensions: [gb, gbc, zip, 7z, squashfs]
+  group:      snes
+  emulators:
+    libretro:
+      bsnes:       { requireAnyOf: [BR2_PACKAGE_LIBRETRO_BSNES]     }
+      bsnes_hd:    { requireAnyOf: [BR2_PACKAGE_LIBRETRO_BSNES_HD]  }
+
 gbc2players:
   name:       Game Boy Color (2 players)
   manufacturer: Nintendo
@@ -4860,15 +4872,15 @@ doom3:
             │   ├── pak007.pk4
             │   └── pak008.pk4
             └── d3xp/
-                ├── pak000.pk4 
+                ├── pak000.pk4
                 └── pak001.pk4
-    
-    Create a `Doom 3.d3` file in the roms/doom3 directory. 
+
+    Create a `Doom 3.d3` file in the roms/doom3 directory.
     If you have the Resurrection of Evil mod then Create a `Doom 3 - Resurrection of Evil.d3` file too.
 
     The `Doom 3.d3` file should contain the path to the base game. - i.e. base/pak000.pk4
     Similarly `Doom 3 - Resurrection of Evil.d3` should be - d3xp/pak000.pk4
-    
+
     For more info: https://wiki.batocera.org/systems:doom3
   comment_fr: |
     Trouvez la documentation ici: https://wiki.batocera.org/systems:doom3
@@ -5500,7 +5512,7 @@ ps4:
     Before you can play a game you must install the game via the associated .PKG file of your backed-up game using the F1 menu.
     Then in the new installation directory for the installed game, create a file with a .ps4 extension so EmularionStation will see it.
     i.e. /userdata/roms/ps4/CUSA03173/Bloodborne.ps4
-    
+
     Then you can launch the game from EmulationStation accordingly.
 
     DLC content will be stored in: /userdata/roms/ps4/DLC


### PR DESCRIPTION
In the following PR squashfs was added for MSU-MD: https://github.com/batocera-linux/batocera.linux/pull/12390

In this PR I have added SGB-MSU1 as a new system with squashfs extension support. 

 You can use Super GameBoy games with this which have msu1 sound, it will check for GameBoy and GameBoy Color file extensions.

I have tested both sgb msu1 with a normal folder structure and as a squashfs file both seem to work.