### PR TITLE
[wii] Fix profile clash on two controllers with the same name

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -435,11 +435,13 @@ def generateControllerConfig_any(system: Emulator, playersControllers: Controlle
             nsamepad = double_pads.get(pad.real_name.strip(), 0)
             double_pads[pad.real_name.strip()] = nsamepad+1
 
+            device = f"evdev/{str(nsamepad).strip()}/{pad.real_name.strip()}"
+
             f.write(f"[{anyDefKey}{nplayer}]\n")
-            f.write(f"Device = evdev/{str(nsamepad).strip()}/{pad.real_name.strip()}\n")
+            f.write(f"Device = {device}\n")
 
             if system.config.get_bool("use_pad_profiles"):
-                if not generateControllerConfig_any_from_profiles(f, pad, system):
+                if not generateControllerConfig_any_from_profiles(f, device, system):
                     generateControllerConfig_any_auto(f, pad, anyMapping, anyReverseAxes, anyReplacements, extraOptions, system, nplayer, nsamepad)
             else:
                 if pad.device_path in wheels:
@@ -563,7 +565,7 @@ def generateControllerConfig_any_auto(f: codecs.StreamReaderWriter, pad: Control
                 f.write("Main Stick/Gate Size = 95.0\n")
                 f.write("C-Stick/Gate Size = 88.0\n")
 
-def generateControllerConfig_any_from_profiles(f: codecs.StreamReaderWriter, pad: Controller, system: Emulator) -> bool:
+def generateControllerConfig_any_from_profiles(f: codecs.StreamReaderWriter, device: str, system: Emulator) -> bool:
     glob_path: Path | None = None
     if system.name == "gamecube":
         glob_path = DOLPHIN_CONFIG / "Profiles" / "GCPad"
@@ -581,8 +583,7 @@ def generateControllerConfig_any_from_profiles(f: codecs.StreamReaderWriter, pad
             profileDevice = profileConfig.get("Profile","Device")
             _logger.debug("Profile device : %s", profileDevice)
 
-            deviceVals = re.match("^([^/]*)/[0-9]*/(.*)$", profileDevice)
-            if deviceVals is not None and deviceVals.group(1) == "evdev" and deviceVals.group(2).strip() == pad.real_name.strip():
+            if profileDevice == device:
                 _logger.debug("Eligible profile device found")
                 for key, val in profileConfig.items("Profile"):
                     if key != "Device":


### PR DESCRIPTION
I two Dualsense controllers, enumerated in Dolphin's wiimote config as

```
Device = evdev/0/DualSense Wireless Controller
```
and

```
Device = evdev/1/DualSense Wireless Controller
```

I also have profiles on them, as I want to use Dolphin's native motion control support via evdev. This is mostly to play New Super Mario Bros Wii.

So my profiles contain

```
IMUAccelerometer/Up = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel Y+`
IMUAccelerometer/Down = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel Y-`
IMUAccelerometer/Left = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel X-`
IMUAccelerometer/Right = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel X+`
IMUAccelerometer/Forward = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel Z-`
IMUAccelerometer/Backward = `evdev/1/DualSense Wireless Controller Motion Sensors:Accel Z+`
IMUGyroscope/Pitch Up = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro X+`
IMUGyroscope/Pitch Down = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro X-`
IMUGyroscope/Roll Left = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro Z+`
IMUGyroscope/Roll Right = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro Z-`
IMUGyroscope/Yaw Left = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro Y+`
IMUGyroscope/Yaw Right = `evdev/1/DualSense Wireless Controller Motion Sensors:Gyro Y-`
Options/Sideways Wiimote = True
```

however, as the current code matches pads to profiles using only the pad name, the accelerometer configuration for controller 0 ends up in the wiimote config for controller 1 - effectively making player 1 shake the remote and send the shake command to both player 1 and player 2 remotes.

With this change instead we don't do any matching on the pad name, rather we match the profile against the entire device id, with the `evdev/` prefix - so no possibility of overlap.