### PR TITLE
fix fs-uae inputs

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/fsuae/fsuaeGenerator.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ... import Command
+from ...controller import generate_sdl_game_controller_config
 from ..Generator import Generator
 from . import fsuaeControllers
 from .fsuaePaths import FSUAE_BIOS_DIR, FSUAE_CONFIG_DIR, FSUAE_SAVES
@@ -108,4 +109,9 @@ class FsuaeGenerator(Generator):
         for n, pad in enumerate(playersControllers[:4]):
             commandArray.append(f"--joystick_port_{n}={pad.real_name}")
 
-        return Command.Command(array=commandArray)
+        # SDL GameController mappings for virtual mouse (right stick + R3 click)
+        env = {
+            "SDL_GAMECONTROLLERCONFIG": generate_sdl_game_controller_config(playersControllers)
+        }
+
+        return Command.Command(array=commandArray, env=env)

--- a/package/batocera/emulators/fsuae/006-virtual-mouse-rightstick.patch
+++ b/package/batocera/emulators/fsuae/006-virtual-mouse-rightstick.patch
@@ -1,0 +1,96 @@
+--- a/libfsemu/src/ml/input.c
++++ b/libfsemu/src/ml/input.c
+@@ -203,7 +203,7 @@
+ {
+     FS_ML_INIT_ONCE;
+ 
+-    SDL_Init(SDL_INIT_JOYSTICK);
++    SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
+ 
+     fs_log("[INPUT] fs_ml_input_init\n");
+ 
+@@ -336,6 +336,15 @@
+         }
+ 
+         g_fs_ml_sdl_joystick_index_map[instance_id] = k;
++
++        if (SDL_IsGameController(i)) {
++            SDL_GameController *gc = SDL_GameControllerOpen(i);
++            if (gc) {
++                fs_log("[INPUT] Device #%d opened as GameController: %s\n",
++                       i, SDL_GameControllerName(gc));
++            }
++        }
++
+         k += 1;
+     }
+ 
+--- a/libfsemu/src/ml/sdl.c
++++ b/libfsemu/src/ml/sdl.c
+@@ -886,6 +886,32 @@
+     g_fs_ml_video_height = height;
+ }
+ 
++static int g_virtual_mouse_rx = 0;
++static int g_virtual_mouse_ry = 0;
++#define VIRTUAL_MOUSE_DEADZONE 8000
++#define VIRTUAL_MOUSE_SPEED 10.0f
++
++static void process_virtual_mouse(void)
++{
++    int xrel = 0, yrel = 0;
++    if (abs(g_virtual_mouse_rx) > VIRTUAL_MOUSE_DEADZONE) {
++        xrel = (int)((float)g_virtual_mouse_rx / 32767.0f * VIRTUAL_MOUSE_SPEED);
++    }
++    if (abs(g_virtual_mouse_ry) > VIRTUAL_MOUSE_DEADZONE) {
++        yrel = (int)((float)g_virtual_mouse_ry / 32767.0f * VIRTUAL_MOUSE_SPEED);
++    }
++    if (xrel != 0 || yrel != 0) {
++        fs_ml_event *me = fs_ml_alloc_event();
++        me->type = FS_ML_MOUSEMOTION;
++        me->motion.device = g_fs_ml_first_mouse_index;
++        me->motion.xrel = xrel;
++        me->motion.yrel = yrel;
++        me->motion.x = FS_ML_NO_ABSOLUTE_MOUSE_POS;
++        me->motion.y = FS_ML_NO_ABSOLUTE_MOUSE_POS;
++        fs_ml_post_event(me);
++    }
++}
++
+ int fs_ml_event_loop(void)
+ {
+     // printf("fs_ml_event_loop\n");
+@@ -1034,6 +1060,25 @@
+             new_event->key.keysym.mod = event.key.keysym.mod;
+             new_event->key.state = event.key.state;
+         }
++        else if (event.type == SDL_CONTROLLERAXISMOTION) {
++            if (event.caxis.axis == SDL_CONTROLLER_AXIS_RIGHTX) {
++                g_virtual_mouse_rx = event.caxis.value;
++            } else if (event.caxis.axis == SDL_CONTROLLER_AXIS_RIGHTY) {
++                g_virtual_mouse_ry = event.caxis.value;
++            }
++        }
++        else if (event.type == SDL_CONTROLLERBUTTONDOWN ||
++                 event.type == SDL_CONTROLLERBUTTONUP) {
++            if (event.cbutton.button == SDL_CONTROLLER_BUTTON_RIGHTSTICK) {
++                int pressed = (event.type == SDL_CONTROLLERBUTTONDOWN);
++                new_event = fs_ml_alloc_event();
++                new_event->type = pressed ? FS_ML_MOUSEBUTTONDOWN
++                                          : FS_ML_MOUSEBUTTONUP;
++                new_event->button.device = g_fs_ml_first_mouse_index;
++                new_event->button.button = FS_ML_BUTTON_LEFT;
++                new_event->button.state = pressed;
++            }
++        }
+         else if (event.type == SDL_JOYBUTTONDOWN) {
+             if (g_fs_log_input) {
+                 fs_log("SDL_JOYBUTTONDOWN which %d button %d state %d\n",
+@@ -1171,6 +1216,7 @@
+             fs_ml_post_event(new_event);
+         }
+     }
++    process_virtual_mouse();
+     return result;
+ }
+ 

--- a/package/batocera/emulators/fsuae/fsuae.mk
+++ b/package/batocera/emulators/fsuae/fsuae.mk
@@ -29,7 +29,12 @@ define FSUAE_INSTALL_EVMAPY
 	        $(TARGET_DIR)/usr/share/evmapy/
 endef
 
-FSUAE_POST_INSTALL_TARGET_HOOKS = FSUAE_INSTALL_EVMAPY
+define FSUAE_INSTALL_INPUT_DATA
+	mkdir -p $(TARGET_DIR)/usr/share/fs-uae/input
+	cp -r $(@D)/share/fs-uae/input/* $(TARGET_DIR)/usr/share/fs-uae/input/
+endef
+
+FSUAE_POST_INSTALL_TARGET_HOOKS += FSUAE_INSTALL_EVMAPY FSUAE_INSTALL_INPUT_DATA
 
 $(eval $(autotools-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
Input controls in fs-uae are a broken fest. This PR will:

- Install `share/fs-uae/input/` to target (required for .conf files)
- Fix .conf filename from `{guid}_linux.conf` to `{guid}.conf` (game controls)
- Write a second .conf with the long device name for menu support (overlay/menu controls)
- Pass `SDL_GAMECONTROLLERCONFIG` env var (standardize the controls across all controllers, with ES)
- Add virtual mouse patch (right stick + R3 click)