### PR TITLE
handle moving the mouse to the primary display for emu start & exit. …

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -183,6 +183,11 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: Path, original_r
                             cmd.array.insert(0, "mangohud")
 
                 with profiler.pause():
+                    try:
+                        _logger.debug("Triggering mouse reset to primary display")
+                        subprocess.call(["/usr/bin/hotkeygen", "--reset-mouse"])
+                    except Exception as e:
+                        _logger.warning(f"Failed to reset mouse: {e}")
                     monitor_thread.start()
                     exitCode = runCommand(cmd)
 

--- a/package/batocera/emulationstation/batocera-emulationstation/wayland/labwc/rc.xml
+++ b/package/batocera/emulationstation/batocera-emulationstation/wayland/labwc/rc.xml
@@ -55,6 +55,13 @@
       <action name="SnapToEdge" direction="down" />
     </keybind>
   </keyboard>
+  <mouse>
+    <context name="root">
+      <mousebind button="Left" action="None" />
+      <mousebind button="Right" action="None" />
+      <mousebind button="Middle" action="None" />
+    </context>
+  </mouse>
   <windowRules>
     <windowRule identifier="*" serverDecoration="no" />
     <windowRule identifier="emulationstation">

--- a/package/batocera/utils/hotkeygen/hotkeygen.mk
+++ b/package/batocera/utils/hotkeygen/hotkeygen.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-HOTKEYGEN_VERSION = 1.0
+HOTKEYGEN_VERSION = 1.1
 HOTKEYGEN_LICENSE = GPL
 HOTKEYGEN_SOURCE=
 HOTKEYGEN_DEPENDENCIES = python-pyudev python-evdev


### PR DESCRIPTION
…fixes ayn thor:

- Avoid backglass from exiting with Hotkey + Start (pointer on the screen)
- Hotkey exit doesn't close properly if bottom touchscreen used
- Fix game starting on the bottom display based on LabWC last pointer position