### PR TITLE
scummvm: fix stretch_mode

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -87,8 +87,6 @@ class ScummVMGenerator(Generator):
         #  stretch mode
         if system.isOptSet("scumm_stretch"):
             commandArray.append(f"--stretch-mode={system.config['scumm_stretch']}")
-        else:
-            commandArray.append("--stretch-mode=center")
 
         # renderer
         if system.isOptSet("scumm_renderer"):

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -9602,11 +9602,11 @@ scummvm:
           prompt: STRETCH MODE
           description: Stretches the output to fill the display area.
           choices:
-              "Center (Default)":     "centre"
+              "Center":               "center"
               "Pixel Perfect":        "pixel-perfect"
               "Even Pixels":          "even-pixels"
-              "Fit resolution scale": "fit"
               "Stretch to screen":    "stretch"
+              "Fit resolution scale": "fit"
               "Fit 4:3 Aspect Ratio": "fit_force_aspect"
       scumm_renderer:
           prompt: RENDERER


### PR DESCRIPTION
since https://github.com/batocera-linux/batocera.linux/pull/9630/commits/8cc8b2790a118a56786fff9ef112044aaa3b59de, default stretch mode is broken.

The default stretch_mode of scummvm (if not defined in command line) is "fit", not "center". (Center don't scale at all, so if you have a 4k screen with a 320x200 games, it'll be displayed too small)

This patch simply don't force it command line

also, es_features.yml is buggy, as "center" value is currently defined in french "centre".   (and scummvm is fallbacking to "fit" if a wrong value is defined)