### PR TITLE
fix: ra/mame dont see send-exit when the key combination is executed …

### DIFF
--- a/package/batocera/utils/hotkeygen/hotkeygen.py
+++ b/package/batocera/utils/hotkeygen/hotkeygen.py
@@ -276,7 +276,7 @@ def do_send(key: str, delay: None | int) -> None:
             if delay:
                 time.sleep(delay)
             else:
-                time.sleep(0.1)
+                time.sleep(0.3) # some emulators (ra, mame) needs some time otherwise they don't see the touch was pressed
             send_keys(sender, code, False)
 
 def send_reset_signal(target_device: evdev.UInput) -> None:


### PR DESCRIPTION
…too fast