### PR TITLE
Support writable overlay mounts on squash mounts

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -93,6 +93,7 @@
 - You can now choose to create a Win32 WINE bottle only via the option to run 32-bit Windows games.
 - DOSBox Staging's working directory is now set to the games' folder, allowing for local and relative (img)mount and conf file references.
 - DOSBox Staging will fallback to a C:\> prompt inside the games' folder if its missing dosbox.cfg/.conf/.bat files.
+- DOSBox Staging now stores DOS filesystem changes in /userdata/saves/dos/<game> for squashfs ROMs.
 - Systems like WINE and DOSBOX can now be prepared from PCManFM context menu. Right click on file items inside supported ones.
   to presetup them. This is mostly thought for startup files like dosbox.bat and autorun.cmd and for handling squashed archive files.
 - RPCS3 PS Move (light gun) mapping simplified. D-pad buttons are now PS Move face buttons. Check wiki for more info.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -9,6 +9,7 @@ profiler.start()
 
 ### import always needed ###
 import argparse
+import contextlib
 import ctypes
 import json
 import logging
@@ -35,7 +36,8 @@ from .utils import bezels as bezelsUtil, metadata, videoMode, wheelsUtils
 from .utils.evmapy import evmapy
 from .utils.hotkeygen import set_hotkeygen_context
 from .utils.logger import setup_logging
-from .utils.squashfs import squashfs_rom
+from .utils.squashfs import mount_squashfs
+from .utils.overlayfs import mount_overlayfs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -55,12 +57,14 @@ _active_player_controllers = []
 _evmapy_instance = None
 
 def main(args: argparse.Namespace, maxnbplayers: int) -> int:
+    original_rom = args.rom
+
     # squashfs roms if squashed
-    if args.rom.suffix == ".squashfs":
-        with squashfs_rom(args.rom) as rom:
-            return start_rom(args, maxnbplayers, rom, args.rom)
+    if original_rom.suffix == ".squashfs":
+        with mount_squashfs(original_rom) as squash_rom:
+            return start_rom(args, maxnbplayers, squash_rom, original_rom)
     else:
-        return start_rom(args, maxnbplayers, args.rom, args.rom)
+        return start_rom(args, maxnbplayers, original_rom, original_rom)
 
 def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: Path, original_rom: Path) -> int:
     global _active_player_controllers, _evmapy_instance
@@ -98,142 +102,147 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: Path, original_r
         # find the generator
         generator = get_generator(system.config.emulator, system.config.core)
 
-        # the resolution must be changed before configuration while the configuration may depend on it (ie bezels)
-        wantedGameMode = generator.getResolutionMode(system.config)
-        systemMode = videoMode.getCurrentMode()
+        with (
+            mount_overlayfs(rom, SAVES / original_rom.parent.name / original_rom.stem)
+            if original_rom.suffix == ".squashfs" and generator.writesToRom(system.config)
+            else contextlib.nullcontext(rom)
+        ) as rom:
+            # the resolution must be changed before configuration while the configuration may depend on it (ie bezels)
+            wantedGameMode = generator.getResolutionMode(system.config)
+            systemMode = videoMode.getCurrentMode()
 
