### PR TITLE
sdl: add an option to revert triggers z-axis values

### DIFF
--- a/board/batocera/patches/sdl2/sdl2_input_add_invert_trigger_support.patch
+++ b/board/batocera/patches/sdl2/sdl2_input_add_invert_trigger_support.patch
@@ -1,0 +1,21 @@
+diff --git a/src/joystick/SDL_gamecontroller.c b/src/joystick/SDL_gamecontroller.c
+index 410c985d4..22eec9495 100644
+--- a/src/joystick/SDL_gamecontroller.c
++++ b/src/joystick/SDL_gamecontroller.c
+@@ -951,8 +951,13 @@ static void SDL_PrivateGameControllerParseElement(SDL_GameController *gamecontro
+         bind.outputType = SDL_CONTROLLER_BINDTYPE_AXIS;
+         bind.output.axis.axis = axis;
+         if (axis == SDL_CONTROLLER_AXIS_TRIGGERLEFT || axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT) {
+-            bind.output.axis.axis_min = 0;
+-            bind.output.axis.axis_max = SDL_JOYSTICK_AXIS_MAX;
++	    if (*szGameButton == '~') {
++                bind.output.axis.axis_max = 0;
++                bind.output.axis.axis_min = SDL_JOYSTICK_AXIS_MAX;
++            } else {
++                bind.output.axis.axis_min = 0;
++                bind.output.axis.axis_max = SDL_JOYSTICK_AXIS_MAX;
++            }
+         } else {
+             if (half_axis_output == '+') {
+                 bind.output.axis.axis_min = 0;
+

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controller.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controller.py
@@ -59,6 +59,8 @@ def _key_to_sdl_game_controller_config(keyname: str, input: Input, /) -> str | N
             return f"{keyname}:a{input.id}{'~' if int(input.value) > 0 else ''}"
         elif keyname in ('dpup', 'dpdown', 'dpleft', 'dpright'):
             return f"{keyname}:{'-' if int(input.value) < 0 else '+'}a{input.id}"
+        elif 'trigger' in keyname:
+            return f"{keyname}:a{input.id}{'~' if int(input.value) < 0 else ''}"
         else:
             return f'{keyname}:a{input.id}'
     elif input.type == 'key':


### PR DESCRIPTION
Logitech g25,g29 wheel pedals are sending the values reversed, this is breaking
games mapped to gamepad (or wine xinput), where calibration is not possible,
as sdl gamepad is expecting 0 for unpressed and max for pressed

This patch allow to revert trigger axis with ~,

it's using value="-1" from es_input.cfg, as it's mostly setup only on logitech && thrustmaster wheels devices triggers axis.

Here the list of devices from es_input.cfg:

```
DEvice SFR Controller
GameForce ACE Gamepad

Thrustmaster F430 Force Feedback
Thrustmaster Thrustmaster Advance Racer
Thrustmaster Thrustmaster T300RS Racing wheel
Thrustmaster Thrustmaster T150RS
Thrustmaster Thrustmaster Racing Wheel FFB

Driving Force GT
G25 Racing Wheel
G25 Racing Wheel
Logitech G29 Driving Force Racing Wheel
Logitech Logitech MOMO Racing 
Logitech Logitech Driving Force
Logitech G923 Racing Wheel for PlayStation 4 and PC
Logitech G923 Racing Wheel for PlayStation 4 and PC
Logitech Logitech Driving Force Pro
```

The logitech wheel are using the same drivers, so it's 100% sure that they are inverted like the g29.

I don't have tested yet thrustmaster wheels
    


