### PR TITLE
fix retroarch system library linking

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/025-fix-glslang-linking.patch
+++ b/package/batocera/emulators/retroarch/retroarch/025-fix-glslang-linking.patch
@@ -1,0 +1,31 @@
+diff --git a/Makefile.common b/Makefile.common
+index c9ed198..5beda08 100644
+--- a/Makefile.common
++++ b/Makefile.common
+@@ -1904,10 +1904,6 @@ else ifeq ($(HAVE_GLSLANG),1)
+ 
+    # The order of these libs are somewhat specific
+    LIBS += $(GLSLANG_LIBS) \
+-           $(GLSLANG_MACHINEINDEPENDENT_LIBS) \
+-           $(GLSLANG_GENERICCODEGEN_LIBS) \
+-           $(GLSLANG_OSDEPENDENT_LIBS) \
+-           $(GLSLANG_OGLCOMPILER_LIBS) \
+            $(GLSLANG_SPIRV_LIBS) \
+            $(GLSLANG_SPIRV_TOOLS_OPT_LIBS) \
+            $(GLSLANG_SPIRV_TOOLS_LIBS)
+diff --git a/qb/config.libs.sh b/qb/config.libs.sh
+index c19fe32..fdd532e 100644
+--- a/qb/config.libs.sh
++++ b/qb/config.libs.sh
+@@ -669,11 +669,6 @@ if [ "$HAVE_GLSLANG" != no ]; then
+       glslang/SPIRV/GlslangToSpv.h
+ 
+    check_lib cxx GLSLANG -lglslang '' '-lSPIRV'
+-   check_lib cxx GLSLANG_OSDEPENDENT -lOSDependent
+-   check_lib cxx GLSLANG_OGLCOMPILER -lOGLCompiler
+-   check_lib cxx GLSLANG_MACHINEINDEPENDENT -lMachineIndependent
+-   check_lib cxx GLSLANG_GENERICCODEGEN -lGenericCodeGen
+-   check_lib cxx GLSLANG_HLSL -lHLSL '' '-lglslang -lSPIRV'
+    check_lib cxx GLSLANG_SPIRV -lSPIRV
+    check_lib cxx GLSLANG_SPIRV_TOOLS_OPT -lSPIRV-Tools-opt
+    check_lib cxx GLSLANG_SPIRV_TOOLS -lSPIRV-Tools

--- a/package/batocera/emulators/retroarch/retroarch/retroarch.mk
+++ b/package/batocera/emulators/retroarch/retroarch/retroarch.mk
@@ -11,8 +11,8 @@ RETROARCH_DEPENDENCIES = host-pkgconf dejavu retroarch-assets flac noto-cjk-font
 # install in staging for debugging (gdb)
 RETROARCH_INSTALL_STAGING = YES
 
-RETROARCH_CONF_OPTS = --disable-oss --enable-zlib --disable-qt --enable-threads --enable-ozone \
-    --enable-xmb --disable-discord --enable-flac --enable-lua --enable-networking \
+RETROARCH_CONF_OPTS = --disable-oss --disable-qt --enable-threads --enable-ozone \
+    --enable-xmb --disable-discord --disable-builtinflac --enable-flac --enable-lua --enable-networking \
 	--enable-translate --enable-rgui --disable-cdrom
 
 ifeq ($(BR2_ENABLE_DEBUG),y)
@@ -103,7 +103,7 @@ ifeq ($(BR2_PACKAGE_HAS_LIBOPENVG),y)
 endif
 
 ifeq ($(BR2_PACKAGE_ZLIB),y)
-    RETROARCH_CONF_OPTS += --enable-zlib
+    RETROARCH_CONF_OPTS += --disable-builtinzlib --enable-zlib
     RETROARCH_DEPENDENCIES += zlib
 else
     RETROARCH_CONF_OPTS += --disable-zlib
@@ -153,6 +153,11 @@ endif
 ifeq ($(BR2_PACKAGE_VULKAN_LOADER)$(BR2_PACKAGE_VULKAN_HEADERS),yy)
     RETROARCH_CONF_OPTS += --enable-vulkan
     RETROARCH_DEPENDENCIES += vulkan-headers vulkan-loader slang-shaders
+endif
+
+ifeq ($(BR2_PACKAGE_GLSLANG),y)
+    RETROARCH_CONF_OPTS += --disable-builtinglslang --enable-glslang
+    RETROARCH_DEPENDENCIES += glslang
 endif
 
 ifeq ($(BR2_riscv),y)


### PR DESCRIPTION
Unless explicitly told to, RA will build zlib, flac, and glslang while linking against the system libraries as well. Disabling the builtin glslang requires RA to stop checking for library files that our newer glslang release has combined into the main glslang library file.