### PR TITLE
batocera-wine: add stop action

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -5,6 +5,49 @@ ACTION=$2
 shift
 shift
 
+stopWineServer() {
+    if [[ -z "${WINESERVER}" ]]; then
+        exit 0
+    fi
+
+    if [[ -z "${WINEPOINT}" ]]; then
+        exit 0
+    fi
+
+    #try to cleanly exit wineserver
+    WINEPREFIX=${WINEPOINT} "${WINESERVER}" -k &
+
+    #wait 10s for clean exit
+    for i in {1..10}; do
+        echo "waiting wineserver shutdown" >&2
+        if ! pgrep -f "${WINESERVER}" ; then
+            echo "wineserver has cleanly exited" >&2
+            cleanAndExit 0
+        fi
+        sleep 1
+    done
+
+    #kill all process with wineprefix as envvar if wineserver is still not stopped
+
+    declare -a PIDS
+
+    # find all process with wineprefix environement
+    for PID in $(ps -e -o pid=); do
+        if grep -z "WINEPREFIX=${WINEPOINT}" "/proc/$PID/environ" 2>/dev/null; then
+            PIDS+=("$PID")
+        fi
+    done
+
+    # kill all pids
+    if [ ${#PIDS[@]} -gt 0 ]; then
+        echo "Killing stuck wine processes: ${PIDS[*]}"
+        kill -9 "${PIDS[@]}"
+    fi
+    cleanAndExit 1
+}
+
+trap stopWineServer SIGHUP SIGINT SIGTERM
+
 # Arguments: key, system, game
 get_setting() {
     /usr/bin/batocera-settings-get "$2[\"$3\"].$1" "$2.$1" "global.$1"
@@ -118,6 +161,7 @@ usage() {
     echo "${1} windows tricks  	     <game>.wine directplay" >&2
     echo "${1} windows wine2squashfs <game.wine>"            >&2
     echo "${1} windows wine2winetgz  <game.wine>"            >&2
+    echo "${1} windows stop"                                 >&2
 }
 
 waitWineServer() {
@@ -778,17 +822,7 @@ play_squashfs() {
     fi
 
     waitWineServer
-
-    # Safely unmount and clean up
-    safe_umount "${WINEPOINT}" || return 1
-    safe_umount "${SQUASHFSPOINT}" || return 1
-
-    # Remove directories if they exist
-    [[ -d "${SQUASHFSPOINT}" ]] && rm -rf "${SQUASHFSPOINT}"
-    [[ -d "${WORKPOINT}" ]] && rm -rf "${WORKPOINT}"
-    [[ -d "${WINEPOINT}" ]] && rm -rf "${WINEPOINT}"
-
-    return 0
+    cleanAndExit 0
 }
 
 init_cmd() {
@@ -868,9 +902,6 @@ install_iso() {
     waitWineServer
     init_cmd "${WINEPOINT}"
 
-    # try to clean the cdrom
-    safe_umount "${GAMEISOMOUNT}"
-    [[ -d "${GAMEISOMOUNT}" ]] && rm -rf "${GAMEISOMOUNT}"
 }
 
 wine2squashfs() {
@@ -907,14 +938,35 @@ cleanAndExit() {
         rm -f "${GST_REGISTRY_1_0}"
     fi
 
+    case "${GAMEEXT}" in
+        "iso")
+            # try to clean the cdrom
+            [[ -n "${GAMEISOMOUNT}" ]] && [[ -d "${GAMEISOMOUNT}" ]] && safe_umount "${GAMEISOMOUNT}" || return 1
+            [[ -n "${GAMEISOMOUNT}" ]] && [[ -d "${GAMEISOMOUNT}" ]] && rm -rf "${GAMEISOMOUNT}"
+            ;;
+        "wsquashfs")
+            # Safely unmount and clean up
+            [[ -n "${WINEPOINT}" ]] && [[ -d "${WINEPOINT}" ]] && safe_umount "${WINEPOINT}" || return 1
+            [[ -n "${SQUASHFSPOINT}" ]] && [[ -d "${SQUASHFSPOINT}" ]] && safe_umount "${SQUASHFSPOINT}" || return 1
+
+            # Remove directories if they exist
+            [[ -n "${SQUASHFSPOINT}" ]] && [[ -d "${SQUASHFSPOINT}" ]] && rm -rf "${SQUASHFSPOINT}"
+            [[ -n "${WORKPOINT}" ]] && [[ -d "${WORKPOINT}" ]] && rm -rf "${WORKPOINT}"
+            [[ -n "${WINEPOINT}" ]] && [[ -d "${WINEPOINT}" ]] && rm -rf "${WINEPOINT}"
+            ;;
+    esac
+
     exit "${1}"
-    # TODO : unmount always, trap, later
 }
 
 G_RESCUR=$(batocera-resolution currentMode)
 
 case "${ACTION}" in
-    "play")
+   "stop")
+        killall -1 batocera-wine
+        exit 0
+   ;;
+   "play")
 	GAMENAME=$1
 	GAMEEXT=$(gameext "${GAMENAME}")
 	case "${GAMEEXT}" in

--- a/package/batocera/utils/batocera-wine/batocera-wine.mk
+++ b/package/batocera/utils/batocera-wine/batocera-wine.mk
@@ -25,6 +25,8 @@ define BATOCERA_WINE_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BATOCERA_WINE_SOURCE_PATH)/mugen.keys \
 	    $(TARGET_DIR)/usr/share/evmapy
+	cp $(BATOCERA_WINE_SOURCE_PATH)/windows.keys \
+	    $(TARGET_DIR)/usr/share/evmapy
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/utils/batocera-wine/mugen.keys
+++ b/package/batocera/utils/batocera-wine/mugen.keys
@@ -2,8 +2,8 @@
     "actions_player1": [
         {
             "trigger": [ "hotkey", "start" ],
-            "type": "key",
-            "target": [ "KEY_LEFTALT", "KEY_F4" ]
+            "type": "exec",
+            "target": [ "/usr/bin/batocera-wine mugen stop" ]
         },
         {
                 "trigger": ["joystick1up"],

--- a/package/batocera/utils/batocera-wine/windows.keys
+++ b/package/batocera/utils/batocera-wine/windows.keys
@@ -1,0 +1,12 @@
+{
+    "actions_player1": [
+        {
+            "trigger": [
+                "hotkey",
+                "start"
+            ],
+            "type": "exec",
+            "target": [ "/usr/bin/batocera-wine windows stop" ]
+        }
+    ]
+}

--- a/package/batocera/utils/evmapy-system-config/evmapy-system-config.mk
+++ b/package/batocera/utils/evmapy-system-config/evmapy-system-config.mk
@@ -9,7 +9,6 @@ EVMAPY_SYSTEM_CONFIG_SOURCE =
 
 define EVMAPY_SYSTEM_CONFIG_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
-	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/hotkey.keys $(TARGET_DIR)/usr/share/evmapy/windows.keys
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/utils/evmapy-system-config/mouse.keys $(TARGET_DIR)/usr/share/evmapy/windows_installers.keys
 endef
 


### PR DESCRIPTION
This cleanly stop wineserver with "wineserver -k" option, and after 10s, if winserver is still running, kill the process using the specific wineprefix.

From my tests, wineserver is shutting down in 2s, so 10s should be far enough.


The next step is to replace the evmapy alt-f4 with executing batocera-wine stop.