### PR TITLE
add option to force left analog to dpad for libretroflycast v2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroConfig.py
@@ -345,11 +345,16 @@ def createLibretroConfig(
                         retroarchConfig[f'input_libretro_device_p{pad.player_number}'] = 517 # DualShock Controller
 
     ## Sega Dreamcast controller
+    ## Left Analog To Dpad (Forced) is convenient for Arcade Systems (Atomiswave, Naomi 1 and 2)
     if system.config.core == 'flycast':
-        retroarchConfig['input_libretro_device_p1'] = system.config.get('controller1_dc', '1')
-        retroarchConfig['input_libretro_device_p2'] = system.config.get('controller2_dc', '1')
-        retroarchConfig['input_libretro_device_p3'] = system.config.get('controller3_dc', '1')
-        retroarchConfig['input_libretro_device_p4'] = system.config.get('controller4_dc', '1')
+        for i in range(1, 5):
+            dc_val = system.config.get(f'controller{i}_dc', '1')
+            if dc_val == '5': # "Gamepad using left analog stick"
+                retroarchConfig[f'input_libretro_device_p{i}'] = '1'
+                retroarchConfig[f'input_player{i}_analog_dpad_mode'] = '3'
+            else:
+                retroarchConfig[f'input_libretro_device_p{i}'] = dc_val
+                retroarchConfig[f'input_player{i}_analog_dpad_mode'] = '0'
 
         # wheel
         if system.config.use_wheels and wheels:

--- a/package/batocera/emulationstation/batocera-es-system/es_features.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_features.yml
@@ -2133,6 +2133,7 @@ libretro:
                 prompt:      CONTROLLER 1 TYPE
                 choices:
                     "Gamepad":   1
+                    "Gamepad Using Left Analog Stick":   5                    
                     "Keyboard":  3
                     "Mouse":     2
                     "Light Gun": 4
@@ -2140,6 +2141,7 @@ libretro:
                 prompt:      CONTROLLER 2 TYPE
                 choices:
                     "Gamepad":   1
+                    "Gamepad Using Left Analog Stick":   5                                        
                     "Keyboard":  3
                     "Mouse":     2
                     "Light Gun": 4
@@ -2147,6 +2149,7 @@ libretro:
                 prompt:      CONTROLLER 3 TYPE
                 choices:
                     "Gamepad":   1
+                    "Gamepad Using Left Analog Stick":   5                                        
                     "Keyboard":  3
                     "Mouse":     2
                     "Light Gun": 4
@@ -2154,6 +2157,7 @@ libretro:
                 prompt:      CONTROLLER 4 TYPE
                 choices:
                     "Gamepad":   1
+                    "Gamepad Using Left Analog Stick":   5                                        
                     "Keyboard":  3
                     "Mouse":     2
                     "Light Gun": 4


### PR DESCRIPTION
Hopefully a better version of #15084: I followed the logic used for "pcsx_rearmed".
Now allows individual configuration for each player, which is better in case of mixed gamepads.

closes #15032