-        resolutionChanged = False
-        mouseChanged = False
-        exitCode = 0
-        try:
-            # lower the resolution if mode is auto
-            newsystemMode = systemMode  # newsystemMode is the mode after minmax (ie in 1K if tv was in 4K), systemmode is the mode before (ie in es)
-            if system.config.video_mode == "" or system.config.video_mode == "default":
-                _logger.debug("minTomaxResolution")
-                _logger.debug("video mode before minmax: %s", systemMode)
-                videoMode.minTomaxResolution()
-                newsystemMode = videoMode.getCurrentMode()
-                if newsystemMode != systemMode:
+            resolutionChanged = False
+            mouseChanged = False
+            exitCode = 0
+            try:
+                # lower the resolution if mode is auto
+                newsystemMode = systemMode  # newsystemMode is the mode after minmax (ie in 1K if tv was in 4K), systemmode is the mode before (ie in es)
+                if system.config.video_mode == "" or system.config.video_mode == "default":
+                    _logger.debug("minTomaxResolution")
+                    _logger.debug("video mode before minmax: %s", systemMode)
+                    videoMode.minTomaxResolution()
+                    newsystemMode = videoMode.getCurrentMode()
+                    if newsystemMode != systemMode:
+                        resolutionChanged = True
+
+                _logger.debug("current video mode: %s", newsystemMode)
+                _logger.debug("wanted video mode: %s", wantedGameMode)
+
+                if wantedGameMode != 'default' and wantedGameMode != newsystemMode:
+                    videoMode.changeMode(wantedGameMode)
                     resolutionChanged = True
+                gameResolution = videoMode.getCurrentResolution()
 
-            _logger.debug("current video mode: %s", newsystemMode)
-            _logger.debug("wanted video mode: %s", wantedGameMode)
+                # if resolution is reversed (ie ogoa boards), reverse it in the gameResolution to have it correct
+                if videoMode.isResolutionReversed():
+                    x = gameResolution["width"]
+                    gameResolution["width"]  = gameResolution["height"]
+                    gameResolution["height"] = x
+                _logger.debug('resolution: %sx%s', gameResolution["width"], gameResolution["height"])
 
-            if wantedGameMode != 'default' and wantedGameMode != newsystemMode:
-                videoMode.changeMode(wantedGameMode)
-                resolutionChanged = True
-            gameResolution = videoMode.getCurrentResolution()
+                # savedir: create the save directory if not already done
+                dirname = SAVES / system.name
+                if not dirname.exists():
+                    dirname.mkdir(parents=True)
 
-            # if resolution is reversed (ie ogoa boards), reverse it in the gameResolution to have it correct
-            if videoMode.isResolutionReversed():
-                x = gameResolution["width"]
-                gameResolution["width"]  = gameResolution["height"]
-                gameResolution["height"] = x
-            _logger.debug('resolution: %sx%s', gameResolution["width"], gameResolution["height"])
+                # core
+                effectiveCore = ""
+                if "core" in system.config and system.config.core is not None:
+                    effectiveCore = system.config.core
 
-            # savedir: create the save directory if not already done
-            dirname = SAVES / system.name
-            if not dirname.exists():
-                dirname.mkdir(parents=True)
+                if generator.getMouseMode(system.config, rom):
+                    mouseChanged = True
+                    videoMode.changeMouse(True)
 
-            # core
-            effectiveCore = ""
-            if "core" in system.config and system.config.core is not None:
-                effectiveCore = system.config.core
+                # SDL VSync is a big deal on OGA and RPi4
+                if not system.config.get_bool('sdlvsync', True):
+                    system.config["sdlvsync"] = '0'
+                else:
+                    system.config["sdlvsync"] = '1'
+                os.environ.update({'SDL_RENDER_VSYNC': system.config["sdlvsync"]})
 
-            if generator.getMouseMode(system.config, rom):
-                mouseChanged = True
-                videoMode.changeMouse(True)
+                # run a script before emulator starts
+                callExternalScripts(SYSTEM_SCRIPTS, "gameStart", [systemName, system.config.emulator, effectiveCore, rom])
+                callExternalScripts(USER_SCRIPTS, "gameStart", [systemName, system.config.emulator, effectiveCore, rom])
 
-            # SDL VSync is a big deal on OGA and RPi4
-            if not system.config.get_bool('sdlvsync', True):
-                system.config["sdlvsync"] = '0'
-            else:
-                system.config["sdlvsync"] = '1'
-            os.environ.update({'SDL_RENDER_VSYNC': system.config["sdlvsync"]})
+                # run the emulator
+                _evmapy_instance = evmapy(systemName, system.config.emulator, effectiveCore, original_rom, player_controllers, guns)
+                with (
+                    _evmapy_instance,
+                    set_hotkeygen_context(generator, system)
+                ):
+                    # change directory if wanted
+                    executionDirectory = generator.executionDirectory(system.config, rom)
+                    if executionDirectory is not None:
+                        os.chdir(executionDirectory)
 
