### PR TITLE
Fix hotkey mapping and name for Nacon/BigBen PS4 controller.

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -3965,11 +3965,11 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="0" value="1" code="304" />
 	</inputConfig>
-	<inputConfig type="joystick" deviceName="Generic X-Box pad" deviceGUID="030000006b1400000506000014010000">
+	<inputConfig type="joystick" deviceName="Nacon/Bigben Interactive Revolution Unlimited Pro Controller Wired" deviceGUID="030000006b1400000506000014010000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />
 		<input name="down" type="hat" id="0" value="4" />
-		<input name="hotkey" type="button" id="6" value="1" code="314" />
+		<input name="hotkey" type="button" id="8" value="1" code="316" />
 		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
 		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
 		<input name="joystick2left" type="axis" id="3" value="-1" code="3" />


### PR DESCRIPTION
That controller was added in https://github.com/batocera-linux/batocera.linux/commit/8e95d260e46d46ff405f51de6fe24047a130d8a9 The commit message says "PS4 Nacon Revolution Unlimited Pro Controller". The `deviceName` says "Generic X-Box pad".
The physical controller I have access to says "Nacon Revolution Unlimited Pro Controller". The [associated website](https://www.nacongaming.com/en-GB/revolution-unlimited-pro-controller) says it's a PS4 controller. The `lsusb` command says "BigBen Interactive Revolution Unlimited Pro Controller".
    
This change updates the name to be more accurate as it's definitely not an X-Box controller.

This change also fixes the hotkey mapping to match the central PS button.