### PR TITLE
treat bytes as unsigned in dolphin SYSCONF

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -44,11 +44,11 @@ def readString(f, x):
 
 def readInt8(f):
     bytes = f.read(1)
-    unpacked = unpack("b", bytes)
+    unpacked = unpack("B", bytes)
     return unpacked[0]
 
 def writeInt8(f, x):
-    bytes = pack("b", x)
+    bytes = pack("B", x)
     f.write(bytes)
 
 def readWriteEntry(f, setval):


### PR DESCRIPTION
Given the operations we're doing, both `b` and `B` do the same thing. However, when I was parsing a SYSCONF file in the python REPL, some larger numbers would be read as negative numbers.