### PR TITLE
Retroflag 64Pi CASE support

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S72gpioinput
+++ b/package/batocera/utils/rpigpioswitch/S72gpioinput
@@ -35,8 +35,8 @@ case "$1" in
   start)
     ba_gpio_configure
 
-    # Required to initialize GPIO pins on RPi4
-    if [ "$arch" = "bcm2711" ] && [ $gpio_enabled -eq 1 ]
+    # Required to initialize GPIO pins on RPi4 and RPi5
+    if { [ "$arch" = "bcm2711" ] || [ "$arch" = "bcm2712" ]; } && [ $gpio_enabled -eq 1 ]
     then
     /usr/bin/python - <<-_EOF_
         import gpiod


### PR DESCRIPTION
I updated the shell script "S72gpioinput" in order to make gpio pins fully usable with the case Retroflag 64Pi.

Once the OS has been compiled. You have to run this command in the ssh shell : "/etc/init.d/S92switch setup" (according to this [documentation ] (https://wiki.batocera.org/add_powerdevices_rpi_only)). After a reboot, the safe shutdown should work with the case.

However, when you plug the power supply for the first time. The RPi5 is powered on automatically. I will try to find a solution for this issue.