### PR TITLE
scummvmGenerator: get game ID from file content

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -45,16 +45,21 @@ class ScummVMGenerator(Generator):
         if rom.is_dir():
           # rom is a directory: must contains a <game name>.scummvm file
           romPath = rom
-          romName = next(rom.glob("*.scummvm")).stem
-
-        if rom.is_file():
-          # rom is a file: split in directory and file name
-          romPath = rom.parent
+          romName = next(rom.glob("*.scummvm"),0)
+          if romName:
+            romName = romName.stem
+        # rom is a file: split in directory and file name
+        elif rom.is_file():
           # obtain game ID within file
+          romPath = rom.parent
           romName = Path(rom).read_text().strip()
-          # if value is empty get rom name without extension
-          if not romName:
-            romName = rom.stem
+
+        # if value is empty get gameID name without extension from file/dirname
+        if not romName:
+          romName = rom.stem
+        # if value is not a valid gameID then set autodetection
+        if not romName.islower():
+          romName = "--auto-detect"
 
         # pad number
         id = 0

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -48,18 +48,17 @@ class ScummVMGenerator(Generator):
           romName = next(rom.glob("*.scummvm"),0)
           if romName:
             romName = romName.stem
-        # rom is a file: split in directory and file name
+        # rom is a file: get the gameID from file content
         elif rom.is_file():
-          # obtain game ID within file
           romPath = rom.parent
           romName = Path(rom).read_text().strip()
 
         # if value is empty get gameID name without extension from file/dirname
         if not romName:
           romName = rom.stem
-        # if value is not a valid gameID then set autodetection
-        if not romName.islower():
-          romName = "--auto-detect"
+          # No valid gameID then set autodetection: "monkey2" is a valid one
+          if not romName.islower():
+            romName = "--auto-detect"
 
         # pad number
         id = 0

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -41,16 +41,20 @@ class ScummVMGenerator(Generator):
         with ensure_parents_and_open(scummConfigFile, 'w') as configfile:
             scummConfig.write(configfile)
 
-        # Find rom path
+        # Find rom path and rom name
         if rom.is_dir():
           # rom is a directory: must contains a <game name>.scummvm file
           romPath = rom
           romName = next(rom.glob("*.scummvm")).stem
-        else:
+
+        if rom.is_file():
           # rom is a file: split in directory and file name
           romPath = rom.parent
-          # Get rom name without extension
-          romName = rom.stem
+          # obtain game ID within file
+          romName = Path(rom).read_text().strip()
+          # if value is empty get rom name without extension
+          if not romName:
+            romName = rom.stem
 
         # pad number
         id = 0


### PR DESCRIPTION
In favour of https://github.com/batocera-linux/batocera.linux/pull/13922

Tested and method works with libretro and standalone scummvm. 

Just a small addition... we can add files to scummvm and call them `whatever.scummvm` and just set the game ID inside the file.

I added a handler that files less then 3 bytes are getting ignored and handled like usually (see ... a "empty" windows file with with CRLF is 2 bytes long) ... afaik the shortest game ID is `11h` and this is 3 bytes ;)  So we should have a perfect match here.

An example....
Create a file `Goblins III [DOS 1.02 CD French].scummvm` inside the Goblins3 games folder. Edit it and add `gob3-cd-fr` as ID inside.... isn't that nice?

The great **plus** is that we can achive compatibility with Windows ScummVM for example ... I really struggled about the save-game names -- they are built from the ID-name!