### PR TITLE
catacombglGenerator: align game-file with folder names

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/catacombgl/catacombglGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/catacombgl/catacombglGenerator.py
@@ -76,6 +76,7 @@ class CatacombGLGenerator(Generator):
             "abyss": "--abyss",
             "abyss_sw13": "--abyss_sw13",
             "descent": "--descent",
+            "cat3d": "--descent",
             "armageddon": "--armageddon",
             "apocalypse": "--apocalypse",
         }.items():


### PR DESCRIPTION
Just a bit cosmetic, all .game files names align with dir-content. Except DESCENT aka Cat3D