### PR TITLE
Fix the issue where devices using Sway get stuck on the ES boot screen during startup

### DIFF
--- a/package/batocera/core/batocera-system/Config.in
+++ b/package/batocera/core/batocera-system/Config.in
@@ -2072,6 +2072,7 @@ config BR2_PACKAGE_BATOCERA_WAYLAND_SWAY
 	# Compositor for wayland
 	select BR2_PACKAGE_SWAY
 	select BR2_PACKAGE_SWAYBG
+	select BR2_PACKAGE_WLR_RANDR
 
 config BR2_PACKAGE_BATOCERA_WAYLAND_LABWC
 	bool "batocera.linux wayland labwc packages selection"


### PR DESCRIPTION
# Version

43-dev 42

# Description

I compiled the 43-dev version of Batocera for my S922X device and flashed it onto the device. After booting, it consistently got stuck on the logo screen. 

Using the UART shell, I confirmed the device was booting normally. I then checked the display logs and found that ES was repeatedly attempting to restart. 

```
[root@BATOCERA ~]# tail -F /userdata/system/logs/display.log 
Standalone: Waiting for Wayland compositor...
Standalone: Timed out waiting for Wayland compositor.
Standalone: --- Top of display configuration loop ---
Standalone: Waiting for Wayland compositor...
Standalone: Timed out waiting for Wayland compositor.
Standalone: --- Top of display configuration loop ---
Standalone: Waiting for Wayland compositor...
Standalone: Timed out waiting for Wayland compositor.
Standalone: --- Top of display configuration loop ---
Standalone: Waiting for Wayland compositor...
Standalone: Timed out waiting for Wayland compositor.
```

Based on the log output, I pinpointed the exact location in the ES startup script [emulationstation-standalone](https://github.com/batocera-linux/batocera.linux/blob/cfbc332ba0bd5ba9bfd348a2c42da0498f4ab547/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone).

```
_wait_for_compositor() {
    # If not in a Wayland session, no need to wait.
    if [ -z "$WAYLAND_DISPLAY" ]; then return 0; fi
    local i=0
    echo "Standalone: Waiting for Wayland compositor..." >> "$log"
    while [ "$i" -lt 50 ]; do # 5 second timeout
        if wlr-randr > /dev/null 2>&1; then                        <<<<<<<<<<<<<<<<<<<<<<here!!!
            echo "Standalone: Compositor is ready." >> "$log"
            return 0
        fi
        sleep 0.1
        i=$((i + 1))
    done
    echo "Standalone: Timed out waiting for Wayland compositor." >> "$log"
    return 1
}
```

 I investigated why wlr-randr was failing and discovered that wlr-randr was not present on the device. 

```
[root@BATOCERA ~]# which wlr-randr
[root@BATOCERA ~]#
```

Ultimately, I located the issue in the source tree: when selecting LABWC, WLR_RANDR was enabled, but it was forgotten for SWAY. 

After adding the missing WLR_RANDR selection and recompiling the firmware, I performed a manual update via `batocera-upgrade manual`, and the system successfully booted to the ES interface.

```
[root@BATOCERA ~]# tail -F /userdata/system/logs/display.log 
Standalone: Found screen checker status file. Reading outputs.
Standalone: Assigned from file - HDMI-A-1, , 
Standalone: Validating detected outputs...
Standalone: --- Enabling Outputs ---
Updated video outputs: HDMI-A-1, , 
Standalone: --- Applying Resolutions ---
Standalone: No resolution in boot config for 'HDMI-A-1'. Using minTomaxResolution-secure.
Standalone: --- Applying Rotations ---
Rotation for output HDMI-A-1: 
Standalone: --- Launching EmulationStation ---
[root@BATOCERA ~]# which wlr-randr
/usr/bin/wlr-randr
```