### PR TITLE
DOSBox Staging: enable mouse by default

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
@@ -61,6 +61,11 @@ class DosBoxStagingGenerator(Generator):
 
         return Command.Command(array=commandArray)
 
+
+    def getMouseMode(self, config, rom):
+        return True
+
+
     def getHotkeysContext(self) -> HotkeysContext:
         return {
             "name": "dosboxstaging",


### PR DESCRIPTION
DOS games were primarily keyboard & mouse controlled, so make sure the mouse is available.