### PR TITLE
improve configgen logging performance

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -1,14 +1,15 @@
-import os
-from pathlib import Path
-import xml.etree.ElementTree as ET
-import yaml
 import collections
 import logging
+import os
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import yaml
 
 from .batoceraPaths import BATOCERA_CONF, BATOCERA_SHADERS, DEFAULTS_DIR, ES_SETTINGS, USER_SHADERS
 from .settings.unixSettings import UnixSettings
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class Emulator():
     def __init__(self, name, rom):
@@ -21,7 +22,7 @@ class Emulator():
             DEFAULTS_DIR / "configgen-defaults-arch.yml"
         )
         if "emulator" not in self.config or not self.config["emulator"]:
-            eslog.error("no emulator defined. exiting.")
+            _logger.error("no emulator defined. exiting.")
             raise Exception("No emulator found")
 
         system_emulator = self.config["emulator"]
@@ -49,7 +50,7 @@ class Emulator():
         Emulator.updateConfiguration(self.config, folderSettings)
         Emulator.updateConfiguration(self.config, gameSettings)
         self.updateFromESSettings()
-        eslog.debug("uimode: {}".format(self.config['uimode']))
+        _logger.debug("uimode: %s", self.config['uimode'])
 
         # forced emulators ?
         self.config["emulator-forced"] = False
@@ -103,7 +104,7 @@ class Emulator():
         # see FileData::getConfigurationName() on batocera-emulationstation
         rom = rom.replace('=','')
         rom = rom.replace('#','')
-        eslog.info("game settings name: "+rom)
+        _logger.info("game settings name: %s", rom)
         return rom
 
     # to be updated for python3: https://gist.github.com/angstwad/bf22d1822c38a92ec0a9

--- a/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/controllersConfig.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from .types import DeviceInfoDict, DeviceInfoMapping, GunDict, GunMapping
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 def gunsNeedCrosses(guns: GunMapping) -> bool:
     # no gun, enable the cross for joysticks, mouses...
@@ -136,7 +136,7 @@ def getGuns() -> GunDict:
     nmouse = 0
     ngun   = 0
     for eventid in sorted(mouses):
-        eslog.info("found mouse {} at {} with id_mouse={}".format(nmouse, mouses[eventid].device_node, nmouse))
+        _logger.info("found mouse %s at %s with id_mouse=%s", nmouse, mouses[eventid].device_node, nmouse)
         if "ID_INPUT_GUN" not in mouses[eventid].properties or mouses[eventid].properties["ID_INPUT_GUN"] != "1":
             nmouse = nmouse + 1
             continue
@@ -148,12 +148,12 @@ def getGuns() -> GunDict:
         need_cross   = "ID_INPUT_GUN_NEED_CROSS"   in mouses[eventid].properties and mouses[eventid].properties["ID_INPUT_GUN_NEED_CROSS"]   == '1'
         need_borders = "ID_INPUT_GUN_NEED_BORDERS" in mouses[eventid].properties and mouses[eventid].properties["ID_INPUT_GUN_NEED_BORDERS"] == '1'
         guns[ngun] = {"node": mouses[eventid].device_node, "id_mouse": nmouse, "need_cross": need_cross, "need_borders": need_borders, "name": device.name, "buttons": buttons}
-        eslog.info("found gun {} at {} with id_mouse={} ({})".format(ngun, mouses[eventid].device_node, nmouse, guns[ngun]["name"]))
+        _logger.info("found gun %s at %s with id_mouse=%s (%s)", ngun, mouses[eventid].device_node, nmouse, guns[ngun]["name"])
         nmouse = nmouse + 1
         ngun = ngun + 1
 
     if len(guns) == 0:
-        eslog.info("no gun found")
+        _logger.info("no gun found")
 
     return guns
 
@@ -181,7 +181,7 @@ def getGamesMetaData(system: str, rom: str | Path) -> dict[str, str]:
     root = tree.getroot()
     game = shortNameFromPath(rom)
     res: dict[str, str] = {}
-    eslog.info("looking for game metadata ({}, {})".format(system, game))
+    _logger.info("looking for game metadata (%s, %s)", system, game)
 
     targetSystem = system
     # hardcoded list of system for arcade
@@ -200,7 +200,7 @@ def getGamesMetaData(system: str, rom: str | Path) -> dict[str, str]:
                             for attribute in child.attrib:
                                 key = "{}_{}".format(child.tag, attribute)
                                 res[key] = child.get(attribute)
-                                eslog.info("found game metadata {}={} (system level)".format(key, res[key]))
+                                _logger.info("found game metadata %s=%s (system level)", key, res[key])
                         break
                 for nodegame in nodesystem.findall(".//game"):
                     if nodegame.get("name") != "default" and nodegame.get("name") in game:
@@ -208,7 +208,7 @@ def getGamesMetaData(system: str, rom: str | Path) -> dict[str, str]:
                             for attribute in child.attrib:
                                 key = "{}_{}".format(child.tag, attribute)
                                 res[key] = child.get(attribute)
-                                eslog.info("found game metadata {}={}".format(key, res[key]))
+                                _logger.info("found game metadata %s=%s", key, res[key])
                         return res
     return res
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from .generators.Generator import Generator
     from .types import DeviceInfoDict, GunDict, Resolution
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 def main(args: argparse.Namespace, maxnbplayers: int) -> int:
     # squashfs roms if squashed
@@ -61,7 +61,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
 
     # find the system to run
     systemName = args.system
-    eslog.debug(f"Running system: {systemName}")
+    _logger.debug("Running system: %s", systemName)
     system = Emulator(systemName, romConfiguration)
 
     if args.emulator is not None:
@@ -73,12 +73,12 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
     debugDisplay = system.config.copy()
     if "retroachievements.password" in debugDisplay:
         debugDisplay["retroachievements.password"] = "***"
-    eslog.debug(f"Settings: {debugDisplay}")
+    _logger.debug("Settings: %s", debugDisplay)
     if "emulator" in system.config and "core" in system.config:
-        eslog.debug(f'emulator: {system.config["emulator"]}, core: {system.config["core"]}')
+        _logger.debug('emulator: %s, core: %s', system.config["emulator"], system.config["core"])
     else:
         if "emulator" in system.config:
-            eslog.debug(f'emulator: {system.config["emulator"]}')
+            _logger.debug('emulator: %s', system.config["emulator"])
 
     # metadata
     metadata = controllers.getGamesMetaData(systemName, rom)
@@ -91,7 +91,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
         guns = controllers.getGuns()
         gunsUtils.precalibration(systemName, system.config['emulator'], system.config.get("core"), rom)
     else:
-        eslog.info("guns disabled.")
+        _logger.info("guns disabled.")
         guns: GunDict = {}
 
     # search wheels in case use_wheels is enabled for this game
@@ -104,7 +104,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
         (wheelProcesses, player_controllers, deviceInfos) = wheelsUtils.reconfigureControllers(player_controllers, system, rom, metadata, deviceInfos)
         wheels = wheelsUtils.getWheelsFromDevicesInfos(deviceInfos)
     else:
-        eslog.info("wheels disabled.")
+        _logger.info("wheels disabled.")
         wheels: DeviceInfoDict = {}
 
     # find the generator
@@ -121,15 +121,15 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
         # lower the resolution if mode is auto
         newsystemMode = systemMode # newsystemmode is the mode after minmax (ie in 1K if tv was in 4K), systemmode is the mode before (ie in es)
         if system.config["videomode"] == "" or system.config["videomode"] == "default":
-            eslog.debug("minTomaxResolution")
-            eslog.debug(f"video mode before minmax: {systemMode}")
+            _logger.debug("minTomaxResolution")
+            _logger.debug("video mode before minmax: %s", systemMode)
             videoMode.minTomaxResolution()
             newsystemMode = videoMode.getCurrentMode()
             if newsystemMode != systemMode:
                 resolutionChanged = True
 
-        eslog.debug(f"current video mode: {newsystemMode}")
-        eslog.debug(f"wanted video mode: {wantedGameMode}")
+        _logger.debug("current video mode: %s", newsystemMode)
+        _logger.debug("wanted video mode: %s", wantedGameMode)
 
         if wantedGameMode != 'default' and wantedGameMode != newsystemMode:
             videoMode.changeMode(wantedGameMode)
@@ -141,7 +141,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
             x = gameResolution["width"]
             gameResolution["width"]  = gameResolution["height"]
             gameResolution["height"] = x
-        eslog.debug(f'resolution: {gameResolution["width"]}x{gameResolution["height"]}')
+        _logger.debug('resolution: %sx%s', gameResolution["width"], gameResolution["height"])
 
         # savedir: create the save directory if not already done
         dirname = SAVES / system.name
@@ -247,14 +247,14 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: str, romConfigur
             try:
                 wheelsUtils.resetControllers(wheelProcesses)
             except Exception:
-                eslog.error("hum, unable to reset wheel controllers !")
+                _logger.error("hum, unable to reset wheel controllers !")
                 pass # don't fail
     # exit
     return exitCode
 
 def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution: Resolution, bordersSize: str | None, bordersRatio: str | None):
     if generator.supportsInternalBezels():
-        eslog.debug(f"skipping bezels for emulator {system.config['emulator']}")
+        _logger.debug("skipping bezels for emulator %s", system.config['emulator'])
         return None
     # no good reason for a bezel
     if ('bezel' not in system.config or system.config['bezel'] == "" or system.config['bezel'] == "none") and not (system.isOptSet('bezel.tattoo') and system.config['bezel.tattoo'] != "0") and bordersSize is None:
@@ -270,12 +270,12 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
         with overlay_info_file.open("w") as fd:
             fd.write(f'{{ "width":{w}, "height":{h}, "opacity":1.0000000, "messagex":0.220000, "messagey":0.120000 }}')
     else:
-        eslog.debug(f"hud enabled. trying to apply the bezel {system.config['bezel']}")
+        _logger.debug("hud enabled. trying to apply the bezel %s", system.config['bezel'])
 
         bezel = system.config['bezel']
         bz_infos = bezelsUtil.getBezelInfos(rom, bezel, system.name, system.config['emulator'])
         if bz_infos is None:
-            eslog.debug("no bezel info file found")
+            _logger.debug("no bezel info file found")
             return None
 
         overlay_info_file = bz_infos["info"]
@@ -288,7 +288,7 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
             with overlay_info_file.open() as f:
                 infos = json.load(f)
         except:
-            eslog.warning(f"unable to read {overlay_info_file}")
+            _logger.warning("unable to read %s", overlay_info_file)
             infos = {}
     else:
         infos = {}
@@ -296,10 +296,10 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     if "width" in infos and "height" in infos:
         bezel_width  = infos["width"]
         bezel_height = infos["height"]
-        eslog.info(f"bezel size read from {overlay_info_file}")
+        _logger.info("bezel size read from %s", overlay_info_file)
     else:
         bezel_width, bezel_height = bezelsUtil.fast_image_size(overlay_png_file)
-        eslog.info(f"bezel size read from {overlay_png_file}")
+        _logger.info("bezel size read from %s", overlay_png_file)
 
     # max cover proportion and ratio distortion
     max_cover = 0.05 # 5%
@@ -311,7 +311,14 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     # the screen and bezel ratio must be approximatly the same
     if bordersSize is None:
         if abs(screen_ratio - bezel_ratio) > max_ratio_delta:
-            eslog.debug(f"screen ratio ({screen_ratio}) is too far from the bezel one ({bezel_ratio}) : {screen_ratio} - {bezel_ratio} > {max_ratio_delta}")
+            _logger.debug(
+                "screen ratio (%(screen_ratio)s) is too far from the bezel one (%(bezel_ratio)s) : %(screen_ratio)s - %(bezel_ratio)s > %(max_ratio_delta)s",
+                {
+                    'screen_ratio': screen_ratio,
+                    'bezel_ratio': bezel_ratio,
+                    'max_ratio_delta': max_ratio_delta
+                }
+            )
             return None
 
     # the ingame image and the bezel free space must feet
@@ -319,10 +326,10 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     # in case there is a border, force it
     if bordersSize is None:
         if "top" in infos and infos["top"] / bezel_height > max_cover:
-            eslog.debug(f'bezel top covers too much the game image : {infos["top"]} / {bezel_height} > {max_cover}')
+            _logger.debug('bezel top covers too much the game image : %s / %s > %s', infos["top"], bezel_height, max_cover)
             return None
         if "bottom" in infos and infos["bottom"] / bezel_height > max_cover:
-            eslog.debug(f'bezel bottom covers too much the game image : {infos["bottom"]} / {bezel_height} > {max_cover}')
+            _logger.debug('bezel bottom covers too much the game image : %s / %s > %s', infos["bottom"], bezel_height, max_cover)
             return None
 
     # if there is no information about top/bottom, assume default is 0
@@ -333,29 +340,29 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     img_width  = img_height * ingame_ratio
 
     if "left" not in infos:
-        eslog.debug(f"bezel has no left info in {overlay_info_file}")
+        _logger.debug("bezel has no left info in %s", overlay_info_file)
         # assume default is 4/3 over 16/9
         infos_left = (bezel_width - (bezel_height / 3 * 4)) / 2
         if bordersSize is None:
             if abs((infos_left  - ((bezel_width-img_width)/2.0)) / img_width) > max_cover:
-                eslog.debug(f"bezel left covers too much the game image : {infos_left  - ((bezel_width-img_width)/2.0)} / {img_width} > {max_cover}")
+                _logger.debug("bezel left covers too much the game image : %s / %s > %s", infos_left  - ((bezel_width-img_width)/2.0), img_width, max_cover)
                 return None
 
     if "right" not in infos:
-        eslog.debug(f"bezel has no right info in {overlay_info_file}")
+        _logger.debug("bezel has no right info in %s", overlay_info_file)
         # assume default is 4/3 over 16/9
         infos_right = (bezel_width - (bezel_height / 3 * 4)) / 2
         if bordersSize is None:
             if abs((infos_right - ((bezel_width-img_width)/2.0)) / img_width) > max_cover:
