### PR TITLE
Load driver for Comfast 785 AC WiFi, blacklisted because of conflict with xone

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-mt76x2u.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-mt76x2u.rules
@@ -1,0 +1,2 @@
+# for Comfast 785 AC WiFi, blacklisted because of conflict with xone
+ACTION=="add", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0e8d", ATTRS{idProduct}=="7612", RUN+="/sbin/modprobe mt76x2u"


### PR DESCRIPTION
Load driver for Comfast 785 AC WiFi, blacklisted because of conflict with xone