### PR TITLE
MAME custom cmd filename and format

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -577,9 +577,9 @@ class MameGenerator(Generator):
             mameControllers.generatePadsConfig(cfgPath, playersControllers, messModel, buttonLayout, customCfg, specialController, bezelSet, useGuns, guns, useWheels, wheels, useMouse, multiMouse, system)
 
         # If user provided a custom cmd file at the default location, use that as the customized commandArray
-        if Path(defaultCustomCmdFilepath := f"{rom}.cmd").is_file():
+        if Path(defaultCustomCmdFilepath := f"{rom}.mamecmd").is_file():
             with open(defaultCustomCmdFilepath) as f:
-                commandArray = f.read().splitlines()  # type: ignore
+                commandArray = f.read().strip("\n").splitlines()  # type: ignore
 
         # Change directory to MAME folder (allows data plugin to load properly)
         os.chdir('/usr/bin/mame')


### PR DESCRIPTION
a small improvement upon #13643 

* Use `.mamecmd` instead of libretroMAME's `.cmd` since they have drastically different contents and formats. This way, users still get to use both emulators.
* tolerate leading and trailing newlines