### PR TITLE
Remap "enter" to "select" in KeboardToPads for Ultimarc based Rec Room Masters controllers

### DIFF
--- a/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC2ultimarcIPAC2.vd209.p0420.yml
+++ b/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC2ultimarcIPAC2.vd209.p0420.yml
@@ -8,7 +8,7 @@ target_devices:
       "key:left":      "abs:hat0x:-1"
       "key:right":     "abs:hat0x:1"
       "key:leftshift": "btn:south"
-      "key:enter":     "btn:south"
+      "key:enter":     "btn:select"
       "key:z":         "btn:east"
       "key:leftctrl":  "btn:west"
       "key:leftalt":   "btn:north"

--- a/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC4.vd209.p0430.yml
+++ b/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC4.vd209.p0430.yml
@@ -8,7 +8,7 @@ target_devices:
       "key:left":      "abs:hat0x:-1"
       "key:right":     "abs:hat0x:1"
       "key:leftshift": "btn:south"
-      "key:enter":     "btn:south"
+      "key:enter":     "btn:select"
       "key:z":         "btn:east"
       "key:leftctrl":  "btn:west"
       "key:leftalt":   "btn:north"

--- a/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC4X.vd209.p0430.yml
+++ b/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcIPAC4X.vd209.p0430.yml
@@ -8,7 +8,7 @@ target_devices:
       "key:left":      "abs:hat0x:-1"
       "key:right":     "abs:hat0x:1"
       "key:leftshift": "btn:south"
-      "key:enter":     "btn:south"
+      "key:enter":     "btn:select"
       "key:z":         "btn:east"
       "key:leftctrl":  "btn:west"
       "key:leftalt":   "btn:north"

--- a/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcMiniPAC.v0b9a.p0800.yml
+++ b/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcMiniPAC.v0b9a.p0800.yml
@@ -8,7 +8,7 @@ target_devices:
       "key:left":      "abs:hat0x:-1"
       "key:right":     "abs:hat0x:1"
       "key:leftshift": "btn:south"
-      "key:enter":     "btn:south"
+      "key:enter":     "btn:select"
       "key:z":         "btn:east"
       "key:leftctrl":  "btn:west"
       "key:leftalt":   "btn:north"

--- a/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcMiniPAC.vd209.p0440.yml
+++ b/package/batocera/controllers/pads/keyboardtopads/inputs/UltimarcMiniPAC.vd209.p0440.yml
@@ -8,7 +8,7 @@ target_devices:
       "key:left":      "abs:hat0x:-1"
       "key:right":     "abs:hat0x:1"
       "key:leftshift": "btn:south"
-      "key:enter":     "btn:south"
+      "key:enter":     "btn:select"
       "key:z":         "btn:east"
       "key:leftctrl":  "btn:west"
       "key:leftalt":   "btn:north"


### PR DESCRIPTION
Fixes batocera-linux/batocera.linux#15454

This change maps the physical "Select" button on Ultimarc based, Rec Room Master controllers to "Select" in Batocera, via KeyboardToPads.  The previous configuration mapped the physical "Select" button to "South".  This works ok in many cases in Batocera, but not in all.  The current configuration is less intuitive for the end user.   It assumes the user knows that "Coin 1" also maps to select.  This can cause issues when a user attempts to configure the controller. (Main Menu → CONTROLLER & BLUETOOTH SETTINGS → CONTROLLER MAPPING) When they get to the "Select" button, it will say "Already mapped" because it was mapped to South.  (and the bottom left physical button is already mapped to South) 

Another example where the way it is coded now will "break": open up Super Mario Brothers and Duck Hunt on NES. The first menu you are presented with is the ability to either select SMB or Duck Hunt. The way it is coded now will not let you select Duck Hunt. Hitting "Select" on a Rec Room Master's controller will just start SMB, because that is what South does. On the other hand, if you make the way I suggested (or the way it used to be), then hitting Select will select the Duck Hunt menu option, which is the the proper NES behavior.

Below are images of the physical layout and keyboard mapping for both a Rec Room Masters 2 player and 4 player controllers:
2 Player:
![553199515-a5c325ea-cfe3-4ce7-a0fc-f9f4bdd46e8e](https://github.com/user-attachments/assets/3f0e1cc4-8f93-4837-9338-a54b66a49617)

4 Player:
<img width="1280" height="490" alt="utf-8&#39;&#39;Screenshot 2026-02-27 at 10 06 14u202fAM" src="https://github.com/user-attachments/assets/91110bce-512a-4446-b631-252a3b275464" />
