### PR TITLE
fix gsevo offscreen reload + accuracy + crosshairs

### DIFF
--- a/board/batocera/scripts/doWineWow64-32package.sh
+++ b/board/batocera/scripts/doWineWow64-32package.sh
@@ -223,6 +223,7 @@ mkdir -p "${TMPOUT}/usr/bin/lindbergh" || exit 1
 mkdir -p "${TMPOUT}/lib32/extralibs" || exit 1
 cp -prv "${G_TARGETDIR}/usr/bin/lindbergh/lind"*        "${TMPOUT}/usr/bin/lindbergh/" || exit 1
 cp -prv "${G_TARGETDIR}/usr/bin/lindbergh/controls"*    "${TMPOUT}/usr/bin/lindbergh/" || exit 1
+cp -prv "${G_TARGETDIR}/usr/bin/lindbergh/crosshairs"   "${TMPOUT}/usr/bin/lindbergh/" || exit 1
 cp -prv "${G_TARGETDIR}/usr/bin/lindbergh/lib"*"so"*    "${TMPOUT}/lib32/" || exit 1
 cp -prv "${G_TARGETDIR}/usr/bin/lindbergh/extralibs/lib"*"so"* "${TMPOUT}/lib32/extralibs/" || exit 1
 cp -prv "${G_TARGETDIR}/usr/lib/libglut.so"*            "${TMPOUT}/lib32/" || exit 1

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
@@ -374,6 +374,12 @@ class LindberghGenerator(Generator):
         crosshairs = system.config.get("lindbergh_crosshairs") == "1"
         self.setConf(conf, "P1_CROSSHAIR_PATH", "/usr/bin/lindbergh/crosshairs/p1_crosshair.png" if crosshairs else "")
         self.setConf(conf, "P2_CROSSHAIR_PATH", "/usr/bin/lindbergh/crosshairs/p2_crosshair.png" if crosshairs else "")
+        if "ghostsev" in romName.lower():
+            self.setConf(conf, "CUSTOM_CROSSHAIRS_WIDTH", "28")
+            self.setConf(conf, "CUSTOM_CROSSHAIRS_HEIGHT", "28")
+        else:
+            self.setConf(conf, "CUSTOM_CROSSHAIRS_WIDTH", "64")
+            self.setConf(conf, "CUSTOM_CROSSHAIRS_HEIGHT", "64")
 
         self.setup_controllers(conf, system, romName, playersControllers, guns, wheels)
 
@@ -878,9 +884,8 @@ class LindberghGenerator(Generator):
             del mappings_actions["2"]
 
         if shortRomName == "ghostsev":
-            mappings_actions["right"] = "BUTTON_2"
-            mappings_actions["2"]     = "BUTTON_3"
-            mappings_actions["7"]     = "BUTTON_4"
+            mappings_actions["right"] = "BUTTON_3" # Action
+            mappings_actions["2"]     = "BUTTON_4" # Cycle firerate
             del mappings_actions["3"]
 
         if shortRomName == "hotdex":

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -342,6 +342,8 @@ lcdgames:
 lindbergh:
   emulator: lindbergh-loader
   core:     lindbergh-loader
+  options:
+    hud_support: false
 loopy:
   emulator: libretro
   core:     mame

