### PR TITLE
steering wheel support for supermodel (WIP)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/wheelsUtils.py
@@ -104,6 +104,17 @@ _EMULATOR_MAPPING: Final = {
         "x":  "y",
         "y":  "x",
     },
+    "supermodel": {
+        "JOY1_XAXIS":      "wheel",
+        "JOY1_ZAXIS_POS":  "accelerate",
+        "JOY1_RZAXIS_POS": "brake",
+        "JOY1_BUTTON5":    "upshift",
+        "JOY1_BUTTON6":    "downshift",
+        "JOY1_BUTTON1":    "a",
+        "JOY1_BUTTON2":    "b",
+        "JOY1_BUTTON3":    "x",
+        "JOY1_BUTTON4":    "y",
+    },
 }
 
 


### PR DESCRIPTION
Needs virtual wheel for pedals. 
- JOY1_ZAXIS_POS for acceleration.
- JOY1_RZAXIS_POS for brake.

Some wheel have JOY1_ZAXIS_NEG and JOY1_RZAXIS_NEG instead, which won't work here. (POS = positive; NEG = negative value)

Must enable `pedalSwap` (modern controls, using Supermodel-Driving.ini file) and `-force-feedback` by default for wheels.