### PR TITLE
lindbergh: symlink /dev/dsp if not exist

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
@@ -79,6 +79,13 @@ class LindberghGenerator(Generator):
         ### libraries
         self.setup_libraries(romDir, romName)
 
+        #some hardware expose /dev/dsp1|2 instead /dev/dsp required by 2spicy && gsevo
+        if not os.path.exists("/dev/dsp"):
+            if os.path.exists("/dev/dsp1"):
+                os.symlink("/dev/dsp1", "/dev/dsp")
+            elif os.path.exists("/dev/dsp2"):
+                os.symlink("/dev/dsp2", "/dev/dsp")
+
         # Change to the ROM path before launching
         os.chdir(romDir)
 


### PR DESCRIPTION
some hardware don't expose /dev/dsp,  but /dev/dsp1 or /dev/dsphttps://github.com/aderumier/batocera.linux/pull/new/lindbergh32.

ghost squad evolution && 2spicy have hardcorded path to /dev/dsp, and crash if not present