### PR TITLE
Add light gun support to libretro Dolphin core

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -785,7 +785,8 @@ def createLibretroConfig(
         "beetle-saturn" : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
         "opera"         : { "default" : { "device": 260, "p1": 0, "p2": 1 } },
         "stella"        : { "default" : { "device":   4, "p1": 0, "p2": 1 } },
-        "vice_x64"      : { "default" : { "gameDependant": [ { "key": "type", "value": "stack_light_rifle", "mapcorekey": "vice_joyport_type", "mapcorevalue": "15" } ] } }
+        "vice_x64"      : { "default" : { "gameDependant": [ { "key": "type", "value": "stack_light_rifle", "mapcorekey": "vice_joyport_type", "mapcorevalue": "15" } ] } },
+        "dolphin"       : { "default" : { "device": 769, "p1": 0, "p2": 1, "p3": 2, "p4": 3 } }
     }
 
     # apply mapping
@@ -805,6 +806,12 @@ def createLibretroConfig(
                         ragunconf[gd["mapkey"]] = gd["mapvalue"]
                     if f'gun_{gd["key"]}' in metadata and metadata[f'gun_{gd["key"]}'] == gd["value"] and "mapcorekey" in gd and "mapcorevalue" in gd:
                         raguncoreconf[gd["mapcorekey"]] = gd["mapcorevalue"]
+
+            # Dolphin IR calibration from metadata
+            if system.config.core == "dolphin":
+                raguncoreconf["dolphin_ir_offset"] = metadata.get("gun_vertical_offset", "10")
+                raguncoreconf["dolphin_ir_yaw"]    = metadata.get("gun_yaw", "25")
+                raguncoreconf["dolphin_ir_pitch"]  = metadata.get("gun_pitch", "20")
 
             for nplayer in range(1, 4):
                 if f"p{nplayer}" in ragunconf and len(guns)-1 >= ragunconf[f"p{nplayer}"]:
@@ -964,6 +971,44 @@ def configureGunInputsForPlayer(
         retroarchConfig[f'input_player{n}_gun_aux_a_mbtn'         ] = 2
         pedalconfig = f'input_player{n}_gun_aux_a'
         retroarchConfig[f'input_player{n}_gun_aux_b_mbtn'         ] = 3
+
+    if core == "dolphin":
+        # Dolphin uses Wiimote via RetroArch joypad, not RETRO_DEVICE_LIGHTGUN
+        # Clear all gun-specific mappings
+        retroarchConfig[f'input_player{n}_gun_trigger_mbtn'       ] = ''
+        retroarchConfig[f'input_player{n}_gun_offscreen_shot_mbtn'] = ''
+        retroarchConfig[f'input_player{n}_gun_aux_a_mbtn'         ] = ''
+        retroarchConfig[f'input_player{n}_gun_aux_b_mbtn'         ] = ''
+        retroarchConfig[f'input_player{n}_gun_aux_c_mbtn'         ] = ''
+        retroarchConfig[f'input_player{n}_gun_start_mbtn'         ] = ''
+        retroarchConfig[f'input_player{n}_gun_select_mbtn'        ] = ''
+        retroarchConfig[f'input_player{n}_gun_dpad_up_mbtn'       ] = ''
+        retroarchConfig[f'input_player{n}_gun_dpad_down_mbtn'     ] = ''
+        retroarchConfig[f'input_player{n}_gun_dpad_left_mbtn'     ] = ''
+        retroarchConfig[f'input_player{n}_gun_dpad_right_mbtn'    ] = ''
+
+        # Wiimote/Nunchuk to RetroArch's Dolphin input
+        wiimote_to_ra = {"b": "b", "a": "a", "1": "start", "2": "select", "+": "r", "-": "l",
+                         "up": "up", "down": "down", "left": "left", "right": "right",
+                         "c": "x", "z": "y", "shake": "r2", "tiltforward": "l3"}
+
+        # Gun button names to Wiimote buttons (defaults)
+        action_to_wiimote = {"trigger": "b", "action": "a", "start": "+", "select": "-",
+                             "sub1": "1", "sub2": "2", "up": "up", "down": "down", "left": "left", "right": "right"}
+
+        # Override with game-specific metadata
+        for action in action_to_wiimote:
+            if f"gun_{action}" in metadata and metadata[f"gun_{action}"]:
+                action_to_wiimote[action] = metadata[f"gun_{action}"]
+
+        # Gun button names to virtual light gun mapping in RetroArch
+        action_to_gun = {"trigger": 1, "action": 2, "start": 3, "select": 4, "sub1": 5, "sub2": 6,
+                         "up": 8, "down": 9, "left": 10, "right": 11}
+
+        # Apply mapping to RetroArch config
+        for action, wiimote in action_to_wiimote.items():
+            if wiimote in wiimote_to_ra and action in action_to_gun:
+                retroarchConfig[f'input_player{n}_{wiimote_to_ra[wiimote]}_mbtn'] = action_to_gun[action]
 
     # pedal
     if pedalconfig is not None and pedalkey is not None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -580,6 +580,11 @@ def _dolphin_options(
     # OSD
     _set_from_system(coreSettings, 'dolphin_osd_enabled', system, 'wii_osd', default="enabled")
 
+    # Light gun
+    if system.config.use_guns and guns:
+        _set(coreSettings, 'dolphin_ir_mode', '3')
+    else:
+        _set(coreSettings, 'dolphin_ir_mode', '1')
 
 # Magnavox - Odyssey2 / Phillips Videopac+
 def _o2em_options(

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -1283,7 +1283,7 @@ libretro:
                     "14": 14
                     "15": 15
     dolphin:
-      shared: [autosave, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
+      shared: [autosave, use_guns, use_wheels, wheel_rotation, wheel_deadzone, wheel_midzone]
       cfeatures:
                     wii_resolution:
                         prompt: RENDERING RESOLUTION

--- a/package/batocera/emulators/retroarch/libretro/libretro-dolphin/002-lightgun-support.patch
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dolphin/002-lightgun-support.patch
@@ -1,0 +1,128 @@
+--- a/Source/Core/DolphinLibretro/Common/Options.cpp
++++ b/Source/Core/DolphinLibretro/Common/Options.cpp
+@@ -1017,6 +1017,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
+       { "0", "Right Stick controls pointer (relative)" },
+       { "1", "Right Stick controls pointer (absolute)" },
+       { "2", "Mouse controls pointer" },
++      { "3", "Light Gun" },
+       { nullptr, nullptr }
+     },
+     "1"
+@@ -1043,6 +1044,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
+       // Small positives
+       { "1", nullptr }, { "2", nullptr }, { "3", nullptr }, { "4", nullptr }, { "5", nullptr },
+       { "6", nullptr }, { "7", nullptr }, { "8", nullptr }, { "9", nullptr },
++      { "8.7", nullptr }, { "14.5", nullptr }, { "14.6", nullptr }, { "14.7", nullptr }, { "14.8", nullptr }, { "14.9", nullptr }, { "15.15", nullptr }, { "15.2", nullptr }, { "15.3", nullptr },
+       { nullptr, nullptr }
+     },
+     "0"
+@@ -1067,6 +1069,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
+       { "0", nullptr }, { "1", nullptr }, { "2", nullptr }, { "3", nullptr }, { "4", nullptr },
+       { "5", nullptr }, { "6", nullptr }, { "7", nullptr }, { "8", nullptr }, { "9", nullptr },
+       { "10", nullptr }, { "11", nullptr }, { "12", nullptr }, { "13", nullptr }, { "14", nullptr },
++      { "12.35", nullptr }, { "12.5", nullptr }, { "15.3", nullptr }, { "16.9", nullptr }, { "18.3", nullptr }, { "18.5", nullptr }, { "18.6", nullptr }, { "18.7", nullptr }, { "18.75", nullptr }, { "18.8", nullptr }, { "18.9", nullptr }, { "19.1", nullptr }, { "20.6", nullptr }, { "24.7", nullptr }, { "30.7", nullptr }, { "41.3", nullptr },
+       { nullptr, nullptr }
+     },
+     "15"
+@@ -1092,6 +1095,7 @@ static struct retro_core_option_v2_definition option_defs[] = {
+       { "0", nullptr }, { "1", nullptr }, { "2", nullptr }, { "3", nullptr }, { "4", nullptr },
+       { "5", nullptr }, { "6", nullptr }, { "7", nullptr }, { "8", nullptr }, { "9", nullptr },
+       { "10", nullptr }, { "11", nullptr }, { "12", nullptr }, { "13", nullptr }, { "14", nullptr },
++      { "11.7", nullptr }, { "12.3", nullptr }, { "12.6", nullptr }, { "15.75", nullptr }, { "18.4", nullptr }, { "18.69", nullptr }, { "18.75", nullptr }, { "18.8", nullptr }, { "18.9", nullptr }, { "19.15", nullptr }, { "19.3", nullptr }, { "19.4", nullptr }, { "31.6", nullptr },
+       { nullptr, nullptr }
+     },
+     "15"
+--- a/Source/Core/DolphinLibretro/Input.cpp
++++ b/Source/Core/DolphinLibretro/Input.cpp
+@@ -758,9 +758,9 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+ #endif
+ 
+     const int irMode = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_MODE);
+-    const int irCenter = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_OFFSET);
+-    const int irWidth = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_YAW);
+-    const int irHeight = Libretro::Options::GetCached<int>(Libretro::Options::wiimote::IR_PITCH);
++    const double irCenter = Libretro::Options::GetCached<double>(Libretro::Options::wiimote::IR_OFFSET);
++    const double irWidth = Libretro::Options::GetCached<double>(Libretro::Options::wiimote::IR_YAW);
++    const double irHeight = Libretro::Options::GetCached<double>(Libretro::Options::wiimote::IR_PITCH);
+ 
+     static_cast<ControllerEmu::NumericSetting<double>*>(wmIR->numeric_settings[1].get())
+       ->SetValue(irCenter); // IR Vertical Offset
+@@ -773,8 +773,16 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+       ncShake->SetControlExpression(1, "L2 | `" + devMouse + ":Middle`");  // Nunchuk shake Y
+       ncShake->SetControlExpression(2, "L2 | `" + devMouse + ":Middle`");  // Nunchuk shake Z
+ 
+-      wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
+-      wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
++      if (irMode == 3)
++      {
++        wmButtons->SetControlExpression(0, "A");
++        wmButtons->SetControlExpression(1, "B");
++      }
++      else
++      {
++        wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
++        wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
++      }
+       wmButtons->SetControlExpression(2, "Start");                         // 1
+       wmButtons->SetControlExpression(3, "Select");                        // 2
+       wmButtons->SetControlExpression(4, "L");                             // -
+@@ -782,7 +790,14 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+ 
+       if (irMode != 0 && irMode != 1)
+       {
+-        wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y1-`");  // Forward
++        if (irMode == 3)
++        {
++          wmTilt->SetControlExpression(0, "L3");
++        }
++        else
++        {
++          wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y1-`");  // Forward
++        }
+         wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y1+`");  // Backward
+         wmTilt->SetControlExpression(2, "`" + devAnalog + ":X1-`");  // Left
+         wmTilt->SetControlExpression(3, "`" + devAnalog + ":X1+`");  // Right
+@@ -792,8 +807,16 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+     {
+       if (device == RETRO_DEVICE_WIIMOTE)
+       {
+-        wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
+-        wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
++        if (irMode == 3)
++        {
++          wmButtons->SetControlExpression(0, "A");
++          wmButtons->SetControlExpression(1, "B");
++        }
++        else
++        {
++          wmButtons->SetControlExpression(0, "A | `" + devMouse + ":Left`");   // A
++          wmButtons->SetControlExpression(1, "B | `" + devMouse + ":Right`");  // B
++        }
+         wmButtons->SetControlExpression(2, "X");                             // 1
+         wmButtons->SetControlExpression(3, "Y");                             // 2
+       }
+@@ -803,7 +826,14 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+         wmButtons->SetControlExpression(2, "B");  // 1
+         wmButtons->SetControlExpression(3, "A");  // 2
+       }
+-      wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y0-`");  // Forward
++      if (irMode == 3)
++      {
++        wmTilt->SetControlExpression(0, "L3");
++      }
++      else
++      {
++        wmTilt->SetControlExpression(0, "`" + devAnalog + ":Y0-`");  // Forward
++      }
+       wmTilt->SetControlExpression(1, "`" + devAnalog + ":Y0+`");  // Backward
+       wmTilt->SetControlExpression(2, "`" + devAnalog + ":X0-`");  // Left
+       wmTilt->SetControlExpression(3, "`" + devAnalog + ":X0+`");  // Right
+@@ -820,7 +850,7 @@ void retro_set_controller_port_device_wii(unsigned port, unsigned device)
+       static_cast<ControllerEmu::NumericSetting<bool>*>(wmIR->numeric_settings[5].get())
+         ->SetValue(true);                                           // Auto hide
+     }
+-    else
++    else  // irMode == 2 || irMode == 3
+     {
+       // Mouse controls IR
+       wmIR->SetControlExpression(0, "`" + devPointer + ":Y0-`");    // Up


### PR DESCRIPTION
Add light gun support for libretro Dolphin core. Fully compiled and tested.

Notes :

- if aspect ratio on `auto`, it's always 4:3. If on `core provided`, it switches to 16:9 if natively supported.
- right analog stick tilting (Y axis) has an impact on centering the vertical offset if the controller disconnects or is not centered when launching the game. Super weird bug.
- crosshair are forced on. Can't disable it yet, I'll check that for another time.