### PR TITLE
Add TRS-80 and Colour Genie (EACA EG2000) systems

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -140,6 +140,9 @@ cdogs:
 cgenius:
   emulator: cgenius
   core:     cgenius
+cgenie:
+  emulator: libretro
+  core:     mame
 channelf:
   emulator: libretro
   core:     freechaf
@@ -745,6 +748,9 @@ traider2:
 triforce:
   emulator: dolphin
   core:     dolphin
+trs80:
+  emulator: libretro
+  core:     mame
 tutor:
   emulator: libretro
   core:     mame

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -13,6 +13,7 @@ pcw;pcw8256;flop;
 camplynx;lynx48k;cass;'mload""'
 loopy;casloopy;cart;
 cdi;cdimono1;cdrm;
+cgenie;cgenie;cass;'\n\nCLOAD\n'
 coco;coco3;cart;
 dragon64;dragon64;cart;
 mc10;mc10;cass;'CLOAD\n'
@@ -52,6 +53,7 @@ socrates;socrates;cart;
 sv8000;sv8000;cart;
 supracan;supracan;cart;
 ti99;ti99_4a;cart;
+trs80;trs80m3;quik;
 tutor;tutor;cart;
 tvgames;;;
 uzebox;uzebox;cart;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -440,6 +440,9 @@ systems = {
                                                 { "md5": "", "file": "bios/coco_fdc_v11.zip"  },
                                                 { "md5": "8cab28f4b7311b8df63c07bb3b59bfd5", "zippedFile": "disk11.rom", "file": "bios/coco_fdc_v11.zip"} ] },
 
