### PR TITLE
evmapy: don't merge duplicate actions from different files

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
@@ -83,9 +83,7 @@ class evmapy(AbstractContextManager[None, None]):
         for file in filesToMerge:
             values = json.load(open(file))
             for action in values:
-                if action in mergedValues:
-                    mergedValues[action].extend(values[action])
-                else:
+                if action not in mergedValues:
                     mergedValues[action] = values[action]
         with open(mergedFile, "w") as fd:
             fd.write(json.dumps(mergedValues, indent=2))


### PR DESCRIPTION
if we have duplicate defition of an action in different files, we need to keep the one declared on the top key file on the list.

for example,

if we have the default system exit key configured to alt-f4, and the game have a specific pad2key exit to "esc",

we need to keep only the "esc" mapping.

It was the default behaviour on v40 before this commit: https://github.com/batocera-linux/batocera.linux/commit/a65da815b998a392f91bec5f26d8b1f89e1ad368

(on v41, on same example, the actions are duplicated in the json, and the last one (from the system alt-f4) is used by evmapy instead "esc")