### PR TITLE
Fix: Volume buttons not working in games

### DIFF
--- a/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
+++ b/package/batocera/core/batocera-triggerhappy/conf/multimedia_keys.conf
@@ -5,3 +5,5 @@ KEY_F2          1               LANG=en_US HOME=/userdata/system XAUTHORITY=/var
 KEY_F10+KEY_LEFTCTRL+KEY_LEFTALT 1 /etc/init.d/S31emulationstation stop
 KEY_F11+KEY_LEFTCTRL+KEY_LEFTALT 1 chvt 1
 KEY_LEFTMETA    1               batocera-brightness cycle
+KEY_VOLUMEUP    1   			batocera-audio setSystemVolume +5
+KEY_VOLUMEDOWN  1    			batocera-audio setSystemVolume -5

--- a/package/batocera/utils/hotkeygen/conf/common_context.conf
+++ b/package/batocera/utils/hotkeygen/conf/common_context.conf
@@ -1,7 +1,5 @@
 {
   "screenshot":       "batocera-screenshot",
-  "volumeup":         "batocera-audio setSystemVolume +5",
-  "volumedown":       "batocera-audio setSystemVolume -5",
   "volumemute":       "batocera-audio setSystemVolume mute-toggle",
   "brightness-cycle": "batocera-brightness cycle",
   "bezels":           [ "KEY_RIGHTSHIFT", "KEY_UNDO" ],


### PR DESCRIPTION
**Problem:**
Volume buttons (VOL+/VOL-) only work in EmulationStation menu, not during gameplay.

**Root cause:**
- hotkeygen handles volume but only in ES context
- Volume events not propagated to running emulators

**Solution:**
- Move volume handling from hotkeygen to triggerhappy
- triggerhappy runs globally, works everywhere (ES + in-game)

**Tested on:** Retroid Pocket 5

**Changes:**
- Removed volume* keys from hotkeygen/common_context.conf
- Added KEY_VOLUMEUP/DOWN to triggerhappy/multimedia_keys.conf