### PR TITLE
batocera-xtract: added InnoSetup

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-xtract
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-xtract
@@ -4,11 +4,11 @@
 # This file is part of the batocera distribution (https://batocera.org).
 # Copyright (c) 2025+.
 #
-# This program is free software: you can redistribute it and/or modify  
-# it under the terms of the GNU General Public License as published by  
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, version 3.
 #
-# You should have received a copy of the GNU General Public License 
+# You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 # YOU MUST KEEP THIS HEADER AS IT IS
@@ -21,7 +21,7 @@
 # inital idea and inspired by brunoeduardobrasil, 07/19/2025 cyperghost aka crcerror
 # ec-codes: ec-0 okay, ec-1 error, ec-10 parameter l used
 # ec-11 archives not supported for extraction, ec-12 archives not supported for showing content
-# ec-21 to 28 -- file extraction error zip rar 7z gz xy tar tar.xz tar.gz
+# ec-21 to 29 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz exe (only InnoSetup)
 
 # Is pcmanfm is active then use yad as output. test -t will not work because pcmanfm creates a virtual terminal
 # SSH_CONNECTION and SSH_TTY are active if SSH connection is used
@@ -39,11 +39,11 @@ list_archive () {
         *.iso) readarray -t array < <($bin7z l -ba "$FILE"  | awk '{ print "FALSE"; for(i=4; i<NF; ++i) if ($i ~ /^[0-9]+$/) continue; else printf $i" "; print $NF; if ($3 ~ /^D/) print "DIR"; else print $4; print $1,$2; }') ;;
         *.rar) readarray -t array < <(printf "FALSE\n%s\nna\nna\n" $(unrar lb "$FILE")) ;;
         *.7z)  readarray -t array < <($bin7z l -ba "$FILE" | awk '{ print "FALSE"; for(i=5; i<NF; ++i) if ($i ~ /^[0-9]+$/) continue; else printf $i" "; print $NF; if ($3 ~ /^D/) print "DIR"; else print $4; print $1,$2; }') ;;
-        # Unlike gzip is xy only compression formats for single files, so always open with tar extension and do not use the single compression types
         *.tar) readarray -t array < <(tar -tvf "$FILE"  | awk '{ print "FALSE"; for(i=6; i<NF; ++i) printf $i" "; print $NF; if ($1 ~ /^d/) print "DIR"; else print $3; print $4, $5; }') ;;
         *.tar.gz|*.tgz) readarray -t array < <(tar -tvzf "$FILE" | awk '{ print "FALSE"; for(i=6; i<NF; ++i) printf $i" "; print $NF; if ($1 ~ /^d/) print "DIR"; else print $3; print $4, $5; }') ;;
         *.gz) readarray -t array < <($bin7z l -ba "$FILE"  | awk '{ print "FALSE"; for(i=6; i<NF; ++i) printf $i" "; print $NF; if ($3 ~ /^D/) print "DIR"; else print $4; print $1,$2 }') ;;
-        *.tar.xz) readarray -t array < <(tar -tvJf "$FILE" | awk '{ print "FALSE"; for(i=6; i<NF; ++i) printf $i" "; print $NF; if ($1 ~ /^d/) print "DIR"; else $3; print $4, $5; }') ;; 
+        # Unlike gzip is xy only a compression format for a single file, so always open with tar extension and do not use the single compression types
+        *.tar.xz) readarray -t array < <(tar -tvJf "$FILE" | awk '{ print "FALSE"; for(i=6; i<NF; ++i) printf $i" "; print $NF; if ($1 ~ /^d/) print "DIR"; else print $3; print $4, $5; }') ;; 
         *) return 12
     esac
 
@@ -57,26 +57,24 @@ list_archive () {
 
 extract_archive () {
     case  "$1" in
-        # Multiple dotted extensions at first
-        *.tar.xz) tar -xJf "$FILE" "${files[@]}" -C "$DEST" || return 27 ;;
-        *.tar.gz|*.tgz) tar -xzf "$FILE" "${files[@]}" -C "$DEST" || return 28 ;;
-        # Single dotted extensions later
-        # 7z is better to handle zip files, 7z extracts all files from selected dir
-        #*.zip) unzip -o "$FILE" "${files[@]}" -d "$DEST" || return 21 ;;
         *.zip) $bin7z x -y "$FILE" -o"$DEST" "${files[@]}" || return 21 ;;
         *.rar) unrar x -o+ "$FILE" "${files[@]}" "$DEST/" || return 22 ;;
         *.7z)  $bin7z x -y "$FILE" -o"$DEST" "${files[@]}" || return 23 ;;
         *.gz)  $bin7z x -y "$FILE" -o"$DEST" "${files[@]}" || return 24 ;;
         *.iso) $bin7z x -y "$FILE" -o"$DEST" "${files[@]}" || return 25 ;;
         *.tar) tar -xf "$FILE" "${files[@]}" -C "$DEST" || return 26 ;;
