### PR TITLE
Add Dragon 64 and MC-10 system support

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xroar/xroarGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xroar/xroarGenerator.py
@@ -32,7 +32,9 @@ class XroarGenerator(Generator):
             f.write("rompath /userdata/bios/xroar\n")
 
             # Machine Selection
-            f.write(f"default-machine {system.config.get('xroar_machine', 'coco2bus')}\n")
+            default_machines = {'mc10': 'mc10', 'dragon64': 'dragon64'}
+            default_machine = default_machines.get(system.name, 'coco2bus')
+            f.write(f"default-machine {system.config.get('xroar_machine', default_machine)}\n")
 
             # Set audio volume to 100
             f.write("ao-volume 100\n")
@@ -44,6 +46,25 @@ class XroarGenerator(Generator):
             # VSync
             if system.config.get_bool('xroar_vsync'):
                 f.write("vo-vsync\n")
+
+            # RAM Size
+            xroar_ram = system.config.get('xroar_ram')
+            if xroar_ram:
+                f.write(f"ram {xroar_ram}\n")
+
+            # TV Type
+            xroar_tv_type = system.config.get('xroar_tv_type')
+            if xroar_tv_type:
+                f.write(f"tv-type {xroar_tv_type}\n")
+
+            # TV Input
+            xroar_tv_input = system.config.get('xroar_tv_input')
+            if xroar_tv_input:
+                f.write(f"tv-input {xroar_tv_input}\n")
+
+            # Keyboard Translation
+            if system.config.get_bool('xroar_kbd_translate'):
+                f.write("kbd-translate\n")
 
             # Fullscreen
             f.write("fs\n")

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -177,6 +177,12 @@ doom3:
 dos:
   emulator: libretro
   core:     dosbox_pure
+dragon64:
+  emulator: libretro
+  core:     mame
+mc10:
+  emulator: libretro
+  core:     mame
 dreamcast:
   emulator: libretro
   core:     flycast

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -12,6 +12,8 @@ camplynx;lynx48k;cass;'mload""'
 loopy;casloopy;cart;
 cdi;cdimono1;cdrm;
 coco;coco3;cart;
+dragon64;dragon64;cart;
+mc10;mc10;cass;'CLOAD\n'
 crvision;crvision;cart;
 electron;electron64;cass;'*T.\nCH.""\n'
 fm7;fm7;flop1;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -430,6 +430,20 @@ systems = {
                                                 { "md5": "", "file": "bios/coco_fdc_v11.zip"  },
                                                 { "md5": "8cab28f4b7311b8df63c07bb3b59bfd5", "zippedFile": "disk11.rom", "file": "bios/coco_fdc_v11.zip"} ] },
 
