### PR TITLE
fix Sinden camera freeze when exiting Wine

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -67,6 +67,7 @@
 - Sega Gaelco support (currently x86 systems only)
 - Sega Hikaru support (currently x86 systems only)
 - Added support for GUO HUA PS3 GamePad in the Bluez package's Sixaxis plugin (models VOYEE - HY-2208 and MiniThink - CECHZC2U)
+- Experimental Sinden light gun borders for RPCS3 and Wine
 ### Fixed
 - Not being able to exit emulator on first controller disconnection. i.e. Bluetooth disconnects.
 - Odin 2 variants wifi not working in some regions
@@ -76,6 +77,7 @@
 - Massive MAME log (switchres verbose disabled by default)
 - PCSX2 light gun mapping (START can now be pressed on the light gun instead of controller)
 - PS4 and PSVita games not appearing in the "last played" auto collection
+- Sinden light gun's camera freezing after exiting Wine
 ### Changed / Improved
 - Wifi country can now be chosen under the Network Setting option.
   This improves Wifi connectivity by aligning your device with regional regulations as well as 6GHz band support.

--- a/package/batocera/wine/wine-tkg/002-fix-mountmgr-serial-noctty.patch
+++ b/package/batocera/wine/wine-tkg/002-fix-mountmgr-serial-noctty.patch
@@ -1,0 +1,29 @@
+--- a/dlls/mountmgr.sys/unixlib.c
++++ b/dlls/mountmgr.sys/unixlib.c
+@@ -299,26 +299,6 @@
+     char *path;
+     NTSTATUS status = STATUS_SUCCESS;
+ 
+-#ifdef linux
+-    /* Serial port device files almost always exist on Linux even if the corresponding serial
+-     * ports don't exist. Do a basic functionality check before advertising a serial port. */
+-    if (params->serial)
+-    {
+-        struct termios tios;
+-        int fd;
+-
+-        if ((fd = open( params->dest, O_RDONLY )) == -1)
+-            return FALSE;
+-
+-        if (tcgetattr( fd, &tios ) == -1)
+-        {
+-            close( fd );
+-            return FALSE;
+-        }
+-
+-        close( fd );
+-    }
+-#endif
+ 
+     if (!(path = get_dosdevices_path( params->dev ))) return STATUS_NO_MEMORY;
+ 


### PR DESCRIPTION
Doesn't happen on Wine-Proton, just Wine-TKG. This will prevent Wine serial port enumeration from resetting active USB serial devices like Sinden Lightgun.