### PR TITLE
Clean up old DBUS sessions

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -344,8 +344,6 @@ while [ -e "${REBOOT_FLAG}" ]; do
     fi
 
     echo "${settings_output}" > "/var/run/switch_screen_current"
-    # DBUS launch is required for the gio/gvfs/trash:///...
-    eval "$(dbus-launch --sh-syntax --exit-with-session)"
 
     ### BACKGLASS ###
     if which batocera-backglass; then
@@ -384,7 +382,9 @@ while [ -e "${REBOOT_FLAG}" ]; do
 
     echo "Standalone: --- Launching EmulationStation ---" >> "$log"
     cd /userdata # ES need a PWD
-    %BATOCERA_EMULATIONSTATION_PREFIX% emulationstation ${GAMELAUNCHOPT} --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
+
+    # DBUS is required for the gio/gvfs/trash:///...
+    %BATOCERA_EMULATIONSTATION_PREFIX% dbus-run-session -- emulationstation ${GAMELAUNCHOPT} --exit-on-reboot-required %BATOCERA_EMULATIONSTATION_ARGS% ${CUSTOMESOPTIONS}
 
     if which batocera-backglass; then
         if [ -n "${settings_output2}" ]; then


### PR DESCRIPTION
Tested and confirmed that old DBUS sessions are being cleaned up after multiple standby and on/off cycles.

Fixes #15297

Boot up & display on:

```
dbus       153     1  0 14:48 ?        00:00:00 dbus-daemon --system
root      4235     1  0 14:49 ?        00:00:00 dbus-launch --sh-syntax --exit-with-session
root      4236     1  0 14:49 ?        00:00:00 /usr/bin/dbus-daemon --syslog --fork --print-pid 5 --print-address 7 --session
```

display off & on cycle, multiple times:

```
dbus       153     1  0 14:48 ?        00:00:00 dbus-daemon --system
root      6697     1  0 15:06 ?        00:00:00 dbus-launch --sh-syntax --exit-with-session
root      6698     1  0 15:06 ?        00:00:00 /usr/bin/dbus-daemon --syslog --fork --print-pid 5 --print-address 7 --session
```

Before this PR, many prior DBUS sessions would still exist.