### PR TITLE
batocera-resolution : fix batocera-boot es.resolution=max-....

### DIFF
--- a/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.xorg
+++ b/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.xorg
@@ -44,7 +44,7 @@ f_minTomaxResolution() {
     if [ -z "$1" ]; then
         # reinit the screen (in case it was off)
         if [ -n "${BOOTRESOLUTION}" ] && [ "${BOOTRESOLUTION}" != "auto" ]; then
-            BOOT_RES=$(echo "${BOOTRESOLUTION}" | cut -d'.' -f1)
+            BOOT_RES=$(echo "${BOOTRESOLUTION}" | cut -d'.' -f1 | sed 's/max-//;s/\..*//')
             BOOT_RATE=$(echo "${BOOTRESOLUTION}" | cut -s -d'.' -f2-)
             if [ -n "$BOOT_RATE" ]; then
                 echo "es.resolution setting found. Initializing screen to: ${BOOT_RES} @ ${BOOT_RATE}Hz" >> "$log"


### PR DESCRIPTION
commit c7afbf130cbd75e0c8d83b066aace8a3dfa1474f introduce xorg init with value from batocera-boot, but if value is configured with max-.. (the default commented value), it's not working