### PR TITLE
Add NeGcon (Rumble) controller entries to Beetle PSX and SwanStation

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1490,6 +1490,7 @@ libretro:
                     "Analog Controller (DualShock)": 261
                     "Analog Joystick":               517
                     "NeGcon":                        773
+                    "NeGcon (Rumble)":               1029
                     "Namco GunCon":                  260
                     "PlayStation Mouse":             258
             swanstation_Controller2:
@@ -1501,6 +1502,7 @@ libretro:
                     "Analog Controller (DualShock)": 261
                     "Analog Joystick":               517
                     "NeGcon":                        773
+                    "NeGcon (Rumble)":               1029
                     "Namco GunCon":                  260
                     "PlayStation Mouse":             258
             swanstation_Controller_ShowCrosshair:
@@ -3921,6 +3923,7 @@ libretro:
                     "Analog Joystick (Flystick)":    773
                     "Namco GunCon":                  260
                     "NeGcon":                        1029
+                    "NeGcon (Rumble)":               1285
                     "Justifier":                     516
                     "PlayStation Mouse":             258
             beetle_psx_hw_Controller2:
@@ -3934,6 +3937,7 @@ libretro:
                     "Analog Joystick (Flystick)":    773
                     "Namco GunCon":                  260
                     "NeGcon":                        1029
+                    "NeGcon (Rumble)":               1285
                     "Justifier":                     516
                     "PlayStation Mouse":             258
     mednafen_supergrafx:


### PR DESCRIPTION
Adds NeGcon with rumble feedback as controller entries for Beetle PSX and SwanStation.