### PR TITLE
Add Sharp MZ-80K, MZ-700, MZ-800, MZ-2000 and MZ-2500 systems

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -410,6 +410,21 @@ msx2+:
 msxturbor:
   emulator: libretro
   core:     bluemsx
+mz2000:
+  emulator: libretro
+  core:     mame
+mz2500:
+  emulator: libretro
+  core:     mame
+mz700:
+  emulator: libretro
+  core:     mame
+mz800:
+  emulator: libretro
+  core:     mame
+mz80k:
+  emulator: libretro
+  core:     mame
 mugen:
   emulator: mugen
   core:     wine-tkg

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -26,6 +26,11 @@ laser310;laser310;dump;
 lcdgames;;;
 macintosh;maclc3;flop1;
 megaduck;megaduck;cart;
+mz2000;mz2000;cass;'L\n'
+mz2500;mz2500;flop1;
+mz700;mz700;cass;'L\n'
+mz800;mz800;cass;'L\n'
+mz80k;mz80k;cass;'L\n'
 oricatmos;orica;cass;
 pc60;pc6001;cart1;
 pdp1;pdp1;ptap1;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -662,6 +662,37 @@ systems = {
                                                 { "md5": "bf69d9538192f65571dbed43dc4a99bb", "zippedFile": "lynx128-2.ic2", "file": "bios/lynx128k.zip"},
                                                 { "md5": "f9f54913cdedb22bb8f0c549ad121379", "zippedFile": "lynx128-3.ic3", "file": "bios/lynx128k.zip"} ] },
 
