### PR TITLE
Fix Genesis Plus GX core option for CD System BRAM

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -66,6 +66,7 @@
 - OpenMOHAA to play Medal of Honor: Allied Assault including Spearhead and Breakthrough expansions
 - WiringOP-Python for OrangePi board GPIO scripting.
 ### Fixed
+- Fix CD System BRAM core option for Genesis Plus GX to use the per game setting
 - Fix some problems in ES and Batocera with IPv6 networks
 - Fix ES behavior with usb network tethering
 - Fix handling of luks.enabled setting to allow disabling LUKS integration

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1677,7 +1677,7 @@ def _genesisplusgx_options(
     coreSettings: UnixSettings, system: Emulator, rom: Path, guns: Guns, wheels: DeviceInfoMapping, /,
 ) -> None:
     # Allows each game to have its own one brm file for save without lack of space
-    _set(coreSettings, 'genesis_plus_gx_bram', 'per game')
+    _set(coreSettings, 'genesis_plus_gx_system_bram', 'per game')
 
     # Sometimes needs to be forced to NTSC-U for MSU-MD to work (this is to avoid an intentionally coded lock-out screen):
     # https://arcadetv.github.io/msu-md-patches/wiki/Lockout-screen.html


### PR DESCRIPTION
The name of the CD System BRAM option in the Genesis Plus GX libretro core has been changed to genesis_plus_gx_system_bram, so the core options generator needed to be updated to work correctly.