### PR TITLE
batocera-wine: add sandboxing for play_wine && play_winetgz

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -500,6 +500,7 @@ play_wine() {
     msi_install "${WINEPOINT}" || return 1
     reg_install "${WINEPOINT}" || return 1
     fonts_install "${WINEPOINT}" || return 1
+    sandboxing_prefix "${WINEPOINT}" || return 1
     dxvk_install "${WINEPOINT}" || return 1
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")
     WINE_DIR=$(getWine_var "${WINEPOINT}" "DIR" "")
@@ -594,6 +595,7 @@ play_winetgz() {
     msi_install "${WINEPOINT}" || return 1
     reg_install "${WINEPOINT}" || return 1
     fonts_install "${WINEPOINT}" || return 1
+    sandboxing_prefix "${WINEPOINT}" || return 1
     dxvk_install "${WINEPOINT}" || return 1
 
     WINE_CMD=$(getWine_var "${WINEPOINT}" "CMD" "explorer")


### PR DESCRIPTION
Seem that sandboxing is missing for play_wine && play_winetgz,

I have seen some games with .wine extension writing to /userdata/system/ because of this

```
[root@BATOCERA /userdata/roms/windows/test.wine/drive_c/users/root]# ls -lah
total 24K
drwxr-xr-x 1 root root 192 Jan  4 08:58  .
drwxr-xr-x 1 root root  20 Jan  4 08:58  ..
drwxr-xr-x 1 root root  40 Jan  4 08:58  AppData
drwxr-xr-x 1 root root   0 Jan  4 08:58  Contacts
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Desktop -> /userdata/system
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Documents -> /userdata/system
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Downloads -> /userdata/system
drwxr-xr-x 1 root root   0 Jan  4 08:58  Favorites
drwxr-xr-x 1 root root   0 Jan  4 08:58  Links
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Music -> /userdata/system
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Pictures -> /userdata/system
drwxr-xr-x 1 root root   0 Jan  4 08:58 'Saved Games'
drwxr-xr-x 1 root root   0 Jan  4 08:58  Searches
drwxr-xr-x 1 root root   0 Jan  4 08:58  Temp
lrwxrwxrwx 1 root root  16 Jan  4 08:58  Videos -> /userdata/system
```