### PR TITLE
S92switch: Send scripts to background - merge for v42 please

### DIFF
--- a/package/batocera/utils/rpigpioswitch/S92switch
+++ b/package/batocera/utils/rpigpioswitch/S92switch
@@ -14,7 +14,7 @@ fi
 case "$1" in
     start)
         if [ -n "$powerswitch" ]; then
-            $RUN start "$powerswitch"
+            $RUN start "$powerswitch" &
         fi
     ;;
 


### PR DESCRIPTION
If you edit `/etc/init.d/rcS` then you see that no process is sent to background. Some scripts start rpi_gpio and use `wait` command. So Batocera will stop at init.d S92 position so I assume S92+ script like S99service will never start