### PR TITLE
fix-resume-audio-desync-sm8250

### DIFF
--- a/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-audio-resync
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/etc/pm/sleep.d/99-audio-resync
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This fixes issue when audio desyncs after suspend/resume on sm8250 devices (rp5, etc)
+
+read -r ARCH < /usr/share/batocera/batocera.arch
+[ "$ARCH" = "sm8250" ] || exit 0
+
+case "$1" in
+    thaw|resume)
+        sm8250-audio-resync # resync audio
+        ;;
+esac
+
+exit 0

--- a/board/batocera/qualcomm/sm8250/fsoverlay/usr/bin/sm8250-audio-resync
+++ b/board/batocera/qualcomm/sm8250/fsoverlay/usr/bin/sm8250-audio-resync
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Force pipewire to resync. Fixes audio desyncing quirk for sm8250
+
+pw-metadata -n settings 0 clock.force-quantum 1023
+pw-metadata -n settings 0 clock.force-quantum 1024
+
+exit 0


### PR DESCRIPTION
Workaround to a quick for sm8250 where when resuming from suspend, audio can become distorted/desynced