### PR TITLE
wifi: special chars allowed in S08connman [44]

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S08connman
+++ b/board/batocera/fsoverlay/etc/init.d/S08connman
@@ -52,7 +52,7 @@ batocera_wifi_configure() {
     [ "$X" = ".hidden" ] && { settings_name="hidden_AP"; settings_hide=true; }
 
     settings_ssid="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.ssid)"
-    settings_key="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.key)"
+    settings_key="$(/usr/bin/batocera-settings-get -f "$BATOCONF" wifi${X}.key | tr -d '\\')"
     settings_file="/var/lib/connman/batocera_wifi${X}.config"
     optionalPassphrase=""
     

--- a/package/batocera/core/batocera-system/batocera.conf
+++ b/package/batocera/core/batocera-system/batocera.conf
@@ -109,7 +109,7 @@ wifi.enabled=0
 ## Wi-Fi SSID (string)
 #wifi.ssid=new ssid
 ## Wi-Fi KEY (string)
-## Escape your special chars (# ; $) with a backslash. eg. $ becomes \$
+## Escape your special chars (# ; $) with a backslash : $ => \$ also if entering them inside ES GUI
 #wifi.key=new key
 
 ## Secondary Wi-Fi (not configurable via the user interface)


### PR DESCRIPTION
Tested with several wifi keys... we can remove trailing backslashes.
**Needs further testing**
should be prior to ai https://github.com/batocera-linux/batocera.linux/pull/15514