### PR TITLE
Renamed `segacd` to `megacd` (consistency with `megadrive` not `genesis`

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -7,6 +7,7 @@
 - Removed the buggy Libretro-Openlara in favor of the standalone TRX1 Tomb Raider port.
   If you have saved games, it is recommended to stick with v41 or earlier as the same data is not compatible.
 - Zedmd upgraded. You need firmware zedmd 5.1.5. See https://wiki.batocera.org/hardware:diy_zedmd?s[]=dmd#zedmd_configuration.
+- The folder for SegaCD/MegaCD roms is now called `megacd` to keep consistency (like `megadrive` is used, not `genesis`)
 - Removed Future Pinball in favor of Visual Pinball which has been available for some time and runs native on Linux.
 ### Hardware
 - Add OrangePi 4a board support

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -746,7 +746,7 @@ def createLibretroConfig(
         "genesisplusgx" : { "megadrive" : { "device": 516, "p2": 0,
                                             "gameDependant": [ { "key": "type", "value": "justifier", "mapkey": "device", "mapvalue": "772" } ] },
                             "mastersystem" : { "device": 260, "p1": 0, "p2": 1 },
-                            "segacd" : { "device": 516, "p2": 0,
+                            "megacd" : { "device": 516, "p2": 0,
                                          "gameDependant": [ { "key": "type", "value": "justifier", "mapkey": "device", "mapvalue": "772" } ]} },
         "fbneo"         : { "default" : { "device":   4, "p1": 0, "p2": 1 } },
         "mame"          : { "default" : { "p1": 0, "p2": 1, "p3": 2 } },

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1720,7 +1720,7 @@ def _picodrive_options(
 
     # Sega MegaCD
     # Emulate the Backup RAM Cartridge for games save (ex: Shining Force CD)
-    _set(coreSettings, 'picodrive_ramcart', 'enabled' if system.name == 'segacd' else 'disabled')
+    _set(coreSettings, 'picodrive_ramcart', 'enabled' if system.name == 'megacd' else 'disabled')
 
 
 # Sega Saturn

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2835.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-bcm2835.yml
@@ -23,7 +23,7 @@ mastersystem:
 megadrive:
   emulator: libretro
   core:     picodrive
-segacd:
+megacd:
   emulator: libretro
   core:     picodrive
 satellaview:

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -549,7 +549,7 @@ sdlpop:
 sega32x:
   emulator: libretro
   core:     picodrive
-segacd:
+megacd:
   emulator: libretro
   core:     genesisplusgx
 sg1000:

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -516,13 +516,13 @@ megadrive:
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:megadrive
 
-segacd:
-  name:       Sega CD
+megacd:
+  name:       Mega CD
   manufacturer: Sega
   release: 1991
   hardware: console
   extensions: [cue, iso, chd, m3u]
-  platform:   segacd
+  platform:   megacd
   emulators:
     libretro:
       genesisplusgx: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_GENESISPLUSGX] }

--- a/package/batocera/emulators/retroarch/batocera-bezel/batocera-bezel.mk
+++ b/package/batocera/emulators/retroarch/batocera-bezel/batocera-bezel.mk
@@ -3,8 +3,8 @@
 # batocera bezel
 #
 ################################################################################
-# Version.: Commits on Oct 18, 2024
-BATOCERA_BEZEL_VERSION = c849638c73106a9f33d9634c564d0c1e94f753d3
+# Version.: Commits on Mar 28, 2025
+BATOCERA_BEZEL_VERSION = f72a3d366da9a3e50604cdf881279c6f49009d98
 BATOCERA_BEZEL_SITE = $(call github,batocera-linux,batocera-bezel,$(BATOCERA_BEZEL_VERSION))
 
 define BATOCERA_BEZEL_INSTALL_TARGET_CMDS


### PR DESCRIPTION
…is`)