### PR TITLE
add support for HORI mario kart racing pro deluxe

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -30,6 +30,7 @@
 - Steering wheel support added for :
   - Logitech: G923 (Xbox), PRO Racing Wheel
   - Speedlink: 4in1 Leather Power Feedback Wheel
+  - HORI: Mario Kart Racing Wheel Pro Deluxe for Nintendo Switch (DP mode)
 - Sega Lindbergh loader
 - Variable Refresh Rate (VRR) support for modern AMD gpus
 - Support of Shanwan Twin USB Joystick (new revision)

--- a/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-wheels.rules
@@ -51,6 +51,9 @@ KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTR{idV
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Microsoft X-Box One pad", ATTR{idVendor}=="0f0d", ATTR{idProduct}=="0121", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Microsoft Xbox Controller", ATTRS{id/vendor}=="0f0d", ATTRS{id/product}=="0152", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
 
+# HORI Mario Kart Racing Wheel Pro Deluxe for Nintendo Switch (switch to DP mode)
+KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTRS{id/vendor}=="0f0d", ATTRS{id/product}=="013e", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
+
 # PXN-V10 (X-INPUT MODE ONLY, HARDWARE SWITCH TO 270 DEGREES)
 KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="Generic X-Box pad", ATTR{idVendor}=="llff", ATTR{idProduct}=="f201", MODE="0666", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_WHEEL}="1", ENV{WHEEL_ROTATION_ANGLE}="270"
 

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5551,4 +5551,24 @@
 		<input name="x" type="button" id="3" value="1" code="308" />
 		<input name="y" type="button" id="2" value="1" code="307" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="030000000d0f00003e01000015010000">
+		<input name="a" type="button" id="0" value="1" code="304" />
+		<input name="b" type="button" id="1" value="1" code="305" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="l2" type="axis" id="2" value="1" code="2" />
+		<input name="l3" type="button" id="9" value="1" code="317" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="5" value="1" code="311" />
+		<input name="pageup" type="button" id="4" value="1" code="310" />
+		<input name="r2" type="axis" id="5" value="1" code="5" />
+		<input name="r3" type="button" id="10" value="1" code="318" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="6" value="1" code="314" />
+		<input name="start" type="button" id="7" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="2" value="1" code="307" />
+		<input name="y" type="button" id="3" value="1" code="308" />
+	</inputConfig>
 </inputList>


### PR DESCRIPTION
Must be on DP mode:
![image](https://github.com/user-attachments/assets/ac81f26f-3dd1-4955-97b7-a71204ad0a95)

And 270 degrees mode:
![image](https://github.com/user-attachments/assets/037f62f0-347f-4113-837c-9cf6925ed984)

`-` is SELECT
`+` is START
`HOME` is Hotkey