### PR TITLE
add cpu slider for hotd4 (lindbergh)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
@@ -298,11 +298,13 @@ class LindberghGenerator(Generator):
             self.setConf(conf, "EMULATE_CARDREADER", 0)
 
         # House of the Dead 4 - CPU speed
-        cpu_speed = self.get_cpu_min_speed()
-        if cpu_speed is not None:
-            _logger.debug("Current CPU Speed: %.2f GHz", cpu_speed)
-            if "hotd" in romName.lower() and system.config.get_bool("lindbergh_speed"):
-                self.setConf(conf, "CPU_FREQ_GHZ", cpu_speed)
+        cpu_speed = system.config.get("lindbergh_speed")
+        if "hotd4" in romName.lower() and cpu_speed:
+            cpu_speed = float(cpu_speed)
+            _logger.debug("Current CPU Speed : %.2f GHz", cpu_speed)
+            self.setConf(conf, "CPU_FREQ_GHZ", cpu_speed)
+        else:
+            self.commentConf(conf, "CPU_FREQ_GHZ")
 
         # OutRun 2 - Network
         ip = self.get_ip_address()
@@ -919,31 +921,31 @@ class LindberghGenerator(Generator):
         # copy the config file in the rom dir, where it is used
         shutil.copy2(LINDBERGH_CONFIG_FILE, romDir / "lindbergh.conf")
 
-    def get_cpu_min_speed(self):
-        try:
-            # Run lscpu to get CPU frequency information
-            result = subprocess.run(
-                ["lscpu"],
-                capture_output=True,
-                text=True,
-                check=True
-            )
-            output = result.stdout
-
-            # Find the "CPU min MHz" value
-            match = re.search(r"CPU min MHz:\s+([\d.]+)", output)
-            if match:
-                min_speed_mhz = float(match.group(1))
-                # Convert to GHz
-                _logger.debug(f"CPU min MHz is {min_speed_mhz}.")
-                return min_speed_mhz / 1000
-
-            _logger.debug("CPU min MHz information not found.")
-            return None
-
-        except subprocess.CalledProcessError as e:
-            _logger.debug("Error running lscpu: %s", e)
-            return None
+#    def get_cpu_min_speed(self):
+#        try:
+#            # Run lscpu to get CPU frequency information
+#            result = subprocess.run(
+#                ["lscpu"],
+#                capture_output=True,
+#                text=True,
+#                check=True
+#            )
+#            output = result.stdout
+#
+#            # Find the "CPU min MHz" value
+#            match = re.search(r"CPU min MHz:\s+([\d.]+)", output)
+#            if match:
+#                min_speed_mhz = float(match.group(1))
+#                # Convert to GHz
+#                _logger.debug(f"CPU min MHz is {min_speed_mhz}.")
+#                return min_speed_mhz / 1000
+#
+#            _logger.debug("CPU min MHz information not found.")
+#            return None
+#
+#        except subprocess.CalledProcessError as e:
+#            _logger.debug("Error running lscpu: %s", e)
+#            return None
 
     def get_ip_address(self, destination: str = "1.1.1.1", port: int = 80) -> Any | None:
         try:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -13873,10 +13873,9 @@ lindbergh-loader:
     lindbergh_speed:
       group: GAME OPTIONS
       prompt: CPU SPEED
-      description: House of the Dead 4 speed fix. Sets the game to the CPU minimum frequency of your processor.
-      choices:
-        "Off (Default)": 0
-        "On":            1
+      description: House of the Dead 4 speed fix. Select CPU base frequency of your processor.
+      preset: sliderauto
+      preset_parameters: 0.5 4.0 0.1 GHz
     lindbergh_ip:
       group: GAME OPTIONS
       prompt: IP ADDRESS


### PR DESCRIPTION
At default/auto, it keeps the formula for minimum frequency. If the user changes the slider in ES, then it takes the value chosen between 2.0 to 4.0 (moving 0.1 each). Idea is to select base frequency. I have 3600MHz processor, I need to go with 3.6 for perfect speed accuracy on this game.