### PR TITLE
Provide /etc/pam.d/system-auth for pkexec

### DIFF
--- a/board/batocera/fsoverlay/etc/pam.d/system-auth
+++ b/board/batocera/fsoverlay/etc/pam.d/system-auth
@@ -1,0 +1,12 @@
+auth		required	pam_unix.so nullok
+
+account		required	pam_unix.so
+
+password	required	pam_unix.so nullok
+
+# session	required	pam_selinux.so close
+session		required	pam_limits.so
+session		required	pam_env.so
+session		required	pam_unix.so
+# session	optional	pam_lastlog.so
+# session	required	pam_selinux.so open


### PR DESCRIPTION
Warehouse, which is being considered as a replacement for bauh, uses /usr/bin/pkexec to launch subprocesses.  On Batocera, this always fails, since pkexec requires PAM configuration in
/etc/pam.d/system-auth to run.  Add this file to allow the Warehouse flatpak to run, which is desirable even if it doesn't become the default flatpak manager.