+    # ---------- Sharp MZ-80K ---------- #
+    "mz80k":   { "name": "Sharp MZ-80K", "biosFiles":  [ { "md5": "", "file": "bios/mz80k.zip"  },
+                                                { "md5": "", "zippedFile": "80kcg.rom", "file": "bios/mz80k.zip"},
+                                                { "md5": "", "zippedFile": "80kcgf.rom", "file": "bios/mz80k.zip"},
+                                                { "md5": "", "file": "bios/mz80kj.zip"  },
+                                                { "md5": "", "zippedFile": "sp1002.rom", "file": "bios/mz80kj.zip"},
+                                                { "md5": "", "zippedFile": "mz80kfdif.rom", "file": "bios/mz80kj.zip"} ] },
+
+    # ---------- Sharp MZ-700 ---------- #
+    "mz700":   { "name": "Sharp MZ-700", "biosFiles":  [ { "md5": "", "file": "bios/mz700.zip"  },
+                                                { "md5": "", "zippedFile": "1z-013a.rom", "file": "bios/mz700.zip"},
+                                                { "md5": "", "zippedFile": "mz700fon.int", "file": "bios/mz700.zip"} ] },
+
+    # ---------- Sharp MZ-800 ---------- #
+    "mz800":   { "name": "Sharp MZ-800", "biosFiles":  [ { "md5": "", "file": "bios/mz800.zip"  },
+                                                { "md5": "", "zippedFile": "mz800.rom", "file": "bios/mz800.zip"} ] },
+
+    # ---------- Sharp MZ-2000 ---------- #
+    "mz2000":   { "name": "Sharp MZ-2000", "biosFiles":  [ { "md5": "", "file": "bios/mz2000.zip"  },
+                                                { "md5": "", "zippedFile": "mz20ipl.bin", "file": "bios/mz2000.zip"},
+                                                { "md5": "", "zippedFile": "font.bin", "file": "bios/mz2000.zip"} ] },
+
+    # ---------- Sharp MZ-2500 ---------- #
+    "mz2500":   { "name": "Sharp MZ-2500", "biosFiles":  [ { "md5": "", "file": "bios/mz2500.zip"  },
+                                                { "md5": "", "zippedFile": "ipl.rom", "file": "bios/mz2500.zip"},
+                                                { "md5": "", "zippedFile": "cg.rom", "file": "bios/mz2500.zip"},
+                                                { "md5": "", "zippedFile": "kanji.rom", "file": "bios/mz2500.zip"},
+                                                { "md5": "", "zippedFile": "kanji2.rom", "file": "bios/mz2500.zip"},
+                                                { "md5": "", "zippedFile": "dict.rom", "file": "bios/mz2500.zip"},
+                                                { "md5": "", "zippedFile": "phone.rom", "file": "bios/mz2500.zip"} ] },
+
     # ---------- Video Game Music Player ---------- #
     "vgmplay":   { "name": "Video Game Music Player", "biosFiles":  [ { "md5": "", "file": "bios/qsound.zip"  },
                                                 { "md5": "108b113a596e800a02fece73f784eeb0", "zippedFile": "dl-1425.bin", "file": "bios/qsound.zip"},

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -1854,7 +1854,82 @@ msxturbor:
     openmsx:
       openmsx: { requireAnyOf: [BR2_PACKAGE_OPENMSX] }
 
-odyssey2:
+mz2000:
+  name:       Sharp MZ-2000
+  manufacturer: Sharp
+  release: 1982
+  hardware: computer
+  extensions: [mzf, mzt, m12, wav, d88, dsk, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file mz2000.zip
+          Using software list mode is recommended.
+
+mz2500:
+  name:       Sharp MZ-2500
+  manufacturer: Sharp
+  release: 1985
+  hardware: computer
+  extensions: [d88, dsk, mfi, dfi, hfe, mfm, td0, imd, d77, 1dd, cqm, cqi, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file mz2500.zip
+          Using software list mode is recommended.
+
+mz700:
+  name:       Sharp MZ-700
+  manufacturer: Sharp
+  release: 1982
+  hardware: computer
+  extensions: [mzf, mzt, m12, wav, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file mz700.zip
+          Using software list mode is recommended.
+
+mz800:
+  name:       Sharp MZ-800
+  manufacturer: Sharp
+  release: 1984
+  hardware: computer
+  extensions: [mzf, mzt, m12, wav, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file mz800.zip
+          Using software list mode is recommended.
+
+mz80k:
+  name:       Sharp MZ-80K
+  manufacturer: Sharp
+  release: 1978
+  hardware: computer
+  extensions: [mzf, mzt, m12, wav, zip, 7z]
+  emulators:
+    libretro:
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+  comment_en: |
+          Requires MAME BIOS file mz80k.zip
+          Using software list mode is recommended.
+
+o2em:
   name:       Odyssey2
   manufacturer: Magnavox - Philips
   release: 1978

--- a/package/batocera/emulators/mame/mame.emulator.yml
+++ b/package/batocera/emulators/mame/mame.emulator.yml
@@ -797,6 +797,136 @@ systems:
         choices:
           "On": 1
           "Off": 0
+  - name: mz2000
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-2000 cassettes: mz2000_cass
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Cassette: cass
+          Disk (Drive 1): flop1
+          Disk (Drive 2): flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
+  - name: mz2500
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-2500 floppy disks: mz2500_flop
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Disk (Drive 1): flop1
+          Disk (Drive 2): flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
+  - name: mz700
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-700 cassettes: mz700_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
+  - name: mz800
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-800 cassettes: mz800_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
+  - name: mz80k
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-80K cassettes: mz80k_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          "On": 1
+          "Off": 0
   - name: macintosh
     custom_features:
       softList:

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
@@ -797,6 +797,136 @@ systems:
         choices:
           'On': 1
           'Off': 0
+  - name: mz2000
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-2000 cassettes: mz2000_cass
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Cassette: cass
+          Disk (Drive 1): flop1
+          Disk (Drive 2): flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mz2500
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-2500 floppy disks: mz2500_flop
+      altromtype:
+        group: ADVANCED OPTIONS
+        prompt: MEDIA TYPE
+        description: Type of ROM file to load.
+        choices:
+          Disk (Drive 1): flop1
+          Disk (Drive 2): flop2
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mz700
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-700 cassettes: mz700_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mz800
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-800 cassettes: mz800_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
+  - name: mz80k
+    custom_features:
+      softList:
+        group: ADVANCED OPTIONS
+        prompt: SOFTWARE LIST
+        description: Use MAME software lists to identify ROM
+        choices:
+          Don't Use (Default): none
+          Sharp MZ-80K cassettes: mz80k_cass
+      enableui:
+        group: ADVANCED OPTIONS
+        prompt: UI KEYS
+        description: Toggle with hotkey + D-pad up or Scroll Lock in-game.
+        choices:
+          Off at Start: 0
+          On at Start: 1
+      pergamecfg:
+        group: ADVANCED OPTIONS
+        prompt: CUSTOM GAME CONFIG
+        description: Enable per-game custom configuration via MAME menu.
+        choices:
+          'On': 1
+          'Off': 0
   - name: macintosh
     features:
       - padtokeyboard


### PR DESCRIPTION
Add five Sharp MZ computer systems emulated via MAME:
- MZ-80K (1978) - cassette based
- MZ-700 (1982) - cassette based
- MZ-800 (1984) - cassette based
- MZ-2000 (1982) - cassette and floppy
- MZ-2500 (1985) - floppy based