-                eslog.debug(f"bezel right covers too much the game image : {infos_right  - ((bezel_width-img_width)/2.0)} / {img_width} > {max_cover}")
+                _logger.debug("bezel right covers too much the game image : %s / %s > %s", infos_right  - ((bezel_width-img_width)/2.0), img_width, max_cover)
                 return None
 
     if bordersSize is None:
         if "left"  in infos and abs((infos["left"]  - ((bezel_width-img_width)/2.0)) / img_width) > max_cover:
-            eslog.debug("bezel left covers too much the game image : {} / {} > {}".format(infos["left"]  - ((bezel_width-img_width)/2.0), img_width, max_cover))
+            _logger.debug("bezel left covers too much the game image : %s / %s > %s", infos["left"]  - ((bezel_width-img_width)/2.0), img_width, max_cover)
             return None
         if "right" in infos and abs((infos["right"] - ((bezel_width-img_width)/2.0)) / img_width) > max_cover:
-            eslog.debug("bezel right covers too much the game image : {} / {} > {}".format(infos["right"]  - ((bezel_width-img_width)/2.0), img_width, max_cover))
+            _logger.debug("bezel right covers too much the game image : %s / %s > %s", infos["right"]  - ((bezel_width-img_width)/2.0), img_width, max_cover)
             return None
 
     # if screen and bezel sizes doesn't match, resize
@@ -365,12 +372,12 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
     else:
         bezel_stretch = False
     if (bezel_width != gameResolution["width"] or bezel_height != gameResolution["height"]):
-        eslog.debug("bezel needs to be resized")
+        _logger.debug("bezel needs to be resized")
         output_png_file = Path("/tmp/bezel.png")
         try:
             bezelsUtil.resizeImage(overlay_png_file, output_png_file, gameResolution["width"], gameResolution["height"], bezel_stretch)
         except Exception as e:
-            eslog.error(f"failed to resize the image {e}")
+            _logger.error("failed to resize the image %s", e)
             return None
         overlay_png_file = output_png_file
 
