### PR TITLE
4dapter retro controller adapter configuration

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5475,4 +5475,23 @@
 		<input name="x" type="button" id="0" value="1" code="304" />
 		<input name="y" type="button" id="2" value="1" code="306" />
 	</inputConfig>
+ 	<inputConfig type="joystick" deviceName="4dapter Retro Controller Adapter" deviceGUID="03000000412300003680000001010000">
+		<input name="a" type="button" id="1" value="1" code="289" />
+		<input name="b" type="button" id="0" value="1" code="288" />
+		<input name="down" type="button" id="10" value="1" code="298" />
+		<input name="hotkey" type="button" id="6" value="1" code="294" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="l2" type="button" id="14" value="1" code="302" />
+		<input name="left" type="button" id="11" value="1" code="299" />
+		<input name="pagedown" type="button" id="5" value="1" code="293" />
+		<input name="pageup" type="button" id="4" value="1" code="292" />
+		<input name="r2" type="button" id="13" value="1" code="301" />
+		<input name="right" type="button" id="12" value="1" code="300" />
+		<input name="select" type="button" id="6" value="1" code="294" />
+		<input name="start" type="button" id="7" value="1" code="295" />
+		<input name="up" type="button" id="9" value="1" code="297" />
+		<input name="x" type="button" id="3" value="1" code="291" />
+		<input name="y" type="button" id="2" value="1" code="290" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Configuration for the _Batocera/Retroach Optimized_ firmware for the ultra low latency 4dapter Retro Controller adapter
Product link is here -> https://www.tindie.com/products/timville/4dapter-switch-mister-retro-controller-adapter/

Mapping is automatic for NES, SNES and Genesis controllers. Nintendo 64 controllers require mapping according this diagram below
<img width="792" alt="n64-mapping" src="https://github.com/user-attachments/assets/6b7fdb44-1de3-4bbd-b076-6a43fabc36aa" />
