### PR TITLE
Add initial support for XGunner light gun

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -5,6 +5,9 @@
 - Add OrangePi 3b board support
 - Initial support for RS3 Reaper light gun
 - Add Anbernic RG351V support
+- Initial support for XGunner light gun
+- Initial support for OpenFIRE light gun
+- Initial support for Fusion P.I.G.S. light gun
 ### Added
 - Wireguard VPN for RK3326 boards
 - Image scaling option for Drastic

--- a/package/batocera/controllers/guns/xgunner-lightguns/99-xgunner-lightguns.rules
+++ b/package/batocera/controllers/guns/xgunner-lightguns/99-xgunner-lightguns.rules
@@ -1,0 +1,13 @@
+# disable raw devices to merge them
+
+# Light gun 1 to 4
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="HONGWEIHUA XGUNNER-P1 *", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", RUN+="/usr/bin/xgunner-lightguns-add 1"
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="HONGWEIHUA XGUNNER-P2 *", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", RUN+="/usr/bin/xgunner-lightguns-add 2"
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="HONGWEIHUA XGUNNER-P3 *", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", RUN+="/usr/bin/xgunner-lightguns-add 3"
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="HONGWEIHUA XGUNNER-P4 *", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", RUN+="/usr/bin/xgunner-lightguns-add 4"
+
+# Virtual light gun 1 to 4
+SUBSYSTEM=="input", KERNEL=="event*", ACTION=="add", ATTRS{name}=="XGunner P[1-4]", MODE="0666", ENV{ID_INPUT_JOYSTICK}="0", ENV{ID_INPUT_GUN}="1", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", ENV{ID_INPUT_MOUSE}="1"
+
+# Gamepad event must be disabled, this mode is unsupported for now
+SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="HONGWEIHUA XGUNNER-P[1-4]", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_JOYSTICK}="0"

--- a/package/batocera/controllers/guns/xgunner-lightguns/Config.in
+++ b/package/batocera/controllers/guns/xgunner-lightguns/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_XGUNNER_LIGHTGUNS
+	bool "xgunner_lightguns"
+	select BR2_PACKAGE_EVSIEVE
+
+	help
+	  xgunner lightguns support

