### PR TITLE
enable readline in python

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -235,6 +235,7 @@ config BR2_PACKAGE_BATOCERA_SYSTEM
 	select BR2_PACKAGE_PYTHON3
 	select BR2_PACKAGE_PYTHON3_SSL
 	select BR2_PACKAGE_PYTHON3_PYOPENSSL
+	select BR2_PACKAGE_PYTHON3_READLINE
 
 	select BR2_PACKAGE_PARTED				# partition management (for the first boot)
 	select BR2_PACKAGE_USBMOUNT				# usb key/sd card mounter


### PR DESCRIPTION
This enables using arrow keys in the REPL. This could possibly go in `BR2_PACKAGE_BATOCERA_DEV`.