### PR TITLE
xpad-noone: allow to use triggers_to_button to any model

### DIFF
--- a/package/batocera/controllers/pads/xpad-noone/007-allow-to-use-triggers_to_button-to-any-model.patch
+++ b/package/batocera/controllers/pads/xpad-noone/007-allow-to-use-triggers_to_button-to-any-model.patch
@@ -1,0 +1,20 @@
+diff --git a/xpad.c b/xpad.c
+index d8bf5cd..ebf2401 100644
+--- a/xpad.c
++++ b/xpad.c
+@@ -1609,12 +1609,13 @@ static int xpad_probe(struct usb_interface *intf, const struct usb_device_id *id
+ 
+ 		if (dpad_to_buttons)
+ 			xpad->mapping |= MAP_DPAD_TO_BUTTONS;
+-		if (triggers_to_buttons)
+-			xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
+ 		if (sticks_to_null)
+ 			xpad->mapping |= MAP_STICKS_TO_NULL;
+ 	}
+ 
++	if (triggers_to_buttons)
++		xpad->mapping |= MAP_TRIGGERS_TO_BUTTONS;
++
+ 	ep_irq_in = ep_irq_out = NULL;
+ 
+ 	for (i = 0; i < 2; i++) {


### PR DESCRIPTION
some cheap chineses clone gamepad (datafrog S80 for example), are re-using microsoft usb vendor|modelid, and have bad implementation of triggers sending digital values.

the module have a triggers_to_button option, but it's only work for unknown vendor|modelid

Retropie have same patch to allow it on any devices too https://github.com/RetroPie/RetroPie-Setup/blob/381020245f9be6a82be13bd81c0da04b971522b0/scriptmodules/supplementary/xpad/01_enable_leds_and_trigmapping.diff