### PR TITLE
vpinball: bump deps. add support for DOF

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,9 +3,9 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on May 31, 2025
+# Version: Commits on Jun 29, 2025
 # uses standalone tree for now
-VPINBALL_VERSION = be2431991b3a184e997950328f6cb62421bb9cfa
+VPINBALL_VERSION = d1924397b31131c233d2cdd1e92632d5941c443b
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on May 27, 2025
-LIBDMDUTIL_VERSION = f1d90154b0cb21938e7f608329197705ba76e9cf
+# Version: Commits on Jun 23, 2025
+LIBDMDUTIL_VERSION = f3aa0a011e9d209630880795e3e15bce2e168050
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdof/libdof.mk
+++ b/package/batocera/libraries/libdof/libdof.mk
@@ -3,12 +3,12 @@
 # libdof
 #
 ################################################################################
-# Version: Commits on May 27, 2025
-LIBDOF_VERSION = 6a5c15c3f16d76e77bc2bc8b3abcb1c1f8856d23
+# Version: Commits on Jun 29, 2025
+LIBDOF_VERSION = 6d221ab092ff4577a6103ca4083ca6cdebced2a2
 LIBDOF_SITE = $(call github,jsm174,libdof,$(LIBDOF_VERSION))
 LIBDOF_LICENSE = BSD-3-Clause
 LIBDOF_LICENSE_FILES = LICENSE
-LIBDOF_DEPENDENCIES = libserialport hidapi sockpp cargs
+LIBDOF_DEPENDENCIES = libusb libserialport hidapi libftdi1
 LIBDOF_SUPPORTS_IN_SOURCE_BUILD = NO
 # Install to staging to build Visual Pinball Standalone
 LIBDOF_INSTALL_STAGING = YES

--- a/package/batocera/libraries/libpinmame/libpinmame.mk
+++ b/package/batocera/libraries/libpinmame/libpinmame.mk
@@ -3,8 +3,8 @@
 # libpinmame
 #
 ################################################################################
-# Version: Commits on May 31, 2025
-LIBPINMAME_VERSION = e92f9e25bc666e09b791a32712269e1096c88445
+# Version: Commits on Jun 23, 2025
+LIBPINMAME_VERSION = 1b4a7c7ec16fb062862d2b9d9e9fecc6102ae3a7
 LIBPINMAME_SITE = $(call github,vpinball,pinmame,$(LIBPINMAME_VERSION))
 LIBPINMAME_LICENSE = BSD-3-Clause
 LIBPINMAME_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libserum/libserum.mk
+++ b/package/batocera/libraries/libserum/libserum.mk
@@ -3,8 +3,8 @@
 # libserum
 #
 ################################################################################
-# Version: Commits on May 27, 2025
-LIBSERUM_VERSION = 9e071b9b0062352476786ff578368c7dc019ac07
+# Version: Commits on Jun 23, 2025
+LIBSERUM_VERSION = 607bee2ab6e73a08a28f207a42be676e967cf876
 LIBSERUM_SITE = $(call github,ppuc,libserum_concentrate,$(LIBSERUM_VERSION))
 LIBSERUM_LICENSE = GPLv2+
 LIBSERUM_LICENSE_FILES = LICENSE.md

--- a/package/batocera/libraries/libzedmd/libzedmd.mk
+++ b/package/batocera/libraries/libzedmd/libzedmd.mk
@@ -3,8 +3,8 @@
 # libzedmd
 #
 ################################################################################
-# Version: Commits on Apr 1, 2025
-LIBZEDMD_VERSION = 154772800e8f36378c629f066bfee563862728ac
+# Version: Commits on Jun 23, 2025
+LIBZEDMD_VERSION = 6fe707d675c806353b685fb323d5e224eff56677
 LIBZEDMD_SITE = $(call github,PPUC,libzedmd,$(LIBZEDMD_VERSION))
 LIBZEDMD_LICENSE = GPLv3
 LIBZEDMD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Adds support for the following output controllers:

- Teensy and Wemos D1 Addressable LED Strips
- Pinscape
- Pinscape Pico