### PR TITLE
Fix SyntaxWarning: invalid escape sequence in evsieve-helper

### DIFF
--- a/package/batocera/utils/evsieve/evsieve-helper
+++ b/package/batocera/utils/evsieve/evsieve-helper
@@ -45,7 +45,7 @@ def devicepathWithoutConf(path):
     previouslastNode = basename(dirname(path))
 
     # if last node is like previous node + :number.number => usb
-    if lastNode[0:len(previouslastNode)+1] == previouslastNode+":" and re.search("^[0-9]+\.[0-9]+$", lastNode[len(previouslastNode)+1:]) is not None:
+    if lastNode[0:len(previouslastNode)+1] == previouslastNode+":" and re.search(r"^[0-9]+\.[0-9]+$", lastNode[len(previouslastNode)+1:]) is not None:
         return dirname(path)
     else:
         return path


### PR DESCRIPTION
This PR fixes a `SyntaxWarning: invalid escape sequence '\.'` located at line 48 of `evsieve-helper`.

This warning occurs in newer Python versions because the regex string contains an escaped character without being a raw string or properly escaped.

**Fix:**
Use of r"..." raw regexp string to fix escaping.

**Error log:**
> /usr/bin/evsieve-helper:48: SyntaxWarning: invalid escape sequence '\.'