### PR TITLE
DOSBox Staging: Handle mixed-case when checking 8.3 DOS files

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ... import Command
+from ...batoceraPaths import CONFIGS
 from ..Generator import Generator
 
 if TYPE_CHECKING:
@@ -10,36 +11,50 @@ if TYPE_CHECKING:
 
     from ...types import HotkeysContext
 
-class DosBoxStagingGenerator(Generator):
+def _find_iname(directory: Path, filename: str) -> Path | None:
+    if not directory.is_dir():
+        return None
 
+    lower_filename = filename.lower()
+    return next((f for f in directory.iterdir()
+                 if f.is_file() and f.name.lower() == lower_filename), None)
+
+
+class DosBoxStagingGenerator(Generator):
     # Main entry of the module
     # Returns a populated Command object
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
 
-        # Common arguments
-        commandArray: list[Path | str] = [
+        # DOSBox Staging common resource data and conf file
+        common_resource_dir = CONFIGS / 'dosbox'
+        common_resource_conf = _find_iname(common_resource_dir, "dosbox-staging.conf")
+
+        dosbox_cfg =  _find_iname(rom, "dosbox.cfg")
+        dosbox_conf = _find_iname(rom, "dosbox.conf")
+        dosbox_bat = _find_iname(rom, "dosbox.bat")
+
+        is_configured = dosbox_cfg or dosbox_conf or dosbox_bat
+
+        commandArray = [
             '/usr/bin/dosbox-staging',
-            "--working-dir", f"""{rom!s}""",
-            "--fullscreen"
+            "--fullscreen",
+            "--working-dir", str(rom),
+            "-c", f"set WORKDIR={rom}",
         ]
 
-        dosbox_cfg = rom / "dosbox.cfg"
-        dosbox_conf = rom / "dosbox.conf"
-        dosbox_bat = rom / "dosbox.bat"
+        if common_resource_dir.is_dir():
+            commandArray.extend(["-c", f"set RESDIR={str(common_resource_dir)}"])
 
-        is_configured = False
+        if common_resource_conf:
+            commandArray.extend(["-c", f"set RESCONF={str(common_resource_conf)}"])
 
-        if dosbox_cfg.is_file():
-            is_configured = True
-            commandArray.extend(["-conf", dosbox_cfg.name])
+        if dosbox_cfg:
+            commandArray.extend(["--conf", dosbox_cfg.name, "-c", f"set GAMECFG={dosbox_cfg.name}"])
+        elif dosbox_conf:
+            commandArray.extend(["--conf", dosbox_conf.name, "-c", f"set GAMECONF={dosbox_conf.name}"])
 
-        elif dosbox_conf.is_file():
-            is_configured = True
-            commandArray.extend(["-conf", dosbox_conf.name])
-
-        if dosbox_bat.is_file():
-            is_configured = True
-            commandArray.extend([dosbox_bat.name])
+        if dosbox_bat:
+            commandArray.extend([dosbox_bat.name, "-c", f"set GAMEBAT={dosbox_bat.name}"])
 
         if is_configured:
            # If the game's configured, then we can disable the startup logos and
@@ -53,7 +68,6 @@ class DosBoxStagingGenerator(Generator):
             # prompt inside the game's root directory.
             #
             commandArray.extend([
-                "-c", f"""set ROOT={rom!s}""",
                 "-c", "@echo off",
                 "-c", "mount c .",
                 "-c", "c:"


### PR DESCRIPTION
I've come across a handful of games that have mixed case content like: `dosbox.BAT` and `DOSBOX.CONF` that the baseline doesn't handle and kicks back to emulation station. This find them and launches successfully.

Also adds a bit more verbosity at the DOS prompt showing users where DOSBox Staging's common resources are being read from as well as the game's conf and bat files being used.