### PR TITLE
Update duckstation.mk

### DIFF
--- a/package/batocera/emulators/duckstation/duckstation.mk
+++ b/package/batocera/emulators/duckstation/duckstation.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 DUCKSTATION_VERSION = v0.1-7294
-DUCKSTATION_SITE = https://github.com/stenzek/duckstation.git
+DUCKSTATION_SITE = https://github.com/duckstation/old-releases.git
 DUCKSTATION_SITE_METHOD=git
 DUCKSTATION_GIT_SUBMODULES=YES
 DUCKSTATION_LICENSE = GPLv2


### PR DESCRIPTION
The tagged version of Duckstation in this file is no longer available at the main Duckstation repository. [The `README.md` for Duckstation](https://github.com/stenzek/duckstation?tab=readme-ov-file#downloading-and-running) says about older releases:

> The main releases page is limited to the last 30 releases due to automatic updater limitations. Older releases can be downloaded from https://github.com/duckstation/old-releases/releases.

This commit and pull request changes the site to that repository where the tagged version exists.