--- a/package/batocera/controllers/guns/xgunner-lightguns/xgunner-lightguns-add
+++ b/package/batocera/controllers/guns/xgunner-lightguns/xgunner-lightguns-add
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+PLAYER=$1
+
+test "${ACTION}" = "add" || exit 0
+echo "${DEVNAME}" | grep -E "^/dev/input/event[0-9]+$" || exit 0
+
+PARENTHASH=$(evsieve-helper parent "${DEVNAME}" input usb)
+BASEFILE="/var/run/virtual-xgunner-lightguns-devices.${PARENTHASH}"
+PIDFILE="${BASEFILE}.pid"
+LOCKFILE="${BASEFILE}.lock"
+LOGFILE="${BASEFILE}.log"
+
+unlockAndExit() {
+    rmdir "${LOCKFILE}"
+    exit "${1}"
+}
+
+checkRunningPIDAndExit1() {
+    test ! -e "${PIDFILE}" && return 0
+    LPID=$(cat "${PIDFILE}")
+    test ! -d "/proc/${LPID}" && return 0
+    unlockAndExit 1
+}
+
+trylock() {
+    # lock
+    N=0
+    while ! mkdir "${LOCKFILE}"
+    do
+	sleep 1
+	let N++
+	test "${N}" -gt 30 && exit 1 # give up
+    done
+}
+
+trylock
+checkRunningPIDAndExit1
+
+CHILDREN=$(evsieve-helper children "${PARENTHASH}" input usb | grep -vE "HONGWEIHUA XGUNNER-P[1-4]$")
+NDEVS=$(echo "${CHILDREN}" | wc -l)
+
+if test "${NDEVS}" = 2
+then
+    DEV1=$(echo "${CHILDREN}" | head -1           | cut -f 1)
+    DEV2=$(echo "${CHILDREN}" | head -2 | tail -1 | cut -f 1)
+
+    if test "${PLAYER}" = "1"
+    then
+	nohup evsieve --input "${DEV1}" "${DEV2}" persist=exit --map yield btn:middle btn:2 --map yield key:1 btn:middle --map yield key:5 btn:1 --map yield key:q btn:3 --map yield key:e btn:4 --map yield key:d btn:5 --map yield key:a btn:6 --map yield key:w btn:7 --map yield key:s btn:8 --map yield key:kpenter btn:right --block key:esc --output name="XGunner P1" >/dev/null 2>"${LOGFILE}" &
+    fi
+
+    if test "${PLAYER}" = "2"
+    then
+	nohup evsieve --input "${DEV1}" "${DEV2}" persist=exit --map yield btn:middle btn:2 --map yield key:2 btn:middle --map yield key:5 btn:1 --map yield key:q btn:3 --map yield key:e btn:4 --map yield key:d btn:5 --map yield key:a btn:6 --map yield key:w btn:7 --map yield key:s btn:8 --map yield key:kpenter btn:right --block key:esc --output name="XGunner P2" >/dev/null 2>"${LOGFILE}" &
+    fi
+
+    if test "${PLAYER}" = "3"
+    then
+	nohup evsieve --input "${DEV1}" "${DEV2}" persist=exit --map yield btn:middle btn:2 --map yield key:3 btn:middle --map yield key:5 btn:1 --map yield key:q btn:3 --map yield key:e btn:4 --map yield key:d btn:5 --map yield key:a btn:6 --map yield key:w btn:7 --map yield key:s btn:8 --map yield key:kpenter btn:right --block key:esc --output name="XGunner P3" >/dev/null 2>"${LOGFILE}" &
+    fi
+
+    if test "${PLAYER}" = "4"
+    then
+	nohup evsieve --input "${DEV1}" "${DEV2}" persist=exit --map yield btn:middle btn:2 --map yield key:4 btn:middle --map yield key:5 btn:1 --map yield key:q btn:3 --map yield key:e btn:4 --map yield key:d btn:5 --map yield key:a btn:6 --map yield key:w btn:7 --map yield key:s btn:8 --map yield key:kpenter btn:right --block key:esc --output name="XGunner P4" >/dev/null 2>"${LOGFILE}" &
+    fi
+
+    echo $! > "${PIDFILE}"
+else
+    unlockAndExit 1
+fi
+
+unlockAndExit 0

--- a/package/batocera/controllers/guns/xgunner-lightguns/xgunner-lightguns.mk
+++ b/package/batocera/controllers/guns/xgunner-lightguns/xgunner-lightguns.mk
@@ -1,0 +1,15 @@
+################################################################################
+#
+# XGunner Lightguns
+#
+################################################################################
+XGUNNER_LIGHTGUNS_VERSION = 1
+XGUNNER_LIGHTGUNS_LICENSE = GPL
+XGUNNER_LIGHTGUNS_SOURCE=
+
+define XGUNNER_LIGHTGUNS_INSTALL_TARGET_CMDS
+	$(INSTALL) -m 0644 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guns/xgunner-lightguns/99-xgunner-lightguns.rules $(TARGET_DIR)/etc/udev/rules.d/99-xgunner-lightguns.rules
+	$(INSTALL) -m 0755 -D $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/controllers/guns/xgunner-lightguns/xgunner-lightguns-add $(TARGET_DIR)/usr/bin/xgunner-lightguns-add
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
All 4 players light gun supported. Button mapping was a bit tricky.

- ESC key has been disabled to avoid mispressing and exiting game by accident.
- Analog stick is arrow keys and only work for calibration. Use dpad for navigation.
- Start and Space enables the calibration mode. Use fake analog stick on the back to adjust calibration.
- For PCSX2 calibration, use the sub1 location on the key distribution image below:

![image](https://github.com/user-attachments/assets/b0f7ea09-1434-43b4-8460-3ff3b85d0d6c)

Sub2 and Sub3 are mostly unused in most emulators.