### PR TITLE
Fix ECWolf build by updating URL to GitHub

### DIFF
--- a/package/batocera/ports/ecwolf/ecwolf.mk
+++ b/package/batocera/ports/ecwolf/ecwolf.mk
@@ -4,8 +4,9 @@
 #
 ################################################################################
 # Version: 2024-05-20
-ECWOLF_VERSION = d1de69a576d4bb39e89124185a6dfd6991202cb9
-ECWOLF_SITE = https://bitbucket.org/ecwolf/ecwolf.git
+# temporary fix, change ECWOLF_SITE to https://github.com/ECWolfEngine/ECWolf when upgrade version to a newer one
+ECWOLF_VERSION = b5732a685b660df98ab2d9914b3ce9eeac9b95c9
+ECWOLF_SITE = https://github.com/victorgawk/ECWolf.git
 ECWOLF_SITE_METHOD=git
 ECWOLF_GIT_SUBMODULES=YES
 ECWOLF_LICENSE = Non-commercial

--- a/package/batocera/ports/ecwolf/ecwolf.mk
+++ b/package/batocera/ports/ecwolf/ecwolf.mk
@@ -5,7 +5,7 @@
 ################################################################################
 # Version: 2024-05-20
 # temporary fix, change ECWOLF_SITE to https://github.com/ECWolfEngine/ECWolf when upgrade version to a newer one
-ECWOLF_VERSION = b5732a685b660df98ab2d9914b3ce9eeac9b95c9
+ECWOLF_VERSION = 80d8645f0a271e135d25c5b184e07df736ea5e9b
 ECWOLF_SITE = https://github.com/victorgawk/ECWolf.git
 ECWOLF_SITE_METHOD=git
 ECWOLF_GIT_SUBMODULES=YES


### PR DESCRIPTION
ECWolf repository has been moved from BitBucket to GitHub.

This PR fix ECWolf build by updating its URL to GitHub while keeping the same version (SHA1 commit `d1de69a576d4bb39e89124185a6dfd6991202cb9`).

OBS: since `.patch` file only takes effect after repository and their submodules are loaded, I had to fork ECWolf myself and fix the submodules URL so it will build properly.