### PR TITLE
Set correct environment before initializing PySDL2

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -17,6 +17,7 @@ import subprocess
 import time
 import threading
 import pyudev
+os.environ["PYSDL2_DLL_PATH"] = "/usr/lib"
 import sdl2
 import sdl2.ext
 import ctypes


### PR DESCRIPTION
# Issue

Launching games using a controller causes a crash back to EmulationStation

Affected Version: https://github.com/batocera-linux/batocera.linux/tree/42e1848e37e9f05629b4eda2a359ddee64edda4c

# Troubleshooting

```
[root@BATOCERA ~]# emulatorlauncher 
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/sdl2/dll.py", line 362, in <module>
    dll = DLL("SDL2", ["SDL2", "SDL2-2.0", "SDL2-2.0.0"], os.getenv("PYSDL2_DLL_PATH"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/sdl2/dll.py", line 253, in __init__
    raise RuntimeError("could not find any library for %s (%s)" %
RuntimeError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/emulatorlauncher", line 9, in <module>
    from configgen.emulatorlauncher import launch
  File "/usr/lib/python3.12/site-packages/configgen/emulatorlauncher.py", line 20, in <module>
    import sdl2
  File "/usr/lib/python3.12/site-packages/sdl2/__init__.py", line 2, in <module>
    from .dll import get_dll_file, _bind
  File "/usr/lib/python3.12/site-packages/sdl2/dll.py", line 364, in <module>
    raise ImportError(exc)
ImportError: could not find any library for SDL2 (PYSDL2_DLL_PATH: unset)
[root@BATOCERA ~]# find /usr -iname "libSDL2*"
/usr/lib/libSDL2-2.0.so.0
/usr/lib/libSDL2-2.0.so.0.3200.8
/usr/lib/libSDL2.so
/usr/lib/libSDL2_gfx-1.0.so.0
/usr/lib/libSDL2_gfx-1.0.so.0.0.2
/usr/lib/libSDL2_gfx.so
/usr/lib/libSDL2_image-2.0.so.0
/usr/lib/libSDL2_image-2.0.so.0.800.5
/usr/lib/libSDL2_image.so
/usr/lib/libSDL2_mixer-2.0.so.0
/usr/lib/libSDL2_mixer-2.0.so.0.800.1
/usr/lib/libSDL2_mixer.so
/usr/lib/libSDL2_mixer_ext.so
/usr/lib/libSDL2_mixer_ext.so.2
/usr/lib/libSDL2_mixer_ext.so.2.8.0.0
/usr/lib/libSDL2_net-2.0.so.0
/usr/lib/libSDL2_net-2.0.so.0.200.0
/usr/lib/libSDL2_net.so
/usr/lib/libSDL2_ttf-2.0.so.0
/usr/lib/libSDL2_ttf-2.0.so.0.2400.0
/usr/lib/libSDL2_ttf.so
```

# After adding PYSDL2_DLL_PATH to the .py file

```
[root@BATOCERA ~]# emulatorlauncher 
2026-02-03 14:28:49,758 INFO (emulatorlauncher.py:597):launch Batocera version: 43-dev-8fcbd60441 2026/02/01 19:55
usage: emulatorlauncher [-h] [-p1index P1INDEX] [-p1guid P1GUID]
                        [-p1name P1NAME] [-p1devicepath P1DEVICEPATH]
                        [-p1nbbuttons P1NBBUTTONS] [-p1nbhats P1NBHATS]
                        [-p1nbaxes P1NBAXES] [-p2index P2INDEX]
                        [-p2guid P2GUID] [-p2name P2NAME]
                        [-p2devicepath P2DEVICEPATH]
                        [-p2nbbuttons P2NBBUTTONS] [-p2nbhats P2NBHATS]
                        [-p2nbaxes P2NBAXES] [-p3index P3INDEX]
                        [-p3guid P3GUID] [-p3name P3NAME]
                        [-p3devicepath P3DEVICEPATH]
                        [-p3nbbuttons P3NBBUTTONS] [-p3nbhats P3NBHATS]
                        [-p3nbaxes P3NBAXES] [-p4index P4INDEX]
                        [-p4guid P4GUID] [-p4name P4NAME]
                        [-p4devicepath P4DEVICEPATH]
                        [-p4nbbuttons P4NBBUTTONS] [-p4nbhats P4NBHATS]
                        [-p4nbaxes P4NBAXES] [-p5index P5INDEX]
                        [-p5guid P5GUID] [-p5name P5NAME]
                        [-p5devicepath P5DEVICEPATH]
                        [-p5nbbuttons P5NBBUTTONS] [-p5nbhats P5NBHATS]
                        [-p5nbaxes P5NBAXES] [-p6index P6INDEX]
                        [-p6guid P6GUID] [-p6name P6NAME]
                        [-p6devicepath P6DEVICEPATH]
                        [-p6nbbuttons P6NBBUTTONS] [-p6nbhats P6NBHATS]
                        [-p6nbaxes P6NBAXES] [-p7index P7INDEX]
                        [-p7guid P7GUID] [-p7name P7NAME]
                        [-p7devicepath P7DEVICEPATH]
                        [-p7nbbuttons P7NBBUTTONS] [-p7nbhats P7NBHATS]
                        [-p7nbaxes P7NBAXES] [-p8index P8INDEX]
                        [-p8guid P8GUID] [-p8name P8NAME]
                        [-p8devicepath P8DEVICEPATH]
                        [-p8nbbuttons P8NBBUTTONS] [-p8nbhats P8NBHATS]
                        [-p8nbaxes P8NBAXES] -system SYSTEM -rom ROM
                        [-emulator EMULATOR] [-core CORE]
                        [-netplaymode NETPLAYMODE] [-netplaypass NETPLAYPASS]
                        [-netplayip NETPLAYIP] [-netplayport NETPLAYPORT]
                        [-netplaysession NETPLAYSESSION]
                        [-state_slot STATE_SLOT]
                        [-state_filename STATE_FILENAME] [-autosave AUTOSAVE]
                        [-systemname SYSTEMNAME] [-gameinfoxml [GAMEINFOXML]]
                        [-lightgun] [-wheel] [-trackball] [-spinner]
emulatorlauncher: error: the following arguments are required: -system, -rom
[root@BATOCERA ~]# 
```