### PR TITLE
moonlight-qt: add batocera-moonlight helper script

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/moonlight/moonlightGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/moonlight/moonlightGenerator.py
@@ -64,7 +64,6 @@ class MoonlightGenerator(Generator):
         )
 
     def generate_qt(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
-        gameName, confFile = self.getRealGameNameAndConfigFile(rom)
         commandArray = ['/usr/bin/moonlight-qt', 'stream']
 
         # resolution
@@ -114,7 +113,8 @@ class MoonlightGenerator(Generator):
         commandArray.append(host)
 
         # app
-        commandArray.append(gameName)
+        app = rom.read_text().rstrip()
+        commandArray.append(app)
 
         return commandArray
 

--- a/package/batocera/utils/moonlight-qt/batocera-moonlight
+++ b/package/batocera/utils/moonlight-qt/batocera-moonlight
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -eu
+
+help="\
+Manage batocera moonlight integration
+
+Usage:
+  $(basename $0) <command> [options] [arguments]
+
+Commands:
+  pair   <host>        pair with sunshine host
+  sync   <host>        fetch apps list from sunshine host
+  list                 list available apps
+  clean                remove all available apps and metadata
+  stream <host> <app>  stream application from host
+
+Options:
+  -h, --help           display current help message
+"
+
+moonlight="/usr/bin/moonlight-qt"
+romsdir="/userdata/roms/moonlight"
+romsext=".moonlight"
+
+join_by() {
+    local d=${1-} f=${2-}
+    if shift 2; then
+        printf %s "$f" "${@/#/$d}"
+    fi
+}
+
+log() {
+    local callstack=("${FUNCNAME[@]}")
+    callstack=($(printf "%s\n" "${callstack[@]}" | tac | tr "\n" " "; echo))
+    callstack=("$(basename $0)" "${callstack[@]:2}")
+    unset callstack[-1]
+
+    local prefix=$(join_by ": " "${callstack[@]}")
+    echo "$prefix: $@"
+}
+
+error() {
+    echo "error: $@" >&2;
+}
+
+pair() {
+    local host="${1:-}"
+    if [ -z "$host" ]; then
+        error "missing required argument <host>"
+        exit 1
+    fi
+
+    log "pairing with host '$host'"
+    $moonlight pair "$host"
+}
+
+romfname() {
+    local app="$1"
+    echo "$app" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -r -e 's/\s+/ /g' -e 's/[^A-Za-z0-9.-]/-/g'
+}
+
+sync() {
+    local host="$1"
+    if [ -z "$host" ]; then
+        error "missing required argument <host>"
+        exit 1
+    fi
+
+    log "fetching apps list from host '$host'"
+    local apps
+    readarray -t apps < <($moonlight list "$host")
+
+    log "populating moonlight roms"
+    for app in "${apps[@]}"; do
+        local fname="$(romfname "$app")"
+        local rom="${fname}${romsext}"
+        log "creating moonlight rom entry '$rom' for app '$app'"
+        echo "$app" > "$romsdir/$rom"
+    done
+}
+
+list() {
+    find "$romsdir" \
+        -name "*$romsext" \
+        -type f \
+        -exec cat {} \;
+}
+
+clean() {
+    log "purging romsdir in $romsdir"
+    rm -rfv $romsdir/*$romsext
+}
+
+stream() {
+    local host="${1:-}"
+    local app="${2:-}"
+
+    if [ -z "$host" ]; then
+        error "missing required argument <host>"
+        exit 1
+    fi
+
+    if [ -z "$app" ]; then
+        error "missing required argument <app>"
+        exit 1
+    fi
+
+    log "streaming app '$app' from host '$host'"
+    $moonlight stream "$host" "$app"
+}
+
+help() {
+    echo "$help"
+    exit 0
+}
+
+main() {
+    case "${1:-}" in
+        pair)
+            local host="${2:-}"
+            pair "$host"
+            ;;
+        sync)
+            local host="${2:-}"
+            sync "$host"
+            ;;
+        list)
+            list
+            ;;
+        clean)
+            clean
+            ;;
+        stream)
+            local host="${2:-}"
+            local app="${3:-}"
+            stream "$host" "$app"
+            ;;
+        -h|--help)
+            help
+            ;;
+        *)
+            help
+            ;;
+    esac
+}
+
+main "$@"

--- a/package/batocera/utils/moonlight-qt/moonlight-qt.mk
+++ b/package/batocera/utils/moonlight-qt/moonlight-qt.mk
@@ -96,6 +96,9 @@ endef
 define MOONLIGHT_QT_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/app/moonlight \
 		$(TARGET_DIR)/usr/bin/moonlight-qt
+	$(INSTALL) -m 0755 \
+		$(MOONLIGHT_QT_PKGDIR)/batocera-moonlight \
+		$(TARGET_DIR)/usr/bin/
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
Adds `batocera-moonlight` helper script for pairing and syncing available applications as pseudo-roms in ES 