### PR TITLE
flycast-fix-controller-assignment

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flycast/flycastGenerator.py
@@ -59,7 +59,7 @@ class FlycastGenerator(Generator):
             Config.set("input", f'device{controller.player_number}.2', system.config.get_str(ctrlpackconfig, '1'))  # Sega VMU
             # Ensure controller(s) are on seperate Ports
             port = controller.player_number-1
-            Config.set("input", f'maple_sdl_joystick_{port}', str(port))
+            Config.set("input", f'maple_sdl_joystick_{port}', str(controller.index))
 
         # add the keyboard mappings for hotkeys
         flycastControllers.generateKeyboardConfig()


### PR DESCRIPTION
Fixes a bug where if you manually change player assignment in ES controller menu it will be ignored. 