### PR TITLE
fix(luajit): support building on aarch64 hosts

### DIFF
--- a/package/batocera/libraries/batocera-luajit/Config.in
+++ b/package/batocera/libraries/batocera-luajit/Config.in
@@ -20,7 +20,7 @@ config BR2_PACKAGE_BATOCERA_LUAJIT
 	# luajit.mk uses the "-m32" compiler option to build 32bit
 	# binaries, so check if that option is supported. See
 	# luajit.mk for details.
-	select BR2_HOSTARCH_NEEDS_IA32_COMPILER if !BR2_ARCH_IS_64
+	select BR2_HOSTARCH_NEEDS_IA32_COMPILER if !BR2_ARCH_IS_64 && BR2_HOSTARCH != "aarch64"
 	help
 	  LuaJIT implements the full set of language features defined
 	  by Lua 5.1. The virtual machine (VM) is API- and


### PR DESCRIPTION
LuaJIT requires its host tools (minilua, buildvm) to match the target's bitness. On x86_64 hosts this is solved with gcc -m32, but aarch64 has no equivalent flag.

Use Buildroot's own cross-compiler (TARGET_CC) to build the host tools as static arm32 binaries, which run natively on aarch64 via the kernel's 32-bit compat mode (CONFIG_COMPAT). Also use TARGET_CFLAGS/TARGET_LDFLAGS for the host tools on aarch64, since HOST_CFLAGS/HOST_LDFLAGS contain aarch64-specific include/library paths that are wrong for arm32.

Skip selecting BR2_HOSTARCH_NEEDS_IA32_COMPILER on aarch64 since the IA32 multilib check is not applicable.