### PR TITLE
ecwolf - spaces in filenames allowed

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ecwolf/ecwolfGenerator.py
@@ -4,6 +4,7 @@ import codecs
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING
+from shlex import split
 
 from ... import Command
 from ...batoceraPaths import CONFIGS, SAVES, mkdir_if_not_exists
@@ -46,8 +47,6 @@ class ECWolfGenerator(Generator):
             f.write('Vid_Aspect = 0;\n')
             f.write('Vid_Vsync = 1;\n')
             f.write('QuitOnEscape = 1;\n')
-            f.write(f'FullScreenWidth = {gameResolution["width"]};\n')
-            f.write(f'FullScreenHeight = {gameResolution["height"]};\n')
             f.close()
 
         # Set the resolution and some other defaults
@@ -82,7 +81,7 @@ class ECWolfGenerator(Generator):
                 print(f"Error: couldn't go into directory {rom_path} ({e})")
 
         # File method .ecwolf (recommended) for command parameters, first argument is path to dataset,
-        # next parameters according ecwolf --help
+        # next parameters according ecwolf --help, use doublequotes if path or filenames contains spaces
         # File method .pk3, put pk3 files next to wl6 dataset and start the mod in ES
         if rom_path.is_file():
             os.chdir(rom_path.parent)
@@ -90,7 +89,7 @@ class ECWolfGenerator(Generator):
 
             if fextension == ".ecwolf":
                 with codecs.open(str(rom_path),"r") as f:
-                    ecwolfArray += (f.readline().split())
+                    ecwolfArray += split(f)
 
                 # If 1. parameter isn't an argument then assume it's a path
                 if not "--" in ecwolfArray[1]:


### PR DESCRIPTION
If your path or filename contains spaces, then use doppelquotes. This allows the generator to read the whole string as one argument.

```
Wolfenstein (HD).ecwolf
"./Wolfenstein (full version)" -data wl6
```

Thanks to @bryanforbes for the idea, helped me alot.