-            # run a script before emulator starts
-            callExternalScripts(SYSTEM_SCRIPTS, "gameStart", [systemName, system.config.emulator, effectiveCore, rom])
-            callExternalScripts(USER_SCRIPTS, "gameStart", [systemName, system.config.emulator, effectiveCore, rom])
+                    cmd = generator.generate(system, rom, player_controllers, md, guns, wheels, gameResolution)
 
-            # run the emulator
-            _evmapy_instance = evmapy(systemName, system.config.emulator, effectiveCore, original_rom, player_controllers, guns)
-            with (
-                _evmapy_instance,
-                set_hotkeygen_context(generator, system)
-            ):
-                # change directory if wanted
-                executionDirectory = generator.executionDirectory(system.config, rom)
-                if executionDirectory is not None:
-                    os.chdir(executionDirectory)
+                    if system.config.get_bool('hud_support'):
+                        hud_bezel = getHudBezel(system, generator, rom, gameResolution, system.guns_borders_size_name(guns), system.guns_border_ratio_type(guns))
+                        if ((hud := system.config.get('hud')) and hud != "none") or hud_bezel is not None:
+                            cmd.env["MANGOHUD_DLSYM"] = "1"
+                            hudconfig = getHudConfig(system, args.systemname, system.config.emulator, effectiveCore, rom, hud_bezel)
+                            hud_config_file = Path('/var/run/hud.config')
+                            with hud_config_file.open('w') as f:
+                                f.write(hudconfig)
+                            cmd.env["MANGOHUD_CONFIGFILE"] = hud_config_file
+                            if not generator.hasInternalMangoHUDCall():
+                                cmd.array.insert(0, "mangohud")
 
-                cmd = generator.generate(system, rom, player_controllers, md, guns, wheels, gameResolution)
-
-                if system.config.get_bool('hud_support'):
-                    hud_bezel = getHudBezel(system, generator, rom, gameResolution, system.guns_borders_size_name(guns), system.guns_border_ratio_type(guns))
-                    if ((hud := system.config.get('hud')) and hud != "none") or hud_bezel is not None:
-                        cmd.env["MANGOHUD_DLSYM"] = "1"
-                        hudconfig = getHudConfig(system, args.systemname, system.config.emulator, effectiveCore, rom, hud_bezel)
-                        hud_config_file = Path('/var/run/hud.config')
-                        with hud_config_file.open('w') as f:
-                            f.write(hudconfig)
-                        cmd.env["MANGOHUD_CONFIGFILE"] = hud_config_file
-                        if not generator.hasInternalMangoHUDCall():
-                            cmd.array.insert(0, "mangohud")
-
-                # generate the gun help
-                try:
-                    default_gun_help_dir = Path("/var/run/batocera-overlays")
-                    bezelsUtil.generate_gun_help(systemName, rom, system.config.use_guns, guns, default_gun_help_dir, "gun_help.png", gameResolution)
-                except Exception as e:
-                    _logger.error("Failed to generate the gun help image")
-                    _logger.error(e)
-
-                # gun borders
-                try:
-                    if system.config.use_guns and guns:
-                        if generator.supportsInternalBezels() or system.config.get_bool('hud_support'):
-                            _logger.debug("skipping configgen internal gun borders for emulator %s", system.config.emulator)
-                        else:
-                            gun_border_size_name = system.guns_borders_size_name(guns)
-                            if gun_border_size_name is not None:
-                                _logger.debug("using configgen internal gun borders for emulator %s", system.config.emulator)
-                                from .utils.gun_borders import draw_gun_borders
-                                draw_gun_borders(
-                                    gun_border_size_name,
-                                    bezelsUtil.gunsBordersColorFomConfig(system.config),
-                                    system.guns_border_ratio_type(guns)
-                                )
-                except Exception as e:
-                    _logger.error("Failed to draw_gun_borders for gun_borders")
-                    _logger.error(e)
-
-                with profiler.pause():
+                    # generate the gun help
                     try:
