### PR TITLE
Enable BR2_PACKAGE_USB_MODESWITCH_DATA for modeswitch data and udev rules

### DIFF
--- a/package/batocera/core/batocera-udev-rules/Config.in
+++ b/package/batocera/core/batocera-udev-rules/Config.in
@@ -1,5 +1,5 @@
 config BR2_PACKAGE_BATOCERA_UDEV_RULES
 	bool "batocera-udev-rules"
 
-	select BR2_PACKAGE_USB_MODESWITCH
+	select BR2_PACKAGE_USB_MODESWITCH_DATA
 


### PR DESCRIPTION
BR2_PACKAGE_USB_MODESWITCH is already selected by batocera-system.  For udev rules we need BR2_PACKAGE_USB_MODESWITCH_DATA.