### PR TITLE
Fix inconsistent service script execution in batocera-services

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-services
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-services
@@ -25,9 +25,9 @@ call_service() {
     local argument="${2}"
 
     if [ -x "${service_file_path}" ]; then
-        "${service_file_path}" "${argument}" &
+        "${service_file_path}" "${argument}"
     else
-        bash "${service_file_path}" "${argument}" &
+        bash "${service_file_path}" "${argument}"
     fi
 }
 


### PR DESCRIPTION
This pull request addresses an inconsistency between how service scripts are executed at boot time versus when manually invoked using `batocera-services start <service_name>` (stop, status, restart variants as well)

At boot, service scripts are executed directly if they have the executable bit set, allowing proper handling of Python scripts, binaries, or any other interpreter declared via shebang ([reference](https://github.com/batocera-linux/batocera.linux/blob/5ec576e9c352860577134e7eac8d600948bd425c/board/batocera/fsoverlay/etc/init.d/S99userservices#L3)).
However, `batocera-services` currently runs all scripts forcing `bash` as interpreter, ignoring the executable bit or declared interpreter ([reference](https://github.com/batocera-linux/batocera.linux/blob/5ec576e9c352860577134e7eac8d600948bd425c/package/batocera/core/batocera-scripts/scripts/batocera-services#L120)). This leads to errors when managing non-bash service scripts after the system has booted, often leaving users confused as to why a script works at startup but fails when run manually.

This fix aligns both behaviors, ensuring scripts are executed consistently whether triggered at boot or via batocera-services, making the behavior simpler to understand and document.