### PR TITLE
Fix incorrect mapping of L and ZR

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5181,8 +5181,8 @@
 		<input name="l2" type="button" id="8" value="1" code="312" />
 		<input name="left" type="hat" id="0" value="8" />
 		<input name="pagedown" type="button" id="7" value="1" code="311" />
-		<input name="pageup" type="button" id="9" value="1" code="313" />
-		<input name="r2" type="button" id="6" value="1" code="310" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="button" id="9" value="1" code="313" />
 		<input name="right" type="hat" id="0" value="2" />
 		<input name="select" type="button" id="10" value="1" code="314" />
 		<input name="start" type="button" id="11" value="1" code="315" />


### PR DESCRIPTION
Fix mapping of L and ZR that were accidentally reversed for MayFlash F500V2, controller mode