### PR TITLE
liretro: fix modern arcade stick alt layout

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroControllers.py
@@ -113,6 +113,15 @@ def generateControllerConfig(
                      'pageup': 'l', 'pagedown': 'r', 'l2': 'l2', 'r2': 'r2', \
                      'l3': 'l3', 'r3': 'r3', \
                      'start': 'start', 'select': 'select'}
+
+    # X Y L1 L2  ---> X Y R1 L1
+    # A B R1 R2  ---> A B R2 L2
+    if system.isOptSet("altlayout") and system.config["altlayout"] == "fightstick":
+        retroarchbtns['pageup'] = 'l2'
+        retroarchbtns['pagedown'] = 'l'
+        retroarchbtns['l2'] = 'r2'
+        retroarchbtns['r2'] = 'r'
+
     retroarchGunbtns = {'a': 'aux_a', 'b': 'aux_b', 'y': 'aux_c', \
                         'pageup': 'offscreen_shot', 'pagedown': 'trigger', \
                         'start': 'start', 'select': 'select'}

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -505,26 +505,20 @@ def getMameControlScheme(system: Emulator, rom: Path) -> str:
 
     romName = rom.stem
     if romName in capcomList:
-        if controllerType in [ "auto", "snes" ]:
+        if controllerType in [ "auto", "snes", "fightstick" ]:
             return "sfsnes"
         if controllerType == "megadrive":
             return "megadrive"
-        if controllerType == "fightstick":
-            return "sfstick"
     elif romName in mkList:
-        if controllerType in [ "auto", "snes" ]:
+        if controllerType in [ "auto", "snes", "fightstick" ]:
             return "mksnes"
         if controllerType == "megadrive":
             return "mkmegadrive"
-        if controllerType == "fightstick":
-            return "mkstick"
     elif romName in kiList:
-        if controllerType in [ "auto", "snes" ]:
+        if controllerType in [ "auto", "snes", "fightstick" ]:
             return "kisnes"
         if controllerType == "megadrive":
             return "megadrive"
-        if controllerType == "fightstick":
-            return "sfstick"
     elif romName in  neogeoList:
         return "neomini"
     elif romName in  twinstickList:
@@ -533,7 +527,7 @@ def getMameControlScheme(system: Emulator, rom: Path) -> str:
         return "qbert"
     else:
         if controllerType == "fightstick":
-            return "fightstick"
+            return "sfsnes"
 
     return "default"
 

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1644,6 +1644,12 @@ libretro:
                 choices:
                     "Off":                                always hide
                     "On":                                 always show
+            altlayout:
+                prompt:      SPECIAL CONTROL LAYOUTS
+                description: Controls for 5/6 button games and other unique controls
+                choices:
+                    "Default Only":                 "default"
+                    "Modern Fightstick Style":      "fightstick"
       systems:
             neogeo:
                 cfeatures:
@@ -1941,6 +1947,12 @@ libretro:
                 choices:
                     "Off":     0
                     "On":      1
+            altlayout:
+                prompt:      SPECIAL CONTROL LAYOUTS
+                description: Controls for 5/6 button games and other unique controls
+                choices:
+                    "Default Only":                 "default"
+                    "Modern Fightstick Style":      "fightstick"
       systems:
             atomiswave:
                 cfeatures:


### PR DESCRIPTION
The current implementation in lr-mame with mapping through .cfg is not (or not work anymore) with trigger axis for L2 R2.

That break modern arcade stick alternative layout.

This patch is fixing, doing the switch of L1 R1 -> R1 R2 in the retroarch remap directly. (and the classic layout is still done in lr-mame cfg)

Also add support for fbneo && flycast core