### PR TITLE
libretro: dosbox: allow to read dosbox.conf in game directory

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -827,6 +827,10 @@ def generateCoreSettings(coreSettings: UnixSettings, system: Emulator, rom: Path
 
     # Microsoft DOS
     if (system.config['core'] == 'dosbox_pure'):
+
+	#allow to read a custom dosbox.conf present in the game directory
+        coreSettings.save('dosbox_pure_conf', '"inside"')
+
         # CPU Type
         if system.isOptSet('pure_cpu_type') and system.config['pure_cpu_type'] != "automatic":
             coreSettings.save('dosbox_pure_cpu_type', '"' + system.config['pure_cpu_type'] + '"')


### PR DESCRIPTION
The batocera dosbox doc https://wiki.batocera.org/systems:dos say that we can defined a dosbox.conf inside the game directory

"Adding a custom dosbox.cfg in your game folder alongside dosbox.bat will allow you to specify custom DOSBOX configuration for the game."

This is not working with dosbox pure libretro core without this option