### PR TITLE
winegenerator: fix force_mouse when undefined

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -68,4 +68,4 @@ class WineGenerator(Generator):
         raise BatoceraException("Invalid system: " + system.name)
 
     def getMouseMode(self, config, rom):
-        return config.get('force_mouse') != '0'
+        return config.get('force_mouse') == '1'


### PR DESCRIPTION
config.get('force_mouse') return '...' when force_mouse is undefined, so the expression config.get('force_mouse') != '0' is True (and so the mouse was enabled)