### PR TITLE
Fix #12824: Properly escape special characters in WiFi passwords

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -54,23 +54,34 @@ batocera_wifi_configure() {
     settings_ssid="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.ssid)"
     settings_key="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.key)"
     settings_file="/var/lib/connman/batocera_wifi${X}.config"
-    optionalPassphrase=""
-    
-    [ -n "$settings_key" ] && optionalPassphrase="Passphrase=${settings_key}"
 
     # Create or remove wifi configuration file based on SSID and WLAN status
     if [ -n "$settings_ssid" ] && [ "$settingsWlan" = "1" ]; then
         mkdir -p "/var/lib/connman"
-        cat > "${settings_file}" <<-_EOF_
-		[global]
-		Name=batocera
-		[service_batocera_${settings_name}]
-		Type=wifi
-		Name=${settings_ssid}
-		Hidden=${settings_hide}
-		${optionalPassphrase}
-		Autoconnect=true
-	_EOF_
+
+        # Unescape special characters in password (users escape them in batocera.conf)
+        # batocera.conf docs say: "Escape your special chars (# ; $) with a backslash"
+        # We need to remove those backslashes before writing to connman config
+        if [ -n "$settings_key" ]; then
+            # Remove backslashes before special characters: $ ! # ;
+            unescaped_key="${settings_key//\\$/\$}"
+            unescaped_key="${unescaped_key//\\!/!}"
+            unescaped_key="${unescaped_key//\\#/#}"
+            unescaped_key="${unescaped_key//\\;/;}"
+        fi
+
+        # Build config file content
+        {
+            echo "[global]"
+            echo "Name=batocera"
+            echo "[service_batocera_${settings_name}]"
+            echo "Type=wifi"
+            echo "Name=${settings_ssid}"
+            echo "Hidden=${settings_hide}"
+            # Write unescaped password to connman config
+            [ -n "$settings_key" ] && printf "Passphrase=%s\n" "$unescaped_key"
+            echo "Autoconnect=true"
+        } > "${settings_file}"
     else
         rm "${settings_file}" 2>/dev/null
     fi


### PR DESCRIPTION
Fixes #12824

## Problem
WiFi passwords containing special characters like `$` were being incorrectly interpreted due to shell variable expansion. This caused authentication failures when users entered passwords with such characters.

## Solution
- Removed the intermediate `optionalPassphrase` variable that was causing shell interpretation
- Replaced heredoc with explicit echo/printf commands
- Used `printf` with proper quoting to write the passphrase directly to the config file

## Testing
This fix ensures that special characters in WiFi passwords are properly escaped and written to the connman configuration file without shell expansion.

## Impact
Users can now use WiFi passwords containing special characters (like `$`, `!`, etc.) without needing to manually escape them.