### PR TITLE
Update path of mesa-22.1.3.tar.xz.

### DIFF
--- a/package/batocera/gpu/img-mesa3d/img-mesa3d.mk
+++ b/package/batocera/gpu/img-mesa3d/img-mesa3d.mk
@@ -5,8 +5,9 @@
 ################################################################################
 
 IMG_MESA3D_VERSION = 22.1.3
+IMG_MESA3D_SERIES = $(basename $(basename $(IMG_MESA3D_VERSION))).x
 IMG_MESA3D_SOURCE = mesa-$(IMG_MESA3D_VERSION).tar.xz
-IMG_MESA3D_SITE = https://archive.mesa3d.org
+IMG_MESA3D_SITE = https://archive.mesa3d.org/older-versions/$(IMG_MESA3D_SERIES)
 IMG_MESA3D_LICENSE = MIT, SGI, Khronos
 IMG_MESA3D_LICENSE_FILES = docs/license.rst
 IMG_MESA3D_CPE_ID_VENDOR = mesa3d


### PR DESCRIPTION
I was trying to build batocera for the `jh7110`, and I noticed the fetch of the `mesa-22.1.3.tar.xz` file failed.

Looking at the contents of https://archive.mesa3d.org, it seems that only versions 23.x and onwards are directly available there, and older ones are within the `older-versions/` folder.

Rather than hardcoding the series (`22.x`) for the URL, I used Make's `$(basename ...)` function to extract it from the `$(IMG_MESA3D_VERSION)`.

Thanks for developing this cool project!
