### PR TITLE
vpinball: bump libpinmame to 3.7, libdmdutil, and vpinball

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Mar 31, 2025
+# Version: Commits on May 7, 2025
 # uses standalone tree for now
-VPINBALL_VERSION = c3e8134bebae535689c52f8d841f86a970a89acb
+VPINBALL_VERSION = c0d3b2ff942247c8616f228a3d34f7074abaeffa
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on Mar 6, 2025
-LIBDMDUTIL_VERSION = f54f084e995782948d30554391ea57a02010d3db
+# Version: Commits on May 7, 2025
+LIBDMDUTIL_VERSION = bb4e0ae9a2313373423b3f675ec5f8a3fc915a16
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on Feb 6, 2025
-LIBPINMAME_VERSION = ecd032e55481b261cce4820b53fd28fe478c70b4
+# Version: Commits on May 5, 2025
+LIBPINMAME_VERSION = 4887ec4959b968bb98172469ad7b53021c40458d
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE
@@ -12,21 +12,30 @@ LIBPINMAME_DEPENDENCIES = zlib
 LIBPINMAME_SUPPORTS_IN_SOURCE_BUILD = NO
 
 define LIBPINMAME_RENAME_CMAKE
-    cp $(@D)/cmake/libpinmame/CMakeLists_linux-x64.txt $(@D)/CMakeLists.txt
+    cp $(@D)/cmake/libpinmame/CMakeLists.txt $(@D)
     rm $(@D)/makefile
 endef
 
 LIBPINMAME_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
+LIBPINMAME_CONF_OPTS += -DBUILD_STATIC=OFF
+LIBPINMAME_CONF_OPTS += -DPLATFORM=linux
+LIBPINMAME_CONF_OPTS += -DARCH=$(BUILD_ARCH)
 
-define LIBPINMAME_INSTALL_TARGET_CMDS
-    # staging files
-    $(INSTALL) -D -m 0755 $(@D)/buildroot-build/libpinmame.so.3.6 \
-        $(STAGING_DIR)/usr/lib
-    cp $(@D)/src/libpinmame/libpinmame.h $(STAGING_DIR)/usr/include
-    # copy to target
-    $(INSTALL) -D -m 0755 $(@D)/buildroot-build/libpinmame.so.3.6 \
-        $(TARGET_DIR)/usr/lib
-endef
+# handle supported target platforms
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_RK3588),y)
+    BUILD_ARCH = aarch64
+endif
+
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_BCM2711)$(BR2_PACKAGE_BATOCERA_TARGET_BCM2712),y)
+    BUILD_ARCH = aarch64
+endif
+
+ifeq ($(BR2_PACKAGE_BATOCERA_TARGET_X86_64_ANY),y)
+    BUILD_ARCH = x64
+endif
+
+# Install to staging to build Visual Pinball Standalone
+LIBPINMAME_INSTALL_STAGING = YES
 
 LIBPINMAME_PRE_CONFIGURE_HOOKS += LIBPINMAME_RENAME_CMAKE
 

--- a/package/batocera/libraries/libserum/libserum.mk
+++ b/package/batocera/libraries/libserum/libserum.mk
@@ -3,9 +3,9 @@
 # libserum
 #
 ################################################################################
-# Version: Commits on Feb 6, 2025
-LIBSERUM_VERSION = b0cc2a871d9d5b6395658c56c65402ae388eb78c
-LIBSERUM_SITE = $(call github,zesinger,libserum,$(LIBSERUM_VERSION))
+# Version: Commits on Mar 5, 2025
+LIBSERUM_VERSION = b6f7ea24d1d0145ccda155f779af49a58bbdab8b
+LIBSERUM_SITE = $(call github,ppuc,libserum_concentrate,$(LIBSERUM_VERSION))
 LIBSERUM_LICENSE = GPLv2+
 LIBSERUM_LICENSE_FILES = LICENSE.md
 LIBSERUM_DEPENDENCIES = 


### PR DESCRIPTION
libpinmame now has an install, libdmdutil uses libserum-concentrate a friend fork with major memory optimizations.