### PR TITLE
moonlight-embedded: fix intel dependency inclusion on non x86 systems

### DIFF
--- a/package/batocera/utils/moonlight-embedded/moonlight-embedded.mk
+++ b/package/batocera/utils/moonlight-embedded/moonlight-embedded.mk
@@ -20,7 +20,7 @@ else
     MOONLIGHT_EMBEDDED_CONF_OPTS += -DENABLE_X11=OFF
 endif
 
-ifeq ($(BR2_PACKAGE_LIBVA),y)
+ifeq ($(BR2_PACKAGE_LIBVA_INTEL_DRIVER),y)
     MOONLIGHT_EMBEDDED_DEPENDENCIES += libva-intel-driver intel-mediadriver
 endif
 


### PR DESCRIPTION
Fixes inclusion of libva-intel-driver and intel-mediadriver dependencies when libva package is available on non x86 systems.
Relevant error:
```
Makefile:577: *** intel-mediadriver is in the dependency chain of moonlight-embedded that has added it to its _DEPENDENCIES variable without selecting it or depending on it from Config.in.  Stop.
```