### PR TITLE
Match the Classic Controller in BT mode

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
@@ -1,2 +1,3 @@
 SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
+SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
 SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="virtual spinner", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"


### PR DESCRIPTION
In wired mode, the controller identifies with the name "Atari Classic Controller" In bluetooth mode, it identifies with the name "Classic Controller"