### PR TITLE
Retroflag 64Pi CASE support

### DIFF
--- a/package/batocera/kodi/kodi21-resource-language-de_de/kodi21_resource_language_de_de.mk
+++ b/package/batocera/kodi/kodi21-resource-language-de_de/kodi21_resource_language_de_de.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION = 11.0.87
+KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION = 11.0.89
 KODI21_RESOURCE_LANGUAGE_DE_DE_SOURCE = \
     resource.language.de_de-$(KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_DE_DE_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-el_gr/kodi21_resource_language_el_gr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-el_gr/kodi21_resource_language_el_gr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION = 11.0.65
+KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION = 11.0.67
 KODI21_RESOURCE_LANGUAGE_EL_GR_SOURCE = \
     resource.language.el_gr-$(KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_EL_GR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-es_es/kodi21_resource_language_es_es.mk
+++ b/package/batocera/kodi/kodi21-resource-language-es_es/kodi21_resource_language_es_es.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION = 11.0.83
+KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION = 11.0.85
 KODI21_RESOURCE_LANGUAGE_ES_ES_SOURCE = \
     resource.language.es_es-$(KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_ES_ES_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-eu_es/kodi21_resource_language_eu_es.mk
+++ b/package/batocera/kodi/kodi21-resource-language-eu_es/kodi21_resource_language_eu_es.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION = 11.0.62
+KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION = 11.0.64
 KODI21_RESOURCE_LANGUAGE_EU_ES_SOURCE = \
     resource.language.eu_es-$(KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_EU_ES_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-fr_fr/kodi21_resource_language_fr_fr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-fr_fr/kodi21_resource_language_fr_fr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION = 11.0.87
+KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION = 11.0.90
 KODI21_RESOURCE_LANGUAGE_FR_FR_SOURCE = resource.language.fr_fr-$(KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_FR_FR_SITE = https://mirrors.kodi.tv/addons/omega/resource.language.fr_fr
 KODI21_RESOURCE_LANGUAGE_FR_FR_PLUGINNAME=resource.language.fr_fr

--- a/package/batocera/kodi/kodi21-resource-language-it_it/kodi21_resource_language_it_it.mk
+++ b/package/batocera/kodi/kodi21-resource-language-it_it/kodi21_resource_language_it_it.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION = 11.0.87
+KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION = 11.0.89
 KODI21_RESOURCE_LANGUAGE_IT_IT_SOURCE = \
     resource.language.it_it-$(KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_IT_IT_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-pt_br/kodi21_resource_language_pt_br.mk
+++ b/package/batocera/kodi/kodi21-resource-language-pt_br/kodi21_resource_language_pt_br.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION = 11.0.84
+KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION = 11.0.87
 KODI21_RESOURCE_LANGUAGE_PT_BR_SOURCE = \
     resource.language.pt_br-$(KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_PT_BR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-sv_se/kodi21_resource_language_sv_se.mk
+++ b/package/batocera/kodi/kodi21-resource-language-sv_se/kodi21_resource_language_sv_se.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION = 11.0.79
+KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION = 11.0.81
 KODI21_RESOURCE_LANGUAGE_SV_SE_SOURCE = \
     resource.language.sv_se-$(KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_SV_SE_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-tr_tr/kodi21_resource_language_tr_tr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-tr_tr/kodi21_resource_language_tr_tr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION = 11.0.78
+KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION = 11.0.80
 KODI21_RESOURCE_LANGUAGE_TR_TR_SOURCE = \
     resource.language.tr_tr-$(KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_TR_TR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-zh_cn/kodi21_resource_language_zh_cn.mk
+++ b/package/batocera/kodi/kodi21-resource-language-zh_cn/kodi21_resource_language_zh_cn.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION = 11.0.77
+KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION = 11.0.80
 KODI21_RESOURCE_LANGUAGE_ZH_CN_SOURCE = resource.language.zh_cn-$(KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_ZH_CN_SITE = https://mirrors.kodi.tv/addons/omega/resource.language.zh_cn
 KODI21_RESOURCE_LANGUAGE_ZH_CN_PLUGINNAME=resource.language.zh_cn

--- a/package/batocera/ports/abuse/abuse.mk
+++ b/package/batocera/ports/abuse/abuse.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 # Version.: Commits on Oct 27, 2022
-ABUSE_VERSION = v0.9.1
+ABUSE_VERSION = 9d1f66f57377859bae10e28eabebea0b9c750490
 ABUSE_SITE = $(call github,Xenoveritas,abuse,$(ABUSE_VERSION))
 
 ABUSE_DEPENDENCIES = sdl2 sdl2_mixer

--- a/package/batocera/ports/etlegacy/etlegacy.mk
+++ b/package/batocera/ports/etlegacy/etlegacy.mk
@@ -53,7 +53,7 @@ endif
 
 define ETLEGACY_INSTALL_TARGET_CMDS
     mkdir -p $(TARGET_DIR)/usr/share/etlegacy
-	cp $(@D)/buildroot-build/legacy/legacy_2.83-dirty.pk3 \
+	cp $(@D)/buildroot-build/legacy/legacy_batocera-5.24_dirty.pk3 \
 	    $(TARGET_DIR)/usr/share/etlegacy
     cp $(@D)/buildroot-build/etl \
 	    $(TARGET_DIR)/usr/bin/etl


### PR DESCRIPTION
I updated the shell script "S72gpioinput" in order to make the gpios fully usable with the case Retroflag 64Pi. 

Once the OS has been compiled. You have to run this command in the ssh shell : "/etc/init.d/S92switch setup" (according to this [documentation ] (https://wiki.batocera.org/add_powerdevices_rpi_only)). After this, the safe shutdown should work with the case. 

However, when you plug the power supply for the first time, to RPi5 is powered on automatically. I will try to find a solution for this issue. 

Also, I edited the script "scripts/linux/systemsReport.sh" and I updated some packages. 