### PR TITLE
new-lg4ff: add an option to invert pedals values

### DIFF
--- a/package/batocera/controllers/wheels/new-lg4ff/0001-add-an-option-to-revert-pedals-values.patch
+++ b/package/batocera/controllers/wheels/new-lg4ff/0001-add-an-option-to-revert-pedals-values.patch
@@ -1,0 +1,168 @@
+diff --git a/README.md b/README.md
+index 2e056f0..0fdeaf7 100644
+--- a/README.md
++++ b/README.md
+@@ -39,6 +39,7 @@ following ones:
+ - Rate limited FF updates with best possible latency.
+ - Tunable sprint, damper and friction effects gain.
+ - It can combine accelerator and clutch.
++- Invert pedal values
+ - Use the wheel leds as a FFBmeter to monitor clipping.
+ - Added a system gain setting that modulates the gain setting used by
+   applications.
+@@ -206,6 +207,9 @@ get and set property values.
+ This entry already existed. It has been extended, setting the value to 2
+ combines the clutch and gas pedals in the same axis.
+ 
++### invert_pedals
++Set to 1 to invert the pedals.
++
+ ### gain
+ 
+ Get/set the global FF gain (0-65535). This property is independent of the gain
+diff --git a/hid-lg4ff.c b/hid-lg4ff.c
+index f98afa3..dc88fda 100644
+--- a/hid-lg4ff.c
++++ b/hid-lg4ff.c
+@@ -136,6 +136,7 @@ struct lg4ff_slot {
+ struct lg4ff_wheel_data {
+ 	const u32 product_id;
+ 	u16 combine;
++	u16 invert;
+ 	u16 range;
+ 	u16 autocenter;
+ 	u16 master_gain;
+@@ -1181,6 +1182,57 @@ int lg4ff_adjust_input_event(struct hid_device *hid, struct hid_field *field,
+ 	}
+ }
+ 
++int lg4ff_invert_pedals(struct lg4ff_device_entry *entry, u8 *rd)
++{
++	int offset;
++	int ret = 0;
++	switch (entry->wdata.product_id) {
++		case USB_DEVICE_ID_LOGITECH_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_DFP_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_G25_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_G27_WHEEL:
++			offset = 5;
++			break;
++		case USB_DEVICE_ID_LOGITECH_WINGMAN_FG:
++		case USB_DEVICE_ID_LOGITECH_WINGMAN_FFG:
++		case USB_DEVICE_ID_LOGITECH_MOMO_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_MOMO_WHEEL2:
++			offset = 4;
++			break;
++		case USB_DEVICE_ID_LOGITECH_DFGT_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_G29_WHEEL:
++		case USB_DEVICE_ID_LOGITECH_G923_WHEEL:
++			offset = 6;
++			break;
++		case USB_DEVICE_ID_LOGITECH_WII_WHEEL:
++			offset = 3;
++			break;
++		default:
++			return 0;
++	}
++
++	if (entry->wdata.invert == 1) {
++		rd[offset] = 0xFF - rd[offset];
++		rd[offset+1] = 0xFF - rd[offset+1];
++		ret = 1;
++	}
++
++	if (entry->wdata.invert == 1) {
++		switch (entry->wdata.product_id) {
++			case USB_DEVICE_ID_LOGITECH_G25_WHEEL:
++			case USB_DEVICE_ID_LOGITECH_G27_WHEEL:
++			case USB_DEVICE_ID_LOGITECH_G29_WHEEL:
++			case USB_DEVICE_ID_LOGITECH_G923_WHEEL:
++				break;
++			default:
++				return ret;
++		}
++		rd[offset+2] = 0xFF - rd[offset+2];
++		ret = 1;
++	}
++	return ret;
++}
++
+ int lg4ff_raw_event(struct hid_device *hdev, struct hid_report *report,
+ 		u8 *rd, int size, struct lg_drv_data *drv_data)
+ {
+@@ -1250,7 +1302,12 @@ int lg4ff_raw_event(struct hid_device *hdev, struct hid_report *report,
+ 		return 1;
+ 	}
+ 
+-	return 0;
++	int ret = 0;
++	/* adjust HID report present invert pedals data */
++	if (entry->wdata.invert)
++		ret = lg4ff_invert_pedals(entry, rd) || ret;
++
++	return ret;
+ }
+ 
+ static void lg4ff_init_wheel_data(struct lg4ff_wheel_data * const wdata, const struct lg4ff_wheel *wheel,
+@@ -1271,6 +1328,7 @@ static void lg4ff_init_wheel_data(struct lg4ff_wheel_data * const wdata, const s
+ 		struct lg4ff_wheel_data t_wdata =  { .product_id = wheel->product_id,
+ 						     .real_product_id = real_product_id,
+ 						     .combine = 0,
++						     .invert = 0,
+ 						     .min_range = wheel->min_range,
+ 						     .max_range = wheel->max_range,
+ 						     .set_range = wheel->set_range,
+@@ -1759,6 +1817,35 @@ static ssize_t lg4ff_combine_store(struct device *dev, struct device_attribute *
+ }
+ static DEVICE_ATTR(combine_pedals, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH, lg4ff_combine_show, lg4ff_combine_store);
+ 
++static ssize_t lg4ff_invert_show(struct device *dev, struct device_attribute *attr,
++								  char *buf)
++{
++	struct hid_device *hid = to_hid_device(dev);
++	struct lg4ff_device_entry *entry;
++	size_t count;
++	entry = lg4ff_get_device_entry(hid);
++	if (entry == NULL) {
++		return -EINVAL;
++	}
++	count = scnprintf(buf, PAGE_SIZE, "%u\n", entry->wdata.invert);
++	return count;
++}
++static ssize_t lg4ff_invert_store(struct device *dev, struct device_attribute *attr,
++								  const char *buf, size_t count)
++{
++	struct hid_device *hid = to_hid_device(dev);
++	struct lg4ff_device_entry *entry;
++	u16 invert = simple_strtoul(buf, NULL, 10);
++	entry = lg4ff_get_device_entry(hid);
++	if (entry == NULL) {
++		return -EINVAL;
++	}
++	invert = invert & 0b111;
++	entry->wdata.invert = invert;
++	return count;
++}
++static DEVICE_ATTR(invert_pedals, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH, lg4ff_invert_show, lg4ff_invert_store);
++
+ /* Export the currently set range of the wheel */
+ static ssize_t lg4ff_range_show(struct device *dev, struct device_attribute *attr,
+ 				char *buf)
+@@ -2413,6 +2500,9 @@ int lg4ff_init(struct hid_device *hid)
+ 	error = device_create_file(&hid->dev, &dev_attr_combine_pedals);
+ 	if (error)
+ 		hid_warn(hid, "Unable to create sysfs interface for \"combine\", errno %d\n", error);
++	error = device_create_file(&hid->dev, &dev_attr_invert_pedals);
++	if (error)
++		hid_warn(hid, "Unable to create sysfs interface for \"invert\", errno %d\n", error);
+ 	error = device_create_file(&hid->dev, &dev_attr_range);
+ 	if (error)
+ 		hid_warn(hid, "Unable to create sysfs interface for \"range\", errno %d\n", error);
+@@ -2517,6 +2607,7 @@ int lg4ff_deinit(struct hid_device *hid)
+ 	}
+ 
+ 	device_remove_file(&hid->dev, &dev_attr_combine_pedals);
++	device_remove_file(&hid->dev, &dev_attr_invert_pedals);
+ 	device_remove_file(&hid->dev, &dev_attr_range);
+ 
+ 	if (test_bit(FF_CONSTANT, dev->ffbit)) {


### PR DESCRIPTION
logitech pedals are sending values reversed.

That's break some emulator like model3 but also wine with xinput mapping.

Keep it disabled by default for safety,
but it don't seem to break other emulator which seem to be able to handle values reversed or not.

```echo 1 > /sys/bus/hid/devices/<device-id>/invert```
