### PR TITLE
Update batocera-xtract: open archives, extraction of single files, cr…

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-xtract
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-xtract
@@ -19,56 +19,117 @@
 #           application/x-xz-compressed-tar;application/x-xz;application/zip;
 
 # inital idea and inspired by brunoeduardobrasil, 07/19/2025 cyperghost aka crcerror
+# ec-codes: ec-0 okay, ec-1 error, ec-10 parameter l used
+# ec-11 archives not supported for extraction, ec-12 archives not supported for showing content
+# ec-21 to 28 -- file extraction error zip rar 7z gz xy tar tar.xz tar.gz
+
+# Is pcmanfm is active then use yad as output. test -t will not work because pcmanfm creates a virtual terminal
+pgrep pcmanfm >/dev/null && TERMINAL=0 || TERMINAL=1
+ret=0
+
+get_extension () {
+    FILENAME="$(basename "${1,,}")"
+    for EXT in tar.gz tar.xz tar gz xz zip rar 7z; do
+        [[ "${FILENAME}" =~ ^.*\."$EXT"$ ]] && { echo $EXT; return 0; }
+    done
+    return 1
+}
+list_archive () {
+    # We try just to obtain the file names with minimal filters
+    # For unzip -Z1, unrar lb, 7zr l -ba ... and some awk/sed tools
+    case "$1" in
+        zip) readarray -t array < <(unzip -Z1 "$2") ;;
+        rar) readarray -t array < <(unrar lb "$2") ;;
+        7z)  readarray -t array < <(7zr l -ba "$2" | awk '{$1=$2=$3=$4=""; print $0}' |  sed 's/^[ ]*[0-9]*[ ]//') ;;
+        tar) readarray -t array < <(tar -tvf "$2" | awk '{ for(i=6; i<NF; ++i) printf $i" "; print $NF }') ;;
+        *)   [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Archive type '$1' is not yet supported.\nFailed to open '$2'"; return 12; }
+             [[ $TERMINAL -eq 1 ]] && { echo "Error: Archive type '$1' is not yet supported. Failed to open '$2'"; return 12; }
+    esac
+
+    # Just output for CLI as list - usefull for further scripting
+    [[ "${3}" == "l" ]] && { printf '%s\n' "${array[@]}"; return 10; }
+
+    # Rebuild array with a second column to handle files in yad, set to true if you want checkmarks setted
+    readarray -t array <<< $(printf 'FALSE\n%s\n' "${array[@]}")
+
+    #Options needs to be added to PCmanFM "file-roller --open"
+    readarray -t files <<< $(yad --title="Extract Files" --list --checklist --print-column=2 --separator= --column=Extract:chk --column=Filename:text "${array[@]}" || echo "ABORT" )
+    [[ ${#files[@]} -eq 0 || ${files} == "ABORT" ]] && return 1 #Canceld or no file ticked
+    return 0
+}
 
 case "$1" in
     x|X) #for CLI as universal extraction tool
         FILE="$2"; DEST="$3"
+        EXT=$(get_extension "${FILE}") || { echo "Error: Archive type: '$EXT' is not yet supported. Failed to open '$FILE'"; exit 11; }
         [[ -f "$FILE" ]] || { echo "Error! Archive '$FILE' not found"; exit 1; }
         if [[ -z "$DEST" ]]; then
             FILENAME="$(basename "${FILE%.*}")"
             echo "No Destination directory entered!"
-            echo "(y/Y) to extract to: '$PWD'"
-            echo "(n/N) to extract to: '$FILENAME' in '$PWD'"
-            read -p "Select (y/n) and press Enter: " yn
+            echo "C or 1) to extract to CURRENT: '$PWD'"
+            echo "B or 2) to extract to BASEDIR: '$FILENAME' in '$PWD'"
+            read -p "Select (C/B) and press Enter: " yn
             case ${yn:0:1} in
-                y|Y) DEST="$PWD" ;;
-                n|N) mkdir "$FILENAME"; DEST="${PWD}/${FILENAME}" ;;
+                c|C|1) DEST="$PWD" ;;
+                b|B|2) mkdir "$FILENAME"; DEST="${PWD}/${FILENAME}" ;;
                 *)   echo "...Aborted!"; exit 1
             esac
         fi
         [[ -d "$DEST" ]] || { echo "Error! Destionation directory '$DEST' not found"; exit 1; }
     ;;
     --extract)
-        FILE="$2" 
-        DEST=$(yad --title "Choose destination folder" --file --directory)
-        [[ -z "$DEST" ]] && exit 1
+        FILE="$2"
+        EXT=$(get_extension "${FILE}") || ret=11
+        DEST=$(yad --title "Choose destination folder" --file --directory) || exit 1
     ;;
     --extract-to)
         FILE="$3"
+        EXT=$(get_extension "${FILE}") || ret=11
         DEST="${2/file:\/\/}"
     ;;
