### PR TITLE
fix classic controller spinner process blocks udev and is killed

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
+SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
 SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="virtual spinner", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
Fix Atari classic controller spinner process blocks udev and is killed in 120 seconds
