### PR TITLE
Broadcom: Drop no-longer-valid kernel elevator flag

### DIFF
--- a/board/batocera/broadcom/bcm2711/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2711/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap

--- a/board/batocera/broadcom/bcm2712/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2712/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap

--- a/board/batocera/broadcom/bcm2835/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2835/boot/cmdline.txt
@@ -1,1 +1,1 @@
-snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap

--- a/board/batocera/broadcom/bcm2836/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2836/boot/cmdline.txt
@@ -1,1 +1,1 @@
-snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap

--- a/board/batocera/broadcom/bcm2837/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2837/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 elevator=deadline vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap


### PR DESCRIPTION
The `elevator` flag was dropped a couple years ago. The kernel logs this:

```
Kernel parameter elevator= does not have any effect anymore.
```

The IO scheduler in use is per the kernel config, which is mq-deadline
 (confirmed with: `cat /sys/block/mmcblk0/queue/scheduler`):

```
/sys/block/mmcblk0/queue/scheduler: none [mq-deadline] kyber
```

These broadcom `cmdline.txt`'s were the only ones still setting this.