### PR TITLE
refactor(Makefile): add add-defconfig macro, deprecate `EXTRA_OPTS`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /dl
 /configs/batocera-*_defconfig
 /configs/batocera-board.local.common
+/configs/.user_defconfig
 /.auto.deps
 /.config.cmd
 /.config.old

--- a/batocera.mk.template
+++ b/batocera.mk.template
@@ -1,7 +1,6 @@
 # DL_DIR      :=
 # OUTPUT_DIR  :=
 # CCACHE_DIR  :=
-# EXTRA_OPTS  :=  BR2_PACKAGE_BATOCERA_DEV=y BR2_CCACHE_INITIAL_SETUP=\"--max-size=50G\" 
 # DOCKER_OPTS :=
 # DOCKER_REPO :=
 # IMAGE_NAME  :=
@@ -18,3 +17,6 @@
 
 # SERIAL_DEV      := /dev/tty.usbserial-14310
 # SERIAL_BAUDRATE := 115200
+
+# $(call add-defconfig,BR2_PACKAGE_BATOCERA_DEV=y)
+# $(call add-defconfig,BR2_CCACHE_INITIAL_SETUP="--max-size=50G")

--- a/configs/batocera-board.common
+++ b/configs/batocera-board.common
@@ -1,4 +1,4 @@
-include batocera-board.local.common
+-include batocera-board.local.common
 
 # users
 BR2_ROOTFS_USERS_TABLES="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/users.txt"

--- a/configs/createDefconfig.sh
+++ b/configs/createDefconfig.sh
@@ -1,48 +1,79 @@
-#!/bin/sh
+#!/bin/bash
 
-BNAME=$1
+set -euo pipefail
 
-FBOARD="${BNAME}.board"
+readonly board_file="$1"
+readonly user_defconfig_file="$2"
+readonly defconfig_file="$3"
 
-if ! test -e "${FBOARD}"
-then
-    echo "file ${FBOARD} not found" >&2
+if [[ ! -e "${board_file}" ]]; then
+    echo "file ${board_file} not found" >&2
     exit 1
 fi
 
-TMPL0="${BNAME}_defconfig.tmpl0"
-TMPL1="${BNAME}_defconfig.tmpl1"
-CONFDIR=$(dirname "${FBOARD}")
-FDEFCONFIG="${BNAME}_defconfig"
+if [[ ! -e "${user_defconfig_file}" ]]; then
+    echo "file ${user_defconfig_file} not found" >&2
+    exit 1
+fi
 
-> "${TMPL0}" || exit 1 # level 0
-> "${TMPL1}" || exit 1 # level 1 (includes of includes)
+readonly config_dir="$(dirname "${board_file}")"
 
-# For untracked local changes
-touch -a "${CONFDIR}/batocera-board.local.common"
+readonly tmpl0="${defconfig_file}.tmpl0"
+readonly tmpl1="${defconfig_file}.tmpl1"
 
-grep -E 'include ' "${FBOARD}" | while read INC X
-do
-    echo "# from file ${X}" >> "${TMPL0}"
-    cat "${CONFDIR}/${X}"   >> "${TMPL0}"
-    echo                    >> "${TMPL0}"
-done
+cleanup() {
+    rm -f "${tmpl0}" "${tmpl1}"
+}
+trap cleanup EXIT
 
-grep -E 'include ' "${TMPL0}" | while read INC X
-do
-    echo "# from file ${X}" >> "${TMPL1}"
-    cat "${CONFDIR}/${X}"   >> "${TMPL1}"
-    echo                    >> "${TMPL1}"
-done
+> "${tmpl0}"
+> "${tmpl1}"
 
-> "${FDEFCONFIG}" || exit 1
-grep -vE '^include ' "${TMPL1}" >> "${FDEFCONFIG}"
-grep -vE '^include ' "${TMPL0}" >> "${FDEFCONFIG}"
+# Include only if the file exists:
+# -include something.local
 
-rm -f "${TMPL1}" || exit 1
-rm -f "${TMPL0}" || exit 1
+# Include always:
+# include something.local
 
-echo "### from board file ###"   >> "${FDEFCONFIG}" || exit 1
-grep -vE '^include ' "${FBOARD}" >> "${FDEFCONFIG}" || exit 1
+include_file() {
+    local included_file="$1"
+    local outfile="$2"
 
-exit 0
+    echo "# from file ${included_file}"  >> "${outfile}"
+    cat "${config_dir}/${included_file}" >> "${outfile}"
+    echo                                 >> "${outfile}"
+}
+
+parse_includes() {
+    local infile="$1"
+    local outfile="$2"
+    local inc x
+
+    while read -r inc x; do
+        if [[ "${inc#-}" == "$inc" ]] && [[ ! -f "${config_dir}/${x}" ]]; then
+            echo "Error: included file ${x} not found (included from ${infile})" >&2
+            exit 1
+        fi
+
+        if [[ -f "${config_dir}/${x}" ]]; then
+            include_file "${x}" "${outfile}"
+        fi
+    done < <(grep -E '^-?include ' "${infile}")
+}
+
+parse_includes "${board_file}" "${tmpl0}"
+parse_includes "${tmpl0}" "${tmpl1}"
+
+strip_includes() {
+    grep -vE '^-?include ' "$1" || true
+}
+
+{
+    strip_includes "${tmpl1}"
+    strip_includes "${tmpl0}"
+    echo "### from board file ###"
+    strip_includes "${board_file}"
+    echo
+    echo "### from add-defconfig ###"
+    strip_includes "${user_defconfig_file}"
+} > "${defconfig_file}"


### PR DESCRIPTION
Introduce a new `add-defconfig` macro that writes configuration options to a dedicated user defconfig file at Make parse-time using $(file ...). This replaces the shell-based EXTRA_OPTS approach with a cleaner, more reliable mechanism that is not prone to shell escaping or expansion issues.

Changes:
- Add USER_DEFCONFIG file and add-defconfig macro in Makefile
- Refactor createDefconfig.sh to use explicit arguments and bash
- Support optional includes with `-include` syntax in board configs
- Deprecate EXTRA_OPTS with migration warning
- Update batocera.mk.template with new syntax examples