### PR TITLE
fix-amd-tdp-2[v42]

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-amd-tdp
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-amd-tdp
@@ -4,11 +4,11 @@
 # This file is part of the batocera distribution (https://batocera.org).
 # Copyright (c) 2025+.
 #
-# This program is free software: you can redistribute it and/or modify  
-# it under the terms of the GNU General Public License as published by  
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 3.
 #
-# You should have received a copy of the GNU General Public License 
+# You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # YOU MUST KEEP THIS HEADER AS IT IS
@@ -19,11 +19,6 @@
 
 log="/userdata/system/logs/amd-tdp.log"
 TDP_INPUT="$1"
-
-# --- Helper Function ---
-get_firmware_max_tdp() {
-    /usr/bin/ryzenadj -i | awk '/PPT LIMIT FAST/ {printf "%.0f\n", $6}'
-}
 
 # --- Sanity Checks ---
 if [[ "$(/usr/bin/ryzenadj -i)" =~ "unsupported model" ]]; then
@@ -49,6 +44,7 @@ tdp_ranges=(
 # Determine device's standard min/max TDP
 TDP_MIN=5 # Default min fallback
 BASE_TDP_MAX=35 # Default max fallback
+APPLY_TEMP_LIMIT=0 # Only set 90c for found handhelds
 
 device_model=$(batocera-info | awk -F': ' '/^Model:/ {print $2; exit}')
 
@@ -56,14 +52,16 @@ if [[ -v tdp_ranges["$device_model"] ]]; then
     IFS=';' read -r -a info <<< "${tdp_ranges[$device_model]}"
     TDP_MIN=${info[1]}
     BASE_TDP_MAX=${info[2]}
+    APPLY_TEMP_LIMIT=1
     echo "Device: ${info[0]} detected. Standard range: ${TDP_MIN}W - ${BASE_TDP_MAX}W." >> "$log"
 else
-    firmware_max=$(get_firmware_max_tdp)
-    if [[ -n "$firmware_max" && "$firmware_max" -gt 0 ]]; then
-        BASE_TDP_MAX=$firmware_max
-        echo "Using firmware max of ${BASE_TDP_MAX}W." >> "$log"
+    SYSTEM_TDP=$(/usr/bin/batocera-settings-get system.cpu.tdp)
+    if [ -n "$SYSTEM_TDP" ]; then
+        BASE_TDP_MAX=$SYSTEM_TDP
+        echo "Detected reported max of ${BASE_TDP_MAX}W." >> "$log"
     else
-        echo "Could not read firmware. Using default max of ${BASE_TDP_MAX}W." >> "$log"
+        echo "No system TDP defined." >> "$log"
+        exit 1
     fi
 fi
 
@@ -87,15 +85,26 @@ fi
 
 # --- Apply Settings ---
 WATTS=$((TDP * 1000))
-SLOW_WATTS=$((WATTS * 60 / 100)) # set to 60% of TDP
+SLOW_WATTS=$((WATTS * 80 / 100)) # TODO: Rethink how amd tdp is applied between handhelds and everything else(if not handheld should porobably set all limits to same value)
 
-echo "Applying final TDP: ${TDP}W (STAPM/Fast: ${WATTS}mW, Slow: ${SLOW_WATTS}mW, Temp Limit: 90C)" >> "$log"
+if (( APPLY_TEMP_LIMIT )); then
+    echo "Applying final TDP: ${TDP}W, Temp Limit: 90C" >> "$log"
+else
+    echo "Applying final TDP: ${TDP}W" >> "$log"
+fi
 
-if /usr/bin/ryzenadj \
-    --stapm-limit="${WATTS}" \
-    --fast-limit="${WATTS}" \
-    --slow-limit="${SLOW_WATTS}" \
-    --tctl-temp=90; then
+cmd=(/usr/bin/ryzenadj
+    --stapm-limit="$WATTS"
+    --fast-limit="$WATTS"
+    --slow-limit="$SLOW_WATTS"
+)
+
+# Only set temp limit for known handhelds
+if (( APPLY_TEMP_LIMIT )); then
+    cmd+=(--tctl-temp=90)
+fi
+
+if "${cmd[@]}"; then
     echo "Successfully set TDP to ${TDP}W." >> "$log"
 else
     echo "ERROR: ryzenadj command failed. Power limits may not have been applied." >> "$log"

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -24,8 +24,8 @@ shared:
       group: POWER OPTIONS
       prompt: RYZEN THERMAL DESIGN POWER
       description: Adjust the percentage of power (watts) provided to a Ryzen Mobile Series CPU based on it's default max value. Caution, setting wattage too high could damage your device.
-      preset: slider
-      preset_parameters: 10 120 5 100 %
+      preset: sliderauto
+      preset_parameters: 10 120 5 %
     videomode:
       prompt: VIDEO MODE
       description: Set the display's resolution. Does not affect the rendering resolution.


### PR DESCRIPTION
Lets try this again.

1. Changed tdp slider to sliderauto, so auto = no entry in batocera.conf

2. Adjusted hooks script to account for no global tdp value, if no global tdp or system/game requested tdp change it does nothing. If there is a requested change, it creates a changed flag to then be used on gamestop so it knows a change was made and will revert back to system default tdp if no global defined tdp.

3. Not sure the point of the firmware helper in batocera-amd-tdp, it just gets the current fast limit, which could be anything, I think it's better to just get the default system/reported max tdp and use that since it’s determined at boot and unlikely to change during runtime.

4. Probably most importantly, sets all stapm, fast limit, and slow limits to the actual target tdp requested. On many chips the slow limit is the sustained tdp target so it will kneecap performance if it's at 60%. Better for a target tdp to be set the same across the board. Additionally only sets a temp limit on known handhelds, otherwise it lets bios handle it and does not set a new temp limit.


If at all possible lets try to get this in v42 since many users have reported performance issues due to the slow limit being set at 60%. 

@bryanforbes @dmanlfc I tried to cover all bases after the last go around, let me know what you think or if you have any questions

-UPDATE-

Changed slow limit back to 80% of target tdp like it was before as a temp stop-gap to at least revert back before the performance issues were reported. For v43 we really need to rethink how all the amd tdp stuff works and is applied. It's my opinion that anything that is not explicitly a handheld should have the same value used for all limits. 

Or potentially a better method is on first boot check the bios default limits and if those all equal the same, than use the same target tdp value for all limits to stay consistent with bios defaults, else use some dynamically determined percentage based on bios defaults. But we do not have time for that for v42. 