### PR TITLE
virtual wheel: use correct guid for mapping

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
@@ -181,6 +181,8 @@ def reconfigureControllers(playersControllers: ControllerMapping, system: Emulat
             if wanted_ra < ra or wanted_deadzone > 0:
                 (newdev, p) = reconfigureAngleRotation(pad.device_path, int(pad.inputs["joystick1left"].id), ra, wanted_ra, wanted_deadzone, wanted_midzone)
                 if newdev is not None:
+                    #replace sdl guid by virtualwheel guid for correct sdl mapping
+                    playersControllers[playercontroller].guid='03000000010000000100000001000000'
                     _logger.info("replacing device %s by device %s for player %s", pad.device_path, newdev, playercontroller)
                     deviceList[newdev] = device.copy()
                     deviceList[newdev]["eventId"] = controllersConfig.dev2int(newdev)


### PR DESCRIPTION
the sdl mapping is not working with virtual wheel, because we copy mapping from original wheel without changing the guid.

This fix virtual wheel on wine/model2 where xinput can't work without sdl mapping, also also make pedals works in correct order for wheels like logitech g29 (on model3)