### PR TITLE
vpinball: bump vpinball to latest standalone

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Mar 6, 2025
+# Version: Commits on Mar 31, 2025
 # uses standalone tree for now
-VPINBALL_VERSION = ececff7d0105d52c18872cbf0a84d0840408fc29
+VPINBALL_VERSION = c3e8134bebae535689c52f8d841f86a970a89acb
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE


### PR DESCRIPTION
- Removes default xbox joystick ini entries.
- Several pup fixes