### PR TITLE
configgen: createPPSSPPConfig: Change RenderingMode to SkipBufferEffects.

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -65,19 +65,19 @@ def createPPSSPPConfig(iniConfig: CaseSensitiveConfigParser, system: Emulator):
     iniConfig.set("Graphics", "FrameSkipType", "0") # Use number and not percent
     frameskip = system.config.get_str("frameskip")
     if not frameskip or frameskip == "automatic":
-        if not system.config.get_bool('rendering_mode', True):
+        if system.config.get_bool('skip_buffer_effects', True):
             frameskip = "0"
         else:
             frameskip = "2"
     iniConfig.set("Graphics", "FrameSkip", frameskip)
 
     # Buffered rendering
-    rendering_mode = system.config.get_bool('rendering_mode', True, return_values=("1", "0"))
+    sbe_enabled = system.config.get_bool('skip_buffer_effects', True)
     auto_frameskip = "False"
 
-    iniConfig.set("Graphics", "RenderingMode", rendering_mode)
+    iniConfig.set("Graphics", "SkipBufferEffects", str(sbe_enabled))
 
-    if rendering_mode == "1":
+    if not sbe_enabled:
         # Both internal resolution and auto frameskip are dependent on buffered rendering being on, only check these if the user is actually using buffered rendering.
         iniConfig.set("Graphics", "InternalResolution", system.config.get_str("internal_resolution", "1"))
         # Auto frameskip

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -9032,13 +9032,13 @@ ppsspp:
             choices:
                 "OpenGL": 0 (OPENGL)
                 "Vulkan": 3 (VULKAN)
-        rendering_mode:
+        skip_buffer_effects:
             group: ADVANCED OPTIONS
-            prompt: RENDERING MODE
-            description: Skip buffer disables auto frameskip and renders at display output resolution.
+            prompt: SKIP BUFFER EFFECTS
+            description: Skip buffer effects disables auto frameskip and renders at display output resolution.
             choices:
-                "Skip buffer effects": 0
-                "Buffered rendering":  1
+                "Buffered rendering":  false
+                "Skip buffer effects": true
         internal_resolution:
             prompt: RENDERING RESOLUTION
             description: Enhancement. Increase the rendering resolution. Makes 3D objects clearer.


### PR DESCRIPTION
This fixes the broken RenderingMode option in Batocera as PPSSPP changed it to SkipBufferEffects a couple of years ago (https://github.com/hrydgard/ppsspp/commit/519db766b6a251d8d8032236c401babf29e82553).