### PR TITLE
libretro-holani: include host clang header dir for rust-ffi. #13393

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-holani/libretro-holani.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-holani/libretro-holani.mk
@@ -12,6 +12,10 @@ LIBRETRO_HOLANI_DEPENDENCIES = host-rustc host-rust-bin host-clang retroarch
 LIBRETRO_HOLANI_CARGO_MODE = $(if $(BR2_ENABLE_DEBUG),,release)
 LIBRETRO_HOLANI_BIN_DIR = target/$(RUSTC_TARGET_NAME)/$(LIBRETRO_HOLANI_CARGO_MODE)
 
+# Temporary fix for 'stddef.h file not found'
+# https://github.com/batocera-linux/batocera.linux/issues/13393
+LIBRETRO_HOLANI_CARGO_ENV = BINDGEN_EXTRA_CLANG_ARGS="-I$(HOST_DIR)/lib/clang/18/include/"
+
 define LIBRETRO_HOLANI_INSTALL_TARGET_CMDS
     $(INSTALL) -D $(@D)/$(LIBRETRO_HOLANI_BIN_DIR)/libholani.so \
              $(TARGET_DIR)/usr/lib/libretro/holani_libretro.so


### PR DESCRIPTION
rust's ffi bindgen can't find `stddef.h` from the buildroot host clang for some reason, making `libretro-holani` to FTBFS using the provided Dockerfile.

Temporary fix for

> include/libretro.h:27:10: fatal error: 'stddef.h' file not found

Until proper fix is found.

#13393