### PR TITLE
Fix MAME log and read Switchres default settings (CRT)

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mame/mameGenerator.py
@@ -146,8 +146,9 @@ class MameGenerator(Generator):
         commandArray += [ "-cheat" ]
         commandArray += [ "-cheatpath",    MAME_CHEATS ]       # Should this point to path containing the cheat.7z file
 
-        # logs
+        # Logs and Swithres ini read by default (including its own verbose)
         commandArray += [ "-verbose" ]
+        commandArray += [ "-switchres_ini" ]
 
         # MAME saves a lot of stuff, we need to map this on /userdata/saves/mame/<subfolder> for each one
         commandArray += [ "-nvram_directory" ,    MAME_SAVES / "nvram" ]


### PR DESCRIPTION
I don't know why it was never added. Without it, it doesn't read the default switchres.ini that comes with GroovyMAME, which doesn't trigger many required settings including the verbose one (which is off).

Before: ES log was filled with Switchres noise and cut after 300 lines (ES limitation).
After: ES log doesn't have Switchres spam anymore
