### PR TITLE
flycast: controller : use direction for trigger

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastControllers.py
@@ -181,8 +181,11 @@ def generateControllerConfig(controller: Controller, type: Literal['dreamcast', 
         if input.type == 'axis':
             section = 'analog'
             if input.name == 'l2' or input.name == 'r2':
-                # Use positive axis for full trigger control
-                code = f"{input.id}+"
+		#some wheels pedals hava reversed values
+		if int(input.value) < 0:
+                    code = f"{input.id}-"
+                else:
+                    code = f"{input.id}+"
             else:
                 code = f"{input.id}-"
             option = f"bind{analogbind}"

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
@@ -184,7 +184,6 @@ class FlycastGenerator(Generator):
                 "XDG_DATA_HOME": FLYCAST_SAVES.parent,
                 "FLYCAST_DATADIR": FLYCAST_SAVES.parent,
                 "FLYCAST_BIOS_PATH": FLYCAST_BIOS,
-                "SDL_GAMECONTROLLERCONFIG": generate_sdl_game_controller_config(playersControllers),
                 "SDL_JOYSTICK_HIDAPI": "0"
             }
         )


### PR DESCRIPTION
some wheel pedals like logitech are send reverse values for pressed/unpressed, we need to use correct direction.

Also remove the SDL_GAMECONTROLLER env, because it's seem to break or override the mapping done in flycast, and the direction change is not working if we don't remove it.

change tested with: dualsense, ds4 , xbox one S, 8bitdo sn30, switchpro controller controllers, logitech g25/29 wheel