### PR TITLE
Remap the Atari Classic Controller

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-atariclassic.rules
@@ -1,3 +1,4 @@
-SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
-SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Classic Controller", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0" RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
+SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller", ENV{ID_INPUT_JOYSTICK}="0", RUN+="/usr/bin/setsid -f /usr/bin/evsieve --input $env{DEVNAME} grab --map yield key:menu btn:start --map yield key:back btn:select --output 'name=Atari Classic Controller (evsieve)'"
+SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Classic Controller", ENV{ID_INPUT_JOYSTICK}="0", RUN+="/usr/bin/setsid -f /usr/bin/evsieve --input $env{DEVNAME} grab --map yield key:menu btn:start --map yield key:back btn:select --output 'name=Atari Classic Controller (evsieve)'"
+SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="Atari Classic Controller (evsieve)", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0", RUN+="/usr/bin/setsid -f /usr/bin/batocera-spinner-calibrator -d $env{DEVNAME}"
 SUBSYSTEM=="input", ACTION=="add", KERNEL=="event*", ATTRS{name}=="virtual spinner", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1"

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4548,19 +4548,6 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="0" value="1" code="304" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Atari Classic Controller" deviceGUID="03000000503200000110000000000000">
-		<input name="a" type="button" id="5" value="1" code="305" />
-		<input name="b" type="button" id="4" value="1" code="304" />
-		<input name="down" type="hat" id="0" value="4" />
-		<input name="hotkey" type="button" id="1" value="1" code="158" />
-		<input name="joystick1left" type="axis" id="0" value="1" code="7" />
-		<input name="left" type="hat" id="0" value="8" />
-		<input name="right" type="hat" id="0" value="2" />
-		<input name="select" type="button" id="1" value="1" code="158" />
-		<input name="start" type="button" id="0" value="1" code="139" />
-		<input name="up" type="hat" id="0" value="1" />
-		<input name="x" type="button" id="2" value="1" code="172" />
-	</inputConfig>
 	<inputConfig type="joystick" deviceName="Logitech G920 Driving Force Racing Wheel" deviceGUID="030000006d04000062c2000011010000">
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="a" type="button" id="1" value="1" code="289" />
@@ -4602,17 +4589,16 @@
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="virtual spinner" deviceGUID="03000000010000000100000001000000">
-		<input name="a" type="button" id="5" value="1" code="305" />
-		<input name="b" type="button" id="4" value="1" code="304" />
+		<input name="a" type="button" id="3" value="1" code="305" />
+		<input name="b" type="button" id="2" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />
-		<input name="hotkey" type="button" id="1" value="1" code="158" />
+		<input name="hotkey" type="button" id="0" value="1" code="172" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="left" type="hat" id="0" value="8" />
 		<input name="right" type="hat" id="0" value="2" />
-		<input name="select" type="button" id="1" value="1" code="158" />
-		<input name="start" type="button" id="0" value="1" code="139" />
+		<input name="select" type="button" id="4" value="1" code="314" />
+		<input name="start" type="button" id="5" value="1" code="315" />
 		<input name="up" type="hat" id="0" value="1" />
-		<input name="x" type="button" id="2" value="1" code="172" />
-		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="Logitech G29 Driving Force Racing Wheel" deviceGUID="030000006d0400004fc2000011010000">
 		<input name="a" type="button" id="2" value="1" code="290" />


### PR DESCRIPTION
Remap the Atari Classic Controller
- Remap the values sent by the controller using evsieve to avoid unfortunate behaviors of the original keys chosen by Atari
- Remove the ES mapping for "Atari Classic Controller" as it is currently unused
- Update the ES mapping for "virtual spinner" to reflect the new events sent by the remapped device, and adjusting the layout