### PR TITLE
update blamcon light gun rules

### DIFF
--- a/package/batocera/controllers/guns/blamcon/99-blamcon.rules
+++ b/package/batocera/controllers/guns/blamcon/99-blamcon.rules
@@ -1,9 +1,9 @@
 # Disable raw devices to merge them (mouse and keyboard events)
 # Player light guns 1 to 4
-SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props 3D Blamcon Lightgun - P1*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 1"
-SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props 3D Blamcon Lightgun - P2*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 2"
-SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props 3D Blamcon Lightgun - P3*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 3"
-SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props 3D Blamcon Lightgun - P4*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 4"
+SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props3D Blamcon Lightgun - P1*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 1"
+SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props3D Blamcon Lightgun - P2*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 2"
+SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props3D Blamcon Lightgun - P3*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 3"
+SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Props3D Blamcon Lightgun - P4*", MODE="0666", ENV{ID_INPUT_MOUSE}="0", ENV{ID_INPUT_KEYBOARD}="0", RUN+="/usr/bin/virtual-blamcon-add 4"
 
 # Virtual light gun
 SUBSYSTEM=="input", ACTION=="add", ATTRS{name}=="Blamcon lightgun", MODE="0666", ENV{ID_INPUT_KEYBOARD}="0", ENV{ID_INPUT_KEY}="0", ENV{ID_INPUT_MOUSE}="1", ENV{ID_INPUT_GUN}="1"


### PR DESCRIPTION
New firmware removed the space between "Props" and "3D" in the light gun name.