### PR TITLE
pywebview: fix backglass black screen on Xorg when WAYLAND_DISPLAY is empty

### DIFF
--- a/package/batocera/libraries/pywebview/001-force-as-wayland-background.patch
+++ b/package/batocera/libraries/pywebview/001-force-as-wayland-background.patch
@@ -10,7 +10,7 @@ index 896749c..18e85e6 100755
 +        ### hack to transform as a non focus window
 +        # wayland GtkLayerShell
 +        if not window.focus:
-+            if "WAYLAND_DISPLAY" in os.environ:
++            if os.environ.get("WAYLAND_DISPLAY", "") != "":
 +                import subprocess
 +                gi.require_version('GtkLayerShell', '0.1')
 +                from gi.repository import GtkLayerShell


### PR DESCRIPTION
## Summary

After restarting EmulationStation via `/etc/init.d/S31emulationstation stop` followed by `/etc/init.d/S31emulationstation start`, the backglass (marquee) screen remains black under Xorg (X11) in Batocera v43. The backglass process starts correctly but the GTK window fails to render.

## Environment

* Batocera version: 43-dev-1c220ad243 (2026/02/27)
* Display setup: dual screen — CRT on DP-1 (primary), LCD marquee on HDMI-1
* Display server: Xorg (X11), not Wayland

## Steps to reproduce

1. Start Batocera normally — backglass displays correctly on the second screen.
2. Run `/etc/init.d/S31emulationstation stop`
3. Run `/etc/init.d/S31emulationstation start`
4. EmulationStation restarts but the backglass screen is black.

## Symptoms

* After restarting EmulationStation via S31, the backglass process (`batocera-backglass-window`) starts correctly with the right parameters.
* The HDMI-1 screen is active with the correct resolution (1920x1080).
* The backglass GTK window exists in the X tree but has a size of 10x10 pixels.
* The marquee screen is black.

## Root Cause

The patch `package/batocera/libraries/pywebview/001-force-as-wayland-background.patch` adds a condition in `webview/platforms/gtk.py` to detect Wayland and use `GtkLayerShell`:

```python
if "WAYLAND_DISPLAY" in os.environ:
    gi.require_version('GtkLayerShell', '0.1')
    from gi.repository import GtkLayerShell
    ...
```

Under Xorg, `WAYLAND_DISPLAY` is present in the environment but set to an empty string (`WAYLAND_DISPLAY=`). The Python `in os.environ` check only tests for the **presence** of the key, not whether it has a non-empty value. This causes the code to enter the Wayland branch even under Xorg, where `GtkLayerShell` is not available, resulting in a crash and a 10x10 black window.

This can be confirmed with:

```bash
cat /proc//environ | tr '\0' '\n' | grep WAYLAND
# Output: WAYLAND_DISPLAY=   <- present but empty
```

## Fix

The fix is a one-line change in `package/batocera/libraries/pywebview/001-force-as-wayland-background.patch`.

Before (buggy):

```python
if "WAYLAND_DISPLAY" in os.environ:
```

After (fixed):

```python
if os.environ.get("WAYLAND_DISPLAY", ""):
```

This change ensures the Wayland branch is only entered when `WAYLAND_DISPLAY` is actually set to a non-empty value.

## Additional notes

* This bug does not affect Batocera v42, where `WAYLAND_DISPLAY` was not injected into the environment of the backglass process.
* In Batocera v43, `emulationstation-standalone` uses `dbus-run-session` which injects `WAYLAND_DISPLAY=` (empty) into the child process environment, triggering the bug.
* The bug only manifests on the **second start** of EmulationStation (after a stop/restart via S31), not on the initial boot.
* The fix is minimal and does not affect Wayland setups where `WAYLAND_DISPLAY` is properly set to a non-empty value (e.g. `WAYLAND_DISPLAY=wayland-0`).