### PR TITLE
refactors es_features to eliminate redundancy and improve maintainabi…

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -334,10 +334,12 @@ shared:
         "hidden": "hidden"
 
 global:
-  shared: [powermode, batterymode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, rewind, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain]
+  shared: [powermode, batterymode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rumble_gain]
 
 libretro:
-  shared: [powermode, tdp, videomode, ratio, shaderset, smooth, integerscale, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, rumble_gain, audio_volume, bordersmode]
+  shared_exclude: [batterymode]
+  # specific for libretro and it's cores only
+  shared_include: [shaderset, smooth, integerscale, ai_service_enabled, ai_target_lang, ai_service_url, ai_service_pause, runahead, preemptiveframes, secondinstance, video_frame_delay_auto, vrr_runloop_enable, video_threaded, audio_volume, bordersmode]
   cfeatures:
     gfxbackend:
       archs_include: [x86, x86_64, x86-64-v3, bcm2711, bcm2712, a3gen2, qcs6490, sm8250, sm8550, rk3588, rk3588-sdio]
@@ -7194,11 +7196,11 @@ libretro:
 
     #pcsx2:
 
-# Standalones
+# --- Standalones ---
 
 amiberry:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         amiberry_linemode:
             group: ADVANCED OPTIONS
@@ -7266,7 +7268,7 @@ amiberry:
             preset_parameters: 0 100 5 60
 
 cannonball:
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rumble_gain]
   cfeatures:
         ratio:
             prompt: ASPECT RATIO
@@ -7282,7 +7284,8 @@ cannonball:
                 "On":  1
 
 cemu:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, ratio]
+  shared_include: [use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
   cfeatures:
         cemu_gfxbackend:
             prompt:      GRAPHICS API
@@ -7406,7 +7409,8 @@ cemu:
 
 hypseus-singe:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, use_guns]
+  shared_exclude: [batterymode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rumble_gain]
+  shared_include: [use_guns]
   cfeatures:
         hypseus_api:
             archs_include: [x86, x86_64, x86-64-v3, bcm2711, bcm2712, a3gen2, qcs6490, sm8250, sm8550, rk3588, rk3588-sdio]
@@ -7499,7 +7503,7 @@ hypseus-singe:
 
 devilutionx:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, ratio]
   cfeatures:
         devilutionx_stretch:
             prompt: STRETCH TO FILL
@@ -7511,7 +7515,8 @@ devilutionx:
 dolphin:
   cores:
     'dolphin':
-        shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+        shared_exclude: [batterymode]
+        shared_include: [autosave, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
         features: [cheevos]
         cfeatures:
                 dolphin_aspect_ratio:
@@ -7904,7 +7909,7 @@ dolphin:
                         preset: switchauto
 
 dolphin_triforce:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode]
   cfeatures:
         triforce_api:
             prompt: GRAPHICS API
@@ -8044,7 +8049,7 @@ dolphin_triforce:
 
 dosbox:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         dosbox_cpu_core:
             submenu: EMULATION
