### PR TITLE
bump precalibration lightgun (MAME)

### DIFF
--- a/package/batocera/controllers/guns/lightguns-games-precalibrations/lightguns-games-precalibrations.mk
+++ b/package/batocera/controllers/guns/lightguns-games-precalibrations/lightguns-games-precalibrations.mk
@@ -3,8 +3,8 @@
 # lightguns-games-precalibrations
 #
 ################################################################################
-# Version:Commits on Oct 25, 2022
-LIGHTGUNS_GAMES_PRECALIBRATIONS_VERSION = a30c16db1276ee05250784c8d431357cfb249af0
+# Version:Commits on Jan 04, 2026
+LIGHTGUNS_GAMES_PRECALIBRATIONS_VERSION = b672c3a882fa27964e5e69d77c5857b214e5d58e
 LIGHTGUNS_GAMES_PRECALIBRATIONS_SITE = $(call github,batocera-linux,lightguns-games-precalibrations,$(LIGHTGUNS_GAMES_PRECALIBRATIONS_VERSION))
 
 define LIGHTGUNS_GAMES_PRECALIBRATIONS_INSTALL_TARGET_CMDS


### PR DESCRIPTION
+ hotd (model2)
+ bel (model2)
+ gunblade (model2)

vcop, vcop2 and timecris2 (not model2 but pretty playable now) are already precalibrated, so no eeprom needed.
