### PR TITLE
Fix boxart: correct image source and preserve aspect ratio

### DIFF
--- a/package/batocera/screens/batocera-backglass/www/backglass-boxart/backglass-mini.css
+++ b/package/batocera/screens/batocera-backglass/www/backglass-boxart/backglass-mini.css
@@ -33,12 +33,16 @@ body {
 #game_boxart_internal {
     width: 100%;
     height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 #game_boxart_internal img {
-    width: 100%;
     height: 100%;
-    object-fit: fill;
+    width: auto;
+    object-fit: contain;
+    display: block;
 }
 
 #system_logo {

--- a/package/batocera/screens/batocera-backglass/www/backglass-boxart/backglass-mini.js
+++ b/package/batocera/screens/batocera-backglass/www/backglass-boxart/backglass-mini.js
@@ -13,8 +13,8 @@ function onSystem(infos) {
 function onGame(infos) {
     var html = "";
 
-    if(infos["boxart"]) {
-	html += "<div id=\"game_boxart\"><div id=\"game_boxart_internal\"><img src=\"" + infos["boxart"] + "\" /></div></div>";
+    if(infos["thumbnail"]) {
+	html += "<div id=\"game_boxart\"><div id=\"game_boxart_internal\"><img src=\"" + infos["thumbnail"] + "\" /></div></div>";
     } else {
 	if(infos["name"]) {
 	    html += "<div id=\"game_text\"><div id=\"game_text_internal\">" + infos["name"] + "</div></div>";


### PR DESCRIPTION
Fix boxart display in Batocera Backglass Boxart Template: use correct image source and preserve aspect ratio.
<img width="3840" height="1080" alt="screenshot-2025 09 26-19h30 07" src="https://github.com/user-attachments/assets/d0ab4a76-19e7-4812-b777-7a1bd9632ccb" />
