### PR TITLE
Declutter batocera-es-swissknife

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -4,76 +4,23 @@
 # or to give feedback about state of EmulationStation and active EMULATORS
 # or to give some basic info about your build
 # by cyperghost aka crcerror // 18.03.2019
-# Batocera versions // 04.06.2019
-# Added /bin/usr script // 22.09.2019
-# Added sigterm level, added second parameter to activate sigterm during smart_wait function
-# Added architecture and version information // 05.01.2020
-# Added update information + butterfly branch // 10.02.2020
-# Added --reboot // 26.02.2020
-# Added --overlay and --remount // 13.04.2020
-# Updated version detection only depended from build-date and build-time now
-# Added --reset-ra to reset all settings from RetroArch cores // 27.06.2021
-
-# Get all childpids from calling process
-function getcpid() {
-local cpids="$(pgrep -P $1)"
-    for cpid in $cpids; do
-        pidarray+=($cpid)
-        getcpid $cpid
-    done
-}
-
-# Get a sleep while process is active in background
-# if PID is still active then use kill -9 switch
-function smart_wait() {
-    local PID=$2
-    local disablekill9=$1
-    local watchdog=0
-    sleep 1
-    while [[ -e /proc/$PID ]]; do
-        sleep 0.25
-        ((watchdog++))
-        [[ $disablekill9 -eq 1 ]] && [[ watchdog -gt 12 ]] && kill -9 $PID
-        [[ watchdog -gt 12 ]] && return
-    done
-}
+# cyperghost: 14.02.2025 - use system provided mechanisms to terminate emulators and removed reset-ra switch
 
 # Emulator currently running?
 function check_emurun() {
-    local RC_PID="$(pgrep -f -n emulatorlauncher)"
-    echo $RC_PID
+    echo $(pgrep -f -n emulatorlauncher)
 }
 
 # Emulationstation currently running?
 function check_esrun() {
-    local ES_PID="$(pgrep -f -n emulationstation)"
-    echo $ES_PID
-}
-
-# Wine processes currently running?
-function check_winerun() {
-    local EXE=$1
-    local ES_PID="$(pgrep -f -n $EXE)"
-    echo $ES_PID
+    echo $(pgrep -f -n emulationstation)
 }
 
 # Kill emulators running in a proper way! (SAVE SRM STATE!)
 function emu_kill() {
     RC_PID=$(check_emurun)
     if [[ -n $RC_PID ]]; then
-        getcpid $RC_PID
-        for ((z=${#pidarray[*]}-1; z>-1; z--)); do
-            kill ${pidarray[z]}
-            smart_wait 1 ${pidarray[z]}
-        done
-        unset pidarray
-    fi
-    WINE_PID=$(check_winerun winedevice.exe)
-    if [[ -n $WINE_PID ]]; then
-            for P in winedevice.exe plugplay.exe svchost.exe tabtip.exe services.exe explorer.exe rpcss.exe wineserver ; do
-                # the usual (gentle) way keeps Zombie processes, blame wine.
-                killall -9 "$P" 2>/dev/null
-            done
+        pgrep -f -n winedevice.exe && batocera-wine windows stop || hotkeygen --send exit
     fi
 }
 
@@ -88,7 +35,7 @@ case ${1,,} in
     --restart)
         ES_PID=$(check_esrun)
         /etc/init.d/S31emulationstation stop
-        [[ -z $ES_PID ]] || smart_wait 0 $ES_PID
+        wait $ES_PID
         /etc/init.d/S31emulationstation start
     ;;
 
@@ -106,7 +53,7 @@ case ${1,,} in
 
     --emukill|--shutdown|--reboot)
         RC_PID=$(check_emurun)
-        [[ -n $RC_PID ]] && emu_kill && sleep 2
+        [[ -n $RC_PID ]] && emu_kill && wait $RC_PID
 
         ES_PID=$(check_esrun)
         if [[ "${1,,}" == "--shutdown" && -n $ES_PID ]]; then
@@ -120,7 +67,7 @@ case ${1,,} in
 
     --kodi)
         RC_PID=$(check_emurun)
-        [[ -n $RC_PID ]] && emu_kill && sleep 2
+        [[ -n $RC_PID ]] && emu_kill && wait $RC_PID
 
         /etc/init.d/S31emulationstation stop
         batocera-kodilauncher &
@@ -200,24 +147,7 @@ case ${1,,} in
                echo "Nothing done!"
         esac
     ;;
-    --reset-ra)
-        if [[ -d "$HOME/configs/retroarch" ]]; then
-            rm -rf $HOME/configs/retroarch
-            echo "Deleted: dir $HOME/configs/retroarch"
-        fi
-        if [[ -d "$HOME/.config/retroarch" ]]; then
-            rm -rf $HOME/.config/retroarch
-            echo "Deleted: dir $HOME/.config/retroarch"
-        fi
-        read -p "Do you want to reset RetroArch parameters for 'batocera.conf' file (y/n)? " yn
-        case ${yn:0:1} in
-            y|Y)
-                echo "Reseting RetroArch parameter in 'batocera.conf'"
-                sed -i '/^global.retroarch.*/d' $HOME/batocera.conf
-            ;;
-        esac
-        echo "All done! -- Please reboot"
-    ;;
+
     *)
         cat <<-_EOF_
 		BATOCERA SWISS KNIFE FOR EmulationStation
@@ -241,8 +171,6 @@ case ${1,,} in
 
 		  --overlay  will try to backup your overlay file
 		  --remount  toggle write access to <dir>, default /boot
-		      This switch can have serious effects for your setup
-		  --reset-ra will set all RA settings to default
 		_EOF_
     ;;
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -20,8 +20,14 @@ function check_esrun() {
 function emu_kill() {
     RC_PID=$(check_emurun)
     if [[ -n $RC_PID ]]; then
-        pgrep -f -n winedevice.exe && batocera-wine windows stop || hotkeygen --send exit
+        hotkeygen --send exit
     fi
+}
+
+# Wait for PID to finish
+waitpid() {
+    #https://unix.stackexchange.com/a/427133
+    tail --pid=$1 -f /dev/null
 }
 
 # Future proof update check, depends just on build-date and build-time
@@ -35,7 +41,7 @@ case ${1,,} in
     --restart)
         ES_PID=$(check_esrun)
         /etc/init.d/S31emulationstation stop
-        wait $ES_PID
+        waitpid $ES_PID
         /etc/init.d/S31emulationstation start
     ;;
 
@@ -53,7 +59,7 @@ case ${1,,} in
 
     --emukill|--shutdown|--reboot)
         RC_PID=$(check_emurun)
-        [[ -n $RC_PID ]] && emu_kill && wait $RC_PID
+        [[ -n $RC_PID ]] && emu_kill && waitpid $RC_PID
 
         ES_PID=$(check_esrun)
         if [[ "${1,,}" == "--shutdown" && -n $ES_PID ]]; then
@@ -67,7 +73,7 @@ case ${1,,} in
 
     --kodi)
         RC_PID=$(check_emurun)
-        [[ -n $RC_PID ]] && emu_kill && wait $RC_PID
+        [[ -n $RC_PID ]] && emu_kill && waitpid $RC_PID
 
         /etc/init.d/S31emulationstation stop
         batocera-kodilauncher &


### PR DESCRIPTION
Closing emulators is using systemcalls now
Removed RESET-RETROARCH switch it's not needed anymore Simplified some calls because we are getting older now