### PR TITLE
scummVM all cores use same savegame location

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -9,6 +9,8 @@
 - Zedmd upgraded. You need firmware zedmd 5.1.5. See https://wiki.batocera.org/hardware:diy_zedmd?s[]=dmd#zedmd_configuration.
 - The folder for SegaCD/MegaCD roms is now called `megacd` to keep consistency (like `megadrive` is used, not `genesis`)
 - Removed Future Pinball in favor of Visual Pinball which has been available for some time and runs native on Linux.
+- ScummVM libretro and standalone savegames share the same folders now.
+  If you have saved games from the standalone core, it is recommended to move them from `/userdata/saves/scummvm/saves` to `/userdata/saves/scummvm`
 ### Hardware
 - Add OrangePi 4a board support
 - Add OrangePi 3b board support
@@ -70,6 +72,7 @@
 - BigPEmu now supports .bigpimg CD images
 - ROG Ally gamepad support
 - Batocera-wine: add saves directory and save files options
+- Batocera-wine: improved autodetection for Windows executables, refer to our [Wikipedia](https://wiki.batocera.org/systems:windows#creating_autoruncmd_from_ssh)
 - Libretro-virtualjaguar core can now load .zip ROMs
 - Updated BlamCon code to new firmware (now compatible with 4 light guns)
 - Xenia now uses Wine-Proton for more compatibility (i.e. Halo 4)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/scummvm/scummvmGenerator.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 scummConfigDir: Final = CONFIGS / "scummvm"
 scummConfigFile: Final = scummConfigDir / "scummvm.ini"
 scummExtra: Final = BIOS / "scummvm" / "extra"
+scummSave: Final = SAVES / "scummvm"
 
 class ScummVMGenerator(Generator):
 
@@ -100,6 +101,7 @@ class ScummVMGenerator(Generator):
             [f"--joystick={id}",
             f"--screenshotspath={SCREENSHOTS}",
             f"--extrapath={scummExtra}",
+            f"--savepath={scummSave}",
             f"--path={rom_path}",
             f"{target}"]
         )
@@ -108,7 +110,6 @@ class ScummVMGenerator(Generator):
             array=commandArray,
             env={
                 "XDG_CONFIG_HOME": CONFIGS,
-                "XDG_DATA_HOME": SAVES,
                 "XDG_CACHE_HOME": CACHE,
                 "SDL_GAMECONTROLLERCONFIG": generate_sdl_game_controller_config(playersControllers)
             }


### PR DESCRIPTION
Tested with several games
Monkey 1-3
Goblins 1-3
Full Throttle
Indiana Jones 3+4
Broken Sword 1+2
Sam n Max
DotT

All working - you can create savesgames from libretro and load them from the standalone and vice versa
Only issue with **The Curse of Monkey Island** aka Monkey Island 3, from there games created with newer libretro core can't be loaded to older standalone core - vice versa worked.

I think it is a negligible problem and can also be caused by simply updating the cores to a newer version.