### PR TITLE
add: more systems to m3u-playlist

### DIFF
--- a/package/batocera/core/batocera-desktopapps/contextactions/multidisc.toolbox.m3ufromdir.desktop
+++ b/package/batocera/core/batocera-desktopapps/contextactions/multidisc.toolbox.m3ufromdir.desktop
@@ -7,10 +7,10 @@ Name=Create m3u from Directory
 # /userdata/roms/windows will crash pcmanfm
 Folders=/userdata/roms*;
 # Add more systems to Basenames to activate script for context menu
-Basenames=psx;segacd;saturn;dreamcast
+Basenames=psx;segacd;saturn;dreamcast;megacd;gamecube;ps2;fmtowns;pcenginecd;
 Profiles=Batocera
 SelectionCount==1
 
 [X-Action-Profile Batocera]
 MimeTypes=inode/directory
-Exec=bash -c '/usr/share/file-manager/actions/toolbox/multidisc.toolbox %f | yad --text-info --wrap'
+Exec=bash -c '/usr/share/file-manager/actions/toolbox/multidisc.toolbox %f | yad --text-info --wrap --button=Close:0'

--- a/package/batocera/core/batocera-desktopapps/toolbox/multidisc.toolbox
+++ b/package/batocera/core/batocera-desktopapps/toolbox/multidisc.toolbox
@@ -36,7 +36,7 @@ def find_multi_cd_games(root_dir):
     for root, dirs, files in os.walk(root_dir):
         for file in files:
             # Check game file extensions
-            if file.lower().endswith(('.iso', '.chd', '.cue', '.img', '.bin')):
+            if file.lower().endswith(('.iso', '.chd', '.cue', '.img', '.rvz', '.bin')):
                 # Remove file extension for pattern matching
                 filename_no_ext = os.path.splitext(file)[0]
                 match = cd_pattern.search(filename_no_ext)


### PR DESCRIPTION
- psx;segacd;saturn;dreamcast;megacd;gamecube;ps2;fmtowns;pcenginecd; supported
-rvz as file extension allowed

per demand on discord Dubaishark & Sir_SwampThing