### PR TITLE
Feature: custom_config option for Supermodel (Sega Model 3)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/supermodel/supermodelGenerator.py
@@ -159,6 +159,14 @@ def configPadsIni(system: Emulator, rom: Path, guns: Guns) -> None:
     templateFile = SUPERMODEL_SHARE / "Supermodel.ini.template"
     targetFile = SUPERMODEL_CONFIG / "Supermodel.ini"
 
+    # --- custom_config option: skip .ini generation if it already exists ---
+    custom_config = int(system.config.get("custom_config", 0))
+
+    if custom_config == 1 and targetFile.exists():
+        # Use the existing Supermodel.ini file as-is, do not copy or overwrite
+        return
+    # -----------------------------------------------------------------------
+
     # template
     templateConfig = CaseSensitiveConfigParser(interpolation=None)
     templateConfig.read(templateFile, encoding='utf_8_sig')

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -10104,6 +10104,11 @@ supermodel:
   features: [padtokeyboard]
   shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
   cfeatures:
+        custom_config:
+            group: ADVANCED OPTIONS
+            prompt: ENABLE CUSTOM CONFIG
+            description: Use your own Supermodel.ini file and skip automatic configuration generation.
+            preset: switchauto
         engine3D:
             group: ADVANCED OPTIONS
             prompt:      3D ENGINE


### PR DESCRIPTION
🆕 Feature: custom_config option for Supermodel (Sega Model 3)
This PR adds a new feature option called custom_config to the Supermodel generator.
When enabled (`custom_config=1`), the generator will skip creating or overwriting the `supermodel.ini `configuration file and will instead use the existing file as-is.

🔧 Behavior
custom_config = 0 (default): the .ini file is regenerated from the template each launch.
custom_config = 1 and Supermodel.ini exists: the existing file is preserved and used directly.
custom_config = 1 but no .ini yet: the template is copied as usual (fallback behavior).

🗂️ Purpose
This allows advanced users to maintain a fully customized `supermodel.ini` configuration that won’t be overwritten by Batocera’s automatic generator.