### PR TITLE
... rufomaculata

### DIFF
--- a/board/batocera/scripts/post-image-script.sh
+++ b/board/batocera/scripts/post-image-script.sh
@@ -65,7 +65,8 @@ do
     (cd "${BATOCERA_BINARIES_DIR}/boot" && tar -I "xz -T0" -cf "${BATOCERA_BINARIES_DIR}/images/${BATOCERA_SUBTARGET}/boot.tar.xz" *) || exit 1
 
     # rename the squashfs : the .update is the version that will be renamed at boot to replace the old version
-    mv "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" "${BATOCERA_BINARIES_DIR}/boot/boot/batocera" || exit 1
+    mv "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update"     "${BATOCERA_BINARIES_DIR}/boot/boot/batocera"     || exit 1
+    mv "${BATOCERA_BINARIES_DIR}/boot/boot/rufomaculata.update" "${BATOCERA_BINARIES_DIR}/boot/boot/rufomaculata" || exit 1
 
     # create *.img
     if [ "${BATOCERA_LOWER_TARGET}" = "${BATOCERA_SUBTARGET}" ]; then

--- a/board/batocera/x86/create-boot-script.sh
+++ b/board/batocera/x86/create-boot-script.sh
@@ -23,6 +23,7 @@ mkdir -p "${BATOCERA_BINARIES_DIR}/boot/grub"          || exit 1
 cp "${BINARIES_DIR}/bzImage"         "${BATOCERA_BINARIES_DIR}/boot/boot/linux"           || exit 1
 cp "${BINARIES_DIR}/initrd.gz"       "${BATOCERA_BINARIES_DIR}/boot/boot/"                || exit 1
 cp "${BINARIES_DIR}/rootfs.squashfs" "${BATOCERA_BINARIES_DIR}/boot/boot/batocera.update" || exit 1
+cp "${BINARIES_DIR}/rufomaculata"    "${BATOCERA_BINARIES_DIR}/boot/boot/rufomaculata.update" || exit 1
 
 # Legacy bootloader (vestigial)
 cp "${BOARD_DIR}/boot/syslinux.cfg"       "${BATOCERA_BINARIES_DIR}/boot/boot/"          || exit 1

--- a/package/batocera/boot/batocera-initramfs/init
+++ b/package/batocera/boot/batocera-initramfs/init
@@ -62,21 +62,24 @@ do_root() {
     done
 
     # update the squashfs
-    if test -e /boot_root/boot/batocera.update
-    then
-      mount -o remount,rw /boot_root || return 1
-      mv /boot_root/boot/batocera.update /boot_root/boot/batocera || return 1
-      # remove the overlay when updating
-      if test -e /boot_root/boot/overlay
-      then
-	  mv /boot_root/boot/overlay /boot_root/boot/overlay.old      || return 1
-      fi
-      mount -o remount,ro /boot_root || return 1
-    fi
+    for SIMG in batocera rufomaculata
+    do
+	if test -e /boot_root/boot/${SIMG}.update
+	then
+	    mount -o remount,rw /boot_root || return 1
+	    mv /boot_root/boot/${SIMG}.update /boot_root/boot/${SIMG} || return 1
+	    # remove the overlay when updating
+	    if test -e /boot_root/boot/overlay
+	    then
+		mv /boot_root/boot/overlay /boot_root/boot/overlay.old      || return 1
+	    fi
+	    mount -o remount,ro /boot_root || return 1
+	fi
+    done
 
     # create an overlay on memory
     mount -t tmpfs -o size=256M tmpfs /overlay_root || return 1
-    mkdir /overlay_root/base /overlay_root/overlay /overlay_root/work /overlay_root/saved || return 1
+    mkdir /overlay_root/base /overlay_root/base2 /overlay_root/overlay /overlay_root/work /overlay_root/saved || return 1
 
     # fill the overlay with the stored one
     if test -f /boot_root/boot/overlay
@@ -92,8 +95,15 @@ do_root() {
     # mount the squashfs
     mount /boot_root/boot/batocera /overlay_root/base || return 1
 
+    EXTRALAYERS=
+    if test -e /boot_root/boot/rufomaculata
+    then
+	mount /boot_root/boot/rufomaculata /overlay_root/base2 || return 1
+	EXTRALAYERS=":/overlay_root/base2"
+    fi
+
     # mount the future root in read write
-    if ! mount -t overlay overlay -o rw,lowerdir=/overlay_root/base,upperdir=/overlay_root/overlay,workdir=/overlay_root/work /new_root
+    if ! mount -t overlay overlay -o rw,lowerdir=/overlay_root/base$EXTRALAYERS,upperdir=/overlay_root/overlay,workdir=/overlay_root/work /new_root
     then
 	# mount only as squashfs, no overlay (xu4 doesn't support overlayfs)
 	mount /boot_root/boot/batocera /new_root || return 1


### PR DESCRIPTION
this is my proposal,
this is not perfect cause not perfectly integrated to buildroot, but i wanted to avoid modifyng buildroot.
if that's ok, i will edit all board/batocera/*/create-boot-script.sh to add the line
mksquashfs are copied from current values used in batocera.

[root@BATOCERA ~]# ls -lh /boot/boot/
total 4,1G
-rwxr-xr-x 1 root root 3,2G 28 déc.  20:57 batocera
-rwxr-xr-x 1 root root    7 28 déc.  20:57 batocera.board
-rwxr-xr-x 1 root root 754K 28 déc.  20:57 initrd.gz
-rwxr-xr-x 1 root root  22M 28 déc.  20:57 linux
-rwxr-xr-x 1 root root 100M 16 déc.  19:43 overlay.old
-rwxr-xr-x 1 root root 844M 28 déc.  20:57 rufomaculata
drwxr-xr-x 2 root root 4,0K 28 déc.  20:57 syslinux
-rwxr-xr-x 1 root root  458 28 déc.  20:57 syslinux.cfg
[root@BATOCERA ~]# 
