### PR TITLE
Updated: rpi-retroflag-AdvancedSafeShutdown.py

### DIFF
--- a/package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-retroflag-AdvancedSafeShutdown.py
@@ -44,7 +44,7 @@ def handle_gpio_event(event_line_offset):
             elif output:
                 subprocess.run("batocera-es-swissknife --restart", shell=True, check=True)
             else:
-                subprocess.run("shutdown -r now", shell=True, check=True)
+                subprocess.run("reboot", shell=True, check=True)
         except Exception as e:
             print(f"Reset command error: {e}")
     
@@ -53,9 +53,9 @@ def handle_gpio_event(event_line_offset):
         try:
             output = int(subprocess.check_output(['batocera-es-swissknife', '--espid']))
             if output:
-                subprocess.run("batocera-es-swissknife --shutdown", shell=True, check=True)
+                subprocess.run("batocera-es-swissknife --reboot", shell=True, check=True)
             else:
-                subprocess.run("shutdown -h now", shell=True, check=True)
+                subprocess.run("reboot", shell=True, check=True)
         except Exception as e:
             print(f"Poweroff command error: {e}")
 


### PR DESCRIPTION
Regarding to: PR https://github.com/batocera-linux/batocera.linux/pull/13789 

Retroflag NESPi4 and Pi4 need `reboot` command to proper shutdown (means power cut)
For Pi3 it does not matter it works with `poweroff` and `reboot` command.

RETROGLAG as manufactorer also uses the `reboot` command in their scripts.