@@ -381,14 +388,14 @@ def getHudBezel(system: Emulator, generator: Generator, rom: str, gameResolution
 
     # borders
     if bordersSize is not None:
-        eslog.debug("Draw gun borders")
+        _logger.debug("Draw gun borders")
         output_png_file = Path("/tmp/bezel_gunborders.png")
         innerSize, outerSize = bezelsUtil.gunBordersSize(bordersSize)
-        eslog.debug(f"Gun border ratio = {bordersRatio}")
+        _logger.debug("Gun border ratio = %s", bordersRatio)
         borderSize = bezelsUtil.gunBorderImage(overlay_png_file, output_png_file, bordersRatio, innerSize, outerSize, bezelsUtil.gunsBordersColorFomConfig(system.config))
         overlay_png_file = output_png_file
 
-    eslog.debug(f"applying bezel {overlay_png_file}")
+    _logger.debug("applying bezel %s", overlay_png_file)
     return overlay_png_file
 
 def extractGameInfosFromXml(xml: str) -> dict[str, str]:
@@ -419,7 +426,7 @@ def callExternalScripts(folder: Path, event: str, args: Iterable[str | Path]) ->
             callExternalScripts(file, event, args)
         else:
             if os.access(file, os.X_OK):
-                eslog.debug(f"calling external script: {[file, event, *args]!s}")
+                _logger.debug("calling external script: %s", [file, event, *args])
                 subprocess.call([file, event, *args])
 
 def hudConfig_protectStr(string: str | Path | None) -> str:
@@ -482,33 +489,35 @@ def runCommand(command: Command) -> int:
     envvars.update(command.env)
     command.env = envvars
 
-    eslog.debug(f"command: {command!s}")
-    eslog.debug(f"command: {command.array!s}")
-    eslog.debug(f"env: {command.env!s}")
+    _logger.debug("command: %s", command)
+    _logger.debug("command: %s", command.array)
+    _logger.debug("env: %s", command.env)
+
+    if not command.array:
+        return -1
+
+    proc = subprocess.Popen(command.array, env=command.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     exitcode = -1
-    if command.array:
-        proc = subprocess.Popen(command.array, env=command.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    else:
-        return exitcode
+
     try:
         out, err = proc.communicate()
         exitcode = proc.returncode
-        eslog.debug(out.decode())
-        eslog.error(err.decode())
+        _logger.debug(out.decode())
+        _logger.error(err.decode())
     except BrokenPipeError:
         # Seeing BrokenPipeError? This is probably caused by head truncating output in the front-end
         # Examine es-core/src/platform.cpp::runSystemCommand for additional context
         pass
     except:
-        eslog.error("emulator exited")
+        _logger.error("emulator exited")
 
     return exitcode
 
 def signal_handler(signal, frame):
     global proc
-    eslog.debug('Exiting')
+    _logger.debug('Exiting')
     if proc:
-        eslog.debug('killing proc')
+        _logger.debug('killing proc')
         proc.kill()
 
 def launch() -> None:
@@ -552,14 +561,14 @@ def launch() -> None:
             exitcode = -1
             exitcode = main(args, maxnbplayers)
         except Exception as e:
-            eslog.error("configgen exception: ", exc_info=True)
+            _logger.exception("configgen exception: ")
 
         if _profiler:
             _profiler.disable()
             _profiler.dump_stats('/var/run/emulatorlauncher.prof')
 
         time.sleep(1) # this seems to be required so that the gpu memory is restituated and available for es
-        eslog.debug(f"Exiting configgen with status {exitcode!s}")
+        _logger.debug("Exiting configgen with status %s", exitcode)
 
         exit(exitcode)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -15,7 +15,7 @@ from ..libretro import libretroControllers
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _CONFIG_DIR: Final = CONFIGS / 'amiberry'
 _CONFIG: Final = _CONFIG_DIR / 'conf' / 'amiberry.conf'
@@ -51,7 +51,7 @@ class AmiberryGenerator(Generator):
         amiberryconf.write()
 
         romType = self.getRomType(rom)
-        eslog.debug("romType: "+romType)
+        _logger.debug("romType: %s", romType)
         if romType != 'UNKNOWN' :
             commandArray: list[str | Path] = [ "/usr/bin/amiberry", "-G" ]
             if romType != 'WHDL' :
@@ -264,7 +264,7 @@ class AmiberryGenerator(Generator):
                         if extension == "info":
                             return 'WHDL'
                         elif extension == 'lha' :
-                            eslog.warning("Amiberry doesn't support .lha inside a .zip")
+                            _logger.warning("Amiberry doesn't support .lha inside a .zip")
                             return 'UNKNOWN'
                         elif extension == 'adf' :
                             return 'DISK'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/applewin/applewinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/applewin/applewinGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Final
 
 from ... import Command
@@ -8,8 +7,6 @@ from ...batoceraPaths import CONFIGS, mkdir_if_not_exists
 from ...controller import generate_sdl_game_controller_config
 from ...settings.unixSettings import UnixSettings
 from ..Generator import Generator
-
-eslog = logging.getLogger(__name__)
 
 _CONFIG_DIR: Final = CONFIGS / 'applewin'
 _CONFIG_FILE: Final = _CONFIG_DIR / 'config.txt'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import TYPE_CHECKING, Any
 
 from ... import Command
@@ -13,8 +12,6 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-
-eslog = logging.getLogger(__name__)
 
 bigPemuConfig = CONFIGS / "bigpemu" / "BigPEmuConfig.bigpcfg"
 
@@ -298,7 +295,7 @@ class BigPEmuGenerator(Generator):
                         BINDINGS_SEQUENCE = P2_BINDINGS_SEQUENCE
 
                     for binding_key, binding_info in BINDINGS_SEQUENCE.items():
-                        #eslog.debug(f"Binding sequence input: {binding_key}")
+                        # _logger.debug(f"Binding sequence input: %s", binding_key)
                         if "button" in binding_info:
                             if "keyboard" in binding_info:
                                 generate_func = generate_keyb_button_bindings

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/catacombgl/catacombglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/catacombgl/catacombglGenerator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _CATACOMBGL_CONFIG: Final = CONFIGS / "CatacombGL"
 _CATACOMBGL_SAVES: Final = SAVES / "CatacombGL"
@@ -39,7 +39,7 @@ class CatacombGLGenerator(Generator):
 
         # Check if the ini file exists, and if not, create and adjust it
         if not _CATACOMBGL_CONFIG_FILE.exists():
-            eslog.debug("CatacombGL.ini not found, creating the file.")
+            _logger.debug("CatacombGL.ini not found, creating the file.")
             _CATACOMBGL_CONFIG_FILE.touch()  # Create the file if it doesn't exist
 
         # Define the paths to be added or adjusted in the ini file
@@ -80,7 +80,7 @@ class CatacombGLGenerator(Generator):
             "apocalypse": "--apocalypse",
         }.items():
             if keyword in rom_file_name:
-                eslog.debug(f"Version requested: {keyword}")
+                _logger.debug("Version requested: %s", keyword)
                 commandArray.append(argument)
 
         # Return the configured command

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cdogs/cdogsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cdogs/cdogsGenerator.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class CdogsGenerator(Generator):
 
@@ -230,7 +230,7 @@ class CdogsGenerator(Generator):
                 os.chdir(romdir / assetdir)
             os.chdir(romdir)
         except FileNotFoundError:
-            eslog.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
+            _logger.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
             raise
 
         commandArray = ["cdogs"]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/cemu/cemuGenerator.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class CemuGenerator(Generator):
 
@@ -150,19 +150,19 @@ class CemuGenerator(Generator):
         if api_value == "1":
             # Check if we have a discrete GPU & if so, set the UUID
             if vulkan.is_available():
-                eslog.debug("Vulkan driver is available on the system.")
+                _logger.debug("Vulkan driver is available on the system.")
                 if vulkan.has_discrete_gpu():
                     discrete_uuid = vulkan.get_discrete_gpu_uuid()
                     if discrete_uuid:
                         discrete_uuid_num = discrete_uuid.replace("-", "")
-                        eslog.debug("Using Discrete GPU UUID: {} for Cemu".format(discrete_uuid_num))
+                        _logger.debug("Using Discrete GPU UUID: %s for Cemu", discrete_uuid_num)
                         CemuGenerator.setSectionConfig(config, graphic_root, "device", discrete_uuid_num)
                     else:
-                        eslog.debug("Couldn't get discrete GPU UUID!")
+                        _logger.debug("Couldn't get discrete GPU UUID!")
                 else:
-                    eslog.debug("Discrete GPU is not available on the system. Using default.")
+                    _logger.debug("Discrete GPU is not available on the system. Using default.")
             else:
-                eslog.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
+                _logger.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
                 CemuGenerator.setSectionConfig(config, graphic_root, "api", "0")
 
         # Async VULKAN Shader compilation
@@ -252,12 +252,12 @@ class CemuGenerator(Generator):
         # pactl list sinks-raw | sed -e s+"^sink=[0-9]* name=\([^ ]*\) .*"+"\1"+ | sed 1q | tr -d '\n'
         proc = subprocess.run(["/usr/bin/cemu/get-audio-device"], stdout=subprocess.PIPE)
         cemuAudioDevice = proc.stdout.decode('utf-8')
-        eslog.debug("*** audio device = {} ***".format(cemuAudioDevice))
+        _logger.debug("*** audio device = %s ***", cemuAudioDevice)
         if system.isOptSet("cemu_audio_config") and system.getOptBoolean("cemu_audio_config") == True:
             CemuGenerator.setSectionConfig(config, audio_root, "TVDevice", cemuAudioDevice)
         elif system.isOptSet("cemu_audio_config") and system.getOptBoolean("cemu_audio_config") == False:
             # don't change the config setting
-            eslog.debug("*** use config audio device ***")
+            _logger.debug("*** use config audio device ***")
         else:
             CemuGenerator.setSectionConfig(config, audio_root, "TVDevice", cemuAudioDevice)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/citra/citraGenerator.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class CitraGenerator(Generator):
 
@@ -153,17 +153,17 @@ class CitraGenerator(Generator):
         # Set Vulkan as necessary
         if system.isOptSet("citra_graphics_api") and system.config["citra_graphics_api"] == "2":
             if vulkan.is_available():
-                eslog.debug("Vulkan driver is available on the system.")
+                _logger.debug("Vulkan driver is available on the system.")
                 if vulkan.has_discrete_gpu():
-                    eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                    _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                     discrete_index = vulkan.get_discrete_gpu_index()
                     if discrete_index:
-                        eslog.debug("Using Discrete GPU Index: {} for Citra".format(discrete_index))
+                        _logger.debug("Using Discrete GPU Index: %s for Citra", discrete_index)
                         citraConfig.set("Renderer", "physical_device", discrete_index)
                     else:
-                        eslog.debug("Couldn't get discrete GPU index")
+                        _logger.debug("Couldn't get discrete GPU index")
                 else:
-                    eslog.debug("Discrete GPU is not available on the system. Using default.")
+                    _logger.debug("Discrete GPU is not available on the system. Using default.")
         # Use VSYNC
         if system.isOptSet('citra_use_vsync_new') and system.config["citra_use_vsync_new"] == '0':
             citraConfig.set("Renderer", "use_vsync_new", "false")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/corsixth/corsixthGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/corsixth/corsixthGenerator.py
@@ -20,7 +20,7 @@ corsixthSavesPath = SAVES / "corsixth"
 corsixthDataPath = ROMS / "corsixth"
 corsixthFontPath = Path("/usr/share/fonts/dejavu/DejaVuSans.ttf")
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class CorsixTHGenerator(Generator):
 
@@ -45,7 +45,7 @@ class CorsixTHGenerator(Generator):
             os.chdir(corsixthDataPath / "LEVELS")
             os.chdir(corsixthDataPath / "QDATA")
         except:
-            eslog.error("ERROR: Game assets not installed. You can get them from the game Theme Hospital.")
+            _logger.error("ERROR: Game assets not installed. You can get them from the game Theme Hospital.")
 
         # If config file already exists, delete it
         if corsixthConfigFile.exists():
@@ -122,7 +122,7 @@ class CorsixTHGenerator(Generator):
             os.chdir(corsixthDataPath / "MP3")
             source_config_file.write(f"audio_music = [[{corsixthDataPath / 'MP3'}]]\n")
         except:
-            eslog.warning("NOTICE: Audio & Music system loaded, but found no external background tracks. Missing MP3 folder")
+            _logger.warning("NOTICE: Audio & Music system loaded, but found no external background tracks. Missing MP3 folder")
             source_config_file.write("audio_music = nil\n")
 
         # Close config file as we are done

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dhewm3/dhewm3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dhewm3/dhewm3Generator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _DHEWM3_CONFIG: Final = CONFIGS / "dhewm3"
 
@@ -35,7 +35,7 @@ class Dhewm3Generator(Generator):
         # Read the path within the .d3 rom file
         with Path(rom).open() as file:
             directory = file.readline().strip().split("/")[0]
-            eslog.debug(f"Using directory: {directory}")
+            _logger.debug("Using directory: %s", directory)
 
         _DHEWM3_CONFIG_BASE_DIR = _DHEWM3_CONFIG / "base"
         _DHEWM3_CONFIG_DIR = _DHEWM3_CONFIG / directory

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import DeviceInfoMapping, GunMapping
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 # Create the controller configuration file
 def generateControllerConfig(system: Emulator, playersControllers: ControllerMapping, metadata: Mapping[str, str], wheels: DeviceInfoMapping, rom: Path, guns: GunMapping) -> None:
@@ -186,8 +186,8 @@ def generateControllerConfig_emulatedwiimotes(system: Emulator, playersControlle
                 wiiMapping.update(res)
                 line = cconfig.readline()
 
-    eslog.debug(f"Extra Options: {extraOptions}")
-    eslog.debug(f"Wii Mappings: {wiiMapping}")
+    _logger.debug("Extra Options: %s", extraOptions)
+    _logger.debug("Wii Mappings: %s", wiiMapping)
 
     generateControllerConfig_any(system, playersControllers, wheels, "WiimoteNew.ini", "Wiimote", wiiMapping, wiiReverseAxes, None, extraOptions)
 
@@ -343,7 +343,7 @@ def generateControllerConfig_guns(filename: str, anyDefKey: str, metadata: Mappi
             f.write("Device = evdev/" + str(nsamepad).strip() + "/" + gundevname.strip() + "\n")
 
             buttons = guns[nplayer-1]["buttons"]
-            eslog.debug(f"Gun : {buttons}")
+            _logger.debug("Gun : %s", buttons)
 
             # custom remapping
             # erase values
@@ -353,17 +353,17 @@ def generateControllerConfig_guns(filename: str, anyDefKey: str, metadata: Mappi
                         if mval in gunMapping:
                             for x in gunMapping:
                                 if gunMapping[x] == btn:
-                                    eslog.info("erasing {}".format(x))
+                                    _logger.info("erasing %s", x)
                                     gunMapping[x] = ""
                         else:
-                            eslog.info("custom gun mapping ignored for {} => {} (invalid value)".format(btn, mval))
+                            _logger.info("custom gun mapping ignored for %s => %s (invalid value)", btn, mval)
             # setting values
             for btn in gunButtons:
                 if "gun_"+btn in metadata:
                     for mval in metadata["gun_"+btn].split(","):
                         if mval in gunMapping:
                             gunMapping[mval] = btn
-                            eslog.info("setting {} to {}".format(mval, btn))
+                            _logger.info("setting %s to %s", mval, btn)
 
             # write buttons
             for btn in dolphinMappingNames:
@@ -373,9 +373,9 @@ def generateControllerConfig_guns(filename: str, anyDefKey: str, metadata: Mappi
                         if gunButtons[gunMapping[btn]]["button"] in buttons:
                             val = gunButtons[gunMapping[btn]]["code"]
                         else:
-                            eslog.debug("gun has not the button {}".format(gunButtons[gunMapping[btn]]["button"]))
+                            _logger.debug("gun has not the button %s", gunButtons[gunMapping[btn]]["button"])
                     else:
-                        eslog.debug("cannot map the button {}".format(gunMapping[btn]))
+                        _logger.debug("cannot map the button %s", gunMapping[btn])
                 f.write(dolphinMappingNames[btn]+" = `"+val+"`\n")
 
             # map ir
@@ -477,7 +477,7 @@ def generateControllerConfig_wheel(f: codecs.StreamReaderWriter, pad: Controller
         "joystick1right": "Main Stick/Right",
     }
 
-    eslog.debug("configuring wheel for pad {}".format(pad.real_name))
+    _logger.debug("configuring wheel for pad %s", pad.real_name)
 
     f.write(f"Rumble/Motor = Constant\n") # only Constant works on my wheel. maybe some other values could be good
     f.write(f"Rumble/Motor/Range = -100.\n") # value must be negative, otherwise the center is located in extremes (left/right)
@@ -585,22 +585,22 @@ def generateControllerConfig_any_from_profiles(f: codecs.StreamReaderWriter, pad
 
     for profileFile in glob_path.glob("*.ini"):
         try:
-            eslog.debug(f"Looking profile : {profileFile}")
+            _logger.debug("Looking profile : %s", profileFile)
             profileConfig = CaseSensitiveConfigParser(interpolation=None)
             profileConfig.read(profileFile)
             profileDevice = profileConfig.get("Profile","Device")
-            eslog.debug(f"Profile device : {profileDevice}")
+            _logger.debug("Profile device : %s", profileDevice)
 
             deviceVals = re.match("^([^/]*)/[0-9]*/(.*)$", profileDevice)
             if deviceVals is not None:
                 if deviceVals.group(1) == "evdev" and deviceVals.group(2).strip() == pad.real_name.strip():
-                    eslog.debug("Eligible profile device found")
+                    _logger.debug("Eligible profile device found")
                     for key, val in profileConfig.items("Profile"):
                         if key != "Device":
                             f.write(f"{key} = {val}\n")
                     return True
         except:
-            eslog.error(f"profile {profileFile} : FAILED")
+            _logger.error("profile %s : FAILED", profileFile)
 
     return False
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -24,7 +24,7 @@ from .dolphinPaths import (
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class DolphinGenerator(Generator):
 
@@ -149,7 +149,7 @@ class DolphinGenerator(Generator):
             dolphinSettings.set("Core", "GFXBackend", "Vulkan")
             # Check Vulkan
             if not vulkan.is_available():
-                eslog.debug("Vulkan driver is not available on the system. Using OpenGL instead.")
+                _logger.debug("Vulkan driver is not available on the system. Using OpenGL instead.")
                 dolphinSettings.set("Core", "GFXBackend", "OGL")
         else:
             dolphinSettings.set("Core", "GFXBackend", "OGL")
@@ -232,17 +232,17 @@ class DolphinGenerator(Generator):
 
         # Set Vulkan adapter
         if vulkan.is_available():
-            eslog.debug("Vulkan driver is available on the system.")
+            _logger.debug("Vulkan driver is available on the system.")
             if vulkan.has_discrete_gpu():
-                eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                 discrete_index = vulkan.get_discrete_gpu_index()
                 if discrete_index:
-                    eslog.debug("Using Discrete GPU Index: {} for Dolphin".format(discrete_index))
+                    _logger.debug("Using Discrete GPU Index: %s for Dolphin", discrete_index)
                     dolphinGFXSettings.set("Hardware", "Adapter", discrete_index)
                 else:
-                    eslog.debug("Couldn't get discrete GPU index")
+                    _logger.debug("Couldn't get discrete GPU index")
             else:
-                eslog.debug("Discrete GPU is not available on the system. Using default.")
+                _logger.debug("Discrete GPU is not available on the system. Using default.")
 
         # Graphics setting Aspect Ratio
         if system.isOptSet('dolphin_aspect_ratio'):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...types import Resolution
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 def readBEInt16(f):
     bytes = f.read(2)
@@ -85,7 +85,7 @@ def readWriteEntry(f, setval):
             raise Exception(f"unknown type {itemType}")
 
     if not setval or itemName in setval:
-        eslog.debug(f'{itemName:12s} = {itemValue}')
+        _logger.debug('%12s = %s', itemName, itemValue)
 
 def readWriteFile(filepath: Path, setval):
     # open in read read/write depending of the action

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin_triforce/dolphinTriforceControllers.py
@@ -11,10 +11,11 @@ from .dolphinTriforcePaths import DOLPHIN_TRIFORCE_CONFIG
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
+
     from ...controller import Controller, ControllerMapping
     from ...Emulator import Emulator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 # Create the controller configuration file
 def generateControllerConfig(system: Emulator, playersControllers: ControllerMapping, rom: Path) -> None:
@@ -153,9 +154,9 @@ def generateHotkeys(playersControllers: ControllerMapping) -> None:
                 # Write the configuration for this key
                 if keyname is not None:
                     write_key(f, keyname, input.type, input.id, input.value, pad.axis_count, False, hotkey.id)
-        
+
         nplayer += 1
-    
+
     f.write
     f.close()
 
@@ -173,7 +174,7 @@ def generateControllerConfig_any(system: Emulator, playersControllers: Controlle
             nsamepad = double_pads[pad.real_name.strip()]
         else:
             nsamepad = 0
-        
+
         double_pads[pad.real_name.strip()] = nsamepad+1
         f.write("[" + anyDefKey + str(nplayer) + "]" + "\n")
         f.write("Device = SDL/" + str(nsamepad).strip() + "/" + pad.real_name.strip() + "\n")
@@ -189,7 +190,7 @@ def generateControllerConfig_any(system: Emulator, playersControllers: Controlle
         else:
             f.write("Rumble/Motor = \n")
         nplayer += 1
-    
+
     f.write
     f.close()
 
@@ -230,21 +231,21 @@ def generateControllerConfig_any_auto(f: codecs.StreamReaderWriter, pad: Control
 def generateControllerConfig_any_from_profiles(f: codecs.StreamReaderWriter, pad: Controller) -> bool:
     for profileFile in (DOLPHIN_TRIFORCE_CONFIG / "Config" / "Profiles" / "GCPad").glob("*.ini"):
         try:
-            eslog.debug(f"Looking profile : {profileFile}")
+            _logger.debug("Looking profile : %s", profileFile)
             profileConfig = CaseSensitiveConfigParser(interpolation=None)
             profileConfig.read(profileFile)
             profileDevice = profileConfig.get("Profile","Device")
-            eslog.debug(f"Profile device : {profileDevice}")
+            _logger.debug("Profile device : %s", profileDevice)
             deviceVals = re.match("^([^/]*)/[0-9]*/(.*)$", profileDevice)
             if deviceVals is not None:
                 if deviceVals.group(1) == "SDL" and deviceVals.group(2).strip() == pad.real_name.strip():
-                    eslog.debug("Eligible profile device found")
+                    _logger.debug("Eligible profile device found")
                     for key, val in profileConfig.items("Profile"):
                         if key != "Device":
                             f.write(f"{key} = {val}\n")
                     return True
         except:
-            eslog.error(f"profile {profileFile} : FAILED")
+            _logger.error("profile %s : FAILED", profileFile)
 
     return False
 
@@ -263,7 +264,7 @@ def write_key(f: codecs.StreamReaderWriter, keyname: str, input_type: str, input
         elif input_value == "8": # left
             f.write("Hat 0 W")
         elif input_value == "2": # right
-            f.write("Hat 0 E")   
+            f.write("Hat 0 E")
     elif input_type == "axis":
         if (reverse and input_value == "-1") or (not reverse and input_value == "1") or (not reverse and input_value == "0"):
             if "-Analog" in keyname:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation/duckstationGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -16,7 +15,6 @@ if TYPE_CHECKING:
 
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
 
 class DuckstationGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation_legacy/duckstationLegacyGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/duckstation_legacy/duckstationLegacyGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -14,8 +13,6 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-
-eslog = logging.getLogger(__name__)
 
 class DuckstationLegacyGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
@@ -10,7 +10,7 @@ from .flycastPaths import FLYCAST_MAPPING
 if TYPE_CHECKING:
     from ...controller import Controller
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 flycastMapping = { # Directions
@@ -69,10 +69,10 @@ sections = ( 'analog', 'digital', 'emulator' )
 def generateControllerConfig(controller: Controller, type: Literal['dreamcast', 'arcade']):
     # Set config file name
     if type == 'dreamcast':
-        eslog.debug("-=[ Dreamcast Controller Settings ]=-")
+        _logger.debug("-=[ Dreamcast Controller Settings ]=-")
         configFileName = FLYCAST_MAPPING / f"SDL_{controller.real_name}.cfg"
     else: # 'arcade'
-        eslog.debug("-=[ Arcade Controller Settings ]=-")
+        _logger.debug("-=[ Arcade Controller Settings ]=-")
         configFileName = FLYCAST_MAPPING / f"SDL_{controller.real_name}_arcade.cfg"
 
     Config = configparser.ConfigParser(interpolation=None)
@@ -84,7 +84,7 @@ def generateControllerConfig(controller: Controller, type: Literal['dreamcast', 
         Config.add_section(section)
 
     # Parse controller inputs
-    eslog.debug("*** Controller Name = {} ***".format(controller.real_name))
+    _logger.debug("*** Controller Name = %s ***", controller.real_name)
     analogbind = 0
     digitalbind = 0
     for index in controller.inputs:
@@ -93,17 +93,17 @@ def generateControllerConfig(controller: Controller, type: Literal['dreamcast', 
             if input.name not in flycastMapping:
                 continue
             if input.type not in flycastMapping[input.name]:
-                eslog.debug("Input type: {} / {} - not in mapping".format(input.type, input.name))
+                _logger.debug("Input type: %s / %s - not in mapping", input.type, input.name)
                 continue
             var = flycastMapping[input.name][input.type]
         if type == 'arcade':
             if input.name not in flycastArcadeMapping:
                 continue
             if input.type not in flycastArcadeMapping[input.name]:
-                eslog.debug("Input type: {} - not in mapping".format(input.type))
+                _logger.debug("Input type: %s - not in mapping", input.type)
                 continue
             var = flycastArcadeMapping[input.name][input.type]
-        eslog.debug("Input Name = {}, Var = {}, Type = {}".format(input.name, var, input.type))
+        _logger.debug("Input Name = %s, Var = %s, Type = %s", input.name, var, input.type)
         # batocera doesn't retrieve the code for hats, however
         # SDL is 256 for up, 257 for down, 258 for left & 259 for right
         if input.type == 'hat':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fpinball/fpinballGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 from pathlib import Path, PureWindowsPath
@@ -13,8 +12,6 @@ from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
-
-eslog = logging.getLogger(__name__)
 
 _FPINBALL_CONFIG: Final = CONFIGS / "fpinball"
 _FPINBALL_CONFIG_REG: Final = _FPINBALL_CONFIG / "batocera.confg.reg"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
@@ -14,7 +14,7 @@ from .fsuaePaths import FSUAE_BIOS_DIR, FSUAE_CONFIG_DIR, FSUAE_SAVES
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class FsuaeGenerator(Generator):
 
@@ -84,11 +84,11 @@ class FsuaeGenerator(Generator):
                 if (d.endswith("ipf") or d.endswith("adf") or d.endswith("dms") or d.endswith("adz")):
                     diskNames.append(name)
 
-            eslog.debug("Amount of disks in zip " + str(len(diskNames)))
+            _logger.debug("Amount of disks in zip %s", len(diskNames))
 
         # if 2+ files, we have a multidisk ZIP (0=no zip)
         if (len(diskNames) > 1):
-            eslog.debug("extracting...")
+            _logger.debug("extracting...")
             shutil.rmtree(TEMP_DIR, ignore_errors=True) # cleanup
             zf.extractall(TEMP_DIR)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/gsplus/gsplusGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,7 +12,6 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
 _CONFIGDIR  = CONFIGS / 'GSplus'
 _CONFIGFILE = _CONFIGDIR / 'config.txt'
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hatari/hatariGenerator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 # libretro generator uses this, so it needs to be public
 HATARI_CONFIG: Final = CONFIGS / "hatari"
@@ -197,9 +197,9 @@ class HatariGenerator(Generator):
                         biosversion = f"tos{v_tos_version}"
                     tos_path = biosdir / f"{biosversion}{v_language}.img"
                     if tos_path.exists():
-                        eslog.debug(f"tos filename: {tos_path.name}")
+                        _logger.debug("tos filename: %s", tos_path.name)
                         return tos_path
                     else:
-                        eslog.warning(f"tos filename {tos_path.name} not found")
+                        _logger.warning("tos filename %s not found", tos_path.name)
 
         raise Exception(f"no bios found for machine {machine}")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hcl/hclGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hcl/hclGenerator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class HclGenerator(Generator):
 
@@ -27,7 +27,7 @@ class HclGenerator(Generator):
             os.chdir(ROMS / "hcl" / "data" / "map")
             os.chdir(ROMS / "hcl")
         except:
-            eslog.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
+            _logger.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
         commandArray = ["hcl", "-d"]
 
         return Command.Command(

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hurrican/hurricanGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hurrican/hurricanGenerator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class HurricanGenerator(Generator):
 
@@ -21,7 +21,7 @@ class HurricanGenerator(Generator):
             os.chdir(ROMS / "hurrican" / "data" / "levels/")
             os.chdir(ROMS / "hurrican")
         except:
-            eslog.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
+            _logger.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
         commandArray = ["hurrican"]
 
         return Command.Command(

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/hypseus_singe/hypseusSingeGenerator.py
@@ -17,7 +17,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _DATA_DIR: Final = CONFIGS / 'hypseus-singe'
 _CONFIG: Final = _DATA_DIR / 'hypinput.ini'
@@ -52,7 +52,7 @@ class HypseusSingeGenerator(Generator):
         for root, dirs, files in os.walk(start_path):
             if filename in files:
                 full_path = Path(root) / filename
-                eslog.debug("Found m2v file in path - {}".format(full_path))
+                _logger.debug("Found m2v file in path - %s", full_path)
                 return full_path
 
         return None
@@ -161,24 +161,24 @@ class HypseusSingeGenerator(Generator):
         m2v_filename = self.find_m2v_from_txt(frameFile)
 
         if m2v_filename:
-            eslog.debug("First .m2v file found: {}".format(m2v_filename))
+            _logger.debug("First .m2v file found: %s", m2v_filename)
         else:
-            eslog.debug("No .m2v files found in the text file.")
+            _logger.debug("No .m2v files found in the text file.")
 
         # now get the resolution from the m2v file
         video_path = rom_path / m2v_filename if m2v_filename is not None else rom_path
 
         # check the path exists
         if not video_path.exists():
-            eslog.debug("Could not find m2v file in path - {}".format(video_path))
+            _logger.debug("Could not find m2v file in path - %s", video_path)
             video_path = self.find_file(rom_path, cast(str, m2v_filename))
 
-        eslog.debug("Full m2v path is: {}".format(video_path))
+        _logger.debug("Full m2v path is: %s", video_path)
 
         video_resolution: tuple[int, int] | None = None
         if video_path != None:
             video_resolution = self.get_resolution(video_path)
-            eslog.debug("Resolution: {}".format(video_resolution))
+            _logger.debug("Resolution: %s", video_resolution)
 
         if system.name == "singe":
             commandArray = ['/usr/bin/hypseus',
@@ -225,7 +225,7 @@ class HypseusSingeGenerator(Generator):
                 else:
                     bezelRequired = False
             else:
-                eslog.debug("Video resolution not found - using stretch")
+                _logger.debug("Video resolution not found - using stretch")
                 commandArray.extend(["-x", str(gameResolution["width"]), "-y", str(gameResolution["height"])])
                 if abs(gameResolution["width"] / gameResolution["height"] - 4/3) < 0.01:
                     xratio = 4/3

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ikemen/ikemenGenerator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,8 +11,6 @@ from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
-
-eslog = logging.getLogger(__name__)
 
 Keymapping =[
         {

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lemonade/lemonadeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lemonade/lemonadeGenerator.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from ...controller import ControllerMapping
     from ...Emulator import Emulator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class LemonadeGenerator(Generator):
 
@@ -155,17 +155,17 @@ class LemonadeGenerator(Generator):
         # Set Vulkan as necessary
         if system.isOptSet("lemonade_graphics_api") and system.config["lemonade_graphics_api"] == "2":
             if vulkan.is_available():
-                eslog.debug("Vulkan driver is available on the system.")
+                _logger.debug("Vulkan driver is available on the system.")
                 if vulkan.has_discrete_gpu():
-                    eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                    _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                     discrete_index = vulkan.get_discrete_gpu_index()
                     if discrete_index:
-                        eslog.debug("Using Discrete GPU Index: {} for Lemonade".format(discrete_index))
+                        _logger.debug("Using Discrete GPU Index: %s for Lemonade", discrete_index)
                         lemonadeConfig.set("Renderer", "physical_device", discrete_index)
                     else:
-                        eslog.debug("Couldn't get discrete GPU index")
+                        _logger.debug("Couldn't get discrete GPU index")
                 else:
-                    eslog.debug("Discrete GPU is not available on the system. Using default.")
+                    _logger.debug("Discrete GPU is not available on the system. Using default.")
         # Use VSYNC
         if system.isOptSet('lemonade_use_vsync_new') and system.config["lemonade_use_vsync_new"] == '0':
             lemonadeConfig.set("Renderer", "use_vsync_new", "false")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lexaloffle/lexaloffleGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -12,8 +11,6 @@ from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
-
-eslog = logging.getLogger(__name__)
 
 PICO8_BIN_PATH: Final = BIOS / "pico-8" / "pico8"
 PICO8_ROOT_PATH: Final = ROMS / "pico8"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroGenerator.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class LibretroGenerator(Generator):
 
@@ -81,10 +81,10 @@ class LibretroGenerator(Generator):
                 shaderFilename = f"{gameShader}.slangp"
             else:
                 shaderFilename = f"{gameShader}.glslp"
-            eslog.debug(f"searching shader {shaderFilename}")
+            _logger.debug("searching shader %s", shaderFilename)
             if (USER_SHADERS / shaderFilename).exists():
                 video_shader_dir = USER_SHADERS
-                eslog.debug(f"shader {shaderFilename} found in {USER_SHADERS}")
+                _logger.debug("shader %s found in %s", shaderFilename, USER_SHADERS)
             else:
                 video_shader_dir = BATOCERA_SHADERS
             video_shader = video_shader_dir / shaderFilename
@@ -275,7 +275,7 @@ class LibretroGenerator(Generator):
                 first_line = file.readline().strip()
             # creating the new 'rom_path' variable by combining the directory path and the first line
             rom_path = rom_path.parent / first_line
-            eslog.debug(f"New rom path: {rom_path}")
+            _logger.debug("New rom path: %s", rom_path)
             # choose core based on new rom directory
             directory_parts = rom_path.parent.parts
             if "d3xp" in directory_parts:
@@ -304,7 +304,7 @@ class LibretroGenerator(Generator):
                     os.chdir(romdir / assetdir)
                 os.chdir(romdir)
             except FileNotFoundError:
-                eslog.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
+                _logger.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
                 raise
 
             commandArray = [RETROARCH_BIN, "-L", retroarchCore, "--config", system.config['configfile']]

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import GunMapping
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 # Define RetroPad inputs for mapping
 retroPad = {
@@ -164,7 +164,7 @@ def generateMAMEConfigs(playersControllers: ControllerMapping, system: Emulator,
                     commandLine += ["-sl7", "cffa202"]
                 if system.isOptSet('gameio') and system.config['gameio'] != 'none':
                     if system.config['gameio'] == 'joyport' and messModel != 'apple2p':
-                        eslog.debug("Joyport is only compatible with Apple II +")
+                        _logger.debug("Joyport is only compatible with Apple II +")
                     else:
                         commandLine += ["-gameio", system.config['gameio']]
                         specialController = system.config['gameio']

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from ...input import Input
     from ...types import DeviceInfoMapping, GunMapping
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 def generatePadsConfig(cfgPath: Path, playersControllers: ControllerMapping, sysName: str, altButtons: str | int, customCfg: bool, specialController: str, decorations: str | None, useGuns: bool, guns: GunMapping, useWheels: bool, wheels: DeviceInfoMapping, useMouse: bool, multiMouse: bool, system: Emulator) -> None:
     # config file
@@ -105,7 +105,7 @@ def generatePadsConfig(cfgPath: Path, playersControllers: ControllerMapping, sys
             useControls = f"apple2-{specialController}"
     else:
         useControls = sysName
-    eslog.debug(f"Using {useControls} for controller config.")
+    _logger.debug("Using %s for controller config.", useControls)
 
     # Open or create alternate config file for systems with special controllers/settings
     # If the system/game is set to per game config, don't try to open/reset an existing file, only write if it's blank or going to the shared cfg folder
@@ -222,7 +222,7 @@ def generatePadsConfig(cfgPath: Path, playersControllers: ControllerMapping, sys
             for w in wheels:
                 if wheels[w]["joystick_index"] == pad.index:
                     isWheel = True
-                    eslog.debug(f"player {nplayer} has a wheel")
+                    _logger.debug("player %s has a wheel", nplayer)
             if isWheel:
                 for x in mappings_use.copy():
                     if mappings_use[x] == "l2" or mappings_use[x] == "r2" or mappings_use[x] == "joystick1left":
@@ -304,14 +304,14 @@ def generatePadsConfig(cfgPath: Path, playersControllers: ControllerMapping, sys
     #mameXml = open(configFile, "w")
     # TODO: python 3 - workawround to encode files in utf-8
     if overwriteMAME:
-        eslog.debug(f"Saving {configFile}")
+        _logger.debug("Saving %s", configFile)
         with codecs.open(str(configFile), "w", "utf-8") as mameXml:
             dom_string = os.linesep.join([s for s in config.toprettyxml().splitlines() if s.strip()]) # remove ugly empty lines while minicom adds them...
             mameXml.write(dom_string)
 
     # Write alt config (if used, custom config is turned off or file doesn't exist yet)
     if sysName in specialControlList and overwriteSystem:
-        eslog.debug(f"Saving {configFile_alt}")
+        _logger.debug("Saving %s", configFile_alt)
         with codecs.open(str(configFile_alt), "w", "utf-8") as mameXml_alt:
             dom_string_alt = os.linesep.join([s for s in config_alt.toprettyxml().splitlines() if s.strip()]) # remove ugly empty lines while minicom adds them...
             mameXml_alt.write(dom_string_alt)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext, Resolution
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 class MameGenerator(Generator):
@@ -344,7 +344,7 @@ class MameGenerator(Generator):
                 commandArray += ["-sl7", "cffa202"]
                 if system.isOptSet('gameio') and system.config['gameio'] != 'none':
                     if system.config['gameio'] == 'joyport' and messModel != 'apple2p':
-                        eslog.debug("Joyport joystick is only compatible with Apple II Plus")
+                        _logger.debug("Joyport joystick is only compatible with Apple II Plus")
                     else:
                         commandArray += ["-gameio", system.config['gameio']]
                         specialController = system.config['gameio']
@@ -718,19 +718,19 @@ class MameGenerator(Generator):
                         tattoo_file = BATOCERA_SHARE_DIR / 'controller-overlays' / 'generic.png'
                     tattoo = Image.open(tattoo_file)
                 except Exception as e:
-                    eslog.error(f"Error opening controller overlay: {tattoo_file}")
+                    _logger.error("Error opening controller overlay: %s", tattoo_file)
             elif system.config['bezel.tattoo'] == 'custom' and Path(system.config['bezel.tattoo_file']).exists():
+                tattoo_file = Path(system.config['bezel.tattoo_file'])
                 try:
-                    tattoo_file = Path(system.config['bezel.tattoo_file'])
                     tattoo = Image.open(tattoo_file)
                 except:
-                    eslog.error("Error opening custom file: {}".format('tattoo_file'))
+                    _logger.error("Error opening custom file: %s", tattoo_file)
             else:
+                tattoo_file = BATOCERA_SHARE_DIR / 'controller-overlays' / 'generic.png'
                 try:
-                    tattoo_file = BATOCERA_SHARE_DIR / 'controller-overlays' / 'generic.png'
                     tattoo = Image.open(tattoo_file)
                 except:
-                    eslog.error("Error opening custom file: {}".format('tattoo_file'))
+                    _logger.error("Error opening custom file: %s", tattoo_file)
             output_png_file = Path("/tmp/bezel_tattooed.png")
             back = Image.open(pngFile)
             tattoo = tattoo.convert("RGBA")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/model2emu/model2emuGenerator.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 MODEL2_ROMS: Final = ROMS / "model2"
 
@@ -310,7 +310,7 @@ def copy_updated_files(source_path: Path, destination_path: Path) -> None:
 
         if src.is_dir():
             shutil.copytree(src, dst)
-            eslog.debug(f"Copying directory {src} to {dst}")
+            _logger.debug("Copying directory %s to %s", src, dst)
         else:
             shutil.copy2(src, dst)
-            eslog.debug(f"Copying file {src} to {dst}")
+            _logger.debug("Copying file %s to %s", src, dst)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborControllers.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ...controller import Controller, ControllerMapping
     from ...settings.unixSettings import UnixSettings
-
-
-eslog = logging.getLogger(__name__)
 
 def generateControllerConfig(config: UnixSettings, playersControllers: ControllerMapping, core: str):
     if core == "openbor4432":
@@ -58,7 +54,7 @@ def JoystickValue(key: str, pad: Controller, joy_max_inputs: int, new_axis_vals:
     if input.type != "keyboard":
         value += 600
 
-    #eslog.debug("input.type={} input.id={} input.value={} => result={}".format(input.type, input.id, input.value, value))
+    # _logger.debug("input.type=%s input.id=%s input.value=%s => result=%s", input.type, input.id, input.value, value)
     return value
 
 def setupControllers(config: UnixSettings, playersControllers: ControllerMapping, joy_max_inputs: int, new_axis_vals: bool) -> None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openbor/openborGenerator.py
@@ -15,7 +15,7 @@ from . import openborControllers
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class OpenborGenerator(Generator):
 
@@ -35,7 +35,7 @@ class OpenborGenerator(Generator):
         core: str = system.config['core']
         if system.config["core-forced"] == False:
             core = OpenborGenerator.guessCore(rom)
-        eslog.debug(f"core taken is {core}")
+        _logger.debug("core taken is %s", core)
 
         # config file
         configfilename = "config7530.ini"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openjazz/openjazzGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openjazz/openjazzGenerator.py
@@ -11,7 +11,7 @@ from ...batoceraPaths import CACHE, CONFIGS, ROMS, SAVES, mkdir_if_not_exists
 from ...controller import generate_sdl_game_controller_config
 from ..Generator import Generator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
@@ -81,7 +81,7 @@ class OpenJazzGenerator(Generator):
 
     def load(self, filename=_CONFIG):
         if not Path(filename).exists():
-            eslog.info("No config file found, creating default configuration")
+            _logger.info("No config file found, creating default configuration")
             self.create_default_config(filename)
             return
 
@@ -90,12 +90,12 @@ class OpenJazzGenerator(Generator):
                 # Read version
                 data = file.read(1)
                 if not data:
-                    eslog.warning("Empty config file, creating default configuration")
+                    _logger.warning("Empty config file, creating default configuration")
                     self.create_default_config(filename)
                     return
 
                 self.version = struct.unpack("B", data)[0]
-                eslog.debug(f"Loading configuration version: {self.version}")
+                _logger.debug("Loading configuration version: %s", self.version)
 
                 # Video settings
                 self.video_width = struct.unpack("<H", file.read(2))[0]
@@ -150,12 +150,12 @@ class OpenJazzGenerator(Generator):
                 self.scale2x = not bool(gameplay_opts & 8)
 
         except Exception as e:
-            eslog.error(f"Error loading configuration: {e}")
-            eslog.info("Creating new default configuration")
+            _logger.error("Error loading configuration: %s", e)
+            _logger.info("Creating new default configuration")
             self.create_default_config(filename)
 
     def create_default_config(self, filename: Path):
-        eslog.info("Creating default configuration file")
+        _logger.info("Creating default configuration file")
         mkdir_if_not_exists(filename.parent)
 
         try:
@@ -206,10 +206,10 @@ class OpenJazzGenerator(Generator):
                 file.write(struct.pack("B", gameplay_opts))
 
         except Exception as e:
-            eslog.error(f"Error creating default configuration: {e}")
+            _logger.error("Error creating default configuration: %s", e)
 
     def save(self, filename=_CONFIG):
-        eslog.info("Saving configuration")
+        _logger.info("Saving configuration")
         try:
             with filename.open("wb") as file:
                 # Version
@@ -255,27 +255,27 @@ class OpenJazzGenerator(Generator):
                 file.write(struct.pack("B", gameplay_opts))
 
         except Exception as e:
-            eslog.error(f"Error saving configuration: {e}")
+            _logger.error("Error saving configuration: %s", e)
 
     def print_config(self):
-        eslog.info("OpenJazz Configuration:")
-        eslog.info(f"Version: {self.version}")
-        eslog.info(f"Resolution: {self.video_width}x{self.video_height}")
-        eslog.info(f"Fullscreen: {self.fullscreen}")
-        eslog.info(f"Video Scale: {self.video_scale}")
-        eslog.info(f"Character Name: {self.character_name}")
-        eslog.info(f"Character Colors: {self.character_colors}")
-        eslog.info(f"Music Volume: {self.music_volume}")
-        eslog.info(f"Sound Volume: {self.sound_volume}")
-        eslog.info(f"Many Birds: {self.many_birds}")
-        eslog.info(f"Leave Unneeded: {self.leave_unneeded}")
-        eslog.info(f"Slow Motion: {self.slow_motion}")
-        eslog.info(f"Scale2x: {self.scale2x}")
-        eslog.info("Controls Configuration:")
-        eslog.info(f"Keys: {self.controls_keys}")
-        eslog.info(f"Buttons: {self.controls_buttons}")
-        eslog.info(f"Axes: {self.controls_axes}")
-        eslog.info(f"Hats: {self.controls_hats}")
+        _logger.info("OpenJazz Configuration:")
+        _logger.info("Version: %s", self.version)
+        _logger.info("Resolution: %sx%s", self.video_width, self.video_height)
+        _logger.info("Fullscreen: %s", self.fullscreen)
+        _logger.info("Video Scale: %s", self.video_scale)
+        _logger.info("Character Name: %s", self.character_name)
+        _logger.info("Character Colors: %s", self.character_colors)
+        _logger.info("Music Volume: %s", self.music_volume)
+        _logger.info("Sound Volume: %s", self.sound_volume)
+        _logger.info("Many Birds: %s", self.many_birds)
+        _logger.info("Leave Unneeded: %s", self.leave_unneeded)
+        _logger.info("Slow Motion: %s", self.slow_motion)
+        _logger.info("Scale2x: %s", self.scale2x)
+        _logger.info("Controls Configuration:")
+        _logger.info("Keys: %s", self.controls_keys)
+        _logger.info("Buttons: %s", self.controls_buttons)
+        _logger.info("Axes: %s", self.controls_axes)
+        _logger.info("Hats: %s", self.controls_hats)
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
         # Load configuration file
@@ -317,7 +317,7 @@ class OpenJazzGenerator(Generator):
                             self.controls_buttons[12] = int(input.id)
                         elif input.name == 'start':
                             self.controls_buttons[11] = int(input.id)
-                eslog.info(f"Configured Controls - Buttons: {self.controls_buttons}")
+                _logger.info("Configured Controls - Buttons: %s", self.controls_buttons)
 
             nplayer += 1
 
@@ -338,7 +338,7 @@ class OpenJazzGenerator(Generator):
         try:
             os.chdir(ROMS / "openjazz")
         except Exception as e:
-            eslog.error(f"Error: {e}")
+            _logger.error("Error: %s", e)
 
         commandArray = ["OpenJazz"]
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/openmsx/openmsxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/openmsx/openmsxGenerator.py
@@ -16,7 +16,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 openMSX_Homedir: Final = CONFIGS / 'openmsx'
 openMSX_Config: Final = Path('/usr/share/openmsx')
@@ -172,11 +172,11 @@ class OpenmsxGenerator(Generator):
                     file_extension = Path(zip_info.filename).suffix
                     # usually zip files only contain 1 file however break loop if file extension found
                     if file_extension in [".cas", ".dsk", ".ogv"]:
-                        eslog.debug(f"Zip file contains: {file_extension}")
+                        _logger.debug("Zip file contains: %s", file_extension)
                         break
 
         if file_extension == ".ogv":
-            eslog.debug("File is a laserdisc")
+            _logger.debug("File is a laserdisc")
             for i in range(len(commandArray)):
                 if commandArray[i] == "-machine":
                     commandArray[i+1] = "Pioneer_PX-7"
@@ -184,13 +184,13 @@ class OpenmsxGenerator(Generator):
                     commandArray[i] = "-laserdisc"
 
         if file_extension == ".cas":
-            eslog.debug("File is a cassette")
+            _logger.debug("File is a cassette")
             for i in range(len(commandArray)):
                 if commandArray[i] == "-cart":
                     commandArray[i] = "-cassetteplayer"
 
         if file_extension == ".dsk":
-            eslog.debug("File is a disk")
+            _logger.debug("File is a disk")
             disk_type = "-diska"
             if system.isOptSet("openmsx_disk") and system.config["openmsx_disk"] == "hda":
                 disk_type = "-hda"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from ...input import Input
     from ...types import DeviceInfoMapping, GunMapping, HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _PCSX2_BIN_DIR: Final = Path("/usr/pcsx2/bin")
 _PCSX2_RESOURCES_DIR: Final = _PCSX2_BIN_DIR / "resources"
@@ -104,7 +104,7 @@ class Pcsx2Generator(Generator):
 
         with Path("/proc/cpuinfo").open() as cpuinfo:
             if not re.search(r'^flags\s*:.*\ssse4_1\W', cpuinfo.read(), re.MULTILINE):
-                eslog.warning("CPU does not support SSE4.1 which is required by pcsx2.  The emulator will likely crash with SIGILL (illegal instruction).")
+                _logger.warning("CPU does not support SSE4.1 which is required by pcsx2.  The emulator will likely crash with SIGILL (illegal instruction).")
 
         # use their modified shaderc library
         envcmd = {
@@ -304,34 +304,34 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
     # Renderer
     # Check Vulkan first to be sure
     if vulkan.is_available():
-        eslog.debug("Vulkan driver is available on the system.")
+        _logger.debug("Vulkan driver is available on the system.")
         renderer = "12"  # Default to OpenGL
 
         if system.isOptSet("pcsx2_gfxbackend"):
             if system.config["pcsx2_gfxbackend"] == "13":
-                eslog.debug("User selected Software! Man you must have a fast CPU!")
+                _logger.debug("User selected Software! Man you must have a fast CPU!")
                 renderer = "13"
             elif system.config["pcsx2_gfxbackend"] == "14":
-                eslog.debug("User selected Vulkan")
+                _logger.debug("User selected Vulkan")
                 renderer = "14"
                 if vulkan.has_discrete_gpu():
-                    eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                    _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                     discrete_name = vulkan.get_discrete_gpu_name()
                     if discrete_name:
-                        eslog.debug("Using Discrete GPU Name: {} for PCSX2".format(discrete_name))
+                        _logger.debug("Using Discrete GPU Name: %s for PCSX2", discrete_name)
                         pcsx2INIConfig.set("EmuCore/GS", "Adapter", discrete_name)
                     else:
-                        eslog.debug("Couldn't get discrete GPU Name")
+                        _logger.debug("Couldn't get discrete GPU Name")
                         pcsx2INIConfig.set("EmuCore/GS", "Adapter", "(Default)")
                 else:
-                    eslog.debug("Discrete GPU is not available on the system. Using default.")
+                    _logger.debug("Discrete GPU is not available on the system. Using default.")
                     pcsx2INIConfig.set("EmuCore/GS", "Adapter", "(Default)")
         else:
-            eslog.debug("User selected or defaulting to OpenGL")
+            _logger.debug("User selected or defaulting to OpenGL")
 
         pcsx2INIConfig.set("EmuCore/GS", "Renderer", renderer)
     else:
-        eslog.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
+        _logger.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
         pcsx2INIConfig.set("EmuCore/GS", "Renderer", "12")
 
     # Ratio
@@ -584,7 +584,7 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
 
     # wheels
     wtype = Pcsx2Generator.getWheelType(metadata, playingWithWheel, system.config)
-    eslog.info("PS2 wheel type is {}".format(wtype));
+    _logger.info("PS2 wheel type is %s", wtype)
     if Pcsx2Generator.useEmulatorWheels(playingWithWheel, wtype):
         if len(wheels) >= 1:
             wheelMapping = {
@@ -665,7 +665,7 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
     # add multitap as needed
     multiTap = 2
     joystick_count = len(controllers)
-    eslog.debug("Number of Controllers = {}".format(joystick_count))
+    _logger.debug("Number of Controllers = %s", joystick_count)
     if system.isOptSet("pcsx2_multitap") and system.config["pcsx2_multitap"] == "4":
         if joystick_count > 2 and joystick_count < 5:
             pcsx2INIConfig.set("Pad", "MultitapPort1", "true")
@@ -673,10 +673,10 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
         elif joystick_count > 4:
             pcsx2INIConfig.set("Pad", "MultitapPort1", "true")
             multiTap = 4
-            eslog.debug("*** You have too many connected controllers for this option, restricting to 4 ***")
+            _logger.debug("*** You have too many connected controllers for this option, restricting to 4 ***")
         else:
             multiTap = 2
-            eslog.debug("*** You have the wrong number of connected controllers for this option ***")
+            _logger.debug("*** You have the wrong number of connected controllers for this option ***")
     elif system.isOptSet("pcsx2_multitap") and system.config["pcsx2_multitap"] == "8":
         if joystick_count > 4:
             pcsx2INIConfig.set("Pad", "MultitapPort1", "true")
@@ -685,10 +685,10 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
         elif joystick_count > 2 and joystick_count < 5:
             pcsx2INIConfig.set("Pad", "MultitapPort1", "true")
             multiTap = 4
-            eslog.debug("*** You don't have enough connected controllers for this option, restricting to 4 ***")
+            _logger.debug("*** You don't have enough connected controllers for this option, restricting to 4 ***")
         else:
             multiTap = 2
-            eslog.debug("*** You don't have enough connected controllers for this option ***")
+            _logger.debug("*** You don't have enough connected controllers for this option ***")
     else:
         multiTap = 2
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 ppssppConfig: Final   = PPSSPP_PSP_SYSTEM_DIR / 'ppsspp.ini'
 ppssppControls: Final = PPSSPP_PSP_SYSTEM_DIR / 'controls.ini'
@@ -45,19 +45,19 @@ def createPPSSPPConfig(iniConfig, system):
     if system.isOptSet("gfxbackend") and system.config["gfxbackend"] == "3 (VULKAN)":
         # Check if we have a discrete GPU & if so, set the Name
         if vulkan.is_available():
-            eslog.debug("Vulkan driver is available on the system.")
+            _logger.debug("Vulkan driver is available on the system.")
             if vulkan.has_discrete_gpu():
-                eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                 discrete_name = vulkan.get_discrete_gpu_name()
                 if discrete_name:
-                    eslog.debug("Using Discrete GPU Name: {} for PPSSPP".format(discrete_name))
+                    _logger.debug("Using Discrete GPU Name: %s for PPSSPP", discrete_name)
                     iniConfig.set("Graphics", "VulkanDevice", discrete_name)
                 else:
-                    eslog.debug("Couldn't get discrete GPU Name")
+                    _logger.debug("Couldn't get discrete GPU Name")
             else:
-                eslog.debug("Discrete GPU is not available on the system. Using default.")
+                _logger.debug("Discrete GPU is not available on the system. Using default.")
         else:
-            eslog.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
+            _logger.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
             iniConfig.set("Graphics", "GraphicsBackend", "0 (OPENGL)")
 
     # Display FPS

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppControllers.py
@@ -10,7 +10,7 @@ from .ppssppPaths import PPSSPP_CONFIG_INIT, PPSSPP_PSP_SYSTEM_DIR
 if TYPE_CHECKING:
     from ...controller import Controller
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 ppssppControlsIni: Final  = PPSSPP_PSP_SYSTEM_DIR / 'controls.ini'
 ppssppControlsInit: Final = PPSSPP_CONFIG_INIT / 'controls.ini'
@@ -161,7 +161,7 @@ def generateControllerConfig(controller: Controller):
             pspcode = axisToCode(nkAxisId, int(input.value))
             val = f"{DEVICE_ID_PAD_0 + padnum}-{pspcode}"
             val = optionValue(Config, section, var, val)
-            eslog.debug(f"Adding {var} to {val}")
+            _logger.debug("Adding %s to %s", var, val)
             Config.set(section, var, val)
 
             # Skip the rest if it's an axis dpad

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/raze/razeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/raze/razeGenerator.py
@@ -14,7 +14,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class RazeGenerator(Generator):
 
@@ -89,7 +89,7 @@ class RazeGenerator(Generator):
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
 
         architecture = get_cpu_architecture()
-        eslog.debug(f"*** Detected architecture is: {architecture} ***")
+        _logger.debug("*** Detected architecture is: %s ***", architecture)
 
         mkdir_if_not_exists(self.config_dir)
         mkdir_if_not_exists(self.saves_dir)
@@ -124,7 +124,7 @@ class RazeGenerator(Generator):
                                 if architecture in ["x86_64", "amd64", "i686", "i386"]:
                                     line = "gl_es=false\n"
                                 else:
-                                    eslog.debug(f"*** Architecture isn't intel it's: {architecture} therefore es is true ***")
+                                    _logger.debug("*** Architecture isn't intel it's: %s therefore es is true ***", architecture)
                                     line = "gl_es=true\n"
                         else:
                             line = "gl_es=true\n"
@@ -141,14 +141,14 @@ class RazeGenerator(Generator):
 
             # If [GlobalSettings] was not found, add it with the modified options
             if not global_settings_found:
-                eslog.debug("Global Settings NOT found")
+                _logger.debug("Global Settings NOT found")
                 config_file.write("[GlobalSettings]\n")
                 if system.isOptSet("raze_api") and system.config["raze_api"] != "2":
                     if system.isOptSet("raze_api") and system.config["raze_api"] == "0":
                         if architecture in ["x86_64", "amd64", "i686", "i386"]:
                             line = "gl_es=false\n"
                         else:
-                            eslog.debug(f"*** Architecture isn't intel it's: {architecture} therefore es is true ***")
+                            _logger.debug("*** Architecture isn't intel it's: %s therefore es is true ***", architecture)
                             line = "gl_es=true\n"
                 if system.isOptSet("raze_api"):
                     config_file.write(f"vid_preferbackend={system.config['raze_api']}\n")

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Controllers.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ...controller import ControllerMapping
     from ...Emulator import Emulator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _RPCS3_INPUT_DIR: Final = RPCS3_CONFIG_DIR / "input_configs" / "global"
 
@@ -72,10 +72,10 @@ def generateControllerConfig(system: Emulator, controllers: ControllerMapping, r
     f = codecs.open(str(configFileName), "w", encoding="utf_8_sig")
     for controller, pad in sorted(controllers.items()):
         if nplayer <= 7:
-            eslog.debug(f"Controller #{nplayer} - {pad.guid}")
+            _logger.debug("Controller #%s - %s", nplayer, pad.guid)
             # check for DualShock / DualSense
             if pad.guid in valid_sony_guids and f"rpcs3_controller{nplayer}" in system.config and system.config[f"rpcs3_controller{nplayer}"] == "Sony":
-                eslog.debug("*** Using DualShock / DualSense configuration ***")
+                _logger.debug("*** Using DualShock / DualSense configuration ***")
                 # dualshock 3
                 if pad.guid in valid_sony_guids[:4]:
                     f.write(f'Player {nplayer} Input:\n')
@@ -175,7 +175,7 @@ def generateControllerConfig(system: Emulator, controllers: ControllerMapping, r
                 f.write('    Product ID: 616\n')
                 f.write('  Buddy Device: ""\n')
             elif f"rpcs3_controller{nplayer}" in system.config and system.config[f"rpcs3_controller{nplayer}"] == "Evdev":
-                eslog.debug("*** Using EVDEV configuration ***")
+                _logger.debug("*** Using EVDEV configuration ***")
                 # evdev
                 f.write(f'Player {nplayer} Input:\n')
                 f.write('  Handler: Evdev\n')
@@ -275,7 +275,7 @@ def generateControllerConfig(system: Emulator, controllers: ControllerMapping, r
                 f.write('    Product ID: 616\n')
                 f.write('  Buddy Device: ""\n')
             else:
-                eslog.debug("*** Using default SDL2 configuration ***")
+                _logger.debug("*** Using default SDL2 configuration ***")
                 f.write(f'Player {nplayer} Input:\n')
                 f.write(f'  Handler: SDL\n')
                 # workaround controllers with commas in their name - like Nintendo

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -20,7 +20,7 @@ from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class Rpcs3Generator(Generator):
 
@@ -130,27 +130,27 @@ class Rpcs3Generator(Generator):
         # gfx backend - default to Vulkan
         # Check Vulkan first to be sure
         if vulkan.is_available():
-            eslog.debug("Vulkan driver is available on the system.")
+            _logger.debug("Vulkan driver is available on the system.")
             if system.isOptSet("rpcs3_gfxbackend") and system.config["rpcs3_gfxbackend"] == "OpenGL":
-                eslog.debug("User selected OpenGL")
+                _logger.debug("User selected OpenGL")
                 rpcs3ymlconfig["Video"]["Renderer"] = "OpenGL"
             else:
                 rpcs3ymlconfig["Video"]["Renderer"] = "Vulkan"
 
             if vulkan.has_discrete_gpu():
-                eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                 discrete_name = vulkan.get_discrete_gpu_name()
                 if discrete_name:
-                    eslog.debug("Using Discrete GPU Name: {} for RPCS3".format(discrete_name))
+                    _logger.debug("Using Discrete GPU Name: %s for RPCS3", discrete_name)
                     if "Vulkan" not in rpcs3ymlconfig["Video"]:
                         rpcs3ymlconfig["Video"]["Vulkan"] = {}
                     rpcs3ymlconfig["Video"]["Vulkan"]["Adapter"] = discrete_name
                 else:
-                    eslog.debug("Couldn't get discrete GPU Name")
+                    _logger.debug("Couldn't get discrete GPU Name")
             else:
-                eslog.debug("Discrete GPU is not available on the system. Using default.")
+                _logger.debug("Discrete GPU is not available on the system. Using default.")
         else:
-            eslog.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
+            _logger.debug("Vulkan driver is not available on the system. Falling back to OpenGL")
             rpcs3ymlconfig["Video"]["Renderer"] = "OpenGL"
 
         # System aspect ratio (the setting in the PS3 system itself, not the displayed ratio) a.k.a. TV mode.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/shadps4/shadps4Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/shadps4/shadps4Generator.py
@@ -17,7 +17,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class shadPS4Generator(Generator):
 
@@ -41,24 +41,24 @@ class shadPS4Generator(Generator):
         # Check Vulkan first before doing anything
         discrete_index = 0
         if vulkan.is_available():
-            eslog.debug("Vulkan driver is available on the system.")
+            _logger.debug("Vulkan driver is available on the system.")
             vulkan_version = vulkan.get_version()
             if vulkan_version > "1.3":
-                eslog.debug(f"Using Vulkan version: {vulkan_version}")
+                _logger.debug("Using Vulkan version: %s", vulkan_version)
                 if vulkan.has_discrete_gpu():
-                    eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                    _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                     discrete_index = vulkan.get_discrete_gpu_index()
                     if discrete_index:
-                        eslog.debug(f"Using Discrete GPU Index: {discrete_index} for shadPS4")
+                        _logger.debug("Using Discrete GPU Index: %s for shadPS4", discrete_index)
                     else:
-                        eslog.debug("Couldn't get discrete GPU index")
+                        _logger.debug("Couldn't get discrete GPU index")
                         discrete_index = 0
                 else:
-                    eslog.debug("Discrete GPU is not available on the system. Using default.")
+                    _logger.debug("Discrete GPU is not available on the system. Using default.")
             else:
-                eslog.debug(f"Vulkan version: {vulkan_version} is not compatible with shadPS4")
+                _logger.debug("Vulkan version: %s is not compatible with shadPS4", vulkan_version)
         else:
-            eslog.debug("*** Vulkan driver required is not available on the system!!! ***")
+            _logger.debug("*** Vulkan driver required is not available on the system!!! ***")
             sys.exit(1)
 
         # Adjust the config.toml file

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/stella/stellaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/stella/stellaGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from ... import Command
@@ -9,8 +8,6 @@ from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
-
-eslog = logging.getLogger(__name__)
 
 class StellaGenerator(Generator):
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/suyu/suyuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/suyu/suyuGenerator.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ...Emulator import Emulator
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 SUYU_CONFIG: Final = CONFIGS / 'suyu'
 
@@ -168,20 +168,20 @@ class SuyuGenerator(Generator):
             # Add vulkan logic
             if system.config["suyu_backend"] == "1":
                 if vulkan.is_available():
-                    eslog.debug("Vulkan driver is available on the system.")
+                    _logger.debug("Vulkan driver is available on the system.")
                     if vulkan.has_discrete_gpu():
-                        eslog.debug("A discrete GPU is available on the system. We will use that for performance")
+                        _logger.debug("A discrete GPU is available on the system. We will use that for performance")
                         discrete_index = vulkan.get_discrete_gpu_index()
                         if discrete_index:
-                            eslog.debug("Using Discrete GPU Index: {} for Suyu".format(discrete_index))
+                            _logger.debug("Using Discrete GPU Index: %s for Suyu", discrete_index)
                             suyuConfig.set("Renderer", "vulkan_device", discrete_index)
                             suyuConfig.set("Renderer", "vulkan_device\\default", "true")
                         else:
-                            eslog.debug("Couldn't get discrete GPU index, using default")
+                            _logger.debug("Couldn't get discrete GPU index, using default")
                             suyuConfig.set("Renderer", "vulkan_device", "0")
                             suyuConfig.set("Renderer", "vulkan_device\\default", "true")
                     else:
-                        eslog.debug("Discrete GPU is not available on the system. Using default.")
+                        _logger.debug("Discrete GPU is not available on the system. Using default.")
                         suyuConfig.set("Renderer", "vulkan_device", "0")
                         suyuConfig.set("Renderer", "vulkan_device\\default", "true")
         else:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
@@ -9,8 +8,6 @@ from ..Generator import Generator
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
-
-eslog = logging.getLogger(__name__)
 
 _THEXTECH_SAVES: Final = SAVES / "thextech"
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/tr1x/tr1xGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/tr1x/tr1xGenerator.py
@@ -26,7 +26,7 @@ from ... import Command
 from ...controller import generate_sdl_game_controller_config
 from ..Generator import Generator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
@@ -60,14 +60,14 @@ class TR1XGenerator(Generator):
                 else:
                     shutil.copy2(item, dest)
             except PermissionError as e:
-                eslog.debug(f"Permission error while copying {item} -> {dest}: {e}")
+                _logger.debug("Permission error while copying %s -> %s: %s", item, dest, e)
             except Exception as e:
-                eslog.debug(f"Error copying {item} -> {dest}: {e}")
+                _logger.debug("Error copying %s -> %s: %s", item, dest, e)
 
         # Download and extract music.zip if the music directory does not exist
         if not musicDir.exists():
             try:
-                eslog.debug(f"Downloading music.zip from {self.MUSIC_ZIP_URL}...")
+                _logger.debug("Downloading music.zip from %s...", self.MUSIC_ZIP_URL)
                 response = requests.get(self.MUSIC_ZIP_URL, stream=True)
                 response.raise_for_status()
 
@@ -82,13 +82,13 @@ class TR1XGenerator(Generator):
 
                 # Remove the zip file after extraction
                 musicZipPath.unlink()
-                eslog.debug("Music files downloaded and extracted successfully.")
+                _logger.debug("Music files downloaded and extracted successfully.")
             except requests.RequestException as e:
-                eslog.debug(f"Failed to download music.zip: {e}")
+                _logger.debug("Failed to download music.zip: %s", e)
             except zipfile.BadZipFile as e:
-                eslog.debug(f"Error extracting music.zip: {e}")
+                _logger.debug("Error extracting music.zip: %s", e)
             except Exception as e:
-                eslog.debug(f"Unexpected error: {e}")
+                _logger.debug("Unexpected error: %s", e)
 
         commandArray = [tr1xRomPath / "TR1X"]
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/tr2x/tr2xGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/tr2x/tr2xGenerator.py
@@ -2,11 +2,11 @@
 # This file is part of the batocera distribution (https://batocera.org).
 # Copyright (c) 2025+.
 #
-# This program is free software: you can redistribute it and/or modify  
-# it under the terms of the GNU General Public License as published by  
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 3.
 #
-# You should have received a copy of the GNU General Public License 
+# You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # YOU MUST KEEP THIS HEADER AS IT IS
@@ -14,18 +14,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
-import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command
-from ...batoceraPaths import ROMS
 from ...controller import generate_sdl_game_controller_config
 from ..Generator import Generator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ...types import HotkeysContext
@@ -53,21 +52,21 @@ class TR2XGenerator(Generator):
                 else:
                     shutil.copy2(item, dest)
             except PermissionError as e:
-                eslog.debug(f"Permission error while copying {item} -> {dest}: {e}")
+                _logger.debug("Permission error while copying %s -> %s: %s", item, dest, e)
             except Exception as e:
-                eslog.debug(f"Error copying {item} -> {dest}: {e}")
-        
+                _logger.debug("Error copying %s -> %s: %s", item, dest, e)
+
         # Configuration
         tr2xConfigPath.parent.mkdir(parents=True, exist_ok=True)
         config_data = {}
-        
+
         if tr2xConfigPath.exists():
             try:
                 with open(tr2xConfigPath, "r", encoding="utf-8") as f:
                     config_data = json.load(f)
             except json.JSONDecodeError:
-                eslog.debug(f"Invalid JSON format in {tr2xConfigPath}, overwriting with default settings.")
-        
+                _logger.debug("Invalid JSON format in %s, overwriting with default settings.", tr2xConfigPath)
+
         # Update settings
         config_data.update(
             {
@@ -76,10 +75,10 @@ class TR2XGenerator(Generator):
                 "height": gameResolution["height"]
             }
         )
-        
+
         with open(tr2xConfigPath, "w", encoding="utf-8") as f:
             json.dump(config_data, f, indent=2)
-        
+
         commandArray = [tr2xRomPath / "TR2X"]
 
         return Command.Command(

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/tyrian/tyrianGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/tyrian/tyrianGenerator.py
@@ -12,7 +12,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class TyrianGenerator(Generator):
 
@@ -20,7 +20,7 @@ class TyrianGenerator(Generator):
         try:
             os.chdir(ROMS / "tyrian" / "data")
         except:
-            eslog.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
+            _logger.error("ERROR: Game assets not installed. You can get them from the Batocera Content Downloader.")
         commandArray = ["opentyrian"]
 
         return Command.Command(

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ...types import HotkeysContext
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class VPinballGenerator(Generator):
 
@@ -47,8 +47,8 @@ class VPinballGenerator(Generator):
             vpinballSettings = CaseSensitiveConfigParser(interpolation=None, allow_no_value=True)
             vpinballSettings.read(vpinballConfigFile)
         except configparser.DuplicateOptionError as e:
-            eslog.debug(f"Error reading VPinballX.ini: {e}")
-            eslog.debug(f"*** Using default VPinballX.ini file ***")
+            _logger.debug("Error reading VPinballX.ini: %s", e)
+            _logger.debug("*** Using default VPinballX.ini file ***")
             shutil.copy("/usr/bin/vpinball/assets/Default_VPinballX.ini", vpinballConfigFile)
             vpinballSettings = CaseSensitiveConfigParser(interpolation=None, allow_no_value=True)
             vpinballSettings.read(vpinballConfigFile)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -20,7 +20,7 @@ from ..Generator import Generator
 if TYPE_CHECKING:
     from ...types import HotkeysContext
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class XeniaGenerator(Generator):
 
@@ -55,19 +55,19 @@ class XeniaGenerator(Generator):
 
         # check Vulkan first before doing anything
         if vulkan.is_available():
-            eslog.debug("Vulkan driver is available on the system.")
+            _logger.debug("Vulkan driver is available on the system.")
             vulkan_version = vulkan.get_version()
             if vulkan_version > "1.3":
-                eslog.debug("Using Vulkan version: {}".format(vulkan_version))
+                _logger.debug("Using Vulkan version: %s", vulkan_version)
             else:
                 if system.isOptSet('xenia_api') and system.config['xenia_api'] == "D3D12":
-                    eslog.debug("Vulkan version: {} is not compatible with Xenia when using D3D12".format(vulkan_version))
-                    eslog.debug("You may have performance & graphical errors, switching to native Vulkan".format(vulkan_version))
+                    _logger.debug("Vulkan version: %s is not compatible with Xenia when using D3D12", vulkan_version)
+                    _logger.debug("You may have performance & graphical errors, switching to native Vulkan")
                     system.config['xenia_api'] = "Vulkan"
                 else:
-                    eslog.debug("Vulkan version: {} is not recommended with Xenia".format(vulkan_version))
+                    _logger.debug("Vulkan version: %s is not recommended with Xenia", vulkan_version)
         else:
-            eslog.debug("*** Vulkan driver required is not available on the system!!! ***")
+            _logger.debug("*** Vulkan driver required is not available on the system!!! ***")
             sys.exit()
 
         # set to 64bit environment by default
@@ -116,7 +116,7 @@ class XeniaGenerator(Generator):
                     dest_path.unlink()
                 dest_path.symlink_to(src_path)
         except Exception as e:
-            eslog.debug(f"Error creating 64-bit link for {dll}: {e}")
+            _logger.debug("Error creating 64-bit link for %s: %s", dll, e)
 
         # Create symbolic links for 32-bit DLLs
         try:
@@ -128,25 +128,25 @@ class XeniaGenerator(Generator):
                     dest_path.unlink()
                 dest_path.symlink_to(src_path)
         except Exception as e:
-            eslog.debug(f"Error creating 32-bit link for {dll}: {e}")
+            _logger.debug("Error creating 32-bit link for %s: %s", dll, e)
 
         # are we loading a digital title?
         if rom_path.suffix == '.xbox360':
-            eslog.debug(f'Found .xbox360 playlist: {rom}')
+            _logger.debug('Found .xbox360 playlist: %s', rom)
             pathLead = rom_path.parent
             with rom_path.open() as openFile:
                 # Read only the first line of the file.
                 firstLine = openFile.readlines(1)[0]
                 # Strip of any new line characters.
                 firstLine = firstLine.strip('\n').strip('\r')
-                eslog.debug(f'Checking if specified disc installation / XBLA file actually exists...')
+                _logger.debug('Checking if specified disc installation / XBLA file actually exists...')
                 xblaFullPath = pathLead / firstLine
                 if xblaFullPath.exists():
-                    eslog.debug(f'Found! Switching active rom to: {firstLine}')
+                    _logger.debug('Found! Switching active rom to: %s', firstLine)
                     rom_path = xblaFullPath
                     rom = str(xblaFullPath)
                 else:
-                    eslog.error(f'Disc installation/XBLA title {firstLine} from {rom} not found, check path or filename.')
+                    _logger.error('Disc installation/XBLA title %s from %s not found, check path or filename.', firstLine, rom)
 
         # adjust the config toml file accordingly
         config = {}
@@ -308,7 +308,7 @@ class XeniaGenerator(Generator):
             matching_files = [file_path for file_path in (canarypath / 'patches').glob(f'*{rom_name}*.patch.toml') if re.search(rom_name, file_path.name, re.IGNORECASE)]
             if matching_files:
                 for file_path in matching_files:
-                    eslog.debug(f'Enabling patches for: {file_path}')
+                    _logger.debug('Enabling patches for: %s', file_path)
                     # load the matchig .patch.toml file
                     with file_path.open('r') as f:
                         patch_toml = toml.load(f)
@@ -320,7 +320,7 @@ class XeniaGenerator(Generator):
                     with file_path.open('w') as f:
                         toml.dump(patch_toml, f)
             else:
-                eslog.debug(f'No patch file found for {rom_name}')
+                _logger.debug('No patch file found for %s', rom_name)
 
         # now setup the command array for the emulator
         if rom == 'config':

--- a/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/settings/unixSettings.py
@@ -12,7 +12,7 @@ from ..utils.configparser import CaseSensitiveConfigParser
 if typing.TYPE_CHECKING:
     from _typeshed import StrPath
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 def _protect_string(string: str) -> str:
     return re.sub(r'[^A-Za-z0-9-\.]+', '_', string)
@@ -28,7 +28,7 @@ class UnixSettings:
         self.settings_path = Path(filename_or_path)
 
         # use ConfigParser as backend.
-        eslog.debug(f"Creating parser for {self.settings_path!s}")
+        _logger.debug("Creating parser for %s", self.settings_path)
         self.config = CaseSensitiveConfigParser(interpolation=None, strict=False) # strict=False to allow to read duplicates set by users
 
         try:
@@ -44,7 +44,7 @@ class UnixSettings:
 
             self.config.read_file(file)
         except IOError as e:
-            eslog.error(str(e))
+            _logger.error(str(e))
 
     def write(self) -> None:
         with self.settings_path.open('w') as fp:
@@ -55,19 +55,19 @@ class UnixSettings:
                 # PSX Mednafen writes beetle_psx_hw_cpu_freq_scale = "100%(native)"
                 # Python 2.7 is EOL and ConfigParser 2.7 takes "%(" as a won't fix error
                 # TODO: clean that up when porting to Python 3
-                eslog.error("Wrong value detected (after % char maybe?), ignoring.")
+                _logger.error("Wrong value detected (after % char maybe?), ignoring.")
 
     def save(self, name: str, value: object) -> None:
         # at least for cheevos_password
         if "password" in name.lower():
-            eslog.debug(f"Writing {name} = ******** to {self.settings_path!s}")
+            _logger.debug("Writing %s = ******** to %s", name, self.settings_path)
         else:
-            eslog.debug(f"Writing {name} = {value!s} to {self.settings_path!s}")
+            _logger.debug("Writing %s = %s to %s", name, value, self.settings_path)
         # TODO: do we need proper section support? PSP config is an ini file
         self.config.set('DEFAULT', name, str(value))
 
     def disable_all(self, name: str) -> None:
-        eslog.debug(f"Disabling {name} from {self.settings_path!s}")
+        _logger.debug("Disabling %s from %s", name, self.settings_path)
         for key, _ in self.config.items('DEFAULT'):
             if key[0:len(name)] == name:
                 self.config.remove_option('DEFAULT', key)
@@ -76,7 +76,7 @@ class UnixSettings:
         self.config.remove_option('DEFAULT', name)
 
     def load_all(self, name: str, includeName: bool = False) -> dict[str, str]:
-        eslog.debug(f"Looking for {name}.* in {self.settings_path!s}")
+        _logger.debug("Looking for %s.* in %s", name, self.settings_path)
         res: dict[str, str] = {}
         for key, value in self.config.items('DEFAULT'):
             m = re.match(rf"^{_protect_string(name)}\.(.+)", _protect_string(key))

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/batoceraServices.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/batoceraServices.py
@@ -1,7 +1,7 @@
 import logging
 import subprocess
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class batoceraServices:
 
@@ -12,9 +12,9 @@ class batoceraServices:
         for valmod in out.decode().splitlines():
             vals = valmod.split(";")
             if(name == vals[0] and vals[1] == "*"):
-                eslog.debug(f"service {name} is enabled")
+                _logger.debug("service %s is enabled", name)
                 return True
-        eslog.debug(f"service {name} is disabled")
+        _logger.debug("service %s is disabled", name)
         return False
 
     @staticmethod
@@ -22,5 +22,5 @@ class batoceraServices:
         proc = subprocess.Popen(["batocera-services status \"" + name + "\""], stdout=subprocess.PIPE, shell=True)
         (out, err) = proc.communicate()
         val = out.decode().strip()
-        eslog.debug(f"service {name} status : \"" + val + "\"") # strip any end of lines
+        _logger.debug('service %s status : "%s"', name, val) # strip any end of lines
         return val

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/bezels.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
     from ..Emulator import Emulator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 class BezelInfos(TypedDict):
     png: Path
@@ -117,7 +117,7 @@ def getBezelInfos(rom: str | Path, bezel: str, systemName: str, emulator: str) -
                                                 bezel_game = True
                                                 if not overlay_png_file.exists():
                                                     return None
-    eslog.debug(f"Original bezel file used: {overlay_png_file!s}")
+    _logger.debug("Original bezel file used: %s", overlay_png_file)
     return { "png": overlay_png_file, "info": overlay_info_file, "layout": overlay_layout_file, "mamezip": overlay_mamezip_file, "specific_to_game": bezel_game }
 
 # Much faster than PIL Image.size
@@ -139,7 +139,7 @@ def fast_image_size(image_file: str | Path) -> tuple[int, int]:
 def resizeImage(input_png: str | Path, output_png: str | Path, screen_width: int, screen_height: int, bezel_stretch: bool = False) -> None:
     imgin = Image.open(input_png)
     fillcolor = 'black'
-    eslog.debug(f"Resizing bezel: image mode {imgin.mode}")
+    _logger.debug("Resizing bezel: image mode %s", imgin.mode)
     if imgin.mode != "RGBA":
         alphaPaste(input_png, output_png, imgin, fillcolor, (screen_width, screen_height), bezel_stretch)
     else:
@@ -149,7 +149,7 @@ def resizeImage(input_png: str | Path, output_png: str | Path, screen_width: int
 def padImage(input_png: str | Path, output_png: str | Path, screen_width: int, screen_height: int, bezel_width: int, bezel_height: int, bezel_stretch: bool = False) -> None:
     imgin = Image.open(input_png)
     fillcolor = 'black'
-    eslog.debug(f"Padding bezel: image mode {imgin.mode}")
+    _logger.debug("Padding bezel: image mode %s", imgin.mode)
     if imgin.mode != "RGBA":
         alphaPaste(input_png, output_png, imgin, fillcolor, (screen_width, screen_height), bezel_stretch)
     else:
@@ -167,18 +167,18 @@ def tatooImage(input_png: str | Path, output_png: str | Path, system: Emulator) 
                 tattoo_file = BATOCERA_SHARE_DIR / 'controller-overlays' / 'generic.png'
             tattoo = Image.open(tattoo_file)
         except:
-            eslog.error(f"Error opening controller overlay: {tattoo_file}")
+            _logger.error("Error opening controller overlay: %s", tattoo_file)
     elif system.config['bezel.tattoo'] == 'custom' and (tattoo_file := Path(system.config['bezel.tattoo_file'])).exists():
         try:
             tattoo = Image.open(tattoo_file)
         except:
-            eslog.error(f"Error opening custom file: {tattoo_file}")
+            _logger.error("Error opening custom file: %s", tattoo_file)
     else:
         try:
             tattoo_file = BATOCERA_SHARE_DIR / 'controller-overlays' / 'generic.png'
             tattoo = Image.open(tattoo_file)
         except:
-            eslog.error(f"Error opening custom file: {tattoo_file}")
+            _logger.error("Error opening custom file: %s", tattoo_file)
     # Open the existing bezel...
     back = Image.open(input_png)
     # Convert it otherwise it implodes later on...

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/buildargs.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/buildargs.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from pathlib import Path
-
-logger = logging.getLogger(__name__)
 
 """Argument parsing helper functions for launching Build Engine source ports Eduke32 and Raze"""
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from ..types import Gun, GunMapping
 
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 @dataclass(slots=True)
 class evmapy(AbstractContextManager[None, None]):
@@ -68,7 +68,7 @@ class evmapy(AbstractContextManager[None, None]):
                 "/usr/share/evmapy/any.keys",
         ]:
             if os.path.exists(keysfile) and not (os.path.isdir(self.rom) and keysfile == "{}.keys" .format (self.rom)): # "{}.keys" .format (rom) is forbidden for directories, it must be inside
-                eslog.debug(f"evmapy file to merge : {keysfile}")
+                _logger.debug("evmapy file to merge : %s", keysfile)
                 filesToMerge.append(keysfile)
 
         # merge conditionnally on the global hotkeys file until it is set everywhere
@@ -78,9 +78,9 @@ class evmapy(AbstractContextManager[None, None]):
             keysfile = userkeysfile
 
         if os.path.exists(keysfile):
-            eslog.debug(f"evmapy file to merge for hotkeys : {keysfile}")
+            _logger.debug("evmapy file to merge for hotkeys : %s", keysfile)
             filesToMerge.append(keysfile)
-            
+
         if len(filesToMerge) == 0:
             return None
         if len(filesToMerge) == 1:
@@ -117,7 +117,7 @@ class evmapy(AbstractContextManager[None, None]):
     def __prepare(self) -> bool:
         keysfile = self.__build_merged_keys_file()
         if keysfile is not None:
-            eslog.debug(f"evmapy on {keysfile}")
+            _logger.debug("evmapy on %s", keysfile)
             subprocess.call(["batocera-evmapy", "clear"])
 
             padActionConfig = json.load(open(keysfile))
@@ -127,7 +127,7 @@ class evmapy(AbstractContextManager[None, None]):
             for gun in self.guns:
                 if "actions_gun"+str(ngun) in padActionConfig:
                     configfile = "/var/run/evmapy/{}.json" .format (os.path.basename(self.guns[gun]["node"]))
-                    eslog.debug("config file for keysfile is {} (from {}) - gun" .format (configfile, keysfile))
+                    _logger.debug("config file for keysfile is %s (from %s) - gun", configfile, keysfile)
                     padConfig = {}
                     padConfig["buttons"] = []
                     padConfig["axes"] = []
@@ -157,7 +157,7 @@ class evmapy(AbstractContextManager[None, None]):
             for playercontroller, pad in sorted(self.controllers.items()):
                 if "actions_player"+str(nplayer) in padActionConfig:
                     configfile = "/var/run/evmapy/{}.json" .format (os.path.basename(pad.device_path))
-                    eslog.debug("config file for keysfile is {} (from {})" .format (configfile, keysfile))
+                    _logger.debug("config file for keysfile is %s (from %s)", configfile, keysfile)
 
                     # create mapping
                     padConfig = {}
@@ -333,7 +333,7 @@ class evmapy(AbstractContextManager[None, None]):
                 nplayer += 1
             return True
         # otherwise, preparation did nothing
-        eslog.debug("no evmapy config file found for system={}, emulator={}".format(self.system, self.emulator))
+        _logger.debug("no evmapy config file found for system=%s, emulator=%s", self.system, self.emulator)
         return False
 
     # remap evmapy trigger (aka up become HAT0Y:max)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/hotkeygen.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/hotkeygen.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from ..Emulator import Emulator
     from ..generators.Generator import Generator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 @contextmanager
 def set_hotkeygen_context(generator: Generator, system: Emulator, /) -> Iterator[None]:
@@ -32,14 +32,14 @@ def set_hotkeygen_context(generator: Generator, system: Emulator, /) -> Iterator
         if "menu" in hkc["keys"]:
             del hkc["keys"]["menu"]
 
-    eslog.debug("hotkeygen: updating context to {}".format(hkc["name"]))
+    _logger.debug("hotkeygen: updating context to %s", hkc["name"])
     subprocess.call(["hotkeygen", "--new-context", hkc["name"], json.dumps(hkc["keys"])])
 
     try:
         yield
     finally:
         # reset hotkeygen context
-        eslog.debug("hotkeygen: resetting to default context")
+        _logger.debug("hotkeygen: resetting to default context")
         subprocess.call(["hotkeygen", "--default-context"])
 
 def get_hotkeygen_event() -> str | None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/squashfs.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/squashfs.py
@@ -11,7 +11,7 @@ from ..batoceraPaths import mkdir_if_not_exists
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _SQUASHFS_DIR: Final = Path("/var/run/squashfs/")
 
@@ -20,19 +20,19 @@ _SQUASHFS_DIR: Final = Path("/var/run/squashfs/")
 def squashfs_rom(rom: str | Path, /) -> Iterator[str]:
     rom = Path(rom)
 
-    eslog.debug(f"squashfs_rom({rom})")
+    _logger.debug("squashfs_rom(%s)", rom)
     mount_point = _SQUASHFS_DIR / rom.stem
 
     mkdir_if_not_exists(_SQUASHFS_DIR)
 
     # first, try to clean an empty remaining directory (for example because of a crash)
     if mount_point.exists() and mount_point.is_dir():
-        eslog.debug(f"squashfs_rom: {mount_point} already exists")
+        _logger.debug("squashfs_rom: %s already exists", mount_point)
         # try to remove an empty directory, else, run the directory, ignoring the .squashfs
         try:
             mount_point.rmdir()
         except (FileNotFoundError, OSError):
-            eslog.debug(f"squashfs_rom: failed to rmdir {mount_point}")
+            _logger.debug("squashfs_rom: failed to rmdir %s", mount_point)
             yield str(mount_point)
             # No cleanup is necessary
             return
@@ -42,7 +42,7 @@ def squashfs_rom(rom: str | Path, /) -> Iterator[str]:
 
     return_code = subprocess.call(["mount", rom, mount_point])
     if return_code != 0:
-        eslog.debug(f"squashfs_rom: mounting {mount_point} failed")
+        _logger.debug("squashfs_rom: mounting %s failed", mount_point)
         try:
             mount_point.rmdir()
         except (FileNotFoundError, OSError):
@@ -53,7 +53,7 @@ def squashfs_rom(rom: str | Path, /) -> Iterator[str]:
         # if the squashfs contains a single file with the same name, take it as the rom file
         rom_single = mount_point / rom.stem
         if len(list(mount_point.iterdir())) == 1 and rom_single.exists():
-            eslog.debug(f"squashfs: single rom {rom_single}")
+            _logger.debug("squashfs: single rom %s", rom_single)
             yield str(rom_single)
         else:
             try:
@@ -61,15 +61,15 @@ def squashfs_rom(rom: str | Path, /) -> Iterator[str]:
             except OSError:
                 yield str(mount_point)
             else:
-                eslog.debug(f"squashfs: linked rom {rom_linked}")
+                _logger.debug("squashfs: linked rom %s", rom_linked)
                 yield str(rom_linked)
     finally:
-        eslog.debug(f"squashfs_rom: cleaning up {mount_point}")
+        _logger.debug("squashfs_rom: cleaning up %s", mount_point)
 
         # unmount
         return_code = subprocess.call(["umount", mount_point])
         if return_code != 0:
-            eslog.debug(f"squashfs_rom: unmounting {mount_point} failed")
+            _logger.debug("squashfs_rom: unmounting %s failed", mount_point)
             raise Exception(f"unable to unmount the file {mount_point}")
 
         # cleaning the empty directory

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/videoMode.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
     from ..types import Resolution, ScreenInfo
 
-eslog = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 _ROTATION_FILE: Final = Path("/var/run/rk-rotation")
 _GLXINFO_BIN: Final = Path("/usr/bin/glxinfo")
@@ -25,15 +25,15 @@ _GLXINFO_BIN: Final = Path("/usr/bin/glxinfo")
 def changeMode(videomode: str) -> None:
     if checkModeExists(videomode):
         cmd = ["batocera-resolution", "setMode", videomode]
-        eslog.debug(f"setVideoMode({videomode}): {cmd}")
+        _logger.debug("setVideoMode(%s): %s", videomode, cmd)
         max_tries = 2  # maximum number of tries to set the mode
         for i in range(max_tries):
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                eslog.debug(result.stdout.strip())
+                _logger.debug(result.stdout.strip())
                 return
             except subprocess.CalledProcessError as e:
-                eslog.error(f"Error setting video mode: {e.stderr}")
+                _logger.error("Error setting video mode: %s", e.stderr)
                 if i == max_tries - 1:
                     raise
                 time.sleep(1)
@@ -91,8 +91,8 @@ def getScreensInfos(config: Mapping[str, object]) -> list[ScreenInfo]:
         except:
             pass # ignore bad information
 
-    eslog.debug("Screens:")
-    eslog.debug(res)
+    _logger.debug("Screens:")
+    _logger.debug(res)
     return res
 
 def getScreens() -> list[str]:
@@ -142,11 +142,11 @@ def checkModeExists(videomode: str) -> bool:
         if(videomode == vals[0]):
             return True
 
-    eslog.error(f"invalid video mode {videomode}")
+    _logger.error("invalid video mode %s", videomode)
     return False
 
 def changeMouse(mode: bool) -> None:
-    eslog.debug(f"changeMouseMode({mode})")
+    _logger.debug("changeMouseMode(%s)", mode)
     proc = subprocess.Popen([f"batocera-mouse {'show' if mode else 'hide'}"], stdout=subprocess.PIPE, shell=True)
     (out, err) = proc.communicate()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ line-length = 120
 target-version = "py312"
 
 [tool.ruff.lint]
-select = ["TCH", "PYI", "I", "UP", "F", "E", "W", "B", "C4", "SIM", "PTH", "RUF"]
+select = ["TCH", "PYI", "I", "UP", "F", "E", "W", "B", "C4", "SIM", "PTH", "G", "RUF"]
 
 [tool.ruff.lint.isort]
 extra-standard-library = ["typing_extensions", "_typeshed"]


### PR DESCRIPTION
Passing a string with percent formatting and extra arguments to the logging calls allows Python to only format the string if it is needed. Renaming `eslog` to `_logger` allows ruff's "G" rules to lint any logging calls as well as mark it as a private module-level variable.