### PR TITLE
fix: correct input mappings in MAME controller configuration for menu navigation

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py
@@ -253,11 +253,18 @@ def generatePadsConfig(cfgPath: Path, playersControllers: Controllers, sysName: 
 
         #UI Mappings
         if nplayer == 1:
-            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_DOWN", "DOWN", mappings_use["JOYSTICK_DOWN"], pad.inputs[mappings_use["JOYSTICK_UP"]], False, "", ""))      # Down
-            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_LEFT", "LEFT", mappings_use["JOYSTICK_LEFT"], pad.inputs[mappings_use["JOYSTICK_LEFT"]], False, "", ""))    # Left
-            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_UP", "UP", mappings_use["JOYSTICK_UP"], pad.inputs[mappings_use["JOYSTICK_UP"]], False, "", ""))            # Up
-            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_RIGHT", "RIGHT", mappings_use["JOYSTICK_RIGHT"], pad.inputs[mappings_use["JOYSTICK_LEFT"]], False, "", "")) # Right
-            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_SELECT", "ENTER", 'b', pad.inputs['b'], False, "", ""))                                                     # Select
+            # for down and right inputs, we try to use configured input if it exists, but fall back to the up and left
+            # inputs in order to support axis inputs, which might not have down/right configured. 
+            input_up = pad.inputs[mappings_use["JOYSTICK_UP"]]
+            input_down = pad.inputs.get(mappings_use["JOYSTICK_DOWN"], pad.inputs[mappings_use["JOYSTICK_UP"]])
+            input_left = pad.inputs[mappings_use["JOYSTICK_LEFT"]]
+            input_right = pad.inputs.get(mappings_use["JOYSTICK_RIGHT"], pad.inputs[mappings_use["JOYSTICK_LEFT"]])
+
+            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_DOWN", "DOWN", mappings_use["JOYSTICK_DOWN"], input_down, False, "", ""))     # Down
+            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_LEFT", "LEFT", mappings_use["JOYSTICK_LEFT"], input_left, False, "", ""))     # Left
+            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_UP", "UP", mappings_use["JOYSTICK_UP"], input_up, False, "", ""))             # Up
+            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_RIGHT", "RIGHT", mappings_use["JOYSTICK_RIGHT"], input_right, False, "", "")) # Right
+            xml_input.appendChild(generateComboPortElement(pad, config, 'standard', pad.index, "UI_SELECT", "ENTER", 'b', pad.inputs['b'], False, "", ""))                       # Select
 
         if useControls in messControlDict:
             for controlDef in messControlDict[useControls]:


### PR DESCRIPTION
This fixes an issue with menu navigation in Mame for input devices that have joystick directions mapped to a d-pad (such that `input.type == 'hat'`.

In the existing implementation, keyboard and many controllers (e.g those with axis controls) would work fine, but if left/right and up/down buttons used different inputs (like the d-pad example), they'd end up being mapped to the same input, thus breaking navigation.

## Example currently non-working device that starts working

These are variables for an 8-button arcade control device grabbed from debug logging where the code change in this PR is, the variables are the same as in the code. The joystick is mapped as a d-pad in ES.

```python
mappings_use = {'JOYSTICK_UP': 'up', 'JOYSTICK_DOWN': 'down', 'JOYSTICK_LEFT': 'left', 'JOYSTICK_RIGHT': 'right', 'JOYSTICKLEFT_UP': 'joystick1up', 'JOYSTICKLEFT_DOWN': 'joystick1down', 'JOYSTICKLEFT_LEFT': 'joystick1left', 'JOYSTICKLEFT_RIGHT': 'joystick1right', 'JOYSTICKRIGHT_UP': 'joystick2up', 'JOYSTICKRIGHT_DOWN': 'joystick2down', 'JOYSTICKRIGHT_LEFT': 'joystick2left', 'JOYSTICKRIGHT_RIGHT': 'joystick2right', 'BUTTON1': 'b', 'BUTTON2': 'a', 'BUTTON3': 'y', 'BUTTON4': 'x', 'BUTTON5': 'pageup', 'BUTTON6': 'pagedown', 'BUTTON7': 'l2', 'BUTTON8': 'r2', 'BUTTON9': 'l3', 'BUTTON10': 'r3', 'START': 'start', 'COIN': 'select'}

pads.input = {'a': Input(name='a', type='button', id='1', value='1', code='305'), 'b': Input(name='b', type='button', id='0', value='1', code='304'), 'down': Input(name='down', type='hat', id='0', value='4', code=None), 'hotkey': Input(name='hotkey', type='button', id='10', value='1', code='314'), 'l2': Input(name='l2', type='button', id='8', value='1', code='312'), 'left': Input(name='left', type='hat', id='0', value='8', code=None), 'pagedown': Input(name='pagedown', type='button', id='7', value='1', code='311'), 'pageup': Input(name='pageup', type='button', id='6', value='1', code='310'), 'r2': Input(name='r2', type='button', id='9', value='1', code='313'), 'right': Input(name='right', type='hat', id='0', value='2', code=None), 'select': Input(name='select', type='button', id='10', value='1', code='314'), 'start': Input(name='start', type='button', id='11', value='1', code='315'), 'up': Input(name='up', type='hat', id='0', value='1', code=None), 'x': Input(name='x', type='button', id='3', value='1', code='307'), 'y': Input(name='y', type='button', id='4', value='1', code='308')}
```

In the device above, note the following:

```python
mappings_use['JOYSTICK_DOWN'] == 'down'
pads.input['down'] == Input(name='down', type='hat', id='0', value='4', code=None)
mappings_use['JOYSTICK_UP'] == 'up'
pads.input['up'] == Input(name='up', type='hat', id='0', value='1', code=None)
```

When these are eventually pased to `input2definition`, if the same input is used, the same control will be configured. https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py#L464-L472



### Mame config file snippet

Snippet from `default.cfg` before (note that `JOYCODE_3_HAT1UP` is used for both `UI_UP` and `UI_DOWN` and `JOYCODE_3_HAT1LEFT` is used for both `UI_LEFT` and `UI_RIGHT`):

```
<port tag="standard" type="UI_DOWN" mask="" defvalue="">
        <newseq type="standard">KEYCODE_DOWN OR JOYCODE_3_HAT1UP</newseq>
</port>
<port tag="standard" type="UI_LEFT" mask="" defvalue="">
        <newseq type="standard">KEYCODE_LEFT OR JOYCODE_3_HAT1LEFT</newseq>
</port>
<port tag="standard" type="UI_UP" mask="" defvalue="">
        <newseq type="standard">KEYCODE_UP OR JOYCODE_3_HAT1UP</newseq>
</port>
<port tag="standard" type="UI_RIGHT" mask="" defvalue="">
        <newseq type="standard">KEYCODE_RIGHT OR JOYCODE_3_HAT1LEFT</newseq>
</port>
```

Snippet from `default.cfg` after:

```
<port tag="standard" type="UI_DOWN" mask="" defvalue="">
        <newseq type="standard">KEYCODE_DOWN OR JOYCODE_3_HAT1DOWN</newseq>
</port>
<port tag="standard" type="UI_LEFT" mask="" defvalue="">
        <newseq type="standard">KEYCODE_LEFT OR JOYCODE_3_HAT1LEFT</newseq>
</port>
<port tag="standard" type="UI_UP" mask="" defvalue="">
        <newseq type="standard">KEYCODE_UP OR JOYCODE_3_HAT1UP</newseq>
</port>
<port tag="standard" type="UI_RIGHT" mask="" defvalue="">
        <newseq type="standard">KEYCODE_RIGHT OR JOYCODE_3_HAT1RIGHT</newseq>
</port>
```


## Example currently working device

Variables:

```python
mappings_use = {'JOYSTICK_UP': 'joystick1up', 'JOYSTICK_DOWN': 'joystick1down', 'JOYSTICK_LEFT': 'joystick1left', 'JOYSTICK_RIGHT': 'joystick1right', 'JOYSTICKLEFT_UP': 'joystick1up', 'JOYSTICKLEFT_DOWN': 'joystick1down', 'JOYSTICKLEFT_LEFT': 'joystick1left', 'JOYSTICKLEFT_RIGHT': 'joystick1right', 'JOYSTICKRIGHT_UP': 'joystick2up', 'JOYSTICKRIGHT_DOWN': 'joystick2down', 'JOYSTICKRIGHT_LEFT': 'joystick2left', 'JOYSTICKRIGHT_RIGHT': 'joystick2right', 'BUTTON1': 'b', 'BUTTON2': 'a', 'BUTTON3': 'y', 'BUTTON4': 'x', 'BUTTON5': 'pageup', 'BUTTON6': 'pagedown', 'BUTTON7': 'l2', 'BUTTON8': 'r2', 'BUTTON9': 'l3', 'BUTTON10': 'r3', 'START': 'start', 'COIN': 'select'}

pads.input = {'a': Input(name='a', type='button', id='1', value='1', code='305'), 'b': Input(name='b', type='button', id='0', value='1', code='304'), 'down': Input(name='down', type='hat', id='0', value='4', code=None), 'hotkey': Input(name='hotkey', type='button', id='8', value='1', code='316'), 'joystick1left': Input(name='joystick1left', type='axis', id='0', value='-1', code='0'), 'joystick1up': Input(name='joystick1up', type='axis', id='1', value='-1', code='1'), 'joystick2left': Input(name='joystick2left', type='axis', id='3', value='-1', code='3'), 'joystick2up': Input(name='joystick2up', type='axis', id='4', value='-1', code='4'), 'l2': Input(name='l2', type='axis', id='2', value='1', code='2'), 'l3': Input(name='l3', type='button', id='9', value='1', code='317'), 'left': Input(name='left', type='hat', id='0', value='8', code=None), 'pagedown': Input(name='pagedown', type='button', id='5', value='1', code='311'), 'pageup': Input(name='pageup', type='button', id='4', value='1', code='310'), 'r2': Input(name='r2', type='axis', id='5', value='1', code='5'), 'r3': Input(name='r3', type='button', id='10', value='1', code='318'), 'right': Input(name='right', type='hat', id='0', value='2', code=None), 'select': Input(name='select', type='button', id='6', value='1', code='314'), 'start': Input(name='start', type='button', id='7', value='1', code='315'), 'up': Input(name='up', type='hat', id='0', value='1', code=None), 'x': Input(name='x', type='button', id='3', value='1', code='308'), 'y': Input(name='y', type='button', id='2', value='1', code='307')}
```

In the device above, note the following:

```python
mappings_use['JOYSTICK_DOWN'] == 'joystick1down'
#pads.input['joystick1down'] == DOES NOT EXIST
mappings_use['JOYSTICK_UP'] == 'joystick1up'
pads.input['joystick1up'] == Input(name='joystick1up', type='axis', id='1', value='-1', code='1')
```

In this case, passing the `JOYSTICK_UP` input down to `input2definition` is correct, as it explicitly deals with inputs with `type = 'axis'`: https://github.com/batocera-linux/batocera.linux/blob/master/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameControllers.py#L473 