### PR TITLE
add-8bitdo-n64-support

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -481,17 +481,19 @@ def createLibretroConfig(
     if system.config.core in ['mupen64plus-next', 'parallel_n64']:
 
         valid_n64_controller_guids = [
-            # official nintendo switch n64 controller
-            "050000007e0500001920000001800000",
-            # 8bitdo n64 modkit
-            "05000000c82d00006928000000010000",
+            "050000007e0500001920000001800000", # official nintendo switch n64 controller
+            "05000000c82d00006928000000010000", # 8bitdo n64 modkit
             "030000007e0500001920000011810000",
+            "05000000c82d00001930000001000000", # 8bitdo n64 bt
+            "03000000c82d00001930000011010000", # 8bitdo n64 wired
         ]
 
         valid_n64_controller_names = [
             "N64 Controller",
             "Nintendo Co., Ltd. N64 Controller",
             "8BitDo N64 Modkit",
+            "8BitDo 64 BT",
+            "8BitDo 8BitDo 64 Bluetooth Controller",
         ]
 
         def update_n64_controller_config(controller_number: int, /):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenControllers.py
@@ -23,17 +23,19 @@ mupenHatToReverseAxis = {'1': 'Down', '2': 'Left',  '4': 'Up',   '8': 'Right'}
 mupenDoubleAxis = {0:'X Axis', 1:'Y Axis'}
 
 valid_n64_controller_guids = [
-    # official nintendo switch n64 controller
-    "050000007e0500001920000001800000",
-    # 8bitdo n64 modkit
-    "05000000c82d00006928000000010000",
+    "050000007e0500001920000001800000", # official nintendo switch n64 controller
+    "05000000c82d00006928000000010000", # 8bitdo n64 modkit
     "030000007e0500001920000011810000",
+    "05000000c82d00001930000001000000", # 8bitdo n64 bt
+    "03000000c82d00001930000011010000", # 8bitdo n64 wired
 ]
 
 valid_n64_controller_names = [
     "N64 Controller",
     "Nintendo Co., Ltd. N64 Controller",
     "8BitDo N64 Modkit",
+    "8BitDo 64 BT",
+    "8BitDo 8BitDo 64 Bluetooth Controller",
 ]
 
 def getMupenMapping(use_n64_inputs: bool) -> dict[str, str]:

--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -4240,8 +4240,8 @@
 		<input name="y" type="button" id="3" value="1" code="308" />
 	</inputConfig>
 	<inputConfig type="joystick" deviceName="Nintendo Co., Ltd. N64 Controller" deviceGUID="030000007e0500001920000011810000">
-		<input name="a" type="button" id="3" value="1" code="304" />
-		<input name="b" type="button" id="2" value="1" code="305" />
+		<input name="a" type="button" id="3" value="1" code="305" />
+		<input name="b" type="button" id="2" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />
 		<input name="hotkey" type="button" id="0" value="1" code="256" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
@@ -5769,5 +5769,47 @@
 		<input name="up" type="hat" id="0" value="1" />
 		<input name="x" type="button" id="5" value="1" code="308" />
 		<input name="y" type="button" id="4" value="1" code="307" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo 8BitDo 64 Bluetooth Controller" deviceGUID="03000000c82d00001930000011010000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="l2" type="axis" id="3" value="1" code="5" />
+		<input name="l3" type="button" id="17" value="1" code="705" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="axis" id="2" value="1" code="2" />
+		<input name="r3" type="button" id="10" value="1" code="314" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="8" value="1" code="312" />
+		<input name="start" type="button" id="11" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="axis" id="3" value="-1" code="5" />
+		<input name="y" type="axis" id="2" value="-1" code="2" />
+	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo 64 BT" deviceGUID="05000000c82d00001930000001000000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="l2" type="axis" id="3" value="1" code="5" />
+		<input name="l3" type="button" id="17" value="1" code="705" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="axis" id="2" value="1" code="2" />
+		<input name="r3" type="button" id="10" value="1" code="314" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="8" value="1" code="312" />
+		<input name="start" type="button" id="11" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="axis" id="3" value="-1" code="5" />
+		<input name="y" type="axis" id="2" value="-1" code="2" />
 	</inputConfig>
 </inputList>


### PR DESCRIPTION
Add support for the new 8bitdo n64 controller. Note: use dinput mode by selecting "d" on the back on the controller.

Also fixed issue with wired n64 nso controller mapping a and b swapped.