### PR TITLE
fix: batocera-wine autorun.cmd creator does not find exe

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -34,7 +34,7 @@ SYSTEM_SAVEDIR=
 # a basic exe-filter is here in the script, user can set advanced one, see i and ii in function
 AUTORUN_FILEMASK="$4"
 AUTORUN_FOUNDEXE=
-AUTORUN_FILTER=
+#AUTORUN_FILTER=
 # Use requestFileSystem() to check dirs and files for symlinks and filesystem, it's a small dev-tool for monitoring the entire script
 # Usage requestFileSystem "FILE" "DIR" "FILE"
 


### PR DESCRIPTION
All credits for intensive testing, reporting and asking the right questions @zognic 