### PR TITLE
Reload udev rules when user persistent rules are available, fixes #10564

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -148,6 +148,8 @@ chmod 0700 /userdata/system/.ssh
 mkdir -p /userdata/system/udev/rules.d
 rm -rf /run/udev/rules.d
 ln -s /userdata/system/udev/rules.d/ /run/udev/
+udevadm control --reload-rules
+udevadm trigger --type=devices --action=add --settle
 
 # and add the machine-id
 test -e /userdata/system/machine-id || dbus-uuidgen --ensure=/userdata/system/machine-id


### PR DESCRIPTION
Reload udev rules when user persistent rules are available, fixes #10564 when used with the following rule in /userdata/system/udev/rules.d/52-dolphin.rules :

```
ACTION=="add", ENV{PRODUCT}=="57e/305/100", RUN+="/bin/sh -c 'echo -n $kernel > /sys/bus/usb/drivers/btusb/unbind'"
```
