### PR TITLE
add VF5C to lindbergh list

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -5626,6 +5626,7 @@ lindbergh:
     The House of the Dead 4 Special   | hod4M.elf            | hotd4sp.game
     The House of the Dead EX          | hodexRI.elf          | hotdex.game
     Virtua Fighter 5                  | vf5                  | vf5.game
+    Virtua Fighter 5 C                | vf5                  | vf5c.game
     Virtua Fighter 5 R                | vf5                  | vf5r.game
     Virtua Fighter 5 FS               | vf5                  | vf5fs.game
     Virtua Tennis 3                   | vt3 or vt3_Lindbergh | vtennis3.game


### PR DESCRIPTION
It was missing, dump exists.