### PR TITLE
Sync MIME to all platforms, add pcmanfm actions

### DIFF
--- a/package/batocera/core/batocera-desktopapps/batocera-desktopapps.mk
+++ b/package/batocera/core/batocera-desktopapps/batocera-desktopapps.mk
@@ -10,6 +10,11 @@ BATOCERA_DESKTOPAPPS_SCRIPTS = filemanagerlauncher
 BATOCERA_DESKTOPAPPS_APPS  = xterm.desktop
 BATOCERA_DESKTOPAPPS_ICONS =
 
+#file-roller integration for pcmanfm - open/list archives
+BATOCERA_DESKTOPAPPS_APPS    += file-roller-mimics.desktop
+
+## System depended applets
+
 # wiimote
 BATOCERA_DESKTOPAPPS_APPS    += xwiishowir.desktop
 BATOCERA_DESKTOPAPPS_ICONS   += xwiishowir.png
@@ -164,6 +169,9 @@ ifeq ($(BR2_PACKAGE_LINDBERGH_LOADER),y)
   BATOCERA_DESKTOPAPPS_SCRIPTS += batocera-config-lindbergh
 endif
 
+## Context Menu Actions
+BATOCERA_DESKTOPAPPS_ACTIONS = system.md5sum.desktop
+
 define BATOCERA_DESKTOPAPPS_INSTALL_TARGET_CMDS
 	# scripts
 	mkdir -p $(TARGET_DIR)/usr/bin
@@ -172,14 +180,21 @@ define BATOCERA_DESKTOPAPPS_INSTALL_TARGET_CMDS
 	# apps
 	mkdir -p $(TARGET_DIR)/usr/share/applications
 	$(foreach f,$(BATOCERA_DESKTOPAPPS_APPS), cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-desktopapps/apps/$(f) $(TARGET_DIR)/usr/share/applications/$(f)$(sep))
+	# default-mime types
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-desktopapps/mime/defaults.list $(TARGET_DIR)/usr/share/applications/defaults.list
 
 	# icons
 	mkdir -p $(TARGET_DIR)/usr/share/icons/batocera
 	$(foreach f,$(BATOCERA_DESKTOPAPPS_ICONS), cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-desktopapps/icons/$(f) $(TARGET_DIR)/usr/share/icons/batocera/$(f)$(sep))
 
+	# context menu actions
+	mkdir -p $(TARGET_DIR)/usr/share/file-manager/actions
+	$(foreach f,$(BATOCERA_DESKTOPAPPS_ACTIONS), cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-desktopapps/contextactions/$(f) $(TARGET_DIR)/usr/share/file-manager/actions/$(f)$(sep))
+
 	# menu
 	mkdir -p $(TARGET_DIR)/etc/xdg/menus
 	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/core/batocera-desktopapps/menu/batocera-applications.menu $(TARGET_DIR)/etc/xdg/menus/batocera-applications.menu
+
 endef
 
 $(eval $(generic-package))

--- a/package/batocera/core/batocera-desktopapps/contextactions/system.md5sum.desktop
+++ b/package/batocera/core/batocera-desktopapps/contextactions/system.md5sum.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Action
+Name=Get md5 Checksum
+Profiles=Batocera
+
+[X-Action-Profile Batocera]
+MimeTypes=all/allfiles
+Exec=bash -c "md5sum %F | yad --text-info"

--- a/package/batocera/core/batocera-desktopapps/mime/defaults.list
+++ b/package/batocera/core/batocera-desktopapps/mime/defaults.list
@@ -1,0 +1,8 @@
+[Default Applications]
+text/plain=l3afpad.desktop
+application/zip=file-roller-mimics.desktop
+application/vnd.rar=file-roller-mimics.desktop
+application/x-7z-compressed=file-roller-mimics.desktop
+application/x-cd-image=file-roller-mimics.desktop
+application/x-tar=file-roller-mimics.desktop
+application/gzip=file-roller-mimics.desktop


### PR DESCRIPTION
Sync MIME types to all supported platforms
Add md5sum check to context menu
Add file-roller to pcmanfm integration for all supported platforms

alings with:
https://github.com/batocera-linux/batocera.linux/pull/14723
https://github.com/batocera-linux/batocera.linux/pull/14719 --> shifted to correct place now

Refering to https://github.com/batocera-linux/batocera.linux/pull/14736