### PR TITLE
scrape windows from "PC Windows" instead of "PC DOS" on screenscraper

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2464,7 +2464,7 @@ windows:
   release: 1992
   hardware: computer
   extensions: [pc, exe, wine, wsquashfs, wtgz]
-  platform:   pc
+  platform:   windows
   theme:      windows
   emulators:
     wine:
@@ -2482,7 +2482,7 @@ windows_installers:
   release: 1992
   hardware: computer
   extensions: [exe, iso]
-  platform:   pc
+  platform:   windows
   group:      windows
   emulators:
     wine:


### PR DESCRIPTION
Fixes #13336