### PR TITLE
Cleaning up G920/G923 wheel rules

### DIFF
--- a/package/batocera/core/batocera-udev-rules/batocera-udev-rules.mk
+++ b/package/batocera/core/batocera-udev-rules/batocera-udev-rules.mk
@@ -17,8 +17,9 @@ define BATOCERA_UDEV_RULES_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/etc/usb_modeswitch.d
 	#$(INSTALL) -m 0644 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-udev-rules/usb_modeswitch.d/*    $(TARGET_DIR)/etc/usb_modeswitch.d/
 
-	# generate this file cause windows doesn't support file with ':' in git easyly
+	# generate these files cause windows doesn't support file with ':' in git easily
 	(echo "# Logitech G920 Racing Wheel"; echo "DefaultVendor=046d"; echo "DefaultProduct=c261"; echo "MessageEndpoint=01"; echo "ResponseEndpoint=01"; echo "TargetClass=0x03"; echo 'MessageContent="0f00010142"') > $(TARGET_DIR)/etc/usb_modeswitch.d/046d:c261
+	(echo "# Logitech G923 Racing Wheel"; echo "DefaultVendor=046d"; echo "DefaultProduct=c26d"; echo "MessageEndpoint=01"; echo "ResponseEndpoint=01"; echo "TargetClass=0x03"; echo 'MessageContent="0f00010142"') > $(TARGET_DIR)/etc/usb_modeswitch.d/046d:c26d
 
 endef
 

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -13,6 +13,7 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech  Logitech MOMO Raci
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T300RS Racing wheel",   MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="1080"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech Logitech Driving Force",                 MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="200"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech Logitech Driving Force Pro",                 MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech G920 Driving Force Racing Wheel",            MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech G923 Racing Wheel for PlayStation 4 and PC", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="ThrustMaster, Inc. Ferrari 458 Spider",               MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="240"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster T150RS",                    MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="1080"
@@ -24,16 +25,14 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Thrustmaster Thrustmaster Ra
 # for ThrustMaster, Inc. Ferrari 458 Spider, cause xpad driver is blacklisted for the prefered xone
 ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b671", RUN+="/sbin/modprobe xpad"
 
-# G920 Driving Force Racing Wheel for Xbox One & Logitech G920 Driving Force Racing Wheel (2 names, same steering wheel)
-# Old (c261) and new revision (c262)
+# G920 Driving Force Racing Wheel (switch to PC mode)
+# Xbox mode (c261) | PC mode (c262)
 ATTR{idVendor}=="046d", ATTR{idProduct}=="c261", RUN+="usb_modeswitch '%b/%k'"
-ATTR{idVendor}=="046d", ATTR{idProduct}=="c262", RUN+="usb_modeswitch '%b/%k'"
 
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="G920 Driving Force Racing Wheel for Xbox One", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
-KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech G920 Driving Force Racing Wheel", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"
 
-# Logitech G923 (xbox model) wheel switch to PC mode if it's not already
-# c26e = PC mode | c26d = XBOX mode
+# Logitech G923 Racing Wheel (switch to PC mode)
+# Xbox mode (c26d) | PC mode (c26e)
 ATTR{idVendor}=="046d", ATTR{idProduct}=="c26d", RUN+="usb_modeswitch '%b/%k'"
 
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Logitech G923 Racing Wheel for Xbox One and PC", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="900"


### PR DESCRIPTION
Adding mandatory usb_modeswitch to trigger PC mode on the device (G923) 
Deleting wrong line about G920