### PR TITLE
Add Gakken Compact Vision TV Boy (ctvboy) and Amstrad PCW (pcw) systems

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -45,6 +45,9 @@ amigacdtv:
 amstradcpc:
   emulator: libretro
   core:     cap32
+pcw:
+  emulator: libretro
+  core:     mame
 apfm1000:
   emulator: libretro
   core:     mame
@@ -155,6 +158,9 @@ corsixth:
   options:
     hud_support: false
 crvision:
+  emulator: libretro
+  core:     mame
+ctvboy:
   emulator: libretro
   core:     mame
 

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -8,11 +8,13 @@ archimedes;aa4401;flop;
 astrocade;astrocde;cart;
 atom;atom;flop1;'\n*DOS\n*DIR\n*CAT\n*RUN"'
 bbcmicro;bbcb;flop1;
+pcw;pcw8256;flop;
 camplynx;lynx48k;cass;'mload""'
 loopy;casloopy;cart;
 cdi;cdimono1;cdrm;
 coco;coco3;cart;
 crvision;crvision;cart;
+ctvboy;ctvboy;cart;
 electron;electron64;cass;'*T.\nCH.""\n'
 fm7;fm7;flop1;
 fmtowns;fmtmarty;cdrm;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -520,6 +520,13 @@ systems = {
                                                 { "md5": "", "zippedFile": "motoroff.wav", "file": "bios/mame/samples/bbc.zip"},
                                                 { "md5": "", "zippedFile": "motoron.wav", "file": "bios/mame/samples/bbc.zip"} ] },
 
+    # ---------- Amstrad PCW ---------- #
+    "pcw":   { "name": "Amstrad PCW", "biosFiles":  [ { "md5": "", "file": "bios/pcw8256.zip"  },
+                                                { "md5": "a846b928562ca8281bc279f41b475a06", "zippedFile": "40026.ic701", "file": "bios/pcw8256.zip"},
+                                                { "md5": "cefe4b0b7c701c1a80130e3390b007f5", "zippedFile": "40027.ic801", "file": "bios/pcw8256.zip"},
+                                                { "md5": "", "file": "bios/pcw9512.zip"  },
+                                                { "md5": "b664af93987d575b0248832832c61505", "zippedFile": "40103.ic109", "file": "bios/pcw9512.zip"} ] },
+
     # ---------- APF M-1000 ---------- #
     "apfm1000":   { "name": "APF M-1000", "biosFiles":  [ { "md5": "", "file": "bios/apfm1000.zip"  },
                                                 { "md5": "1f4a976350202ee1e32c2b0477c3fc1b", "zippedFile": "apf_4000.rom", "file": "bios/apfm1000.zip"},

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1542,6 +1542,21 @@ amstradcpc:
     Para habilitar o suporte ao controle, vá no menu RetroArch com "Hotkey + B" e altere esta opção:
     De "Quick Menu/Core Input Options/User 1 Device type: Retropad" para "Amstrad Joystick"
 
+pcw:
+  name:       Amstrad PCW
+  manufacturer: Amstrad
+  release: 1985
+  hardware: computer
+  extensions: [mfi, dfi, mfm, td0, imd, 86f, d77, d88, 1dd, cqm, cqi, dsk, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+    Requires MAME BIOS files pcw8256.zip (and pcw9512.zip for the 9512 model).
+    Games are floppy disk images (.dsk). Most games are self-booting and don't require a separate system disk.
+
 msx1:
   name: MSX1
   manufacturer: Microsoft
@@ -3238,6 +3253,20 @@ crvision:
           Requires MAME BIOS file crvision.zip
   comment_br: |
           Requer o arquivo crvision.zip da BIOS do MAME
+
+ctvboy:
+  name:       Compact Vision TV Boy
+  manufacturer: Gakken
+  release: 1983
+  hardware: console
+  extensions: [bin, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          MAME 0.262+ required
 
 laser310:
   name:       Laser 310

--- a/package/batocera/emulators/mame/mame.emulator.yml
+++ b/package/batocera/emulators/mame/mame.emulator.yml
@@ -367,6 +367,46 @@ systems:
         choices:
           "On": 1
           "Off": 0
+  - name: pcw
+    features:
+      - padtokeyboard
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Amstrad PCW disk images: pcw
+      altmodel:
+        prompt: PCW MODEL
+        description: Select model to emulate
+        choices:
+          PCW8256 - 256KB (default): pcw8256
+          PCW8512 - 512KB: pcw8512
+          PCW9256 - 256KB: pcw9256
+          PCW9512 - 512KB: pcw9512
+          PCW10 - 512KB: pcw10
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Disk (Drive A): flop
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
   - name: bbcmicro
     features:
       - padtokeyboard
@@ -523,6 +563,22 @@ systems:
         choices:
           Cartridge: cart
           Cassette: cass
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
+  - name: ctvboy
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Gakken Compact Vision TV Boy cartridges: ctvboy
       pergamecfg:
         group: ADVANCED OPTIONS
         prompt: CUSTOM GAME CONFIG

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
@@ -363,6 +363,44 @@ systems:
         choices:
           'On': 1
           'Off': 0
+  - name: pcw
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Amstrad PCW disk images: pcw
+      altmodel:
+        prompt: PCW MODEL
+        description: Select model to emulate
+        choices:
+          PCW8256 - 256KB (default): pcw8256
+          PCW8512 - 512KB: pcw8512
+          PCW9256 - 256KB: pcw9256
+          PCW9512 - 512KB: pcw9512
+          PCW10 - 512KB: pcw10
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Disk (Drive A): flop
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
   - name: bbcmicro
     custom_features:
       sticktype:
@@ -533,6 +571,22 @@ systems:
         choices:
           Cartridge: cart
           Cassette: cass
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: ctvboy
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Gakken Compact Vision TV Boy cartridges: ctvboy
       pergamecfg:
         group: ADVANCED OPTIONS
         prompt: CUSTOM GAME CONFIG


### PR DESCRIPTION
Add support for two new systems emulated via MAME/libretro-mame:

- **Gakken Compact Vision TV Boy** (1983) - cartridge-based console
- **Amstrad PCW** (1985) - CP/M-based home computer with floppy disk support, model selection (PCW8256/8512/9256/9512/PCW10)