### PR TITLE
binfmt-misc: add service

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S19binfmt
+++ b/board/batocera/fsoverlay/etc/init.d/S19binfmt
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This is a reimplementation of the systemd binfmt.d code to register
+# misc binary formats with the kernel.
+#
+# See the binfmt.d here:
+# https://www.freedesktop.org/software/systemd/man/latest/binfmt.d.html
+#
+# The below code is heavily inspired by the OpenRC implementation here:
+# https://github.com/OpenRC/openrc/blob/master/sh/binfmt.sh.in
+
+mount_binfmt_misc() {
+	[ -e /proc/sys/fs/binfmt_misc/register ] && return
+	mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+}
+
+apply_file() {
+	[ $# -lt 1 ] && return 0
+	FILE="$1"
+	LINENUM=0
+
+	### FILE FORMAT ###
+	# See https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html
+	while read -r line; do
+		LINENUM=$(( LINENUM+1 ))
+		case $line in
+			\#*) continue ;;
+			\;*) continue ;;
+			'')  continue ;;
+		esac
+
+		local reg=${line#*:}
+		[ -e /proc/sys/fs/binfmt_misc/${reg%%:*} ] && echo -1 > /proc/sys/fs/binfmt_misc/${reg%%:*}
+
+		echo "${line}" > /proc/sys/fs/binfmt_misc/register
+		rc=$?
+		if [ $rc -ne 0 ]; then
+			printf "binfmt: invalid entry on line %d of \`%s'\n" \
+				"$LINENUM" "$FILE" >&2
+		fi
+	done <$FILE
+	return $rc
+}
+
+register_formats() {
+	# The hardcoding of these paths is intentional; we are following the relevant spec.
+	binfmt_dirs='/usr/lib/binfmt.d/ /etc/binfmt.d/'
+	binfmt_basenames=''
+	binfmt_d=''
+
+	# Build a list of sorted unique basenames
+	# directories declared later in the binfmt_d list will override earlier
+	# directories, on a per file basename basis.
+	# `/etc/binfmt.d/foo.conf' supersedes `/usr/lib/binfmt.d/foo.conf'.
+	# `/etc/binfmt.d/foo.conf' will always be read after `/etc/binfmt.d/bar.conf'
+	for d in ${binfmt_dirs} ; do
+		[ -d $d ] && for f in ${d}/*.conf ; do
+			[ -e $f ] && binfmt_basenames="${binfmt_basenames}\n${f##*/}"
+		done # for f in ${d}
+	done # for d in ${binfmt_dirs}
+	binfmt_basenames="$(printf "${binfmt_basenames}\n" | sort -u )"
+
+	for b in $binfmt_basenames ; do
+		real_f=''
+		for d in $binfmt_dirs ; do
+			f=${d}/${b}
+			[ -e "${f}" ] && real_f=$f
+		done
+		[ -e "${real_f}" ] && binfmt_d="${binfmt_d} ${real_f}"
+	done
+
+	# loop through the gathered fragments, sorted globally by filename.
+	# `/run/binfmt.d/foo.conf' will always be read after `/etc/binfmt.d/bar.conf'
+	for FILE in $binfmt_d ; do
+		apply_file "$FILE"
+	done
+}
+
+start() {
+	printf "Starting binfmt_misc setup: "
+	mount_binfmt_misc
+	register_formats
+	status=$?
+	[ "$status" -eq 0 ] && echo "OK" || echo "FAIL"
+	return "$status"
+}
+
+case "$1" in
+	start)
+		"$1"
+		;;
+	*)
+		echo "Usage: $0 {start}"
+		exit 1
+esac
+
+exit $?


### PR DESCRIPTION
Adds init service that setups `binfmt_misc` mount and registers binary formats similarly to `systemd-binfmt.service`.
Can be used alongside `box64` and `wine` to allow non native executables to run transparently.

Augments: #15494