### PR TITLE
Automatic Bluetooth audio output switching

### DIFF
--- a/package/batocera/core/batocera-audio/alsa/batocera-audio
+++ b/package/batocera/core/batocera-audio/alsa/batocera-audio
@@ -36,31 +36,37 @@ case "${ACTION}" in
         MODE="$2"
         case "${MODE}" in
             auto)
-                ARCH=$(cat /usr/share/batocera/batocera.arch)
-                BOARD=$(cat /boot/boot/batocera.board)
+                BT_SINK=$(LANG=C pactl list short sinks | grep bluez_output | awk '{print $2}' | head -n1)
+                if [ -n "$BT_SINK" ]; then
+                    MODE="$BT_SINK"
+                    LANG=C pactl set-default-sink "${MODE}" || exit 1
+                else
+                    ARCH=$(cat /usr/share/batocera/batocera.arch)
+                    BOARD=$(cat /boot/boot/batocera.board)
 
-                case "${ARCH}" in
-                    "rk3399")
-                        MODE=alsa_output.platform-hdmi-sound.stereo-fallback
-                        LANG=C pactl set-default-sink "${MODE}" || exit 1
-                        ;;
-                    "s922x")
-                        if [[ "$BOARD" == "ogu" ]]; then
+                    case "${ARCH}" in
+                        "rk3399")
+                            MODE=alsa_output.platform-hdmi-sound.stereo-fallback
+                            LANG=C pactl set-default-sink "${MODE}" || exit 1
+                            ;;
+                        "s922x")
+                            if [[ "$BOARD" == "ogu" ]]; then
+                                LANG=C pactl set-default-sink INTERNAL
+                                amixer -c 0 -q sset "Master" 100%
+                                amixer -c 0 sset 'Playback Mux' SPK
+                                amixer -c 0 -q sset 'FRDDR_A SINK 1 SEL' 'OUT 1'
+                                amixer -c 0 -q sset 'FRDDR_A SRC 1 EN' 'on'
+                            fi
+                            ;;
+                        "rk3326")
                             LANG=C pactl set-default-sink INTERNAL
-                            amixer -c 0 -q sset "Master" 100%
-                            amixer -c 0 sset 'Playback Mux' SPK
-                            amixer -c 0 -q sset 'FRDDR_A SINK 1 SEL' 'OUT 1'
-                            amixer -c 0 -q sset 'FRDDR_A SRC 1 EN' 'on'
-                        fi
-                        ;;
-                    "rk3326")
-                        LANG=C pactl set-default-sink INTERNAL
-                        amixer -c 0 cset name='Playback Path' SPK
-                        ;;
-                    *)
-                        # do nothing!
-                        ;;
-                esac
+                            amixer -c 0 cset name='Playback Path' SPK
+                            ;;
+                        *)
+                            # do nothing!
+                            ;;
+                    esac
+                fi
                 ;;
             *)
                 LANG=C pactl set-default-sink "${MODE}" || exit 1

--- a/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth-agent
+++ b/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth-agent
@@ -11,6 +11,7 @@ import time
 import os
 import logging
 import signal
+import subprocess
 from gi.repository import GLib
 
 AGENT_INTERFACE = 'org.bluez.Agent1'
@@ -250,10 +251,9 @@ def interfaces_added(path, interfaces):
 def interfaces_removed(path, interfaces):
   global gdevices
 
-  if path in gdevices:
+  # Remove from gdevices only if the Device1 interface itself is removed
+  if "org.bluez.Device1" in interfaces and path in gdevices:
     listing_dev_event(path, gdevices[path], False)
-
-  if path in gdevices:
     del gdevices[path]
 
 def propertiesToStr(properties):
@@ -287,18 +287,23 @@ def properties_changed(interface, changed, invalidated, path):
   if "Paired" in changed and changed["Paired"] == True:
     # ok, do as in simple-agent, trust and connect
     connect_device(path, gdevices[path]["Address"], gdevices[path], True, getBluetoothWantedAddr())
+    refresh_audio_on_connect(gdevices[path])
     return
   
   # ok, it is now connected, what else ?
   if "Connected" in changed and changed["Connected"] == True:
+    refresh_audio_on_connect(gdevices[path])
     return
 
   if "Connected" in changed and changed["Connected"] == False:
     logging.info("Skipping (property Connected changed to False)");
+    refresh_audio_on_disconnect()
     return
 
   if "Address" in gdevices[path]:
     connect_device(path, gdevices[path]["Address"], gdevices[path], False, getBluetoothWantedAddr())
+
+  refresh_audio_on_connect(gdevices[path])
 
 def merge2dicts(d1, d2):
   res = d1.copy()
@@ -377,6 +382,30 @@ def user_signal_stop_discovery(signum, frame):
       gadapter.StopDiscovery()
   except:
     pass
+
+def refresh_audio_on_connect(properties):
+  # Skip if the device is not an audio device
+  if "Icon" not in properties or not prop2str(properties["Icon"]).startswith("audio-"):
+    return
+
+  logging.info("Bluetooth audio device connected. Waiting for sink to appear...")
+
+  # Wait up to 10 seconds for a 'bluez_' to appear
+  for i in range(100):
+    sinks = subprocess.check_output(["pactl", "list", "short", "sinks"], encoding='utf-8')
+    if "bluez_" in sinks:
+      current_output = subprocess.check_output(["batocera-audio", "get"], encoding='utf-8').strip()
+      subprocess.run(["batocera-audio", "set", current_output])
+      logging.info("Bluetooth audio sink detected: proceeding with audio refresh.")
+      return
+    time.sleep(0.1)
+
+  logging.warning("Bluetooth sink not detected within timeout.")
+
+def refresh_audio_on_disconnect():
+  current_output = subprocess.check_output(["batocera-audio", "get"], encoding='utf-8').strip()
+  subprocess.run(["batocera-audio", "set", current_output])
+  logging.info("Bluetooth audio disconnected. Refreshing audio output.")
 
 class Agent(dbus.service.Object):
   exit_on_release = True


### PR DESCRIPTION

https://github.com/user-attachments/assets/f7bb8b1e-780b-4722-ab0d-5ce2bb14d06c

0–7s: Audio is playing through the built-in speaker.
3s: A Bluetooth audio device connects.
7s: The system detects the Bluetooth audio sink.
8–12s: Audio is now playing on the Bluetooth device (automatically switched).
12–15s: The Bluetooth device is disconnected, and audio automatically switches back to the built-in speaker.

*Short Summary*
When a Bluetooth audio device is connected, the audio output automatically switches from the built-in speakers to the Bluetooth audio device.
When the Bluetooth audio connection is lost, it automatically switches back to the built-in speakers.
(This only applies if the AUDIO OUTPUT setting is set to “AUTO”)

*Detailed Description*
1. batocera-bluetooth-agent Modifications
- Added `refresh_audio_on_connect`: When a Bluetooth audio device is detected, this function waits up to 10 seconds and then calls `batocera-audio` to reconfigure the audio output.
- Added `refresh_audio_on_disconnect`: When the Bluetooth audio connection is lost, this function immediately calls `batocera-audio` to revert to built-in speakers (no waiting needed).
- Updated `interfaces_removed`: Previously, when a Bluetooth device disconnected, all information in `gdevices` was cleared. As a result, if the same device reconnected before reboot, important properties like `Icon="audio-headset"` were missing. This fix ensures `gdevices` retains the necessary data for reconnection.
2. batocera-audio Modifications
- Updated the AUTO handling so that `Bluetooth audio` is prioritized when available.
