### PR TITLE
add-azahar-screen-proportion

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/azahar/azaharGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/azahar/azaharGenerator.py
@@ -96,6 +96,8 @@ class AzaharGenerator(Generator):
         azaharConfig.set("Layout", r"swap_screen\default", "false")
         azaharConfig.set("Layout", "layout_option", layout_option)
         azaharConfig.set("Layout", r"layout_option\default", "false")
+        azaharConfig.set("Layout", "large_screen_proportion", system.config.get("azahar_large_screen_proportion", "4"))
+        azaharConfig.set("Layout", r"large_screen_proportion\default", "false")
 
         ## [SYSTEM]
         if not azaharConfig.has_section("System"):

--- a/package/batocera/emulators/azahar/azahar.emulator.yml
+++ b/package/batocera/emulators/azahar/azahar.emulator.yml
@@ -24,6 +24,15 @@ custom_features:
       Separate Windows: 4-false
       Hybrid Screen Top: 5-false
       Hybrid Screen Bottom: 5-true
+  azahar_large_screen_proportion:
+      prompt: SCREEN PROPORTION
+      description: Determines the proportion of the larger screen relative to the smaller one.
+      choices:
+        "2":            2
+        "3":            3
+        "4 (Default)":  4
+        "5":            5
+        "6":            6
   azahar_resolution_factor:
     submenu: GRAPHICS
     prompt: RENDERING RESOLUTION


### PR DESCRIPTION
Exposes the azahar screen proportion setting in ES.

Determines the larger screen size relative to the smaller one. Default value is 4.