### PR TITLE
batocera-wine: stop function with better control, some small fixes

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -110,13 +110,15 @@ update_wine_version() {
 }
 
 waitWineServer() {
+    local ret=0 pid=$(pgrep -o -f "${WINESERVER}")
+    [[ -z "$pid" ]] && { echo "${FUNCNAME[0]}: Called by ${FUNCNAME[1]} no process '${WINESERVER}' found - finished with hotkey?" >&2; return 0; }
     #from: https://unix.stackexchange.com/a/427133
     #timeout will report not 0 if setted value is reached
-    if pgrep -f "${WINESERVER}"; then
-        echo "Waiting WineServer: ${WINESERVER}"
-        timeout "$1" tail -q --pid=$(pgrep -f "${WINESERVER}") -f /dev/null
-        echo "Finished waiting for WineServer: ${WINESERVER}"
-    fi
+    echo "${FUNCNAME[0]}: Called by ${FUNCNAME[1]} wait WineServer: [$pid] ${WINESERVER}"
+    timeout "$1" tail -q --pid=$pid -f /dev/null
+    ret=$?
+    echo "${FUNCNAME[0]}: Finished waiting for WineServer [$pid] with errorcode($ret)"
+    return $ret
 }
 
 wine_options() {
@@ -973,15 +975,18 @@ case "${ACTION}" in
 
 # case selections will provide 2 variables here, GAMENAME and WINEPOINT
    "play")
-   init_wine && requestFileSystem "${GAMENAME}" "${WINE_BOTTLE_DIR}/${WINE_VERSION}/${ROMGAMENAME}.wine"
+   init_wine
 	case "${GAMEEXT,,}" in
 	    "wine")
+		requestFileSystem "${GAMENAME}"
 		play_wine "${GAMENAME}" "${GAMENAME}"
 		;;
 	    "pc")
+		requestFileSystem "${GAMENAME}" "${WINE_BOTTLE_DIR}/${WINE_VERSION}/${ROMGAMENAME}.wine"
 		play_pc "${GAMENAME}" "${WINE_BOTTLE_DIR}/${WINE_VERSION}/${ROMGAMENAME}.wine"
 		;;
 	    "exe")
+		requestFileSystem "${GAMENAME}" "${WINE_BOTTLE_DIR}/${WINE_VERSION}/${ROMGAMENAME}.wine"
 		play_exe "${GAMENAME}" "${WINE_BOTTLE_DIR}/${WINE_VERSION}/${ROMGAMENAME}.wine"
 		;;
 #	    "iso")
@@ -989,9 +994,11 @@ case "${ACTION}" in
 #		;;
 	    "wsquashfs")
 		#Arguments, ROMNAME, WINEPREFIX as squashfs, SAVEDIR, WORKDIR
+		requestFileSystem "${GAMENAME}" "${WINE_BOTTLE_DIR}/${ROMGAMENAME}"
 		play_squashfs "${GAMENAME}" "/var/run/wine/${ROMGAMENAME}" "${WINE_BOTTLE_DIR}/${ROMGAMENAME}" "${WINE_BOTTLE_DIR}/${ROMGAMENAME}.work"
 		;;
 	    "wtgz")
+		requestFileSystem "${GAMENAME}" "${WINE_BOTTLE_DIR}/${ROMGAMENAME}.wine"
 		play_winetgz "${GAMENAME}" "${WINE_BOTTLE_DIR}/${ROMGAMENAME}.wine"
 		;;
 	    *)


### PR DESCRIPTION
indeed waitWineServer function can now be improved with timeouts so imho it would be better to use: `waitWineServer 10 || { echo "WinServer reached timeout of 10s with errorcode ($?)"; stopWineServer; }` instead of `waitWineServer 0`

Why?
Commands like

```
WINEPREFIX=${WINEPOINT} eval "${WINE_ENV}" "${WINE} ${VDESKTOP} ${WINE_CMD}"
```

already call a full WINE Instance and the scripts stop at this points.... So the waitWineServer function is called very late (exactly if you quit the game) and is a kind of **"security"** function? I did not introduce this function but I think it's an important one....

Edit: Just for testing purposes I forced a call to stopWineServer with
```
waitWineServer 0.1 || stopWineServer
```
This will turn in a timeout with EC 124 and then call the stop function - and got a log:
```
waitWineServer: Called by play_pc wait WineServer: [12312] /usr/wine/wine-tkg/bin/wineserver
waitWineServer: Finished waiting for WineServer [12312] with errorcode(124)
waitWineServer: Called by stopWineServer wait WineServer: [12312] /usr/wine/wine-tkg/bin/wineserver
waitWineServer: Finished waiting for WineServer [12312] with errorcode(0)
WineServer was 27s active
```

I think that is pretty perfect and will be a usefull feature in future usage. In my setup I never faced a endless looping server but if there is a user report we may can fix it now. 