### PR TITLE
Trigger userscripts upon suspend and resume events

### DIFF
--- a/board/batocera/fsoverlay/etc/pm/sleep.d/99trigger_userscripts
+++ b/board/batocera/fsoverlay/etc/pm/sleep.d/99trigger_userscripts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Execute all user-defined scripts located in the EmulationStation scripts suspend and resume directories upon such events are triggered
+
+SCRIPTS_BASE_PATH=/userdata/system/configs/emulationstation/scripts
+case "$1" in
+    suspend)
+        if [[ -d "$SCRIPTS_BASE_PATH/suspend" ]]; then
+            for script in $SCRIPTS_BASE_PATH/suspend/*; do
+                [[ -x "$script" ]] && /bin/bash $script;
+            done
+        fi
+    ;;
+    resume|thaw)
+        if [[ -d "$SCRIPTS_BASE_PATH/resume" ]]; then
+            for script in $SCRIPTS_BASE_PATH/resume/*; do
+                [[ -x "$script" ]] && /bin/bash $script;
+            done
+        fi
+    ;;
+esac
+exit 0


### PR DESCRIPTION
This pull request adds support for two new EmulationStation script hooks: `suspend` and `resume`. 

These are triggered when the system enters suspend mode (e.g., via `pm-suspend` command from SSH/terminal or the suspend options in the EmulationStation GUI) and when it resumes from 

 Suspend event scripts will be triggered from:
 `/userdata/system/configs/emulationstation/scripts/suspend`

Resume event scripts will be triggered from:
`/userdata/system/configs/emulationstation/scripts/resume`

## Notes

If this is approved and merged, the [EmulationStation scripting documentation](https://wiki.batocera.org/launch_a_script#emulationstation_scripting) should be updated accordingly.

This addresses: https://github.com/batocera-linux/batocera.linux/issues/13894