@@ -8076,14 +8081,14 @@ dosbox:
 
 dosbox_staging:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 dosbox-x:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 duckstation:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_include: [autosave, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
   features: [cheevos]
   cfeatures:
         duckstation_clocking:
@@ -8397,7 +8402,8 @@ duckstation:
                 "Enabled":            "1"
 
 flycast:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_include: [autosave, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [rewind]
   features: [cheevos]
   cfeatures:
     flycast_ratio:
@@ -8564,11 +8570,11 @@ flycast:
 
 fsuae:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 hatari:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         model:
             prompt:      MODEL
@@ -8622,7 +8628,7 @@ hatari:
                 "ACSI":          ACSI
 
 melonds:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         melonds_renderer:
             prompt: GRAPHICS API
@@ -8738,7 +8744,7 @@ melonds:
                 "DSi (experiemental)": 1
 
 moonlight:
-  shared: [powermode, tdp, videomode, ratio]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         moonlight_codec:
             group: ADVANCED OPTIONS
@@ -8807,7 +8813,7 @@ moonlight:
                 "7.1": "7.1"
 
 mupen64plus:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         mupen64plus_ratio:
             prompt:      GAME ASPECT RATIO
@@ -9047,8 +9053,9 @@ mupen64plus:
                 "15%": 0.15
                 "20%": 0.2
                 "25%": 0.25
+
 openbor:
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         openbor_ratio:
             prompt: SCREEN RATIO
@@ -9097,7 +9104,7 @@ openbor:
 pcsx2:
   cores:
     'pcsx2':
-      shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+      shared_exclude: [batterymode, rumble_gain]
       features: [cheevos]
       cfeatures:
         pcsx2_shaderset:
@@ -9372,7 +9379,8 @@ pcsx2:
                 "On":      1
 
 ppsspp:
-  shared: [powermode, tdp, videomode, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rewind]
+  shared_include: [rewind]
+  shared_exclude: [batterymode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, rumble_gain]
   cfeatures:
         gfxbackend:
             submenu: RENDERING
@@ -9554,13 +9562,14 @@ ppsspp:
 
 pygame:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns]
+  shared_exclude: [batterymode, rumble_gain]
 
 reicast:
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 rpcs3:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_include: [use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [rumble_gain]
   cfeatures:
         rpcs3_ppudecoder:
             submenu: CPU
@@ -9979,7 +9988,7 @@ rpcs3:
 
 scummvm:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, ratio, rumble_gain]
   cfeatures:
       scumm_scale:
           prompt: SCALE FACTOR
@@ -10043,7 +10052,7 @@ scummvm:
               "Czech":              "cz"
 
 easyrpg:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         testplay:
             prompt:      TEST PLAY
@@ -10068,7 +10077,7 @@ easyrpg:
                 "Baltic":                        1257
 
 redream:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
       redreamResolution:
           prompt: RENDERING RESOLUTION
@@ -10141,15 +10150,15 @@ redream:
 
 sdlpop:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, hud]
+  shared_exclude: [batterymode, rumble_gain]
 
 superbroswar:
   features: []
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 supermodel:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         engine3D:
             group: ADVANCED OPTIONS
@@ -10228,7 +10237,7 @@ supermodel:
 
 cgenius:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         cgenius_aspect:
             prompt: ASPECT RATIO
@@ -10271,7 +10280,7 @@ cgenius:
 
 vice:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         noborder:
             group: ADVANCED OPTIONS
@@ -10283,7 +10292,7 @@ vice:
 
 tsugaru:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         cdrom_speed:
             group: ADVANCED OPTIONS
@@ -10304,7 +10313,8 @@ tsugaru:
 
 mame:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [ratio, rumble_gain]
+  shared_include: [use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
   cfeatures:
         video:
             prompt:      VIDEO MODE
@@ -11521,7 +11531,7 @@ mame:
 
 wine:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         wine-runner:
             prompt: WINE RUNNER
@@ -11670,7 +11680,7 @@ wine:
                 "On":  1
 
 solarus:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         joystick:
             prompt:      CONTROL CHOICE
@@ -11682,7 +11692,7 @@ solarus:
 
 mugen:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         esync:
             group: ADVANCED OPTIONS
@@ -11708,18 +11718,18 @@ mugen:
 
 ikemen:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 ruffle:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
 
 lightspark:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 drastic:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         drastic_hires:
             prompt:      ENHANCED RENDERING RESOLUTION
@@ -11777,7 +11787,7 @@ drastic:
                 "Single": 3
 
 xemu:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         xemu_api:
             prompt: GRAPHICS API
@@ -11859,15 +11869,15 @@ xemu:
 
 lexaloffle:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 ecwolf:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 sonic2013:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         language:
             prompt:      LANGUAGE
@@ -11922,7 +11932,7 @@ sonic2013:
 
 soniccd:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         language:
             prompt:      LANGUAGE
@@ -11975,7 +11985,7 @@ soniccd:
 
 model2emu:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         model2_renderRes:
             prompt: RENDERING RESOLUTION
@@ -12085,9 +12095,10 @@ model2emu:
             choices:
                 "Off": 0
                 "On":  1
+
 gsplus:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
       gsplus_bios_filename:
           prompt: GSPLUS BIOS FILENAME
@@ -12101,7 +12112,7 @@ gsplus:
 
 play:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
       play_api:
           prompt: GRAPHICS API
@@ -12161,15 +12172,15 @@ play:
 
 flatpak:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
 
 steam:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
 
 citron:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         citron_scale:
           submenu: VIDEO
@@ -12355,7 +12366,7 @@ citron:
 
 ryujinx:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         ryujinx_api:
           prompt: GRAPHICS API
@@ -12454,23 +12465,23 @@ ryujinx:
 
 samcoupe:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 hcl:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, hud, hud_corner]