+        *.tar.xz) tar -xJf "$FILE" "${files[@]}" -C "$DEST" || return 27 ;;
+        *.tar.gz|*.tgz) tar -xzf "$FILE" "${files[@]}" -C "$DEST" || return 28 ;;
+        *.exe) innoextract -e -L -m "$FILE" -d "$DEST" || return 29 ;;
         *) return 11
     esac
 }
 
 case "$1" in
-    x|X) #for CLI as universal extraction tool
+    x|X|clix) #for CLI as universal extraction tool
         FILE="$2"; DEST="$3"
         [[ -f "$FILE" ]] || { echo "Error! Archive '$FILE' not found"; exit 1; }
+        [[ "$1" == "clix" && -z "$DEST" ]] && DEST="$PWD"
         if [[ -z "$DEST" ]]; then
             FILENAME="$(basename "${FILE%.*}")"
             echo "No Destination directory entered!"
@@ -104,8 +102,7 @@ case "$1" in
     --open|open|l|L)
         FILE="$2"
         DEST="$(readlink -f "$(dirname "${FILE}")")"
-        list_archive "$(basename "${FILE,,}")" "${1,,}" || exit $?
-        extract_archive "$(basename "${FILE,,}")" || ret=$?
+        list_archive "$(basename "${FILE,,}")" "${1,,}" && extract_archive "$(basename "${FILE,,}")" || ret=$?
     ;;
     --add)
         # We remove $0 and $1, create filename.zip if single dir/file, create subdirname.zip for several files/dirs, we need the work-dir to have the relative pathes
@@ -124,23 +121,28 @@ esac
 case $ret in
     0|1) true ;;
     2) # Action not defined
-        [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Action: '$1' is unknown"; exit 1; }
+        [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Action: '$1' is unknown"; exit 2; }
         echo "Usage: $(basename "$0") <SWITCHES> [ARCHIVEFILE] {DESTINATION-DIR}"; echo
         echo "    x: extraction of current archivfile"
+        echo " clix: extraction of current archive for without prompt (CLI)"
         echo "    l: list archive content"; echo
         echo "Supported archives for extraction: zip 7z rar tar gz iso tar.gz/tgz tar.xz"
         echo "Supported archives for list/open : zip 7z rar tar gz iso tar.gz/tgz tar.xz"; echo
         echo "error-codes/return codes:"
         echo "  ec-0 no error, ec-10 parameter 'l', okay -- ec-1 general error -- ec-2 unknown action"
         echo "  ec-11 to 12  -- archive type not supported for extraction, listing"
-        echo "  eec-21 to 28 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz";echo
+        echo "  ec-21 to 28 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz"
+        echo "  ec-29       -- file extraction error for exe-files (InnoSetup)" ;echo
     ;;
     3)  echo "Error! Destionation directory '$DEST' not found" ;; #CLI Destination dir not found
     11|12) # Extension not supported for extraction or listing
         [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Archive type: '${FILE##*.}' is not yet supported.\nFailed to open '$FILE'"; }
         [[ $TERMINAL -eq 1 ]] && { echo "Error: Archive type: '${FILE##*.}' is not yet supported. Failed to open '$FILE'"; }
     ;;
-   2[1-8]) echo "Extraction error for archive type: $ret" ;;
+   2[1-9]) # Error in extraction
+        [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Archive type: '${FILE##*.}' Extraction error: $ret\nFailed to extract '$FILE'"; }
+        [[ $TERMINAL -eq 1 ]] && { echo "Error: Archive type: '${FILE##*.}' Extraction error - Failed to extract '$FILE'"; }
+    ;;
 esac
 echo "Exit with code: $ret"
 exit $ret


### PR DESCRIPTION
InnoSetup-Exe can be extracted by mouse context menu or CLI

added parameter `clix` - stand for CLI-Extraction..... This parameter will extract without any further prompts in current folder or destination dir

it is useless for InnoSetups to get a view-list ... because Innoextract does not support single files extraction and I want to avoid that the exe-MIME-type is only bounded to a single script ;)