### PR TITLE
Fix args when building dosbox-x command

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
@@ -50,7 +50,7 @@ class DosBoxxGenerator(Generator):
                         "-c", "c:",
                         "-c", "dosbox.bat",
                         "-fastbioslogo",
-                        f"-conf {customConfFile!s}"]
+                        "-conf", f"{customConfFile!s}"]
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":CONFIGS})
 


### PR DESCRIPTION
The arguments when creating the command to launch dosbox-x haven't been correctly specified. That makes the -conf flag unrecognized by dosbox-x (it genererates a warning about it in the logs)  and no configuration is loaded.