### PR TITLE
Lindbergh: export display

### DIFF
--- a/package/batocera/core/batocera-desktopapps/scripts/batocera-config-lindbergh
+++ b/package/batocera/core/batocera-desktopapps/scripts/batocera-config-lindbergh
@@ -25,10 +25,10 @@ if [[ -z "$1" ]]; then
 fi
 
 # Ensure DISPLAY is set
-if test -z "${DISPLAY}"; then
-    export DISPLAY=:0.0
+if test -z "${DISPLAY}"
+then
+    export DISPLAY=$(getLocalXDisplay || echo :0.0)
 fi
-
 # Define variables
 GAME_PATH="$1"
 FLAG="$2"


### PR DESCRIPTION
check display and then use fallback option according https://github.com/batocera-linux/batocera.linux/pull/13805