### PR TITLE
fix pcsx2 light gun mapping

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -58,6 +58,7 @@
 - Light gun accuracy in MAME
 - Crosshairs for light guns in PCSX2
 - Massive MAME log (switchres verbose disabled by default)
+- PCSX2 light gun mapping (START can now be pressed on the light gun instead of controller)
 ### Changed / Improved
 - Wifi country can now be chosen under the Network Setting option.
   This improves Wifi connectivity by aligning your device with regional regulations as well as 6GHz band support.

--- a/package/batocera/emulators/pcsx2/005-lightguns.patch
+++ b/package/batocera/emulators/pcsx2/005-lightguns.patch
@@ -119,7 +119,7 @@ index a69dbb1..d6d0e04 100644
 +		updateState(us, BID_C, event->value != 0);
 +		break;
 +	    case BTN_MIDDLE:
-+		updateState(us, BID_A, event->value != 0);
++		updateState(us, BID_START, event->value != 0);
 +		break;
 +	    case BTN_1:
 +		updateState(us, BID_B, event->value != 0);
@@ -128,7 +128,7 @@ index a69dbb1..d6d0e04 100644
 +		updateState(us, BID_RECALIBRATE, event->value != 0);
 +		break;
 +	    case BTN_3:
-+		updateState(us, BID_START, event->value != 0);
++		updateState(us, BID_A, event->value != 0);
 +		break;
 +	    case BTN_4:
 +		updateState(us, BID_SELECT, event->value != 0);


### PR DESCRIPTION
START was supposed to be on BTN_MIDDLE, but we did BTN_2 instead for unknown reason. It's fixed now, proper mapping. BTN_2 becomes A button on the GunCon2 which is totally useless for PS2 gun games.
