### PR TITLE
Trigger user‐defined scripts on controller connect/disconnect events

### DIFF
--- a/package/batocera/core/batocera-udev-rules/rules/99-controller-connection-userscripts.rules
+++ b/package/batocera/core/batocera-udev-rules/rules/99-controller-connection-userscripts.rules
@@ -1,0 +1,7 @@
+# Execute all user-defined scripts located in the EmulationStation scripts controller-connected and controller-disconnected directories upon such events are triggered
+
+ACTION=="add", KERNEL=="js[0-9]*", ENV{ID_INPUT_JOYSTICK}=="1", \
+RUN+="/usr/bin/setsid -f /bin/bash -c '(DIR=/userdata/system/configs/emulationstation/scripts/controller-connected; DEV=\"%E{DEVNAME}\"; LOG=/userdata/system/logs/udev.log; TS=$(date); echo \"$TS: $DEV connected\" >> \"$LOG\"; if [[ -d \"$DIR\" ]]; then for script in \"$DIR\"/*; do [ -x \"$script\" ] && (bash \"$script\" \"$DEV\" >> \"$LOG\" 2>&1 &); done; fi)'"
+
+ACTION=="remove", KERNEL=="js[0-9]*", ENV{ID_INPUT_JOYSTICK}=="1", \
+RUN+="/usr/bin/setsid -f /bin/bash -c '(DIR=/userdata/system/configs/emulationstation/scripts/controller-disconnected; DEV=\"%E{DEVNAME}\"; LOG=/userdata/system/logs/udev.log; TS=$(date); echo \"$TS: $DEV disconnected\" >> \"$LOG\"; if [[ -d \"$DIR\" ]]; then for script in \"$DIR\"/*; do [ -x \"$script\" ] && (bash \"$script\" \"$DEV\" >> \"$LOG\" 2>&1 &); done; fi)'"


### PR DESCRIPTION
This pull request adds support for two new EmulationStation script hooks that will be triggered upon controller-connected and controller-disconnected events.

It detect when a joystick (`/dev/input/js*`) is added or removed using two new udev rules. 
For each event it triggers user-defined scripts in `/userdata/system/configs/emulationstation/scripts/controller-connected` and `/userdata/system/configs/emulationstation/scripts/controller-disconnected` respectively.

The script runner process is detached to avoid timeouts and each script is run independently and in parallel from each other (so if one fails, the rest still have the opportunity to run)

The addition of these hooks lets users define custom scripts that persist through system upgrades and give them fine-grained control over controller events to do stuff like: 
- update on-screen marquees (images or videos) and play audio cues when players connect or disconnect
- trigger web-hooks to drive home-automation events, such as changing RGB lighting on the Batocera machine or in the surrounding room 
- or even suspend the system after some delay once the last controller is unplugged

That’s just to name a few, I’m pretty confident Batocera users will come up with countless creative ways to leverage this new feature.


---
Notes:
- My friends, family, and I have been running these rules on multiple systems for over a month now, and they’ve worked flawlessly on all of them.
- If this is approved and merged, the [EmulationStation scripting documentation](https://wiki.batocera.org/launch_a_script#emulationstation_scripting) should be updated accordingly to reflect the new controller-connected and controller-disconnected hooks. 
Feel free to incorporate any of the usage examples I listed above into the wiki so users can get started right away.

This addresses: https://github.com/batocera-linux/batocera.linux/issues/13965