### PR TITLE
fix footpedal blocking udev

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-pedals.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-pedals.rules
@@ -2,4 +2,4 @@
 # Left pedal (coins)     : BTN_0
 # Middle pedal (reload)  : BTN_1
 # Right pedal (start)    : BTN_2
-KERNEL=="event*", SUBSYSTEM=="input", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="00ff", MODE="0666", ENV{ID_INPUT_KEYBOARD}="1", ENV{ID_INPUT_KEY}="1", RUN+="/usr/bin/evsieve --input $env{DEVNAME} grab --map yield btn:0 key:5 --map yield btn:1 key:c --map yield btn:2 key:1 --block --output name=FootPedal"
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{idVendor}=="05f3", ATTRS{idProduct}=="00ff", MODE="0666", ENV{ID_INPUT_KEYBOARD}="1", ENV{ID_INPUT_KEY}="1", RUN+="/usr/bin/setsid -f /usr/bin/evsieve --input $env{DEVNAME} grab --map yield btn:0 key:5 --map yield btn:1 key:c --map yield btn:2 key:1 --block --output name=FootPedal"


### PR DESCRIPTION
After fixing the Atari Classic Controller in #13198 I looked for similar buggy usage of udev RUN and found this.  Untested, but it's clearly not working properly as written.