### PR TITLE
mime: add ISO files

### DIFF
--- a/package/batocera/core/batocera-desktopapps/mime/defaults.list
+++ b/package/batocera/core/batocera-desktopapps/mime/defaults.list
@@ -1,8 +1,9 @@
 [Default Applications]
-text/plain=l3afpad.desktop
-application/zip=file-roller-mimics.desktop
-application/vnd.rar=file-roller-mimics.desktop
-application/x-7z-compressed=file-roller-mimics.desktop
-application/x-cd-image=file-roller-mimics.desktop
-application/x-tar=file-roller-mimics.desktop
-application/gzip=file-roller-mimics.desktop
+text/plain                    =l3afpad.desktop
+application/zip               =file-roller-mimics.desktop
+application/vnd.rar           =file-roller-mimics.desktop
+application/x-7z-compressed   =file-roller-mimics.desktop
+application/x-cd-image        =file-roller-mimics.desktop
+application/x-sega-cd-rom     =file-roller-mimics.desktop
+application/x-tar             =file-roller-mimics.desktop
+application/gzip              =file-roller-mimics.desktop


### PR DESCRIPTION
ISO files can be opened by file-roller (aka batocera-xtract) and can be opened by file explorer
1. x-cd-image
2. x-sega-cd-rom

aligned mimetype-list for better mantainment