### PR TITLE
mugen: fix evmapy mapping

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mugen/mugenGenerator.py
@@ -63,7 +63,7 @@ class MugenGenerator(Generator):
                     "A": "51",
                     "B": "52",
                     "C": "53",
-                    "X": "26",
+                    "X": "38",
                     "Y": "39",
                     "Z": "40",
                     "Start": "28"

--- a/package/batocera/utils/batocera-wine/mugen.keys
+++ b/package/batocera/utils/batocera-wine/mugen.keys
@@ -49,37 +49,37 @@
                 "description": "Right"
         },
         {
-                "trigger": ["b"],
+                "trigger": ["y"],
                 "type": "key",
-                "target": [ "KEY_LEFTBRACE" ],
+                "target": [ "KEY_L" ],
                 "description": "Button X"
         },
         {
-                "trigger": ["a"],
+                "trigger": ["x"],
                 "type": "key",
                 "target": [ "KEY_SEMICOLON" ],
                 "description": "Button Y"
         },
         {
-                "trigger": ["r2"],
+                "trigger": ["pagedown"],
                 "type": "key",
                 "target": [ "KEY_APOSTROPHE" ],
                 "description": "Button Z"
         },
         {
-                "trigger": ["y"],
+                "trigger": ["b"],
                 "type": "key",
                 "target": [ "KEY_COMMA" ],
                 "description": "Button A"
         },
         {
-                "trigger": ["x"],
+                "trigger": ["a"],
                 "type": "key",
                 "target": [ "KEY_DOT" ],
                 "description": "Button B"
         },
         {
-                "trigger": ["pagedown"],
+                "trigger": ["r2"],
                 "type": "key",
                 "target": [ "KEY_SLASH" ],
                 "description": "Button C"
@@ -147,37 +147,37 @@
                 "description": "Right"
         },
         {
-                "trigger": ["b"],
+                "trigger": ["y"],
                 "type": "key",
                 "target": [ "KEY_R" ],
                 "description": "Button X"
         },
         {
-                "trigger": ["a"],
+                "trigger": ["x"],
                 "type": "key",
                 "target": [ "KEY_T" ],
                 "description": "Button Y"
         },
         {
-                "trigger": ["r2"],
+                "trigger": ["pagedown"],
                 "type": "key",
                 "target": [ "KEY_Y" ],
                 "description": "Button Z"
         },
         {
-                "trigger": ["y"],
+                "trigger": ["b"],
                 "type": "key",
                 "target": [ "KEY_F" ],
                 "description": "Button A"
         },
         {
-                "trigger": ["x"],
+                "trigger": ["a"],
                 "type": "key",
                 "target": [ "KEY_G" ],
                 "description": "Button B"
         },
         {
-                "trigger": ["pagedown"],
+                "trigger": ["r2"],
                 "type": "key",
                 "target": [ "KEY_H" ],
                 "description": "Button C"


### PR DESCRIPTION
- KEY_LEFTBRACE for P1 is wrong, it's L    (in the same raw of the keyboard)
- invert X Y R1 <-> A B R2  raw. (this the the standard in arcade sticks)

also fix the L key from my previous patch for old mugen engine.