### PR TITLE
refactor(configgen): evmapy controller monitor and hotkeygen mouse reset

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/hotkeygen.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/hotkeygen.py
@@ -3,52 +3,70 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from contextlib import contextmanager
-from typing import TYPE_CHECKING
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Self
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from types import TracebackType
 
     from ..Emulator import Emulator
     from ..generators.Generator import Generator
 
 _logger = logging.getLogger(__name__)
 
-@contextmanager
-def set_hotkeygen_context(generator: Generator, system: Emulator, /) -> Iterator[None]:
-    # hotkeygen context
-    hkc = generator.getHotkeysContext()
+@dataclass(slots=True)
+class HotkeygenManager(AbstractContextManager['HotkeygenManager', None]):
+    generator: Generator
+    system: Emulator
 
-    exit_hotkey_only = system.config.get_bool("exithotkeyonly")
+    def __enter__(self) -> Self:
+        # hotkeygen context
+        hkc = self.generator.getHotkeysContext()
 
-    # limit hotkeys
-    # there is an option to disable all hotkeys but exit in case the player 1 is a pad with not hotkey specific button
-    if exit_hotkey_only:
-        if "exit" in hkc["keys"]:
-            hkc["keys"] = { "exit": hkc["keys"]["exit"] }
-        else:
-            # should not happen while exit should always be there
-            hkc["keys"] = {}
+        exit_hotkey_only = self.system.config.get_bool("exithotkeyonly")
 
-    # if uimod is not full (aka kiosk or children mode), remove the menu action
-    if system.config.ui_mode != "Full" and "menu" in hkc["keys"]:
-        del hkc["keys"]["menu"]
+        # limit hotkeys
+        # there is an option to disable all hotkeys but exit in case the player 1 is a pad with not hotkey specific button
+        if exit_hotkey_only:
+            if "exit" in hkc["keys"]:
+                hkc["keys"] = { "exit": hkc["keys"]["exit"] }
+            else:
+                # should not happen while exit should always be there
+                hkc["keys"] = {}
 
-    _logger.debug("hotkeygen: updating context to %s", hkc["name"])
+        # if uimod is not full (aka kiosk or children mode), remove the menu action
+        if self.system.config.ui_mode != "Full" and "menu" in hkc["keys"]:
+            del hkc["keys"]["menu"]
 
-    cmd = ["hotkeygen", "--new-context", hkc["name"], json.dumps(hkc["keys"])]
+        _logger.debug("hotkeygen: updating context to %s", hkc["name"])
 
-    if exit_hotkey_only:
-        cmd.append("--disable-common")
+        cmd = ["hotkeygen", "--new-context", hkc["name"], json.dumps(hkc["keys"])]
 
-    subprocess.call(cmd)
+        if exit_hotkey_only:
+            cmd.append("--disable-common")
 
-    try:
-        yield
-    finally:
+        subprocess.call(cmd)
+
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> None:
         # reset hotkeygen context
         _logger.debug("hotkeygen: resetting to default context")
         subprocess.call(["hotkeygen", "--default-context"])
+
+    def reset_mouse(self) -> None:
+        try:
+            _logger.debug("Triggering mouse reset to primary display")
+            subprocess.call(["/usr/bin/hotkeygen", "--reset-mouse"])
+        except Exception as e:
+            _logger.warning("Failed to reset mouse: %s", e)
 
 def get_hotkeygen_event() -> str | None:
     import evdev


### PR DESCRIPTION
Move controller monitoring logic from emulatorlauncher.py into evmapy module as a _ControllerMonitor dataclass, encapsulating thread management, SDL2/pyudev usage, and controller state tracking. The evmapy context manager now returns self and exposes start_monitoring_controllers() for deferred thread startup.

Convert hotkeygen's set_hotkeygen_context() generator function into a HotkeygenManager dataclass-based context manager, and move the mouse reset logic into it as reset_mouse().

Remove global mutable state (_active_player_controllers, _evmapy_instance, _player_controllers_lock) and the standalone _controller_monitor_thread/_reconfigure_evmapy_on_the_fly functions from emulatorlauncher.py.