### PR TITLE
use rsync to copy files for configgen build

### DIFF
--- a/package/batocera/core/batocera-configgen/batocera-configgen.mk
+++ b/package/batocera/core/batocera-configgen/batocera-configgen.mk
@@ -23,7 +23,7 @@ BATOCERA_CONFIGGEN_INSTALL_STAGING = YES
 CONFIGGEN_DIR = $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-configgen
 
 define BATOCERA_CONFIGGEN_EXTRACT_CMDS
-	cp -avf $(CONFIGGEN_DIR)/configgen/* $(@D)
+	rsync -av --exclude=".*" --exclude="**/__pycache__/" --exclude="dist" $(CONFIGGEN_DIR)/configgen/ $(@D)
 	echo "__version__ = '$(BATOCERA_CONFIGGEN_VERSION)'" > $(@D)/configgen/__version__.py
 endef
 


### PR DESCRIPTION
There's no need to copy hidden files, byte code, or any wheels or sdists into the buildroot build directory