### PR TITLE
errorcode for getLocalXDisplay

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/getLocalXDisplay
+++ b/package/batocera/core/batocera-scripts/scripts/getLocalXDisplay
@@ -1,3 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 find /tmp/.X11-unix -name "X*" 2>/dev/null | head -1 | sed -e s+"^.*/X"+":"+
+exit $PIPESTATUS


### PR DESCRIPTION
bash offers $PIPESTATUS to catch error in pipe-chain

Attention: you still need to check if obtained variable is empty because if `/tmp/.X11-unix`-dir is present then there is no error.
@nadenislamarre Are you okay with this?