### PR TITLE
Retroflag 64Pi CASE support

### DIFF
--- a/package/batocera/utils/rpigpioswitch/rpi-retroflag-64PiCase.py
+++ b/package/batocera/utils/rpigpioswitch/rpi-retroflag-64PiCase.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+
+import gpiod
+from gpiod.line import Bias, Edge, Direction, Value
+import os
+from datetime import timedelta
+import subprocess
+
+# Pin Configuration
+POWER_CHIP = "/dev/gpiochip0"
+POWER_PIN = 3  # pin 5
+LED_PIN = 14   # TXD - pin 8
+RESET_PIN = 2  # pin 3
+POWEREN_PIN = 4  # pin 7
+
+def init_gpio():
+    try:
+        gpiod.request_lines(POWER_CHIP,
+            config={
+                LED_PIN: gpiod.LineSettings(
+                    direction=Direction.OUTPUT, 
+                    output_value=Value.ACTIVE
+                ),
+                POWEREN_PIN: gpiod.LineSettings(
+                    direction=Direction.OUTPUT, 
+                    output_value=Value.ACTIVE
+                )
+            }
+        )
+        print("GPIO initialized successfully.")
+    except Exception as e:
+        print(f"Failed to initialize GPIO: {e}")
+        exit(1)
+
+def handle_gpio_event(event_line_offset):
+    if event_line_offset == RESET_PIN:
+        print("RESET button pressed")
+        try:
+            output = int(subprocess.check_output(['batocera-es-swissknife', '--espid']))
+            output_rc = int(subprocess.check_output(['batocera-es-swissknife', '--emupid']))
+            
+            if output_rc:
+                subprocess.run("batocera-es-swissknife --emukill", shell=True, check=True)
+            elif output:
+                subprocess.run("batocera-es-swissknife --restart", shell=True, check=True)
+            else:
+                subprocess.run("reboot", shell=True, check=True)
+        except Exception as e:
+            print(f"Reset command error: {e}")
+
+    elif event_line_offset == POWER_PIN:
+        print("POWER button pressed")
+        try:
+            output = int(subprocess.check_output(['batocera-es-swissknife', '--espid']))
+            if output:
+                print("Exiting emulators and shutting down Batocera")
+                subprocess.run("batocera-es-swissknife --emukill", shell=True, check=True)
+                subprocess.run("batocera-es-swissknife --shutdown", shell=True, check=True)
+            else:
+                print("System shutdown")
+                subprocess.run("shutdown -h now", shell=True, check=True)
+        except Exception as e:
+            print(f"Poweroff command error: {e}")
+
+def watch_gpio_events():
+    try:
+        with gpiod.request_lines(
+            POWER_CHIP,
+            config={
+                POWER_PIN: gpiod.LineSettings(
+                    edge_detection=Edge.FALLING,
+                    bias=Bias.PULL_UP,
+                    debounce_period=timedelta(milliseconds=1000)
+                ),
+                RESET_PIN: gpiod.LineSettings(
+                    edge_detection=Edge.RISING,
+                    bias=Bias.PULL_UP,
+                    debounce_period=timedelta(milliseconds=50)
+                )
+            },
+        ) as request:
+            print("GPIO event monitoring started")
+            for event in request.read_edge_events():
+                handle_gpio_event(event.line_offset)
+    except Exception as e:
+        print(f"Error watching GPIO events: {e}")
+        exit(1)
+
+def main():
+    init_gpio()
+    while True:
+        watch_gpio_events()
+
+if __name__ == "__main__":
+    main()

--- a/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
+++ b/package/batocera/utils/rpigpioswitch/rpi_gpioswitch.sh
@@ -31,10 +31,12 @@
 #v2.9 - add Waveshare WM8960 audio HAT - @dmanlfc
 #v3.0 - migrate RPi scripts from RPi.GPIO to gpiod - @dmanlfc
 #v3.1 - remove the RETROFLAG option in favor of RETROFLAG_ADV & add dtbo for retroflag cases - @dmanlfc
+#v3.2 - add Retroflag 64Pi case for Raspberry Pi 5 support.
 
 ### Array for Powerdevices, add/remove entries here
 
 powerdevices=(
+              RETROFLAG_64PI "Retroflag 64Pi case for Raspberry Pi 5" \
               RETROFLAG_ADV "Retroflag Including NESPi+ SuperPi and MegaPi cases" \
               RETROFLAG_GPI "Retroflag GPi case for Raspberry 0" \
               ARGONONE "Fan control for RPi4 & RPi5 Argon One case" \
@@ -1018,6 +1020,9 @@ case "$CONFVALUE" in
     ;;
     "PIN356ONOFFRESET")
         pin356_$1
+    ;;
+    "RETROFLAG_64PI")
+        retroflag_$1 rpi-retroflag-64PiCase
     ;;
     "RETROFLAG_GPI")
         retroflag_$1 rpi-retroflag-GPiCase

--- a/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
+++ b/package/batocera/utils/rpigpioswitch/rpigpioswitch.mk
@@ -17,6 +17,8 @@ define RPIGPIOSWITCH_INSTALL_TARGET_CMDS
 	    $(TARGET_DIR)/usr/bin/rpi-pin56-power
 	$(INSTALL) -D -m 0755 $(RPIGPIOSWITCH_SRC)/rpi-pin356-power.py \
 	    $(TARGET_DIR)/usr/bin/rpi-pin356-power
+	$(INSTALL) -D -m 0755 $(RPIGPIOSWITCH_SRC)/rpi-retroflag-64PiCase.py \
+	    $(TARGET_DIR)/usr/bin/rpi-retroflag-64PiCase
 	$(INSTALL) -D -m 0755 $(RPIGPIOSWITCH_SRC)/rpi-retroflag-GPiCase.py \
 	    $(TARGET_DIR)/usr/bin/rpi-retroflag-GPiCase
 	$(INSTALL) -D -m 0755 $(RPIGPIOSWITCH_SRC)/rpi-retroflag-AdvancedSafeShutdown.py \


### PR DESCRIPTION
I was a bit hurry with my last [pull](https://github.com/batocera-linux/batocera.linux/pull/13973). 

The reset button worked but not the on/off switch. In order to solve this, I had to write an another script ( rpi-retroflag-64PiCase.py ). 

All went fine when I used it. The switch worked correctly. 
