### PR TITLE
Fix periodic frontend audio dropouts 

### DIFF
--- a/board/batocera/fsoverlay/etc/pipewire/pipewire.conf.d/10-constrain-defaults.conf
+++ b/board/batocera/fsoverlay/etc/pipewire/pipewire.conf.d/10-constrain-defaults.conf
@@ -1,0 +1,24 @@
+context.properties = {
+  # Use constrainted (and reasonable) defaults to hold the output node in place.
+  # This prevents the output node from being recreated by wireplumber (causing
+  # audio drop outs) that can happen when multiple audio source nodes are
+  # rapidly destroyed and created. Note that audio source nodes are still free
+  # to use smaller quantum and different rates.
+  #
+  # Test case: enable frontend music, install a theme like RCBX that shows
+  # videos in the console selection, then hold left or right to rapidly scroll
+  # through consoles. This opens short lived preview movies, each creating an
+  # audio source per video. Listen for audio drop-outs and run 'pw-top' and look
+  # for growing numbers in the 'ERR' column.
+  #
+  default.clock.min-quantum = 1024
+  default.clock.max-quantum = 1024
+  default.clock.allowed-rates = [ 48000 ]
+
+  # allow four streams to be processed simultaneously without congesting the
+  # main thread.
+  context.num-data-loops = 4
+
+  # Lock and reuse all memory buffers to prevent malloc churn.
+  mem.mlock-all = true
+}


### PR DESCRIPTION
@snydar reported on discord getting music drop outs on pi4 + latest butterfly when scrolling in the frontend, and  audio delays sometimes in the PUAE emulator, which didn't happen in a prior butterfly:

https://github.com/user-attachments/assets/2baf604d-fd56-4e92-bb29-47665bcf74c3

https://github.com/user-attachments/assets/35f55282-c7d8-466f-9373-9069497b0651

### Reproduction steps:

1. Use a mid to slow system, like a pi 4 or other SBC. Might show up on earlier gen x86-64 too.
2. Enable front-end music.
3. Install and activate the RCBX theme with default settings (video previews appear in the console list).
4. Hold left or right on your controller to rapidly scroll through consoles. Listen for periodic music drop out.
5. While scrolling continues, SSH in, use `top` to see wireplumber consuming a hefty percent of CPU. 
6. Also run `pw-top` and see the entire audio output and input nodes rapidly being replaced with new configurations. Look for a slowly growing count i 'ERR' column, which indicates buffer under runs.

### What's happening:

Each video preview opens and closes a new audio stream that can differ in their bit-depth, rate, and channels, each time requiring wire plumber to possibly re-configure the entire graph including adjusting the output node's quantum, all of which is costly and can drain the output buffer without enough data to "bridge the gap" during the change.

The solution was to lock in pipewire's ALSA output default quantum of 1024 and 48 KHz rate (used by SDL in prior butterflys). Even if the source media's quantum and rates differ, this constraints the output in place and prevents it from being rolled over and reset by wire plumber. 

I should add that this is only on the output (pipewire's interface to the kernel's ALSA driver). The sources (emulators, music, videos, etc) can still negotiate their own quantum (number of frames in a transfer) and rate (22 KHz, 44.1 KHz, 48 KHz) to pipewire, so there is no API change between pipewire and the source devices.

I've added reasoning and the test case in the conf file as a heads up to future maintainers.

Although the issue was reported on the pi 4, the reality is that this likely affect the majority of mid to slow systems, and the defaults are reasonable on fast systems too. 