-                        _logger.debug("Triggering mouse reset to primary display")
-                        subprocess.call(["/usr/bin/hotkeygen", "--reset-mouse"])
+                        default_gun_help_dir = Path("/var/run/batocera-overlays")
+                        bezelsUtil.generate_gun_help(systemName, rom, system.config.use_guns, guns, default_gun_help_dir, "gun_help.png", gameResolution)
                     except Exception as e:
-                        _logger.warning("Failed to reset mouse: %s", e)
-                    monitor_thread.start()
-                    exitCode = runCommand(cmd)
+                        _logger.error("Failed to generate the gun help image")
+                        _logger.error(e)
 
-            # run a script after emulator shuts down
-            callExternalScripts(USER_SCRIPTS, "gameStop", [systemName, system.config.emulator, effectiveCore, rom])
-            callExternalScripts(SYSTEM_SCRIPTS, "gameStop", [systemName, system.config.emulator, effectiveCore, rom])
+                    # gun borders
+                    try:
+                        if system.config.use_guns and guns:
+                            if generator.supportsInternalBezels() or system.config.get_bool('hud_support'):
+                                _logger.debug("skipping configgen internal gun borders for emulator %s", system.config.emulator)
+                            else:
+                                gun_border_size_name = system.guns_borders_size_name(guns)
+                                if gun_border_size_name is not None:
+                                    _logger.debug("using configgen internal gun borders for emulator %s", system.config.emulator)
+                                    from .utils.gun_borders import draw_gun_borders
+                                    draw_gun_borders(
+                                        gun_border_size_name,
+                                        bezelsUtil.gunsBordersColorFomConfig(system.config),
+                                        system.guns_border_ratio_type(guns)
+                                    )
+                    except Exception as e:
+                        _logger.error("Failed to draw_gun_borders for gun_borders")
+                        _logger.error(e)
 
-        finally:
-            # always restore the resolution
-            if resolutionChanged:
-                try:
-                    videoMode.changeMode(systemMode)
-                except Exception:
-                    pass  # don't fail
+                    with profiler.pause():
+                        try:
+                            _logger.debug("Triggering mouse reset to primary display")
+                            subprocess.call(["/usr/bin/hotkeygen", "--reset-mouse"])
+                        except Exception as e:
+                            _logger.warning("Failed to reset mouse: %s", e)
+                        monitor_thread.start()
+                        exitCode = runCommand(cmd)
 
-            if mouseChanged:
-                try:
-                    videoMode.changeMouse(False)
-                except Exception:
-                    pass  # don't fail
+                # run a script after emulator shuts down
+                callExternalScripts(USER_SCRIPTS, "gameStop", [systemName, system.config.emulator, effectiveCore, rom])
+                callExternalScripts(SYSTEM_SCRIPTS, "gameStop", [systemName, system.config.emulator, effectiveCore, rom])
+
+            finally:
+                # always restore the resolution
+                if resolutionChanged:
+                    try:
+                        videoMode.changeMode(systemMode)
+                    except Exception:
+                        pass  # don't fail
+
+                if mouseChanged:
+                    try:
+                        videoMode.changeMouse(False)
+                    except Exception:
+                        pass  # don't fail
 
     # exit
     return exitCode

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/Generator.py
@@ -38,6 +38,10 @@ class Generator(metaclass=ABCMeta):
     def executionDirectory(self, config: SystemConfig, rom: Path) -> Path | None:
         return None
 