-    *)  [ -t 1 ] || yad --title "Error" --geometry=400x100 --text "Action: '$1' is unknown"
-        echo "Usage: $(basename "$0") x [ARCHIVEFILE] [DESTINATION-DIR]"; echo
-        echo "If parameter DESTINATION-DIR is left empty, extraction takes place in current directory"
-        echo "or basename of archive file is created if you select 'no'";echo
-        echo "Supported archives: zip 7z rar tar gz xz tar.gz tar.xz"
+    --open|open|l|L)
+        FILE="$2"
+        DEST="$(readlink -f "$(dirname "${FILE}")")"
+        EXT=$(get_extension "${FILE}") || ret=11
+        list_archive "${EXT,,}" "$FILE" "${1,,}" || exit $?
+    ;;
+    --add)
+        # We remove $0 and $1, create filename.zip if single dir/file, create subdirname.zip for several files/dirs, we need the work-dir to have the relative pathes
+        FILE=("${@:2}")
+        DEST="${FILE%/*}"
+        [[ -n "${DEST}" ]] && { cd "${DEST}" || { yad --title "Error" --text "Can't open directory '$DEST'"; exit 1; }; } || { DEST="/root"; cd /; }
+        [[ ${#FILE[@]} -gt 1 ]] && { DEST="${DEST}/$(basename "${DEST}")"; }
+        [[ ${#FILE[@]} -eq 1 ]] && { DEST="$(basename "${FILE%.*}")"; }
+        [[ -f "${DEST}.zip" ]] && DEST="${DEST}_$(printf '%x' $(date +%s)).zip" || DEST="${DEST}.zip"
+        FILE=("${FILE[@]/*\/}")   #strip pathes to avoid to build archives with absolue pathes
+        zip -q -r "$DEST" "${FILE[@]}" && { yad --title "Created zip" --text "Created '$(readlink -f $DEST)' and added ${#FILE[@]} files:\n$(printf '%s\n' "${FILE[@]}")"; exit 0; } || exit 1
+    ;;
+   *)   [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Action: '$1' is unknown"; exit 1; }
+        echo "Usage: $(basename "$0") <SWITCHES> [ARCHIVEFILE] {DESTINATION-DIR}"; echo
+        echo "    x: extraction of current archivfile"
+        echo "    l: list archive content"; echo
+        echo "Supported archives for extraction: zip 7z rar tar gz xz tar.gz tar.xz"
+        echo "Supported archives for list/open : zip 7z rar tar"; echo
+        echo "error-codes/return codes:"
+        echo "  ec-0 no error, ec-10 parameter 'l', okay -- ec-1 general error"
+        echo "  ec-11 to 12  -- archive type not supported for extraction, listing"
+        echo "  eec-21 to 28 -- file extraction error zip rar 7z gz xy tar tar.xz tar.gz";echo
         exit 1
 esac
 
-FILENAME="$(basename "$FILE")"
-for EXT in tar.gz tar.xz tar gz xz zip rar 7z; do
-    [[ "${FILENAME,,}" =~ ^.*\."$EXT"$ ]] && break || EXT=
-done
-[[ -z "$EXT" ]] && exit 11
-
-case "$EXT" in
-    zip) unzip "$FILE" -d "$DEST" ;;
-    rar) unrar x "$FILE" "$DEST/" ;;
-    7z)  7zr x "$FILE" -o "$DEST/" ;;
-    gz)  gunzip -c "$FILE" > "$DEST/${FILENAME%.*}" ;;
-    xz)  unxz -c "$FILE" > "$DEST/${FILENAME%.*}" ;;
-    tar) tar -xf "$FILE" -C "$DEST" ;;
+case $EXT in
+    zip) unzip "$FILE" "${files[@]}" -d "$DEST" || ret=21;;
+    rar) unrar x "$FILE" "${files[@]}" "$DEST/" || ret=22;;
+    7z)  7zr x "$FILE" "${files[@]}" -o"$DEST" || ret=23;;
+    gz)  gunzip -c "$FILE" > "$DEST/$(basename "${FILE%.*}")" || ret=24 ;;
+    xz)  unxz -c "$FILE" > "$DEST/$(basename "${FILE%.*}")" || ret=25;;
+    tar) tar -xf "$FILE" "${files[@]}" -C "$DEST" || ret=26;;
     # Multiple TAR variants
-    tar.xz) tar -xJf "$FILE" -C "$DEST" ;;
-    tar.gz) tar -xzf "$FILE" -C "$DEST" ;;
-esac
+    tar.xz) tar -xJf "$FILE" -C "$DEST" || ret=27;;
+    tar.gz) tar -xzf "$FILE" -C "$DEST" || ret=28;;
+    *)   ret=11
+         [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Archive type: '$EXT' is not yet supported.\nFailed to open '$FILE'"; }
+         [[ $TERMINAL -eq 1 ]] && { echo "Error: Archive type: '$EXT' is not yet supported. Failed to open '$FILE'"; }
+    esac
+
+exit $ret


### PR DESCRIPTION
…eation of archives

1. We can open archives (7z, rar, tar and zip) and we can extract files out if them with pcmanfm (you have to write command line `file-roller --open` and save the application with a usage name. It will open a yad dialog, from there you can extract files.
2. Extraction of _zip 7z rar tar gz xz tar.gz tar.xz_ with pcmanfm **context menu**
2. We can create compressed zip files from context menu now. Only zip is supported

----

If you want to help then please add some more archivers. I tried to add more file-info (size, file/dir, time and date) but this ended in an endless battle of timing. I needed 25s to open a zip with 300 files. Now it just takes 1 or 2 seconds.

-----

To add the open function... go to command line and enter `file-roller --open` for each type of archive. Currently only **zip, 7z, tar and rar** can be browsed by filemanager. But it can be extended if you have some coding skills. I avoided to have fancy useless things..... You have to tick the default option and you have to name the application.

This data is stored to `/userdata/system/.config/mimeapps.list` so it is the defalut action for the setted MIME type

-----

I also added the compress option. Currently only zip is supported, so select the files and click **Compress on the context menu**, the file is stored into the parent directory of your selected file(s).... also directories are supported.

----

Greetings fly out to the whole Batocera-dev-Team for this nice piece of software. It's pleasure to see things working!