### PR TITLE
Fix watching for steam game exits

### DIFF
--- a/package/batocera/utils/batocera-steam/batocera-steam
+++ b/package/batocera/utils/batocera-steam/batocera-steam
@@ -49,16 +49,22 @@ if test -z "${GAME}"
 then
     DISPLAY=$(getLocalXDisplay) flatpak run com.valvesoftware.Steam -bigpicture
 else
-    DISPLAY=$(getLocalXDisplay) flatpak run com.valvesoftware.Steam -silent ${GAME} 2>&1 |
-	while read LINE
-	do
-	    echo "${LINE}"
-	    # steam has no option to exit when quitting a game.
-	    if echo "${LINE}" | grep -E '^Exiting app |^Game process removed'
-	    then
-		DISPLAY=$(getLocalXDisplay) flatpak run com.valvesoftware.Steam -shutdown
-	    fi
-	done
+    # Steam has no option to exit when quitting a game. We previously used to monitor the
+    # console output of the steam command, but that is no longer reliable:
+    # https://github.com/ValveSoftware/steam-for-linux/issues/11793
+    #
+    # We thus monitor the log and when the game process exits, we request steam to stop.
+    # This should allow our steam command to actually finish.
+    log_file="$target_dir/.var/app/com.valvesoftware.Steam/.local/share/Steam/logs/console_log.txt"
+    (
+        grep -q -E '^\[.*\] (Exiting app|Game process removed)' <(tail -f -n 0 "$log_file")
+        DISPLAY=$(getLocalXDisplay) flatpak run com.valvesoftware.Steam -shutdown
+    ) &
+    log_watcher_pid=$!
+
+    DISPLAY=$(getLocalXDisplay) flatpak run com.valvesoftware.Steam -silent ${GAME}
+    # Kill our background log watching subshell if it's still there.
+    kill "$log_watcher_pid"
 fi
 
 batocera-mouse hide


### PR DESCRIPTION
Hey folks, I was having an issue where exiting steam games through their in-game menus would leave them in a stuck state because steam was still running.

Digging into it, I found that steam was just not outputting anything to stdout/stderr. As of the latest Steam version, it seems like it won't output if it isn't connected to a tty (see https://github.com/ValveSoftware/steam-for-linux/issues/11793). This means that the code in `batocera-steam` that detects when the games exit no longer works.

As per the response there, it seems like monitoring the log file might be a decent approach. I implemented that in this PR through a subshell that looks for the previous `Game process removed` / `Exiting app` outputs. If it encounters those, it requests steam to shutdown as before.

The format of the log file is slightly different, the lines look like:

```
[2025-03-02 23:14:17] Game process removed: AppID 2379780 "/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/ubuntu12_32/steam-launch-wrapper -- /userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/ubuntu12_32/reaper SteamLaunch AppId=2379780 -- '/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/SteamLinuxRuntime_sniper'/_v2-entry-point --verb=waitforexitandrun -- '/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Proton Hotfix'/proton waitforexitandrun  '/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Balatro/Balatro.exe'", ProcID 1327
[2025-03-02 23:14:17] ThreadGetProcessExitCode: no such process 1327
[2025-03-02 23:14:17] ExecCommandLine: "'~/.steam/root/ubuntu12_32/steam' '-no-cef-sandbox' '-shutdown'"
```
so I updated the `grep` pattern.

One alternative here to keep the existing approach is to fake being a tty. However, I noticed when you do this the output that steam produces has ANSI escape sequences so it might get a little ugly.