### PR TITLE
Source .bashrc in 90-sourcebashrc.sh

### DIFF
--- a/board/batocera/fsoverlay/etc/profile.d/90-sourcebashrc.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/90-sourcebashrc.sh
@@ -1,0 +1,3 @@
+if ! [ -f $HOME/.profile ] && ! [ -f $HOME/.bash_profile ]; then
+  [ -f $HOME/.bashrc ] && . $HOME/.bashrc
+fi


### PR DESCRIPTION
so xterm and ssh terminal use the same resource-file and users can configure terminal extension, unique prompts or new aliases on user level

**force pushed:** it behaves more like a unix systems now... if .profile or .bash_profile is available then .bashrc will be ignored for SSH session ;)