### PR TITLE
xenia: fix regression with leading / in rompath .xbox360 playlists

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -138,7 +138,7 @@ class XeniaGenerator(Generator):
                 # Read only the first line of the file.
                 firstLine = openFile.readlines(1)[0]
                 # Strip of any new line characters.
-                firstLine = firstLine.strip('\n').strip('\r')
+                firstLine = firstLine.strip('\n').strip('\r').lstrip('/')
                 _logger.debug('Checking if specified disc installation / XBLA file actually exists...')
                 xblaFullPath = pathLead / firstLine
                 if xblaFullPath.exists():


### PR DESCRIPTION
since convertion to pathlib https://github.com/batocera-linux/batocera.linux/commit/43f3f9b4dbc9fb807e8adeaafdc80c58f79ef9ed

```
xblaFullPath = pathLead / firstLine
if xblaFullPath.exists():
```

if a playlist have a leading / , it's not working anymore because

```
xblaFullPath = Path("/userdata/roms/xbox360") / "/bar"

xblaFullPath ---> /bar
```

simply trip the leading / to fix it.