### PR TITLE
Add Casio Loopy system support

### DIFF
--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -9,6 +9,7 @@ astrocde;astrocde;cart;
 atom;atom;flop1;'\n*DOS\n*DIR\n*CAT\n*RUN"'
 bbc;bbcb;flop1;
 camplynx;lynx48k;cass;'mload""'
+casloopy;casloopy;cart;
 cdi;cdimono1;cdrm;
 coco;coco3;cart;
 crvision;crvision;cart;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -272,6 +272,11 @@ systems = {
                                                             { "md5": "caf90f22197aed6f14c471c21e64658d", "file": "bios/np2kai/SOUND.ROM"},
                                                             { "md5": "e9fc3890963b12cf15d0a2eea5815b72", "file": "bios/np2kai/ITF.ROM"  },
                                                             { "md5": "7da1e5b7c482d4108d22a5b09631d967", "file": "bios/np2kai/font.bmp" } ] },
+    # ---------- Casio Loopy ---------- #
+    "casloopy": { "name": "Casio Loopy", "biosFiles": [
+                                                          { "md5": "0e1d8dc0110ecf8201c0cef11ef4a858", "file": "bios/mame/casloopy.zip" },
+                                                          { "md5": "d527e3ed1bf9bd0661154c202a65c5bd", "zippedFile": "hd6437021.lsi302", "file": "bios/mame/casloopy.zip" },
+                                                          { "md5": "c0f1c899c9ca098663d046d60779711d", "zippedFile": "hn62434fa.lsi352", "file": "bios/mame/casloopy.zip" } ] },
     # ---------- Fairchild ChannelF ---------- #
     # https://github.com/libretro/FreeChaF/blob/master/README.md#bios
     "channelf":  { "name": "Fairchild ChannelF", "biosFiles": [   { "md5": "ac9804d4c0e9d07e33472e3726ed15c3", "file": "bios/sl31253.bin" },

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3527,7 +3527,7 @@ camplynx:
   comment_br: |
           Requer os arquivo de BIOS MAME lynx128k.zip, lynx96k.zip, lynx48k.zip
           Também pacote de samples bbc.zip em bios/mame/samples
-
+    
 adam:
   name:       ADAM
   manufacturer: Coleco
@@ -5994,3 +5994,21 @@ bennugd:
     Trouvez la documentation ici : https://wiki.batocera.org/systems:bennugd
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:bennugd
+
+casloopy:
+  name:       Casio Loopy
+  manufacturer: Casio
+  release: 1995
+  hardware: console
+  extensions: [bin, ic1, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file:
+          bios/mame/casloopy.zip
+  comment_br: |
+          Requer arquivo de BIOS do MAME:
+          bios/mame/casloopy.zip


### PR DESCRIPTION
**Note:** This is a clean resubmission of #15011 with proper git history and only the necessary file changes.

This PR adds support for the Casio Loopy console (1995, Casio) via MAME emulator.

## Changes Made
- Added casloopy to messSystems.csv for MAME cart support
- Added system definition to es_systems.yml with BIOS location (bios/mame/casloopy.zip)
- Added BIOS verification to batocera-systems with MD5 hashes

## BIOS Requirements
BIOS file location: `bios/mame/casloopy.zip`

Contents:
- hd6437021.lsi302 (32KB CPU BIOS, MD5: d527e3ed1bf9bd0661154c202a65c5bd)
- hn62434fa.lsi352 (524KB Wave ROM, MD5: c0f1c899c9ca098663d046d60779711d)

## Testing
Tested on Batocera v42 with MAME emulator. Games load and play correctly.