+  shared_exclude: [batterymode, rumble_gain]
 
 hurrican:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, hud, hud_corner]
+  shared_exclude: [batterymode, rumble_gain]
 
 tyrian:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, hud, hud_corner]
+  shared_exclude: [batterymode, rumble_gain]
 
 openjazz:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     jazz_resolution:
       prompt: RENDERING RESOLUTION
@@ -12495,15 +12506,15 @@ openjazz:
 
 abuse:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 cdogs:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 openmsx:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         openmsx_loading:
             prompt: LOADING SPEED
@@ -12520,11 +12531,11 @@ openmsx:
 
 sh:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 xenia:
   features: []
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         xenia_api:
             prompt: GRAPHICS API
@@ -12768,7 +12779,7 @@ xenia:
 
 xenia-canary:
   features: []
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         xenia_license:
             prompt: XBOX LIVE ARCADE
@@ -13054,14 +13065,14 @@ xenia-canary:
 
 eka2l1:
   features: []
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 odcommander:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, ratio, hud]
+  shared_exclude: [batterymode, rumble_gain]
 
 gzdoom:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     gz_api:
@@ -13078,7 +13089,7 @@ gzdoom:
         "Enabled":  True
 
 corsixth:
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     cth_new_graphics:
@@ -13101,11 +13112,11 @@ corsixth:
         "Disabled": "false"
 
 stella:
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
 
 eduke32:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: []
   cfeatures:
     nologo:
@@ -13115,7 +13126,7 @@ eduke32:
         "Show (Default)": 0
 
 fury:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: []
   cfeatures:
     nologo:
@@ -13125,7 +13136,7 @@ fury:
         "Show (Default)": 0
 
 raze:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     raze_api:
@@ -13143,7 +13154,7 @@ raze:
 
 # vita3k doesn't handle the hud - so no deocrations etc
 vita3k:
-  shared: [powermode, tdp, videomode]
+  shared_exclude: [batterymode, rumble_gain]
   features: []
   cfeatures:
     vita3k_gfxbackend:
@@ -13195,7 +13206,7 @@ vita3k:
       preset: switchauto
 
 bigpemu:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     bigpemu_vsync:
@@ -13279,10 +13290,10 @@ bigpemu:
 
 pyxel:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 ioquake3:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     ioquake3_mem:
@@ -13297,7 +13308,7 @@ ioquake3:
 
 thextech:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, hud, hud_corner]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     frameskip:
       prompt:      FRAMESKIP
@@ -13315,7 +13326,7 @@ thextech:
 
 vpinball:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     vpinball_folders:
       group: EXPERT SETTINGS
@@ -13547,7 +13558,7 @@ vpinball:
 
 theforceengine:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     force_render_res:
       submenu: GRAPHICS
@@ -13697,7 +13708,7 @@ theforceengine:
         "Skip All":     "skip"
 
 iortcw:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     iortcw_api:
@@ -13760,7 +13771,7 @@ iortcw:
         "Spanish":           4
 
 fallout1-ce:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     fout1_game_difficulty:
