### PR TITLE
fix(azahar): use f-strings where required

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/azahar/azaharGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/azahar/azaharGenerator.py
@@ -229,10 +229,10 @@ class AzaharGenerator(Generator):
         if controller := Controller.find_player_number(playersControllers, 1):
             for x in azaharButtons:
                 azaharConfig.set("Controls", f"profiles\\1\\{x}", f'"{AzaharGenerator.setButton(azaharButtons[x], controller.guid, controller.inputs)}"')
-                azaharConfig.set("Controls", r"profiles\\1\\{x}\default", "false")
+                azaharConfig.set("Controls", f"profiles\\1\\{x}\\default", "false")
             for x in azaharAxis:
                 azaharConfig.set("Controls", f"profiles\\1\\{x}", f'"{AzaharGenerator.setAxis(azaharAxis[x], controller.guid, controller.inputs)}"')
-                azaharConfig.set("Controls", r"profiles\\1\\{x}\default", "false")
+                azaharConfig.set("Controls", f"profiles\\1\\{x}\\default", "false")
 
         ## Update the configuration file
         with ensure_parents_and_open(azaharConfigFile, 'w') as configfile:


### PR DESCRIPTION
I noticed that `~/configs/azaharplus-emu/qt-config.ini` contains an unresolved template variable:

```ini
profiles\\1\\%7Bx%7D\default=false
```

Fortunately seems to have no negative impact.

I assume that this kind of fix is expected as PR against b42 and will be integrated into master afterwards. Please advise if this does not apply.