### PR TITLE
fix base axis mapping in evmapy context manager

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/evmapy.py
@@ -217,14 +217,14 @@ class evmapy(AbstractContextManager[None, None]):
                                     if input.name == "up":
                                         absbasey_positive =  int(input.value) >= 0
                                     else:
-                                        axisId = None # don't duplicate, configuration should be done for up
+                                        absbasey_positive =  int(input.value) < 0
                                 elif input.name == "left" or input.name == "right":
                                     axisId   = "BASE"
                                     axisName = "X"
                                     if input.name == "left":
                                         absbasex_positive = int(input.value) < 0
                                     else:
-                                        axisId = None # don't duplicate, configuration should be done for left
+                                        absbasex_positive = int(input.value) >= 0
                                 else:
                                     axisId   = "_OTHERS_"
                                     axisName = input.name


### PR DESCRIPTION
Since we already skip the axis based on its `input.code` earlier in the loop, we don't need to skip adding the axis to the `axes` list. How we are skipping now prevents the axis being set up if "up" comes after "down" or "left" comes after "right" in the `<inputConfig>` in `es_input.cfg`.