### PR TITLE
Enhancement to batocera-steam-update

### DIFF
--- a/package/batocera/utils/batocera-steam/batocera-steam-update
+++ b/package/batocera/utils/batocera-steam/batocera-steam-update
@@ -61,47 +61,74 @@ fi
 
 # Check if the Steam applications directory exists
 steam_apps_dir="/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/applications"
+
 if [ ! -d "$steam_apps_dir" ]; then
     echo "Steam applications directory not found: $steam_apps_dir" >> $log
 else
-    # add applications
-    find "$steam_apps_dir" -name "*.desktop" |
-        (
-    N=0
-    while read STEAMAPP
-    do
-        if grep -qE '^[ ]*Categories[ ]*=.*Game.*$' "${STEAMAPP}" # game
-        then
-        BASEAPP=$(basename "${STEAMAPP}" | sed -e s+"\.desktop$"++)
-        if ! test -e "/userdata/roms/steam/${BASEAPP}.steam"
-        then
-            echo "adding ${BASEAPP}"
-            GAMEID=$(cat "${STEAMAPP}" | grep -E '^Exec=' | sed -e s+"Exec="++ -e s+"[ ]*steam[ ]*"++ | head -1)
+    # Define a blacklist of words to check in game names
+    BLACKLIST=(
+        "Runtime"
+        "Proton"
+        "SDK"
+        "Dedicated"
+        "Workshop"
+        "Big Picture"
+        "Source"
+        "Linux Runtime"
+        "Redistributables"
+        "Desktop Mode"
+    )
 
-            # add image
-            ICON=$(grep -E "^Icon=" "${STEAMAPP}" | sed -e s+"^Icon=steam_icon_"++)_logo.png
-            IMGFILE="/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/appcache/librarycache/${ICON}"
-            IMGARG=
-            if test -e "${IMGFILE}"
-            then
-            IMGARG="./images/${BASEAPP}.png"
-            mkdir -p "/userdata/roms/steam/images" || return 1
-            cp "${IMGFILE}" "/userdata/roms/steam/${IMGARG}" || return 1
+    # Function to check if a game name contains any blacklisted word
+    contains_blacklisted_word() {
+        local game_name="$1"
+        for word in "${BLACKLIST[@]}"; do
+            if [[ "$game_name" == *"$word"* ]]; then
+                return 0  # Found in blacklist, should be ignored
             fi
-            # add game
-            echo "${GAMEID}" > "/userdata/roms/steam/${BASEAPP}.steam" || return 1
+        done
+        return 1  # Not found, can be added
+    }
 
-            # add game in es
-            if ! es_add_game "${BASEAPP}.steam" "${BASEAPP}" "${IMGARG}"
-            then
-            echo "adding game in es failed" >&2
-            return 1
+    # Find and process applications
+    find "$steam_apps_dir" -name "*.desktop" | (
+        N=0
+        while read STEAMAPP; do
+            if grep -qE '^[ ]*Categories[ ]*=.*Game.*$' "${STEAMAPP}"; then  # Check if it's a game
+                BASEAPP=$(basename "${STEAMAPP}" | sed -e 's/\.desktop$//')
+
+                if contains_blacklisted_word "$BASEAPP"; then
+                    echo "Skipping blacklisted entry: ${BASEAPP}" >> $log
+                    continue
+                fi
+
+                if ! test -e "/userdata/roms/steam/${BASEAPP}.steam"; then
+                    echo "Adding ${BASEAPP}"
+                    GAMEID=$(grep -E '^Exec=' "${STEAMAPP}" | sed -e 's/Exec=//' -e 's/[ ]*steam[ ]*//' | head -1)
+
+                    # Add image
+                    ICON=$(grep -E "^Icon=" "${STEAMAPP}" | sed -e 's/^Icon=steam_icon_//')_logo.png
+                    IMGFILE="/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/appcache/librarycache/${ICON}"
+                    IMGARG=
+                    if test -e "${IMGFILE}"; then
+                        IMGARG="./images/${BASEAPP}.png"
+                        mkdir -p "/userdata/roms/steam/images" || return 1
+                        cp "${IMGFILE}" "/userdata/roms/steam/${IMGARG}" || return 1
+                    fi
+
+                    # Add game
+                    echo "${GAMEID}" > "/userdata/roms/steam/${BASEAPP}.steam" || return 1
+
+                    # Add game in EmulationStation
+                    if ! es_add_game "${BASEAPP}.steam" "${BASEAPP}" "${IMGARG}"; then
+                        echo "Adding game in EmulationStation failed" >&2
+                        return 1
+                    fi
+                    let N++
+                fi
             fi
-            let N++
-        fi
-        fi
-    done
-    echo "${N} games added to the list." >> $log
+        done
+        echo "${N} games added to the list." >> $log
     )
 fi
 


### PR DESCRIPTION
This is a small improvement to the script "batocera-steam-update"
This script was tested and working (by changing code directly in "/usr/bin/batocera-steam-update")

What changed in this version : 
1. A BLACKLIST array is defined with words commonly found in non-game applications.
2. The function contains_blacklisted_word():
- Checks if any blacklist word appears in the game name.
- If found, the game is skipped.
3. Before adding a game, it checks:
- If the game is categorized as a game (Categories=*Game*).
- If the game contains any blacklisted word.
- If the game has already been added to /userdata/roms/steam/.
4. Skipping Blacklisted Entries:
- If the game name contains a blacklisted word, it logs the exclusion and moves to the next entry.
- Otherwise, it proceeds with adding the game.

Example of skipped entries, If a .desktop file is named "Steam Linux Runtime", "Proton Experimental", "Half-Life Dedicated Server"