### PR TITLE
bump libretro-fceumm

### DIFF
--- a/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
+++ b/package/batocera/emulators/retroarch/libretro/libretro-fceumm/libretro-fceumm.mk
@@ -3,8 +3,8 @@
 # libretro-fceumm
 #
 ################################################################################
-# Version: Commits on Jan 25, 2024
-LIBRETRO_FCEUMM_VERSION = 63643ba02c8eaea15dbe167ef907f3da7a3e6fd7
+# Version: Commits on Sep 12, 2025
+LIBRETRO_FCEUMM_VERSION = 5cd4a43e16a7f3cd35628d481c347a0a98cfdfa2
 LIBRETRO_FCEUMM_SITE = $(call github,libretro,libretro-fceumm,$(LIBRETRO_FCEUMM_VERSION))
 LIBRETRO_FCEUMM_LICENSE = GPLv2
 LIBRETRO_FCEUMM_DEPENDENCIES += retroarch


### PR DESCRIPTION
Many homebrew and unlicensed games need the mappers added to the core to run.

compiled, tested on x86_64.