### PR TITLE
Possible fix for Xbox wireless controllers (bt) and Steam

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/flatpak/flatpakGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/flatpak/flatpakGenerator.py
@@ -24,7 +24,11 @@ class FlatpakGenerator(Generator):
 
         # the directory monitor must exist and all the dirs must be owned by batocera
         commandArray = ["/usr/bin/flatpak", "run", "-v", romId]
-        return Command.Command(array=commandArray)
+
+        # needed for SteamLink and other few flatpak apps with the same issue
+        env = {"SDL_JOYSTICK_HIDAPI_XBOX": "0"}
+
+        return Command.Command(array=commandArray, env=env)
 
     def getMouseMode(self, config, rom):
         return True

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/steam/steamGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/steam/steamGenerator.py
@@ -22,7 +22,12 @@ class SteamGenerator(Generator):
             commandArray = ["batocera-steam"]
         else:
             commandArray = ["batocera-steam", gameId]
-        return Command.Command(array=commandArray)
+
+        # Fix for Xbox Bluetooth controllers not working with Steam (issue #12731)
+        # xpadneo fixes mappings at evdev level, but Steam reads raw HIDAPI data
+        env = {"SDL_JOYSTICK_HIDAPI_XBOX": "0"}
+
+        return Command.Command(array=commandArray, env=env)
 
     def getMouseMode(self, config, rom):
         return True


### PR DESCRIPTION
Tested on xbox wireless (model 1914) and dualshock 4 (PS4) controllers. Working fine. No idea about 3rd parties controllers. This solves the issue of BT without breaking anything on system-level (other emulators, emulationstation, etc) mentionned here : https://github.com/batocera-linux/batocera.linux/issues/12731

xpadneo remains intact (which is a must).

Another solution would be to add an option in ES to enable/disable it within the configgen for steam and flatpak (fixing Steamlink issue).