### PR TITLE
Add output for modified version in update-info

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -121,6 +121,7 @@ case ${1,,} in
             NET_VER=$(wget -q -O - "$URL")
             [[ $? -eq 0 ]] || NET_VER="Connection failed!"
             echo "Installed:   $VER"
+            echo "Modified:    $(batocera-version --extra)"
             echo "Webversion:  $NET_VER"
             echo "Update URL:  $(dirname $URL)"
             echo "Branch:      ${BRANCH^^}-branch searched"


### PR DESCRIPTION
Out from a discord thread where the mods where forced to discuss with users complaining about using an unmodified version
<img width="789" height="418" alt="grafik" src="https://github.com/user-attachments/assets/14b7ed1b-bf87-48c3-8ec0-65979fbdcb5a" />