+    # Some systems expect to write into the ROM area, for example: DOS, Amiga, and Wine
+    def writesToRom(self, config: SystemConfig) -> bool:
+        return False
+
     # mame or libretro have internal bezels, don't display the one of mangohud
     def supportsInternalBezels(self) -> bool:
         return False

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dosboxstaging/dosboxstagingGenerator.py
@@ -25,21 +25,24 @@ class DosBoxStagingGenerator(Generator):
     # Returns a populated Command object
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
 
+        # Handle the single-file ROM case
+        game_dir = rom if rom.is_dir() else rom.parent
+
         # DOSBox Staging common resource data and conf file
         common_resource_dir = CONFIGS / 'dosbox'
         common_resource_conf = _find_iname(common_resource_dir, "dosbox-staging.conf")
 
-        dosbox_cfg =  _find_iname(rom, "dosbox.cfg")
-        dosbox_conf = _find_iname(rom, "dosbox.conf")
-        dosbox_bat = _find_iname(rom, "dosbox.bat")
+        dosbox_cfg  = _find_iname(game_dir, "dosbox.cfg")
+        dosbox_conf = _find_iname(game_dir, "dosbox.conf")
+        dosbox_bat  = _find_iname(game_dir, "dosbox.bat")
 
         is_configured = dosbox_cfg or dosbox_conf or dosbox_bat
 
         commandArray = [
             '/usr/bin/dosbox-staging',
             "--fullscreen",
-            "--working-dir", str(rom),
-            "-c", f"set WORKDIR={rom}",
+            "--working-dir", str(game_dir),
+            "-c", f"set WORKDIR={game_dir}",
         ]
 
         if common_resource_dir.is_dir():
@@ -85,3 +88,6 @@ class DosBoxStagingGenerator(Generator):
             "name": "dosboxstaging",
             "keys": { "exit": ["KEY_LEFTCTRL", "KEY_F9"] }
         }