--- a/package/batocera/emulators/lindbergh-loader/008-fix-gsevo.patch
+++ b/package/batocera/emulators/lindbergh-loader/008-fix-gsevo.patch
@@ -1,0 +1,165 @@
+diff --git a/src/lindbergh/blitStretching.h b/src/lindbergh/blitStretching.h
+index e1bd65c..6ea32c6 100644
+--- a/src/lindbergh/blitStretching.h
++++ b/src/lindbergh/blitStretching.h
+@@ -10,6 +10,13 @@ typedef struct
+     float gameScale;
+ } Dest;
+ 
++extern Dest dest;
++extern int drawableW;
++extern int drawableH;
++extern int blitWidth;
++extern int blitHeight;
++extern int fboInitialized;
++
+ void initBlitting();
+ void blitSetWidthandHeightSize();
+ int blitInitializeFbo();
+diff --git a/src/lindbergh/crossHair.c b/src/lindbergh/crossHair.c
+index 558dad1..094796a 100644
+--- a/src/lindbergh/crossHair.c
++++ b/src/lindbergh/crossHair.c
+@@ -14,6 +14,7 @@
+ 
+ #include "config.h"
+ #include "crossHair.h"
++#include "blitStretching.h"
+ #include "resolution.h"
+ 
+ #define MAX_PLAYERS 2
+@@ -23,8 +24,6 @@ extern uint32_t gId;
+ extern int gGrp;
+ extern int gWidth;
+ extern int gHeight;
+-extern int drawableW;
+-extern int drawableH;
+ 
+ extern int phX, phY, phW, phH;
+ extern int phX2, phY2, phW2, phH2;
+@@ -226,8 +225,16 @@ void updateCrosshairPosition(int player, float normX, float normY)
+ {
+     if (player < 0 || player >= MAX_PLAYERS)
+         return;
+-    crossHair[player].x = normX * drawableW;
+-    crossHair[player].y = normY * drawableH;
++    if (fboInitialized && gId == GHOST_SQUAD_EVOLUTION)
++    {
++        crossHair[player].x = normX * blitWidth;
++        crossHair[player].y = normY * blitHeight;
++    }
++    else
++    {
++        crossHair[player].x = normX * drawableW;
++        crossHair[player].y = normY * drawableH;
++    }
+     // crossHair[player].lastMovementTime = time(NULL);
+     // crossHair[player].visible = true;
+     if (testMode || gId == PRIMEVAL_HUNT)
+@@ -375,7 +382,9 @@ void renderGsEvoCrosshairs(void)
+     glMatrixMode(GL_PROJECTION);
+     glPushMatrix();
+     glLoadIdentity();
+-    glOrtho(0, drawableW, drawableH, 0, -1, 1);
++    int orthoW = (fboInitialized) ? blitWidth : drawableW;
++    int orthoH = (fboInitialized) ? blitHeight : drawableH;
++    glOrtho(0, orthoW, orthoH, 0, -1, 1);
+     glMatrixMode(GL_MODELVIEW);
+     glPushMatrix();
+     glLoadIdentity();
+diff --git a/src/lindbergh/evdevInput.c b/src/lindbergh/evdevInput.c
+index 554cfe6..4e93c85 100644
+--- a/src/lindbergh/evdevInput.c
++++ b/src/lindbergh/evdevInput.c
+@@ -16,6 +16,7 @@
+ 
+ #include "evdevInput.h"
+ #include "config.h"
++#include "blitStretching.h"
+ #include "crossHair.h"
+ #include "jvs.h"
+ #include "log.h"
+@@ -1287,6 +1288,28 @@ void *controllerThread(void *_args)
+                             if (scaled > analogue_deadzones[channel].end_min)
+                                 scaled = 1.0;
+ 
++                            /* Remap gun coords when blitStretching letterboxes the game */
++                            if (fboInitialized && dest.W > 0 && dest.H > 0 &&
++                                drawableW > 0 && drawableH > 0)
++                            {
++                                if (channel == ANALOGUE_1 || channel == ANALOGUE_3)
++                                {
++                                    float pixelX = scaled * drawableW;
++                                    float gameX = (pixelX - dest.X) / (float)dest.W;
++                                    if (gameX < 0.0f) gameX = 0.0f;
++                                    if (gameX > 1.0f) gameX = 1.0f;
++                                    scaled = gameX;
++                                }
++                                else if (channel == ANALOGUE_2 || channel == ANALOGUE_4)
++                                {
++                                    float pixelY = scaled * drawableH;
++                                    float gameY = (pixelY - dest.Y) / (float)dest.H;
++                                    if (gameY < 0.0f) gameY = 0.0f;
++                                    if (gameY > 1.0f) gameY = 1.0f;
++                                    scaled = gameY;
++                                }
++                            }
++
+                             // uint32_t gId = getConfig()->crc32;
+ 
+                             if (channel == ANALOGUE_1 || channel == ANALOGUE_2)
+@@ -1333,10 +1356,53 @@ void *controllerThread(void *_args)
+                                 double x_pos = (channel == ANALOGUE_3) ? scaled : args->controller->lastAnalogueValue[ANALOGUE_3];
+                                 double y_pos = (channel == ANALOGUE_4) ? scaled : args->controller->lastAnalogueValue[ANALOGUE_4];
+ 
++                                if (x_pos <= 0.01 || x_pos >= 0.99 || y_pos <= 0.01 || y_pos >= 0.99)
++                                {
++                                    switch (gId)
++                                    {
++                                        case GHOST_SQUAD_EVOLUTION:
++                                            setSwitch(2, BUTTON_2, 1);
++                                            break;
++                                    }
++                                }
++                                else
++                                {
++                                    setSwitch(2, BUTTON_2, 0);
++                                }
++
+                                 updateCrosshairPosition(1, x_pos, y_pos);
+                             }
+ 
+-                            setAnalogue(channel, scaled * (pow(2, jvsBits) - 1));
++                            /* Compensate gsevo asymmetric internal gun mapping (piecewise, per-player) */
++                            float jvsScaled = scaled;
++                            if (gId == GHOST_SQUAD_EVOLUTION)
++                            {
++                                if (channel == ANALOGUE_1)
++                                {
++                                    if (scaled < 0.5f)
++                                        jvsScaled = (scaled - 0.5f) * 1.04f + 0.5f;
++                                    else
++                                        jvsScaled = (scaled - 0.5f) * 0.69f + 0.5f;
++                                }
++                                else if (channel == ANALOGUE_2)
++                                {
++                                    jvsScaled = (scaled - 0.5f) * 0.97f + 0.5f - 0.04f;
++                                }
++                                else if (channel == ANALOGUE_3)
++                                {
++                                    if (scaled < 0.5f)
++                                        jvsScaled = (scaled - 0.5f) * 0.99f + 0.5f;
++                                    else
++                                        jvsScaled = (scaled - 0.5f) * 0.8f + 0.5f;
++                                }
++                                else if (channel == ANALOGUE_4)
++                                {
++                                    jvsScaled = (scaled - 0.5f) * 0.94f + 0.5f - 0.05f;
++                                }
++                                if (jvsScaled < 0.0f) jvsScaled = 0.0f;
++                                if (jvsScaled > 1.0f) jvsScaled = 1.0f;
++                            }
++                            setAnalogue(channel, jvsScaled * (pow(2, jvsBits) - 1));
+                         }
+                         else
+                         {


### PR DESCRIPTION
This is not a true solution but a workaround for the time being to make gsevo have perfect aiming, because it's currently broken : only P1 can reload offscreen; accuracy goes crazy on right side of display; crosshairs are too big and inaccurate.

Plus, I fixed the mapping (fake reload button not needed anymore, just aim offscreen like real hardware).

In bonus, I fix letsgojusp broken border (it will disable mangohud just like RPCS3, but it's not even used for Lindbergh and for the moment it breaks border for 2 games). Mangohud needs a big update.