@@ -13801,7 +13812,7 @@ fallout1-ce:
         "Spanish":           "spanish"
 
 fallout2-ce:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     fout2_game_difficulty:
@@ -13842,7 +13853,7 @@ fallout2-ce:
         "Spanish":           "spanish"
 
 dxx-rebirth:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     rebirth_vsync:
@@ -13871,7 +13882,7 @@ dxx-rebirth:
         "Enabled":            1
 
 etlegacy:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     etlegacy_language:
@@ -13911,11 +13922,11 @@ etlegacy:
         "Ukrainian":  "uk"
 
 sonic3-air:
-  shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
 
 sonic-mania:
-  shared: [videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     smania_vsync:
@@ -13945,15 +13956,15 @@ sonic-mania:
         "Traditional Chinese": "8"
 
 fba2x:
-  shared: [videomode, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, rumble_gain]
 
 taradino:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 x16emu:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     x16emu_scale:
       prompt: RENDERING RESOLUTION
@@ -13979,7 +13990,7 @@ x16emu:
 
 shadps4:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     shadps4_hdr:
       prompt: HDR
@@ -14025,7 +14036,7 @@ shadps4:
 
 dhewm3:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     dhewm3_brightness:
       prompt: BRIGHTNESS
@@ -14054,15 +14065,15 @@ dhewm3:
 
 jazz2-native:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 catacombgl:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 lindbergh-loader:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     lindbergh_freeplay:
       prompt: FREE PLAY
@@ -14179,14 +14190,14 @@ lindbergh-loader:
 
 vkquake:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 vkquake2:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 vkquake3:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     vkquake3_api:
@@ -14206,7 +14217,7 @@ vkquake3:
         "512MB":           "512"
 
 tr1x:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   features: [padtokeyboard]
   cfeatures:
     tr1x-expansion:
@@ -14218,11 +14229,11 @@ tr1x:
 
 tr2x:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
 
 bstone:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     bstone_widescreen:
       prompt: ENABLE WIDESCREEN
@@ -14245,7 +14256,7 @@ bstone:
 
 openjkdf2:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     jkdf2_difficulty:
       prompt: DIFFICULTY
@@ -14474,7 +14485,7 @@ openjkdf2:
 
 openjk:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     openjk_colour:
       submenu: VIDEO
@@ -14634,7 +14645,7 @@ openjk:
         "All voiceovers": 1
 
 azahar:
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
         azahar_screen_layout:
             prompt: SCREEN LAYOUT
@@ -14723,9 +14734,10 @@ azahar:
             choices:
                 "Off": 0
                 "On":  1
+
 openmohaa:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     mohaa_colour:
       submenu: VIDEO
@@ -14876,9 +14888,10 @@ openmohaa:
       choices:
         "Off": 0
         "On":  1
+
 ymir:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]
   cfeatures:
     ymir_aspect:
       prompt: ASPECT RATIO
@@ -14911,4 +14924,4 @@ ymir:
 
 clk:
   features: [padtokeyboard]
-  shared: [powermode, tdp, videomode, bezel, bezel_stretch, hud, hud_corner, bezel.tattoo, bezel.tattoo_corner, bezel.tattoo_file, bezel.resize_tattoo]
+  shared_exclude: [batterymode, rumble_gain]


### PR DESCRIPTION
…lity.

- the previous structure required manually copy-pasting a large list of shared: features for nearly every standalone emulator. this made adding or removing a common feature a tedious and error-prone process.
- with this change an inheritance model has been implemented: the global: shared: list is now a small, base template of truly universal features (power, video, decorations) that all emulators inherit automatically. libretro-specific features (shaders, latency reduction, AI, etc.) have been moved out of global and are now added to the libretro emulator via a shared_include: list. standalone emulators now only need to specify their differences from the base global set using shared_include: (to add features) or shared_exclude: (to remove them).

the batocera-es-system script has been updated to handle this new logic, calculating the final feature set for each emulator.