### PR TITLE
scummvmGenerator: Both cores work the same way

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -24,7 +24,7 @@ class ScummVMGenerator(Generator):
         }
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
-        # crete /userdata/bios/scummvm/extra folder if it doesn't exist
+        # create /userdata/bios/scummvm/extra folder if it doesn't exist
         mkdir_if_not_exists(scummExtra)
 
         # create / modify scummvm config file as needed
@@ -43,14 +43,22 @@ class ScummVMGenerator(Generator):
 
         # Find rom path
         if rom.is_dir():
-          # rom is a directory: must contains a <game name>.scummvm file
           romPath = rom
-          romName = next(rom.glob("*.scummvm")).stem
+          romName = next(rom.glob("*.scummvm"),0)
         else:
           # rom is a file: split in directory and file name
           romPath = rom.parent
-          # Get rom name without extension
-          romName = rom.stem
+          romName = rom
+        # rom is a dir: it should contain a <game name>.scummvm file, otherwise fallback to autodetection
+        # rom is a file or file in dir detected: get gameID from file content or filename (like libretro does), otherwise fallback to autodetection
+        if romName:
+          if romName := Path(romName).read_text().strip():pass
+          else:
+            romName = romName.stem
+            if not romName.islower():
+              romName = "--auto-detect"
+        else:
+          romName = "--auto-detect"
 
         # pad number
         id = 0


### PR DESCRIPTION
I've tested:

**SCUMMVM-file:**
- `Whatever you named this.scummvm` -> empty
  - standalone uses autodetection
  - libretro uses autodetection

- `Whatever you named this.scummvm` -> contains valid gameID `monkey2-cd-fr` or engineID `monkey2`
  - standalone uses the content inside file
  - libretro uses the content inside file

- `engineID.scummvm` -> empty
  - standalone uses filename
  - libretro uses filename

- `engineID.scummvm` -> contains valid gameID `monkey2-cd-fr` 
  - standalone uses the content inside file
  - libretro uses the content inside file

- `gameID.scummvm`-> empty
  - standalone uses the filename and can set valid language automatically or per ES
  - libretro will fallback to autodetection

**SQUASHFS-file:**
behaviour is exactly like SCUMMVM-file except:
- There is no scummvm-file available inside the sqashfs-file
  - standalone uses autodetection
  - libretro uses autodetection

In general:
If the user fills a file with content, this has top priority and is accepted without being checked. This is the natural behaviour of libretro-core and would also affect standalone-core. This PR-commit adds the automatic detection for games also for the standalone-core. This makes a simple setup for the user possible. Especially for squashfs files, which no longer need to contain a scummvm file.

The language setting in ES for the standalone core will always override the one from gameID. The libretro-core needs the the gameID for proper language setting.

I would like to see this featurea in version 42.

PS: This wasn't done with help of AI just HI/NI