+    # ---------- Colour Genie ---------- #
+    "cgenie":  { "name": "Colour Genie", "biosFiles": [ { "md5": "", "file": "bios/cgenie.zip" } ] },
+
     # ---------- Dragon 64 ---------- #
     "dragon64":   { "name": "Dragon 64", "biosFiles":  [ { "md5": "", "file": "bios/dragon64.zip"  },
                                                 { "md5": "", "zippedFile": "d64_1.rom", "file": "bios/dragon64.zip"},
@@ -453,6 +456,16 @@ systems = {
                                                 { "md5": "", "zippedFile": "mc10.rom", "file": "bios/mc10.zip"},
                                                 { "md5": "", "file": "bios/alice.zip"  },
                                                 { "md5": "", "zippedFile": "alice.rom", "file": "bios/alice.zip"} ] },
+
+    # ---------- TRS-80 ---------- #
+    "trs80":   { "name": "TRS-80", "biosFiles":  [ { "md5": "", "file": "bios/trs80.zip"  },
+                                                { "md5": "", "zippedFile": "level1.rom", "file": "bios/trs80.zip"},
+                                                { "md5": "", "zippedFile": "level2.rom", "file": "bios/trs80.zip"},
+                                                { "md5": "", "file": "bios/trs80m3.zip" },
+                                                { "md5": "", "zippedFile": "8041730.u12", "file": "bios/trs80m3.zip"},
+                                                { "md5": "", "file": "bios/trs80m4.zip" },
+                                                { "md5": "", "zippedFile": "8043216.u11", "file": "bios/trs80m4.zip"},
+                                                { "md5": "", "file": "bios/trs80m4p.zip" } ] },
 
     # ---------- Tomy Tutor ---------- #
     "tutor":   { "name": "Tomy Tutor", "biosFiles":  [ { "md5": "", "file": "bios/tutor.zip"  },

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3814,6 +3814,22 @@ coco:
   comment_br: |
           Requer o arquivo coco.zip da BIOS do MAME
 
+cgenie:
+  name: Colour Genie
+  manufacturer: EACA
+  release: 1982
+  hardware: computer
+  extensions: [cas, wav, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          MAME requires BIOS file cgenie.zip
+  comment_br: |
+          Requer o arquivo cgenie.zip da BIOS do MAME
+
 dragon64:
   name: Dragon 64
   manufacturer: Dragon Data
@@ -3865,6 +3881,35 @@ mc10:
 
           Xroar requires BASIC ROMs to be in the /userdata/bios/xroar folder.
           The required rom files can be obtained from here: https://colorcomputerarchive.com/repo/ROMs/XRoar
+
+trs80:
+  name: TRS-80
+  manufacturer: Tandy Radio Shack
+  release: 1977
+  hardware: computer
+  extensions: [cmd, cas, dsk, dmk, bas, wav, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          MAME requires BIOS file trs80.zip (Model I), trs80m3.zip (Model III), or trs80m4.zip (Model 4)
+
+          Default Autoload Behaviors
+          1. Cassette (.cas) files autoload using SYSTEM then filename
+          2. Disk (.dsk/.dmk) files autoload from boot disk
+          3. Command (.cmd) files autoload directly as executables
+          4. BASIC (.bas) files autoload using RUN command
+
+          TRS-80 Models supported by MAME:
+          - Model I (1977) - Original Z80-based microcomputer
+          - Model III (1980) - Integrated design with built-in disk drives
+          - Model 4 (1983) - Enhanced Model III with 80x24 display
+
+          user definable autoload overrides in: `system/configs/mame/autoload/trs80_{cass,flop}_autoload.csv`
+  comment_br: |
+          Requer o arquivo trs80.zip da BIOS do MAME
 
 vc4000:
   name:       VC 4000

--- a/package/batocera/emulators/mame/mame.emulator.yml
+++ b/package/batocera/emulators/mame/mame.emulator.yml
@@ -1621,7 +1621,9 @@ systems:
   - samcoupe
   - tvgames
   - uzebox
-  - name: pv2000
+  - name: cgenie
+    features:
+      - padtokeyboard
     custom_features:
       softList:
         group: ADVANCED OPTIONS
@@ -1629,7 +1631,22 @@ systems:
         description: Use MAME software lists to identify ROM
         choices:
           Don't Use (Default): none
-          Casio PV-2000 cartridges: pv2000
+          Colour Genie Cassettes: cgenie_cass
+          Colour Genie Floppies (ROM required): cgenie_flop_rom
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Floppy Disk 1: flop1
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
       pergamecfg:
         group: ADVANCED OPTIONS
         prompt: CUSTOM GAME CONFIG
@@ -1637,6 +1654,7 @@ systems:
         choices:
           'On': 1
           'Off': 0
+  - enterprise
   - name: pc80
     features:
       - padtokeyboard
@@ -1657,7 +1675,67 @@ systems:
         choices:
           'On': 1
           'Off': 0
-  - enterprise
+  - name: pv2000
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Casio PV-2000 cartridges: pv2000
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: trs80
+    features:
+      - padtokeyboard
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          TRS-80 Cassettes: trs80_cass
+          TRS-80 Floppies: trs80_flop
+          TRS-80 Quickload (.cmd): trs80_quik
+      altmodel:
+        prompt: TRS-80 MODEL
+        description: Select model of TRS-80 to emulate
+        choices:
+          Model I (Level I Basic): trs80
+          Model I (Level II Basic): trs80l2
+          Model III (Default): trs80m3
+          Model 4: trs80m4
+          Model 4P: trs80m4p
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Quickload (.cmd): quik
+          Floppy Disk 1: flop1
+          Floppy Disk 2: flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
   - tvc
   - name: pc60
     features:

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
@@ -1532,7 +1532,9 @@ systems:
   - uzebox
   - vc4000
   - vis
-  - name: pv2000
+  - name: cgenie
+    features:
+      - padtokeyboard
     custom_features:
       softList:
         group: ADVANCED OPTIONS
@@ -1540,7 +1542,22 @@ systems:
         description: Use MAME software lists to identify ROM
         choices:
           Don't Use (Default): none
-          Casio PV-2000 cartridges: pv2000
+          Colour Genie Cassettes: cgenie_cass
+          Colour Genie Floppies (ROM required): cgenie_flop_rom
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Floppy Disk 1: flop1
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
       pergamecfg:
         group: ADVANCED OPTIONS
         prompt: CUSTOM GAME CONFIG
@@ -1548,6 +1565,7 @@ systems:
         choices:
           'On': 1
           'Off': 0
+  - enterprise
   - name: pc80
     features:
       - padtokeyboard
@@ -1568,7 +1586,67 @@ systems:
         choices:
           'On': 1
           'Off': 0
-  - enterprise
+  - name: pv2000
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Casio PV-2000 cartridges: pv2000
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: trs80
+    features:
+      - padtokeyboard
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          TRS-80 Cassettes: trs80_cass
+          TRS-80 Floppies: trs80_flop
+          TRS-80 Quickload (.cmd): trs80_quik
+      altmodel:
+        prompt: TRS-80 MODEL
+        description: Select model of TRS-80 to emulate
+        choices:
+          Model I (Level I Basic): trs80
+          Model I (Level II Basic): trs80l2
+          Model III (Default): trs80m3
+          Model 4: trs80m4
+          Model 4P: trs80m4p
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Quickload (.cmd): quik
+          Floppy Disk 1: flop1
+          Floppy Disk 2: flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
   - tvc
   - name: pc60
     features:


### PR DESCRIPTION
## Summary
- Add TRS-80 (Tandy Radio Shack, 1977) system support using MAME
- Add Colour Genie EG2000 (EACA, 1982) - TRS-80 compatible home computer

## Systems

### TRS-80
- Models: Model I, Model III, Model 4, Model 4P
- Media: cassette (.cas), floppy (.dsk/.dmk), quickload (.cmd), BASIC (.bas)
- BIOS: trs80.zip, trs80m3.zip, trs80m4.zip, trs80m4p.zip
- Software lists: trs80_cass, trs80_flop, trs80_quik

### Colour Genie (cgenie)
- MAME driver: `cgenie`
- Media: cassette (.cas), wav
- BIOS: cgenie.zip
- Software lists: cgenie_cass, cgenie_flop_rom
- Autoload: `CLOAD` command after boot prompts

## Emulators
- libretro-mame (default)
- standalone MAME

## Files changed
- `configgen-defaults.yml` - emulator defaults for both systems
- `messSystems.csv` - MAME mess system definitions
- `batocera-systems` - BIOS file definitions
- `es_systems.yml` - EmulationStation system entries
- `mame.emulator.yml` - MAME standalone config (padtokeyboard, softList, altromtype, enableui, pergamecfg)
- `mame.libretro.core.yml` - libretro-mame config (identical features)