### PR TITLE
allow user to choose GSplus bios filename

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
@@ -105,7 +105,9 @@ class GSplusGenerator(Generator):
             config.save("bram3[e0]", '00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00')
             config.save("bram3[f0]", '00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00')
             config.save("g_limit_speed", "2")
-        config.save("g_cfg_rom_path", f"""{BIOS}/ROM.03""")
+
+        gsplus_rom_filename = system.config["gsplus_rom_filename"] if system.isOptSet("gsplus_rom_filename") else "ROM.03"
+        config.save("g_cfg_rom_path", f"""{BIOS}/{gsplus_rom_filename}""")
 
         config.write()
         commandArray = ["GSplus", "-fullscreen"]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
@@ -106,8 +106,8 @@ class GSplusGenerator(Generator):
             config.save("bram3[f0]", '00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00')
             config.save("g_limit_speed", "2")
 
-        gsplus_rom_filename = system.config["gsplus_rom_filename"] if system.isOptSet("gsplus_rom_filename") else "ROM.03"
-        config.save("g_cfg_rom_path", f"""{BIOS}/{gsplus_rom_filename}""")
+        gsplus_bios_filename = system.config["gsplus_bios_filename"] if system.isOptSet("gsplus_bios_filename") else "ROM.03"
+        config.save("g_cfg_rom_path", f"""{BIOS}/{gsplus_bios_filename}""")
 
         config.write()
         commandArray = ["GSplus", "-fullscreen"]

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11716,7 +11716,7 @@ gsplus:
   cfeatures:
       gsplus_bios_filename:
           prompt: GSPLUS BIOS FILENAME
-          description: Choose which BIOS filename for GSplus to boot from.
+          description: Choose which BIOS file for GSplus to boot with.
           choices:
               "ROM.03 (default)":  "ROM.03"
               "ROM1":              "ROM1"

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -11713,6 +11713,16 @@ model2emu:
 gsplus:
   features: [padtokeyboard]
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  cfeatures:
+      gsplus_bios_filename:
+          prompt: GSPLUS BIOS FILENAME
+          description: Choose which BIOS filename for GSplus to boot from.
+          choices:
+              "ROM.03 (default)":  "ROM.03"
+              "ROM1":              "ROM1"
+              "ROM.00":            "ROM.00"
+              "APPLE2GS.ROM":      "APPLE2GS.ROM"
+              "APPLE2GS-BIOS.ROM": "APPLE2GS-BIOS.ROM"
 
 play:
   features: [padtokeyboard]
@@ -13707,7 +13717,7 @@ lindbergh-loader:
       description: Enable the IP address for OutRun 2 network play against another PC on the same network.
       choices:
         "Off (Default)": 0
-        "On":            1 
+        "On":            1
     lindbergh_test:
       group: ADVANCED OPTIONS
       prompt: RUN TEST MODE


### PR DESCRIPTION
The previous PR https://github.com/batocera-linux/batocera.linux/pull/13067 fixed the config file path for GSPlus by hard-coding the bios filename to the most popular choice.

This PR adds an option `gsplus_bios_filename` for users to choose which bios file to use (the default is still the most popular choice):

  * ROM.03 (default)
  * ROM1
  * ROM.00
  * APPLE2GS.ROM
  * APPLE2GS-BIOS.ROM

p.s. The commonly used filenames represent various BIOS versions.

p.p.s. : GSPlus calls the bios file a `ROM file`. To avoid confusion with Batcoera's ROM definition, the option name uses "bios".

