### PR TITLE
Fix openjk cross-compiling

### DIFF
--- a/package/batocera/ports/openjk/001-cross-compile.patch
+++ b/package/batocera/ports/openjk/001-cross-compile.patch
@@ -1,0 +1,13 @@
+diff --git a/codemp/rd-rend2/CMakeLists.txt b/codemp/rd-rend2/CMakeLists.txt
+index 786cf25..44ecef9 100644
+--- a/codemp/rd-rend2/CMakeLists.txt
++++ b/codemp/rd-rend2/CMakeLists.txt
+@@ -193,7 +193,7 @@ if (NOT WIN32 AND NOT APPLE)
+ 	target_compile_definitions(compact_glsl PRIVATE "ARCH_STRING=\"${Architecture}\"")
+ endif()
+ target_include_directories(compact_glsl PRIVATE "${MPRend2IncludeDirectories}")
+-if (WIN32 OR APPLE)
++if (WIN32 OR APPLE OR CMAKE_CROSSCOMPILING)
+ add_custom_command(
+ 	OUTPUT
+ 		${CMAKE_CURRENT_BINARY_DIR}/glsl_shaders.cpp

--- a/package/batocera/ports/openjk/openjk.mk
+++ b/package/batocera/ports/openjk/openjk.mk
@@ -2,11 +2,11 @@
 # This file is part of the batocera distribution (https://batocera.org).
 # Copyright (c) 2025+.
 #
-# This program is free software: you can redistribute it and/or modify  
-# it under the terms of the GNU General Public License as published by  
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 3.
 #
-# You should have received a copy of the GNU General Public License 
+# You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # YOU MUST KEEP THIS HEADER AS IT IS
@@ -24,7 +24,7 @@ OPENJK_SUPPORTS_IN_SOURCE_BUILD = NO
 OPENJK_LICENSE = GPL-2.0 license
 OPENJK_LICENSE_FILE = LICENSE.txt
 
-OPENJK_DEPENDENCIES += host-libjpeg libjpeg-bato libpng sdl2 zlib
+OPENJK_DEPENDENCIES += host-openjk host-libjpeg libjpeg-bato libpng sdl2 zlib
 
 OPENJK_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
 OPENJK_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
@@ -34,12 +34,24 @@ OPENJK_CONF_OPTS += -DBuildJK2SPEngine=ON
 OPENJK_CONF_OPTS += -DBuildJK2SPGame=ON
 OPENJK_CONF_OPTS += -DBuildJK2SPRdVanilla=ON
 
+HOST_OPENJK_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
+HOST_OPENJK_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
+# Prevents cmake checking if sdl2 is installed (not needed for compact_glsl)
+HOST_OPENJK_CONF_OPTS += -DUseInternalSDL2=ON
+
+HOST_OPENJK_BUILD_OPTS += --target compact_glsl
+
 define OPENJK_EVMAPY
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/ports/openjk/openjk.keys \
 	    $(TARGET_DIR)/usr/share/evmapy
 endef
 
+define HOST_OPENJK_INSTALL_CMDS
+	$(INSTALL) -D -m 0755 $(HOST_OPENJK_BUILDDIR)/compact_glsl $(HOST_DIR)/usr/bin/compact_glsl
+endef
+
 OPENJK_POST_INSTALL_TARGET_HOOKS += OPENJK_EVMAPY
 
 $(eval $(cmake-package))
+$(eval $(host-cmake-package))


### PR DESCRIPTION
Because the openjk build needs to run `compact_glsl`, `compact_glsl` needs to be built for the host machine, installed to the host directory, and run from `PATH` rather than the target build directory.