### PR TITLE
Add cheats setting for mupen64plus allowing cheat index to be passed

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/mupen/mupenGenerator.py
@@ -47,6 +47,10 @@ class MupenGenerator(Generator):
         if state_filename := system.config.get('state_filename'):
             commandArray.extend(["--savestate", state_filename])
 
+        # custom cheats option
+        if cheats := system.config.get_str('mupen64plus_cheats', '').strip():
+            commandArray.extend(["--cheats", cheats])
+
         commandArray.append(rom)
 
         return Command.Command(array=commandArray)

--- a/package/batocera/emulators/mupen64plus/mupen64plus-core/mupen64plus.emulator.yml
+++ b/package/batocera/emulators/mupen64plus/mupen64plus-core/mupen64plus.emulator.yml
@@ -113,6 +113,11 @@ custom_features:
       Game default: -1
       Disable: 0
       Enable: 1
+  mupen64plus_cheats:
+    group: ADVANCED OPTIONS
+    prompt: CHEATS
+    description: Pass custom cheats argument directly to mupen64plus using --cheats.
+    preset: input
   mupen64-controller1:
     submenu: CONTROLLER 1
     prompt: CONTROLLER TYPE


### PR DESCRIPTION
Add cheats setting for mupen64plus allowing cheat index to be passed through to emulator.