### PR TITLE
Changed default Korean font

### DIFF
--- a/package/batocera/fonts/nanum-font/nanum_font.mk
+++ b/package/batocera/fonts/nanum-font/nanum_font.mk
@@ -4,14 +4,14 @@
 #
 ################################################################################
 
-NANUM_FONT_VERSION = 33a5dec3cd6467979fed8ebfa64430d7cebdff9d
-NANUM_FONT_SITE = $(call github,ujuc,nanum-font,$(NANUM_FONT_VERSION))
+NANUM_FONT_VERSION = 2385eb085e4bf326590a2db6d4514e8477d9922f
+NANUM_FONT_SITE = $(call github,bulzipke,nanum-font,$(NANUM_FONT_VERSION))
 
 NANUM_FONT_TARGET_DIR=$(TARGET_DIR)/usr/share/fonts/truetype/nanum
 
 define NANUM_FONT_INSTALL_TARGET_CMDS
 	@mkdir -p $(NANUM_FONT_TARGET_DIR)
-	@cp $(@D)/ttf/NanumMyeongjo.ttf $(NANUM_FONT_TARGET_DIR)
+	@cp $(@D)/ttf/NanumSquare_acB.ttf $(NANUM_FONT_TARGET_DIR)
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/utils/od-commander/Config.in
+++ b/package/batocera/utils/od-commander/Config.in
@@ -15,11 +15,11 @@ if BR2_PACKAGE_OD_COMMANDER
 
 config BR2_PACKAGE_OD_COMMANDER_FONTS
 	string "Font stack"
-	default "{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumMyeongjo.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
+	default "{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumSquare_acB.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
 
 config BR2_PACKAGE_OD_COMMANDER_FONTS_LOW_DPI
 	string "Font stack for low DPI displays"
-	default "{RES_DIR\"Fiery_Turk.ttf\",8},{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumMyeongjo.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
+	default "{RES_DIR\"Fiery_Turk.ttf\",8},{\"/usr/share/fonts/dejavu/DejaVuSansCondensed.ttf\",10},{\"/usr/share/fonts/truetype/nanum/NanumSquare_acB.ttf\",10},{\"/usr/share/fonts/truetype/droid/DroidSansFallback.ttf\",9}"
 
 config BR2_PACKAGE_OD_COMMANDER_AUTOSCALE
 	bool "Enable automatic screen size and PPU detection"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/603a325e-5a22-4c22-9370-b3bd2fff966a)
Replace default Korean font: NanumMyeongjo → NanumSquare_acB

The current default Korean font is NanumMyeongjo. However, similar to Times New Roman, it is often considered dull and outdated in Korea. Many Korean gamers even suggest changing the font as a first step after installing Batocera.

I propose replacing it with NanumSquare_acB, a much more popular and widely preferred font.
Since it shares the same license as NanumMyeongjo, this change should not cause any licensing issues.