### PR TITLE
Use standard 125 Hz mouse polling interval on rpi platforms

### DIFF
--- a/board/batocera/broadcom/bcm2711/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2711/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap usbcore.autosuspend=-1 usbhid.mousepoll=8

--- a/board/batocera/broadcom/bcm2712/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2712/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap usbcore.autosuspend=-1 usbhid.mousepoll=8

--- a/board/batocera/broadcom/bcm2835/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2835/boot/cmdline.txt
@@ -1,1 +1,1 @@
-snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap usbcore.autosuspend=-1 usbhid.mousepoll=8

--- a/board/batocera/broadcom/bcm2836/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2836/boot/cmdline.txt
@@ -1,1 +1,1 @@
-snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+snd_bcm2835.enable_headphones=1 console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap usbcore.autosuspend=-1 usbhid.mousepoll=8

--- a/board/batocera/broadcom/bcm2837/boot/cmdline.txt
+++ b/board/batocera/broadcom/bcm2837/boot/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap
+console=tty3 loglevel=3 vt.global_cursor_default=0 logo.nologo dev=LABEL=BATOCERA rootwait fastboot noswap usbcore.autosuspend=-1 usbhid.mousepoll=8


### PR DESCRIPTION
By default, the combination of 1000 Hz mouse polling + high DPI mice can easily overflow and wrap-around the cursor on Pi systems, resulting in very slow movement.

This can be seen when opening the file manager (F1) in sway in v42 or the latest Feb 05, 2026 butterfly on the Pi 4: the mouse cursor will move extremely slow.

This is also seen in DOSBox Staging and DOSBox X (mouse events are fed in via SDL2), where mouse movements are also extremely slow, to the point where mouse games in DOS are effectively unplayable on pi systems.

This PR uses a 125 Hz polling rate, which is 1.78 polls-per-frame for 70 Hz games and more than two polls-per-frame on <= 60 Hz systems. Also, it was common for PS/2 to poll at 100 Hz while later USB 1.0 and 2.0 mice polled at 125 Hz by default on Windows 9x, 2000, and XP. 

Tested on the Pi 3 and Pi 4; maybe the pi 5 can be set to 250 Hz (value 4 instead of 8).

This PR also defaults to not suspending USB devices to prevent periodic delays if the device falls asleep. Of course, user-space can still turn this back on or selectively per device.

You can test this easily enough on a Pi systems by plugging in a typical gaming (high-ish DPI mouse) and pressing F1 to open the file manager. The mouse should move quite slow, but with this PR the mouse should behave normally.