+    # ---------- Dragon 64 ---------- #
+    "dragon64":   { "name": "Dragon 64", "biosFiles":  [ { "md5": "", "file": "bios/dragon64.zip"  },
+                                                { "md5": "", "zippedFile": "d64_1.rom", "file": "bios/dragon64.zip"},
+                                                { "md5": "", "zippedFile": "d64_2.rom", "file": "bios/dragon64.zip"},
+                                                { "md5": "", "zippedFile": "d64bas.rom", "file": "bios/dragon64.zip"},
+                                                { "md5": "", "file": "bios/dragon32.zip"  },
+                                                { "md5": "", "zippedFile": "d32.rom", "file": "bios/dragon32.zip"} ] },
+
+    # ---------- Tandy MC-10 ---------- #
+    "mc10":   { "name": "Tandy MC-10", "biosFiles":  [ { "md5": "", "file": "bios/mc10.zip"  },
+                                                { "md5": "", "zippedFile": "mc10.rom", "file": "bios/mc10.zip"},
+                                                { "md5": "", "file": "bios/alice.zip"  },
+                                                { "md5": "", "zippedFile": "alice.rom", "file": "bios/alice.zip"} ] },
+
     # ---------- Tomy Tutor ---------- #
     "tutor":   { "name": "Tomy Tutor", "biosFiles":  [ { "md5": "", "file": "bios/tutor.zip"  },
                                                 { "md5": "196ba41dd1184fe754390534cc273116", "zippedFile": "tutor1.bin", "file": "bios/tutor.zip"},

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3608,6 +3608,58 @@ coco:
   comment_br: |
           Requer o arquivo coco.zip da BIOS do MAME
 
+dragon64:
+  name: Dragon 64
+  manufacturer: Dragon Data
+  release: 1983
+  hardware: computer
+  extensions: [wav, cas, dsk, dmk, ccc, rom, bin, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+    xroar:
+      xroar: { requireAnyOf: [BR2_PACKAGE_XROAR] }
+  comment_en: |
+          MAME requires BIOS file dragon64.zip (or dragon32.zip for Dragon 32)
+
+          The Dragon 64 is a British home computer from 1983, compatible with Tandy CoCo.
+          It features a Motorola 6809E CPU, 64KB RAM, and Microsoft Extended BASIC.
+
+          Default Autoload Behaviors
+          1. Cartridge (.ccc/.rom) files autoload directly
+          2. Cassette (.cas/.wav) files autoload using CLOADM:EXEC
+          3. Disk (.dsk/.dmk) files autoload from boot disk
+
+          Dragon Models supported by MAME:
+          - Dragon 32 (1982) - 32KB RAM version
+          - Dragon 64 (1983) - 64KB RAM with RS-232 serial port
+          - Dragon Alpha (prototype) - Enhanced Dragon 64
+
+          user definable autoload overrides in: `system/configs/mame/autoload/dragon64_{cass,flop}_autoload.csv`
+  comment_br: |
+          Requer o arquivo dragon64.zip da BIOS do MAME
+
+mc10:
+  name: MC-10
+  manufacturer: Tandy Radio Shack
+  release: 1983
+  hardware: computer
+  extensions: [wav, cas, rom, bin, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+    xroar:
+      xroar: { requireAnyOf: [BR2_PACKAGE_XROAR] }
+  comment_en: |
+          MAME requires BIOS file mc10.zip
+
+          Xroar requires BASIC ROMs to be in the /userdata/bios/xroar folder.
+          The required rom files can be obtained from here: https://colorcomputerarchive.com/repo/ROMs/XRoar
+
 vc4000:
   name:       VC 4000
   manufacturer: Interton

--- a/package/batocera/emulators/mame/mame.emulator.yml
+++ b/package/batocera/emulators/mame/mame.emulator.yml
@@ -507,6 +507,85 @@ systems:
         choices:
           "On": 1
           "Off": 0
+  - name: dragon64
+    features:
+      - padtokeyboard
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Dragon Cassettes: dragon_cass
+          Dragon Cartridges: dragon_cart
+          Dragon Disk images: dragon_flop
+      altmodel:
+        prompt: DRAGON MODEL
+        description: Select model of Dragon to emulate
+        choices:
+          Dragon 32: dragon32
+          Dragon 64 (Default): dragon64
+          Dragon Alpha: dgnalpha
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Cartridge: cart
+          Floppy Disk 1: flop1
+          Floppy Disk 2: flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mc10
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Tandy MC-10 cassettes: mc10_cass
+      altmodel:
+        prompt: MC-10 MODEL
+        description: Select the model to emulate
+        choices:
+          Tandy MC-10 (Default): mc10
+          Matra & Hachette Alice: alice
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Cassette: cass
+          Cartridge: cart
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
   - name: crvision
     custom_features:
       softList:

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
@@ -517,6 +517,85 @@ systems:
         choices:
           'On': 1
           'Off': 0
+  - name: dragon64
+    features:
+      - padtokeyboard
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Dragon Cassettes: dragon_cass
+          Dragon Cartridges: dragon_cart
+          Dragon Disk images: dragon_flop
+      altmodel:
+        prompt: DRAGON MODEL
+        description: Select model of Dragon to emulate
+        choices:
+          Dragon 32: dragon32
+          Dragon 64 (Default): dragon64
+          Dragon Alpha: dgnalpha
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load
+        choices:
+          Cassette: cass
+          Cartridge: cart
+          Floppy Disk 1: flop1
+          Floppy Disk 2: flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mc10
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Tandy MC-10 cassettes: mc10_cass
+      altmodel:
+        prompt: MC-10 MODEL
+        description: Select the model to emulate
+        choices:
+          Tandy MC-10 (Default): mc10
+          Matra & Hachette Alice: alice
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Cassette: cass
+          Cartridge: cart
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
   - name: crvision
     custom_features:
       softList:

--- a/package/batocera/emulators/xroar/xroar.emulator.yml
+++ b/package/batocera/emulators/xroar/xroar.emulator.yml
@@ -46,5 +46,34 @@ custom_features:
     choices:
       Enabled: True
       Disabled: False
+  xroar_tv_type:
+    prompt: TV Type
+    description: Select the TV standard for video output.
+    choices:
+      PAL: pal
+      NTSC: ntsc
+      PAL-M: pal-m
+  xroar_tv_input:
+    prompt: TV Input
+    description: Select the video signal type.
+    choices:
+      Composite (Colour): svideo
+      Composite (Mono): mono
+      RGB: rgb
+  xroar_kbd_translate:
+    prompt: Keyboard Translation
+    description: Enable host keyboard translation to map typed characters to the emulated machine.
+    choices:
+      Enabled: True
+      Disabled: False
 systems:
   - coco
+  - dragon64
+  - name: mc10
+    custom_features:
+      xroar_ram:
+        prompt: RAM Size
+        description: Select the amount of RAM. MC-10 has 4K by default, expandable to 20K with a 16K expansion module.
+        choices:
+          4K: 4
+          20K: 20


### PR DESCRIPTION
Add Dragon 64 and Tandy MC-10 as new systems with MAME, libretro MAME, and XRoar emulator support.

## Dragon 64
British home computer (1983) by Dragon Data, compatible with Tandy CoCo.
- MAME driver support (dragon32, dragon64, dgnalpha)
- XRoar emulator integration with default machine `dragon64`
- Software list support (cassettes, cartridges, disk images)
- Model selection (Dragon 32, 64, Alpha)
- Media type detection (.cas → cassette, .dsk → floppy, else → cartridge)
- Autoload support (same as CoCo)
- BIOS definitions (dragon64.zip, dragon32.zip)

## Tandy MC-10
Tandy Radio Shack Micro Color Computer (1983).
- MAME driver support (mc10, alice)
- XRoar emulator integration with default machine `mc10`
- Software list support (mc10_cass)
- Model selection (Tandy MC-10, Matra & Hachette Alice)
- Media type detection (.cas → cassette, else → cartridge)
- Autoload support (software list lookup, CLOAD for cassettes)
- BIOS definitions (mc10.zip, alice.zip)

## XRoar enhancements (all systems: coco, dragon64, mc10)
- Fix default machine selection per system
- New options: RAM size, TV type, TV input, keyboard translation