### PR TITLE
systems: revert loopy -> casloopy

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -122,6 +122,9 @@ catacomb:
 cannonball:
   emulator: cannonball
   core:     cannonball
+casloopy:
+  emulator: libretro
+  core:     mame
 cave3rd:
   emulator: libretro
   core:     mame
@@ -342,9 +345,6 @@ lcdgames:
 lindbergh:
   emulator: lindbergh-loader
   core:     lindbergh-loader
-loopy:
-  emulator: libretro
-  core:     mame
 lowresnx:
   emulator: libretro
   core:     lowresnx

--- a/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
+++ b/package/batocera/core/batocera-configgen/data/mame/messSystems.csv
@@ -9,7 +9,7 @@ astrocade;astrocde;cart;
 atom;atom;flop1;'\n*DOS\n*DIR\n*CAT\n*RUN"'
 bbcmicro;bbcb;flop1;
 camplynx;lynx48k;cass;'mload""'
-loopy;casloopy;cart;
+casloopy;casloopy;cart;
 cdi;cdimono1;cdrm;
 coco;coco3;cart;
 crvision;crvision;cart;

--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -292,7 +292,7 @@ systems = {
                                                             { "md5": "e9fc3890963b12cf15d0a2eea5815b72", "file": "bios/np2kai/ITF.ROM"  },
                                                             { "md5": "7da1e5b7c482d4108d22a5b09631d967", "file": "bios/np2kai/font.bmp" } ] },
     # ---------- Casio Loopy ---------- #
-    "loopy": { "name": "Casio Loopy", "biosFiles": [
+    "casloopy": { "name": "Casio Loopy", "biosFiles": [
                                                           { "md5": "0e1d8dc0110ecf8201c0cef11ef4a858", "file": "bios/casloopy.zip" },
                                                           { "md5": "d527e3ed1bf9bd0661154c202a65c5bd", "zippedFile": "hd6437021.lsi302", "file": "bios/casloopy.zip" },
                                                           { "md5": "c0f1c899c9ca098663d046d60779711d", "zippedFile": "hn62434fa.lsi352", "file": "bios/casloopy.zip" } ] },

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -5827,13 +5827,13 @@ bennugd:
   comment_br: |
     Para mais informações: https://wiki.batocera.org/systems:bennugd
 
-loopy:
+casloopy:
   name:       Casio Loopy
   manufacturer: Casio
   release: 1995
   hardware: console
   extensions: [bin, ic1, zip, 7z]
-  theme: loopy
+  theme: casloopy
   emulators:
     libretro:
       mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }

--- a/package/batocera/emulators/mame/mame.emulator.yml
+++ b/package/batocera/emulators/mame/mame.emulator.yml
@@ -1221,7 +1221,7 @@ systems:
         choices:
           Enabled: 1
           Disabled (Default): 0
-  - loopy
+  - casloopy
   - name: gameandwatch
     exclude_extensions:
       - mgw

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/mame.libretro.core.yml
@@ -1136,7 +1136,7 @@ systems:
           'Off': 0
   - gameandwatch
   - lcdgames
-  - loopy
+  - casloopy
   - mame
   - namco22
   - neogeo

--- a/package/batocera/utils/pacman/batocera-makepkg
+++ b/package/batocera/utils/pacman/batocera-makepkg
@@ -34,7 +34,7 @@ GRP_ARRAY=(game music theme bezel misc 3do 3ds amiga1200 amiga500 amigacd32
     atomiswave c128 c20 c64 cannonball cavestory channelf colecovision daphne
     devilutionx dos dreamcast easyrpg fbneo fds flash flatpak fmtowns gamecube
     gameandwatch gamegear gb gb2players gba gbc gbc2players gx4000 halflife intellivision
-    jaguar lightgun loopy lutro lynx mame mastersystem megacd megadrive megadrive-msu
+    jaguar lightgun casloopy lutro lynx mame mastersystem megacd megadrive megadrive-msu
     moonlight mrboom msx1 msx2 msx2+ msxturbor n64 n64dd naomi nds neogeo neogeocd
     nes ngp ngpc odyssey2 openbor pc88 pc98 pcengine pcenginecd pcfx pet pico8
     pokemini ports prboom ps2 ps3 ps4 psp psx pygame satellaview saturn scummvm


### PR DESCRIPTION
This was changed from casloopy->loopy in commit ab447ae43a28d70a1db55f2d31fcea73de0fc4b1

trying to match retrobat behaviour, but retrobat was using casloopy as system too. Retrobat only used "loopy" for theme, and this has been fixed recently in https://github.com/RetroBat-Official/retrobat/commit/b40111a152d91fcef0733abb1b77f796cb399444