### PR TITLE
Revert "enable mouse in wine by default"

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -119,7 +119,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: Path, original_r
             if "core" in system.config and system.config.core is not None:
                 effectiveCore = system.config.core
 
-            if generator.getMouseMode(system.config, rom, system):
+            if generator.getMouseMode(system.config, rom):
                 mouseChanged = True
                 videoMode.changeMouse(True)
 

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/wine/wineGenerator.py
@@ -67,6 +67,5 @@ class WineGenerator(Generator):
 
         raise BatoceraException("Invalid system: " + system.name)
 
-    def getMouseMode(self, config, rom, system):
-        return config.get_bool('force_mouse', system.name == "windows_installers")
-
+    def getMouseMode(self, config, rom):
+        return config.get_bool('force_mouse')


### PR DESCRIPTION
Reverts batocera-linux/batocera.linux#14518

as per @bryanforbes this is going to break everything down. Let's check that back in v43.