### PR TITLE
lr-dice to v0.3.0 to get multi-mouse for spinner games

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-dice/libretro-dice.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dice/libretro-dice.mk
@@ -3,8 +3,8 @@
 # libretro-dice
 #
 ################################################################################
-# Version.: Commits on Mar 28, 2025
-LIBRETRO_DICE_VERSION = 1b42e34e8e7f2fe15654a0035cb08da8158bbb52
+# Version.: Commits on Apr 10, 2025
+LIBRETRO_DICE_VERSION = v0.3.0
 LIBRETRO_DICE_SITE = $(call github,mittonk,dice-libretro,$(LIBRETRO_DICE_VERSION))
 LIBRETRO_DICE_LICENSE = GPLv3
 LIBRETRO_DICE_DEPENDENCIES += retroarch


### PR DESCRIPTION
https://github.com/mittonk/dice-libretro/blob/main/retromouse.md
for all your 4-spinner pong-variant needs.  Works well with existing udev input config.
Seems covered by existing changelog entry for adding lr-dice.