### PR TITLE
scummvmGenerator: read game ID from file

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -46,11 +46,15 @@ class ScummVMGenerator(Generator):
           # rom is a directory: must contains a <game name>.scummvm file
           romPath = rom
           romName = next(rom.glob("*.scummvm")).stem
-        else:
-          # rom is a file: split in directory and file name
+        elif rom.stat().st_size < 3::
+          # rom is a file less than 3 bytes: split in directory and file name
           romPath = rom.parent
           # Get rom name without extension
           romName = rom.stem
+        else:
+          # rom is a file containing the game ID inside, open and read game ID from ROM-file: split directory
+          romName = Path(rom).read_text().rstrip('\n')
+          romPath = rom.parent
 
         # pad number
         id = 0


### PR DESCRIPTION
Just a small addition... we can add files to scummvm and call them `whatever.scummvm` and just set the game ID inside the file.

I added a handler that files less then 3 bytes are getting ignored and handled like usually (see ... a "empty" windows file with with CRLF is 2 bytes long) ... afaik the shortest game ID is `11h` and this is 3 bytes ;)  So we should have a perfect match here.

An example....
Create a file `Goblins III [DOS 1.02 CD French].scummvm` inside the Goblins3 games folder. Edit it and add `gob3-cd-fr` as ID inside.... isn't that nice?

The great **plus** is that we can achive compatibility with Windows ScummVM for example ... I really struggled about the save-game names -- they are built from the ID-name!