### PR TITLE
Providing a workaround to specify autoexec section in dosbox-x

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxx/dosboxxGenerator.py
@@ -45,12 +45,29 @@ class DosBoxxGenerator(Generator):
 
         # -fullscreen removed as it crashes on N2
         commandArray = ['/usr/bin/dosbox-x',
-                        "-exit",
+                        "-exit"]
+
+        # Find autoexec file
+        autoexecFile = rom / "dosbox.aut"
+        if autoexecFile.exists():
+            # Copy autoexec file at the end of the custom config file
+            f1 = open(customConfFile, 'a+')
+            f2 = open(autoexecFile, 'r')
+
+            f1.write(f2.read())
+
+            f1.close()
+            f2.close()
+        else:
+            # Otherwilse, we just mount the game directory as c: and launch dosbox.bat
+            commandArray.extend([
                         "-c", f"""mount c {rom!s}""",
                         "-c", "c:",
-                        "-c", "dosbox.bat",
+                        "-c", "dosbox.bat"])
+
+        commandArray.extend([
                         "-fastbioslogo",
-                        "-conf", f"{customConfFile!s}"]
+                        "-conf", f"{customConfFile!s}"])
 
         return Command.Command(array=commandArray, env={"XDG_CONFIG_HOME":CONFIGS})
 


### PR DESCRIPTION
While auto-mounting the game directory as C: in dosbox-x games works for the majority of users, some expert users may find it restrictive. Methods like adding commands to a dosbox.bat script may fail if, e.g,  you want to unmount C: to mount an image instead.

I propose an expert method that can be used if the current standard is not useful for the user in a given situation: to use a dosbox.aut file created in the game directory (which must include the [autoexec] label) that will be read and appended at the end of the dosbox-custom.conf file. No other commands will be run instead of the ones in this file for this use case.