### PR TITLE
fix melonds package variable

### DIFF
--- a/package/batocera/core/batocera-desktopapps/batocera-desktopapps.mk
+++ b/package/batocera/core/batocera-desktopapps/batocera-desktopapps.mk
@@ -142,7 +142,7 @@ ifeq ($(BR2_PACKAGE_DEMUL),y)
 endif
 
 # melonds
-ifeq ($(BR2_PACKAGE_DEMUL),y)
+ifeq ($(BR2_PACKAGE_MELONDS),y)
   BATOCERA_DESKTOPAPPS_SCRIPTS += batocera-config-melonds
   BATOCERA_DESKTOPAPPS_APPS    += melonds-config.desktop
   BATOCERA_DESKTOPAPPS_ICONS   += melonds.png


### PR DESCRIPTION
Corrected the condition from BR2_PACKAGE_DEMUL to BR2_PACKAGE_MELONDS, ensuring the config script, desktop file, and icon are properly included in the build.