+
+    def writesToRom(self, config) -> bool:
+        return config.get_bool('dosbox_staging_writes_to_rom')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/overlayfs.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/overlayfs.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from ..batoceraPaths import mkdir_if_not_exists
+from ..exceptions import BatoceraException
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_logger = logging.getLogger(__name__)
+
+_OVERLAY_BASE_DIR: Final = Path("/var/run/overlays/")
+
+
+def _unmount_and_remove(mount_point: Path):
+    if mount_point.is_mount():
+        result = subprocess.run(["umount", str(mount_point)], capture_output=True, text=True)
+        if result.returncode != 0:
+            _logger.error("failed unmounting '%s' (rc=%d) because %s",
+                          mount_point, result.returncode, result.stderr.strip())
+
+            # Skip the follow-on removal if the umount failed because it might still
+            # be connected to the ROM's save area (system crashing or bad state?).
+            return
+
+    shutil.rmtree(mount_point, ignore_errors=True)
+
+
+def _mount(read_only_dir: Path, writable_upper_dir: Path, writable_work_dir: Path, mount_point: Path) -> bool:
+
+    components = f"lowerdir={read_only_dir},upperdir={writable_upper_dir},workdir={writable_work_dir}"
+
+    result = subprocess.run(["mount", "-t", "overlay", "overlay",
+                             "-o", components, str(mount_point)],
+                             capture_output=True, text=True)
+
+    if result.returncode == 0:
+        _logger.debug("mounted '%s' with components '%s'",
+                       mount_point, components)
+    else:
+        _logger.error("failed mounting '%s' with components '%s' (rc=%d) because %s",
+                      mount_point, components, result.returncode, result.stderr.strip())
+
+    return result.returncode == 0
+
+
+@contextmanager
+def mount_overlayfs(read_only_dir: Path, writable_dir: Path, /) -> Iterator[Path]:
+    """
+    The Linux kernel's overlay file system (overlayfs) creates a virtual file
+    system mount point based on a "stack" of two or more of underlying directory
+    trees where the lower directories get occluded (or overridden by)
+    directories higher up the stack.
+
+    Three things to note:
+
+    - Changes are only written to the top-most directory or the 'upper'
+      directory, in overlayfs jargon, while the 'lower' directories are
+      effectively read-only.
+
+    - Overlayfs operates at the logical file level as opposed to operating at
+      the block-level, so it's perfectly fine (and normal) to mix file systems,
+      such as a squashfs mount point being used as the read-only lower layer and
+      some writable directory (coming from ext4 or even tmpfs) as the writable
+      layer.
+
+    - Overlayfs requires the writable directory be split into 'upper' and 'work'
+      subdirectories. The 'work' directory is where in-flight changes accumulate
+      before being atomically moved into the public 'upper' area. You'll see
+      these "upper" and "work" sub-directories being created off the passed in
+      "writable_dir" in the code below. This is a requirement of overlayfs and
+      essentially internal workings. They must both exist on the same file
+      system for the atomic moves to work properly.
+
+    The main use-case in batocera will be supporting writes on top of a
+    read-only underlying directory tree of files, specifically for emulators
+    that take in a tree of files like DOS, Wine, Amiga, and probably others. To
+    this end, this function takes in the read-only directory as well as the
+    target writable directory, and returns the mount point of the overlay file
+    system.
+
+    Typically the read-only directory will be a ROM's squashfs mount point, and
+    the writable directory will be the ROM's 'saves' path, while the returned
+    mount-point will be /var/run/overlays/<...> (named after the ROM).
+
+    This also means the user is free to manage their saved changes: they can
+    delete them to reset the state of the game or they can back them up, etc.
+    """
+
+    # If we were passed a single file, then overlay its parent directory
+    maybe_rom_file = None
+    if read_only_dir.is_file():
+        _logger.debug("overlaying single-file or linked rom '%s'", read_only_dir)
+        maybe_rom_file = read_only_dir.name
+        read_only_dir  = read_only_dir.parent
+
+    # Where overlayfs keeps persistent writes
+    writable_upper_dir = writable_dir / "upper"
+    mkdir_if_not_exists(writable_upper_dir)
+
+    # Where overlayfs manages in-flight writes
+    writable_work_dir = writable_dir / "work"
+    mkdir_if_not_exists(writable_work_dir)
+
+    # Where overlayfs exposes the combined filesystem
+    mount_point = _OVERLAY_BASE_DIR / read_only_dir.name
+    _unmount_and_remove(mount_point)
+    mkdir_if_not_exists(mount_point)
+
+    if not _mount(read_only_dir, writable_upper_dir, writable_work_dir, mount_point):
+        raise BatoceraException(f"Unable to setup writable overlay for '{read_only_dir}'")
+    try:
+        yield mount_point / maybe_rom_file if maybe_rom_file else mount_point
+
+    finally:
+        _logger.debug("cleaning up '%s'", mount_point)
+        _unmount_and_remove(mount_point)
+
+        has_writes = writable_upper_dir.is_dir() and any(writable_upper_dir.iterdir())
+
+        _logger.debug("%s save directory '%s'",
+                      "keeping populated" if has_writes else "removing empty",
+                      writable_dir)
+
+        if not has_writes:
+            shutil.rmtree(writable_dir, ignore_errors=True)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/squashfs.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/squashfs.py
@@ -18,8 +18,8 @@ _SQUASHFS_DIR: Final = Path("/var/run/squashfs/")
 
 
 @contextmanager
-def squashfs_rom(rom: Path, /) -> Iterator[Path]:
-    _logger.debug("squashfs_rom(%s)", rom)
+def mount_squashfs(rom: Path, /) -> Iterator[Path]:
+    _logger.debug("mount_squashfs(%s)", rom)
     mount_point = _SQUASHFS_DIR / rom.stem
 
     mkdir_if_not_exists(_SQUASHFS_DIR)
@@ -63,12 +63,12 @@ def squashfs_rom(rom: Path, /) -> Iterator[Path]:
                 _logger.debug("squashfs: linked rom %s", rom_linked)
                 yield rom_linked
     finally:
