### PR TITLE
add: batocera-version some more flags

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-version
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-version
@@ -1,13 +1,27 @@
-#!/bin/bash
+#!/bin/sh
 
-FIND_EXT=$(find /userdata/system -maxdepth 1 -name "extension_*.tar.gz" | head -1)
+## Symbol Matrix
+## According: https://wiki.batocera.org/launch_a_script
+## b    = user setted some boot scripts
+## u{n} = a userservices is active, n shows number of activated services
+## g    = ES user scripts found in $HOME/configs/emulationstations/scripts
+## c2   = custom_service and custom.sh found
+## cu1  = indicating custom_service is active
+## v    = executables found in $HOME/scripts
+
+FIND_EXT=
+FIND_EXT=$(find -L /userdata/system -maxdepth 1 -name "extension_*.tar.gz" -print -quit)
 
 FIND_OVERLAY=
 test -e "/boot/boot/overlay" && FIND_OVERLAY=1
 
+# rather used to check autoconvertion and if users added annother custom.sh 
 FIND_CUSTOMSH=
-test -e "/userdata/system/custom.sh" && FIND_CUSTOMSH=1
-test -e "/userdata/system/services/custom_service" && FIND_CUSTOMSH=1
+test -e "/userdata/system/services/custom_service" && FIND_CUSTOMSH=false
+test -e "/userdata/system/custom.sh"               && FIND_CUSTOMSH=true
+
+FIND_BOOTCUSTOM=
+test -e "/boot/boot-custom.sh" || test -e "/boot/postshare.sh" && FIND_BOOTCUSTOM=1
 
 FIND_CUSTOMESSYSTEMS=
 test -e "/userdata/system/configs/emulationstation/es_systems.cfg" && FIND_CUSTOMESSYSTEMS=1
@@ -15,9 +29,17 @@ test -e "/userdata/system/configs/emulationstation/es_systems.cfg" && FIND_CUSTO
 FIND_CUSTOMESFEATURES=
 test -e "/userdata/system/configs/emulationstation/es_features.cfg" && FIND_CUSTOMESFEATURES=1
 
-FIND_CUSTOMSERVICES=$(batocera-services list user | grep -v "custom_service" | grep '\*$' | head -1)
+# batocera-services user-service;* active, user-service;- inactive
+# echo 0, will only display active services, change to -1 so u0 indicates non active services
+FIND_USERSERVICES=
+FIND_USERSERVICES=$({ batocera-services count user 2>/dev/null || echo 0; } |  awk '{print $NF}')
+test ${FIND_USERSERVICES} -eq 0 && FIND_USERSERVICES=
 
-FIND_USERSCRIPTS=$(find /userdata/system/scripts -type f -executable -print -quit 2>/dev/null)
+FIND_USERSCRIPTS=
+FIND_USERSCRIPTS=$(find -L /userdata/system/scripts -type f -executable -print -quit 2>/dev/null)
+
+FIND_ESGUISCRIPTS=
+FIND_ESGUISCRIPTS=$(find -L /userdata/system/configs/emulationstation/scripts -type f -executable -print -quit 2>/dev/null)
 
 FIND_PRO=
 test -e "/userdata/system/pro" && FIND_PRO=1
@@ -26,24 +48,22 @@ FIND_ADDONS=
 test -e "/userdata/system/add-ons" && FIND_ADDONS=1
 
 EXTRA=
-test -n "${FIND_ADDONS}"           && EXTRA=${EXTRA}a
-test -n "${FIND_CUSTOMSH}"         && EXTRA=${EXTRA}c
-test -n "${FIND_EXT}"              && EXTRA=${EXTRA}e
-test -n "${FIND_CUSTOMESFEATURES}" && EXTRA=${EXTRA}f
-test -n "${FIND_OVERLAY}"          && EXTRA=${EXTRA}o
-test -n "${FIND_PRO}"              && EXTRA=${EXTRA}p
+test -n "${FIND_ADDONS}"           && EXTRA=${EXTRA}A
+test -n "${FIND_BOOTCUSTOM}"       && EXTRA=${EXTRA}b
+test -n "${FIND_CUSTOMSH}"         && EXTRA=${EXTRA}c && if "${FIND_CUSTOMSH}"; then EXTRA=${EXTRA}2; fi
+test -n "${FIND_EXT}"              && EXTRA=${EXTRA}E
+test -n "${FIND_CUSTOMESFEATURES}" && EXTRA=${EXTRA}F
+test -n "${FIND_ESGUISCRIPTS}"     && EXTRA=${EXTRA}g
+test -n "${FIND_OVERLAY}"          && EXTRA=${EXTRA}O
+test -n "${FIND_PRO}"              && EXTRA=${EXTRA}P
 test -n "${FIND_CUSTOMESSYSTEMS}"  && EXTRA=${EXTRA}s
-test -n "${FIND_CUSTOMSERVICES}"   && EXTRA=${EXTRA}u
+test -n "${FIND_USERSERVICES}"     && EXTRA=${EXTRA}u${FIND_USERSERVICES}
 test -n "${FIND_USERSCRIPTS}"      && EXTRA=${EXTRA}v
 
-if test "${1}" = "--extra"
-then
-    if test -z "${EXTRA}"
-    then
-	echo "none"
-    else
-	echo "${EXTRA}"
-    fi
+if test "${1}" = "--extra"; then
+  test -n "${EXTRA}" && echo "${EXTRA}" || echo "none"
 else
-    cat /usr/share/batocera/batocera.version | sed -e s+"^\([0-9]*\)"+"\1${EXTRA}"+
+  # use as many dots and digits for version number
+  cat /usr/share/batocera/batocera.version | sed -e s+"^\([0-9.]*\)"+"\1${EXTRA}"+
 fi
+


### PR DESCRIPTION
Use bare shell now

- b for boot scripts
- g for ES user scripts
- v for user scripts before after launch
- u{n} user services are detected if active (or inactive see script remark, this will result in u0)

all tested in ES GUI, terminal and LOG-View
This will help to hunt down some more bugs and user changes

**examples**
```
User scripts set but all inactive
43-dev-e41da59a3b 2026/02/09 11:09

One active user scripts found and executables in HOME/scripts
43u1v-dev-e41da59a3b 2026/02/09 11:09

custom_service active and additional user service
43cu2-dev-e41da59a3b 2026/02/09 11:09
```

Edit also fixes v43.1 bug as shown here

<img width="4032" height="2268" alt="20260531_112314" src="https://github.com/user-attachments/assets/1ed7717d-bedf-40ae-a828-2b4b562ab5eb" />
