### PR TITLE
Set RetroArch OSD CJK fonts based on user_language or system locale

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/Emulator.py
@@ -146,6 +146,8 @@ class Emulator:
         system_data.update(folder_settings)
         system_data.update(game_settings)
 
+        system_data["language"] = settings.config.get('DEFAULT', 'system.language', fallback=None)
+
         try:
             es_config = ET.parse(ES_SETTINGS)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -265,6 +265,21 @@ def createLibretroConfig(
     retroarchConfig['video_font_enable'] = '"true"'
     retroarchConfig['notification_show_remap_load'] = '"false"'
 
+    systemLanguage = system.config['language']
+    retroarchLanguage = system.config.get('retroarch.user_language', None)
+    # RETRO_LANGUAGE_JAPANESE = 1
+    if retroarchLanguage == '1' or (retroarchLanguage is None and systemLanguage == 'ja_JP'):
+        retroarchConfig['video_font_path'] = "/usr/share/fonts/truetype/noto/NotoSansJP-VF.ttf"
+    # RETRO_LANGUAGE_KOREAN = 10
+    elif retroarchLanguage == '10' or (retroarchLanguage is None and systemLanguage == 'ko_KR'):
+        retroarchConfig['video_font_path'] = "/usr/share/fonts/truetype/nanum/NanumGothicBold.ttf"
+    # RETRO_LANGUAGE_CHINESE_TRADITIONAL = 11
+    elif retroarchLanguage == '11' or (retroarchLanguage is None and systemLanguage == 'zh_TW'):
+        retroarchConfig['video_font_path'] = "/usr/share/fonts/truetype/noto/NotoSansTC-VF.ttf"
+    # RETRO_LANGUAGE_CHINESE_SIMPLIFIED = 12
+    elif retroarchLanguage == '12' or (retroarchLanguage is None and systemLanguage == 'zh_CN'):
+        retroarchConfig['video_font_path'] = "/usr/share/fonts/truetype/noto/NotoSansSC-VF.ttf"
+
     # prevent displaying "QUICK MENU" with "No Items" after DOSBox Pure, TyrQuake and PrBoom games exit
     retroarchConfig['load_dummy_on_core_shutdown'] = '"false"'
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3af6c4a7-ae59-4e14-9af7-5459d4ef6523)

Fixes an issue where the RetroArch OSD font would break when the LANGUAGE setting is changed to CJK.

This update adjusts the configuration accordingly.
Also, https://github.com/batocera-linux/batocera.linux/issues/9001 in the last comment might also be resolved. 

I have confirmed that this issue has been resolved in Batocera 41 (Python 3.11),
but I haven't tested it in the latest dev, which uses Python 3.12.

Depends on: https://github.com/batocera-linux/batocera.linux/pull/14074