-        _logger.debug("squashfs_rom: cleaning up %s", mount_point)
+        _logger.debug("mount_squashfs: cleaning up %s", mount_point)
 
         # unmount
         return_code = subprocess.call(["umount", mount_point])
         if return_code != 0:
-            _logger.debug("squashfs_rom: unmounting %s failed", mount_point)
+            _logger.debug("mount_squashfs: unmounting %s failed", mount_point)
             raise BatoceraException(f"Unable to unmount the file {mount_point}")
 
         # cleaning the empty directory

--- a/package/batocera/emulators/dosbox-staging/dosbox_staging.emulator.yml
+++ b/package/batocera/emulators/dosbox-staging/dosbox_staging.emulator.yml
@@ -17,3 +17,10 @@ systems:
   - name: dos
     exclude_extensions:
       - zip
+custom_features:
+  dosbox_staging_writes_to_rom:
+    prompt: Enable writable overlay for squashfs ROMs
+    description: Writes are saved per-game in saves/dos/game-rom-name
+    choices:
+      Enabled: True
+      Disabled: False


### PR DESCRIPTION
Emulated platforms like DOS, Amiga, macOS, PlayStation 3 PSN, and others expect to change the filesystem (record settings, write save game files, etc), which largely disqualifies them using compressed read-only storage formats like SquashFS.

This PR lets emulators indicate that they need write access to the ROM area, in which case a writable overlayfs mount will be placed on top of the squashfs mount (if squash is used), with the writes going into the usual `/userdata/saves/<platform>/<game>` area.

Implementation wise, the overlay feature is a follow-on context after squashfs handling:
 - It handles squash's directory or single-file and linked output
 - It logs and cleans up the virtual area on context close
 - It preserves the writable area if changes were made, but otherwise cleans it up if it's empty.

Sample log statements:
    
```
DEBUG (overlayfs.py:43):_mount mounted '/var/run/overlays/biomenace-bare.pc'
      with components 'lowerdir=/var/run/squashfs/biomenace-bare.pc,
                       upperdir=/userdata/saves/dos/biomenace-bare.pc/upper,
                       workdir=/userdata/saves/dos/biomenace-bare.pc/work'
    
DEBUG (overlayfs.py:85):mount_overlayfs cleaning up
      '/var/run/overlays/biomenace-bare.pc'
    
DEBUG (overlayfs.py:90):mount_overlayfs keeping populated save directory
      '/userdata/saves/dos/biomenace-bare.pc'
```

I've tested all four types of changes:
 - Modifying an existing file in the squash base
 - Deleting an existing file in the squash base
 - Adding or changing a new file that doesn't exist in the squash base
 - Deleting a previously created file not in the squash base

Using squashfs for PC games has a nice side-effect of keeping the underlying game in a known pristine  state as any risky changes (patches, cracks, cheats and so on that a user might employ) can be wiped clean by deleting the game's save area.

As of this PR I've only toggled it on for the DOSBox Staging generator, but could be easily be added to others if someone has working ROMs for those platforms (Amiga, MacOS, etc..)

---

Testing:

1. Unzip  [biomenace-bare.pc.squashfs.zip](https://github.com/user-attachments/files/24812308/biomenace-bare.pc.squashfs.zip) into your `/userdata/roms/dos/` area
2. Launch it with `main` and observe that `C:\> echo hello > world` creates an access denied error.
3. Launch it with this branch and you'll see `world` is created. This new file will persist across re-launches (and reboots) of the emulator and physical machine. 
4. If you `C:\> del world` and then close the emulator you'll see that the `/userdata/saves/dos/biomenace-bare.pc` folder has been removed because there are no longer any changes versus the underlying squash.
5. Making changes to existing files (for example, `del BMENACE3.EXE`, or changing the content of a file) will persist (and you can dig into the saves area to see how they're represented).