### PR TITLE
Read settings with latin1 codec instead of utf_8_sig, fixes #10650

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
@@ -37,7 +37,7 @@ class UnixSettings:
             file = io.StringIO()
             file.write('[DEFAULT]\n')
 
-            with self.settings_path.open(encoding='utf_8_sig') as f:
+            with self.settings_path.open(encoding='latin1') as f:
                 file.write(f.read())
 
             file.seek(0)


### PR DESCRIPTION
Read settings with latin1 codec instead of utf_8_sig, fixes #10650