### PR TITLE
fix supermodelGenerator to correctly format input values for joystick buttons for p2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
@@ -297,21 +297,21 @@ def configPadsIni(system: Emulator, rom: Path, playersControllers: Controllers, 
                         elif key == "InputStart2":
                             val = transformElement("JOY2_BUTTON9", playersControllers, mapping, mapping_fallback)
                             if val is not None:
-                                val += f",{val}"
+                                val = f",{val}"
                             else:
                                 val = ""
                             targetConfig.set(section, key, f"MOUSE2_BUTTONX1{val}")
                         elif key == "InputCoin1":
                             val = transformElement("JOY2_BUTTON10", playersControllers, mapping, mapping_fallback)
                             if val is not None:
-                                val += f",{val}"
+                                val = f",{val}"
                             else:
                                 val = ""
                             targetConfig.set(section, key,  f"MOUSE2_BUTTONX2{val}")
                         elif key == "InputAnalogJoyEvent2":
                             val = transformElement("JOY2_BUTTON2", playersControllers, mapping, mapping_fallback)
                             if val is not None:
-                                val += f",{val}"
+                                val = f",{val}"
                             else:
                                 val = ""
                             targetConfig.set(section, key, f"MOUSE2_MIDDLE_BUTTON{val}")


### PR DESCRIPTION
When adding input mappings, the code erroneously did a `val += f",{val}"`, which when later coupled with `f"MOUSE2_BUTTONX1{val}"` resulted in some invalid inputs. See example below:

From `Supermodel.log` before this change:

```
[Info]    InputStart1=MOUSE1_BUTTONX1,JOY1_BUTTON10
[Info]    InputStart2=MOUSE2_BUTTONX1JOY2_BUTTON10,JOY2_BUTTON10
...
[Info]    InputCoin1=MOUSE1_BUTTONX2,JOY1_BUTTON14
[Info]    InputCoin2=KEY_4,JOY2_BUTTON14
...
[Info]    InputAnalogJoyEvent=KEY_S,MOUSE1_MIDDLE_BUTTON,JOY1_BUTTON4
[Info]    InputAnalogJoyEvent2=MOUSE2_MIDDLE_BUTTONJOY2_BUTTON4,JOY2_BUTTON4
...
```