### PR TITLE
Use cheevos token from ES instead of password, fixes #13111

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -737,9 +737,9 @@ def createLibretroConfig(generator: Generator, system: Emulator, controllers: Co
         if (system.config['core'] in coreToRetroachievements) or (system.isOptSet('cheevos_force') and system.getOptBoolean('cheevos_force') == True):
             retroarchConfig['cheevos_enable'] = 'true'
             retroarchConfig['cheevos_username'] = systemConfig.get('retroachievements.username', "")
-            retroarchConfig['cheevos_password'] = systemConfig.get('retroachievements.password', "")
+            retroarchConfig['cheevos_password'] = "" # clear the password - only use the token
+            retroarchConfig['cheevos_token'] = systemConfig.get('retroachievements.token', "")
             retroarchConfig['cheevos_cmd'] = DEFAULTS_DIR / "call_achievements_hooks.sh"
-            retroarchConfig['cheevos_token'] = "" # clear the token, otherwise, it may fail (possibly a ra bug)
             # retroachievements_hardcore_mode
             if system.isOptSet('retroachievements.hardcore') and system.getOptBoolean('retroachievements.hardcore') == True:
                 retroarchConfig['cheevos_hardcore_mode_enable'] = 'true'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -259,51 +259,32 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
         pcsx2INIConfig.add_section("Achievements")
     pcsx2INIConfig.set("Achievements", "Enabled", "false")
     if system.isOptSet('retroachievements') and system.getOptBoolean('retroachievements') == True:
-        headers   = {"Content-type": "text/plain", "User-Agent": "Batocera.linux"}
-        login_url = "https://retroachievements.org/"
         username  = system.config.get('retroachievements.username', "")
-        password  = system.config.get('retroachievements.password', "")
+        token     = system.config.get('retroachievements.token', "")
         hardcore  = system.config.get('retroachievements.hardcore', "")
         indicator = system.config.get('retroachievements.challenge_indicators', "")
         presence  = system.config.get('retroachievements.richpresence', "")
         leaderbd  = system.config.get('retroachievements.leaderboards', "")
-        login_cmd = f"dorequest.php?r=login&u={username}&p={password}"
-        try:
-                cnx = httplib2.Http()
-        except:
-                eslog.error("ERROR: Unable to connect to " + login_url)
-        try:
-                res, rout = cnx.request(login_url + login_cmd, method="GET", body=None, headers=headers)
-                if (res.status != 200):
-                    eslog.warning(f"ERROR: RetroAchievements.org responded with #{res.status} [{res.reason}] {rout}")
-                    pcsx2INIConfig.set("Achievements", "Enabled",  "false")
-                else:
-                    parsedout = json.loads(rout.decode('utf-8'))
-                    if not parsedout['Success']:
-                        eslog.warning(f"ERROR: RetroAchievements login failed with ({str(parsedout)})")
-                    token = parsedout['Token']
-                    pcsx2INIConfig.set("Achievements", "Enabled", "true")
-                    pcsx2INIConfig.set("Achievements", "Username", username)
-                    pcsx2INIConfig.set("Achievements", "Token", token)
-                    pcsx2INIConfig.set("Achievements", "LoginTimestamp", str(int(time.time())))
-                    if hardcore == '1':
-                        pcsx2INIConfig.set("Achievements", "ChallengeMode", "true")
-                    else:
-                        pcsx2INIConfig.set("Achievements", "ChallengeMode", "false")
-                    if indicator == '1':
-                        pcsx2INIConfig.set("Achievements", "PrimedIndicators", "true")
-                    else:
-                        pcsx2INIConfig.set("Achievements", "PrimedIndicators", "false")
-                    if presence == '1':
-                        pcsx2INIConfig.set("Achievements", "RichPresence", "true")
-                    else:
-                        pcsx2INIConfig.set("Achievements", "RichPresence", "false")
-                    if leaderbd == '1':
-                        pcsx2INIConfig.set("Achievements", "Leaderboards", "true")
-                    else:
-                        pcsx2INIConfig.set("Achievements", "Leaderboards", "false")
-        except:
-                eslog.error("ERROR: setting RetroAchievements parameters")
+        pcsx2INIConfig.set("Achievements", "Enabled", "true")
+        pcsx2INIConfig.set("Achievements", "Username", username)
+        pcsx2INIConfig.set("Achievements", "Token", token)
+        pcsx2INIConfig.set("Achievements", "LoginTimestamp", str(int(time.time())))
+        if hardcore == '1':
+            pcsx2INIConfig.set("Achievements", "ChallengeMode", "true")
+        else:
+            pcsx2INIConfig.set("Achievements", "ChallengeMode", "false")
+        if indicator == '1':
+            pcsx2INIConfig.set("Achievements", "PrimedIndicators", "true")
+        else:
+            pcsx2INIConfig.set("Achievements", "PrimedIndicators", "false")
+        if presence == '1':
+            pcsx2INIConfig.set("Achievements", "RichPresence", "true")
+        else:
+            pcsx2INIConfig.set("Achievements", "RichPresence", "false")
+        if leaderbd == '1':
+            pcsx2INIConfig.set("Achievements", "Leaderboards", "true")
+        else:
+            pcsx2INIConfig.set("Achievements", "Leaderboards", "false")
     # set other settings
     pcsx2INIConfig.set("Achievements", "TestMode", "false")
     pcsx2INIConfig.set("Achievements", "UnofficialTestMode", "false")

--- a/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
+++ b/package/batocera/emulationstation/batocera-emulationstation/batocera-emulationstation.mk
@@ -3,8 +3,8 @@
 # batocera-emulationstation
 #
 ################################################################################
-# Last update: Commits on Dec 16, 2024
-BATOCERA_EMULATIONSTATION_VERSION = 92ef60d44fab441e279553c52a1f9a84305f2326
+# Last update: Commits on Dec 24, 2024
+BATOCERA_EMULATIONSTATION_VERSION = 8e655299a463cbd88e2a35fdda3356bd58f8a069
 BATOCERA_EMULATIONSTATION_SITE = https://github.com/batocera-linux/batocera-emulationstation
 BATOCERA_EMULATIONSTATION_SITE_METHOD = git
 BATOCERA_EMULATIONSTATION_LICENSE = MIT


### PR DESCRIPTION
- Use cheevos token from ES instead of password in config generators for retroarch and pcsx2.  Avoid parsing issues related to special characters in the password.  Fixes #13111
- Bump ES, for cheevos token refresh at startup