### PR TITLE
libretro : dosboxpure : add dosbox_pure_bootos_ramdisk option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -814,6 +814,8 @@ def _dosbox_pure_options(
     # Midi Type
     _set_from_system(coreSettings, 'dosbox_pure_midi', system, 'pure_midi', default='disabled')
 
+    # OS Disk Modifications
+    _set_from_system(coreSettings, 'dosbox_pure_bootos_ramdisk', system, 'pure_bootos_ramdisk', default='false')
 
 # Microsoft MSX and Colecovision
 def _bluemsx_options(

--- a/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/dosbox_pure.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dosbox-pure/dosbox_pure.libretro.core.yml
@@ -92,6 +92,13 @@ custom_features:
       Switzerland (German): sg
       Switzerland (French): sf
       Turkey: tr
+  pure_bootos_ramdisk:
+    prompt: OS DISK MODIFICATIONS
+    description: OS Disk Modifications
+    choices:
+      Keep (default): "false"
+      Discard: "true"
+      Save Difference Per Content: diff
   pure_savestate:
     prompt: SAVESTATE/REWIND
     description: Rewind can be CPU heavy.


### PR DESCRIPTION
This option if really usefull for windows95/98,
allowing to create an write overlay save file for C: for each game, and keep it or discard it.

Usefull to avoid .reg conflict between games, or to add a different game autostart in windows startup menu.

And avoid to modify the original windows image from bios directory