### PR TITLE
S31emulationstation - declutter

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -6,31 +6,23 @@ BOOTCONF="/boot/batocera-boot.conf"
 
 case "$1" in
 	start)
-	    enabled="$(/usr/bin/batocera-settings-get system.es.atstartup)"
-	    if [ "$enabled" != "0" ]; then
+		enabled="$(/usr/bin/batocera-settings-get system.es.atstartup)"
+		if [ "$enabled" != "0" ]; then
 		%BATOCERA_EMULATIONSTATION_CMD% %BATOCERA_EMULATIONSTATION_POSTFIX%
-	    fi
-	    ;;
+		fi
+		;;
 
 	stop)
-        emulationstation-standalone --stop-rebooting
+		emulationstation-standalone --stop-rebooting
 		killall openbox          2>/dev/null # for xorg
 		killall sway             2>/dev/null # for sway (wayland)
 		killall labwc            2>/dev/null # for labwc (wayland)
 		killall touchegg         2>/dev/null
 
-		# Kill emulationstation and then wait at least 20 seconds for it to exit.
-		# The watchdog 'if' block must follow immediately, as it tests the exit code of the killall.
+		# Kill emulationstation and then wait at least 20 seconds for it to exit, after 25s in total send SIGTERM
 		killall emulationstation 2>/dev/null
-		if [ $? -eq 0 ]; then
-			sleep 20 &
-			watchdog=$!
-			while ! [ -z $(pidof emulationstation) ]; do
-				sleep 0.25
-				$(kill -0 $watchdog) || exit
-			done
-			kill -9 $watchdog
-		fi
+		timeout -k 5 20 tail -q --pid=$(pidof emulationstation) -f /dev/null 2>/dev/null
+
 		;;
 
 	restart|reload)


### PR DESCRIPTION
removed while loop and sleep-watchdog in favour of timeout. It wait's 20s for ES-process to finish, after 25s in total it uses ~~SIGTERM~~ SIGKILL. If we use `killall -w` it could happen that the process is stuck and a shutdown will never happen.