### PR TITLE
fix MAME for Macintosh - games from mac softlist runs on SE, but not on LC3

### DIFF
--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -23,7 +23,7 @@ gmaster;gmaster;cart;
 gp32;gp32;memc;
 laser310;laser310;dump;
 lcdgames;;;
-macintosh;maclc3;flop1;
+macintosh;macse;flop1;
 megaduck;megaduck;cart;
 oricatmos;orica;cass;
 pdp1;pdp1;ptap1;


### PR DESCRIPTION
 also LC3 need a HDD image that is not given so Macintosh emulation did not work at all like this without manual steps