### PR TITLE
add wheel support to triforce + some fixes

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -72,6 +72,7 @@
 - Sega Hikaru support (currently x86 systems only)
 - Added support for GUO HUA PS3 GamePad in the Bluez package's Sixaxis plugin (models VOYEE - HY-2208 and MiniThink - CECHZC2U)
 - Experimental Sinden light gun borders for RPCS3 and Wine
+- Steering wheel support for Triforce system
 ### Fixed
 - Not being able to exit emulator on first controller disconnection. i.e. Bluetooth disconnects.
 - Odin 2 variants wifi not working in some regions

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -52,7 +52,10 @@ def generateControllerConfig(system: Emulator, playersControllers: Controllers, 
                 used_wheels = wheels
         generateControllerConfig_gamecube(system, playersControllers, used_wheels, rom)               # Pass ROM name to allow for per ROM configuration
     elif system.name == "triforce":
-        generateControllerConfig_triforce(system, playersControllers, rom)
+        used_wheels: DeviceInfoMapping = {}
+        if system.config.use_wheels and wheels:
+            used_wheels = wheels
+        generateControllerConfig_triforce(system, playersControllers, used_wheels, rom)
     else:
         raise BatoceraException(f"Invalid system name: '{system.name}'")
 
@@ -246,7 +249,7 @@ def generateControllerConfig_gamecube(system: Emulator, playersControllers: Cont
 
     generateControllerConfig_any(system, playersControllers, wheels, "GCPadNew.ini", "GCPad", gamecubeMapping, gamecubeReverseAxes, gamecubeReplacements)
 
-def generateControllerConfig_triforce(system: Emulator, playersControllers: Controllers, rom: Path) -> None:
+def generateControllerConfig_triforce(system: Emulator, playersControllers: Controllers, wheels: DeviceInfoMapping, rom: Path) -> None:
     # Based on GameCube mapping but with arcade specific overrides
     triforceMapping = {
         'a':             'Buttons/B',
@@ -267,7 +270,7 @@ def generateControllerConfig_triforce(system: Emulator, playersControllers: Cont
         'joystick1left': 'Main Stick/Left',
         'joystick2up':   'C-Stick/Up',
         'joystick2left': 'C-Stick/Left',
-        'hotkey':        'Triforce/Test'
+        'hotkey':        None
     }
     
     triforceReverseAxes: dict[str | None, str] = {
@@ -298,7 +301,33 @@ def generateControllerConfig_triforce(system: Emulator, playersControllers: Cont
                 triforceMapping.update(res)
                 line = cconfig.readline()
 
-    generateControllerConfig_any(system, playersControllers, {}, "GCPadNew.ini", "GCPad", triforceMapping, triforceReverseAxes, triforceReplacements)
+    # Wheel mapping for Triforce arcade racing games.
+    wheelTriforceMapping: dict[str, str | None] = {
+        'select':        'Triforce/Coin',
+        'start':         'Buttons/Start',
+        'up':            'D-Pad/Up',
+        'down':          'D-Pad/Down',
+        'left':          'D-Pad/Left',
+        'right':         'D-Pad/Right',
+        'a':             'Buttons/A',            # Boost (F-Zero AX) / Item (Mario Kart GP)
+        'b':             'Buttons/B',            # VS-Cancel (Mario Kart GP)
+        'y':             'Buttons/Z',            # Jump (Mario Kart GP)
+        'r2':            'Triggers/R-Analog',    # Gas
+        'l2':            'Triggers/L-Analog',    # Brake
+        'joystick1left': 'Main Stick/Left',      # Steering
+        'pageup':        'Buttons/X',            # Paddle left
+        'pagedown':      'Buttons/Y',            # Paddle right
+    }
+
+    wheelTriforceReverseAxes: dict[str | None, str] = {
+        'Main Stick/Left': 'Main Stick/Right',
+    }
+
+    wheelTriforceExtraOptions: dict[str, str] = {
+        'Main Stick/Dead Zone': '0.',
+    }
+
+    generateControllerConfig_any(system, playersControllers, wheels, "GCPadNew.ini", "GCPad", triforceMapping, triforceReverseAxes, triforceReplacements, wheelMapping=wheelTriforceMapping, wheelReverseAxes=wheelTriforceReverseAxes, wheelExtraOptions=wheelTriforceExtraOptions)
 
 def removeControllerConfig_gamecube() -> None:
     configFileName = DOLPHIN_CONFIG / "GCPadNew.ini"
@@ -477,7 +506,7 @@ def get_AltMapping(system: Emulator, nplayer: int, anyMapping: Mapping[str, str 
 
     return mapping
 
-def generateControllerConfig_any(system: Emulator, playersControllers: Controllers, wheels: DeviceInfoMapping, filename: str, anyDefKey: str, anyMapping: Mapping[str, str | None], anyReverseAxes: Mapping[str | None, str], anyReplacements: Mapping[str, str] | None, extraOptions: Mapping[str, str] = {}) -> None:
+def generateControllerConfig_any(system: Emulator, playersControllers: Controllers, wheels: DeviceInfoMapping, filename: str, anyDefKey: str, anyMapping: Mapping[str, str | None], anyReverseAxes: Mapping[str | None, str], anyReplacements: Mapping[str, str] | None, extraOptions: Mapping[str, str] = {}, wheelMapping: Mapping[str, str | None] | None = None, wheelReverseAxes: Mapping[str | None, str] | None = None, wheelExtraOptions: Mapping[str, str] = {}) -> None:
     configFileName = DOLPHIN_CONFIG / filename
     with codecs.open(str(configFileName), "w", encoding="utf_8_sig") as f:
         nsamepad = 0
@@ -497,7 +526,9 @@ def generateControllerConfig_any(system: Emulator, playersControllers: Controlle
                 if not generateControllerConfig_any_from_profiles(f, pad, system):
                     generateControllerConfig_any_auto(f, pad, anyMapping, anyReverseAxes, anyReplacements, extraOptions, system, nplayer, nsamepad)
             else:
-                if pad.device_path in wheels:
+                if pad.device_path in wheels and wheelMapping is not None:
+                    generateControllerConfig_any_auto(f, pad, wheelMapping, wheelReverseAxes or {}, None, wheelExtraOptions, system, nplayer, nsamepad)
+                elif pad.device_path in wheels:
                     generateControllerConfig_wheel(f, pad, nplayer)
                 else:
                     generateControllerConfig_any_auto(f, pad, anyMapping, anyReverseAxes, anyReplacements, extraOptions, system, nplayer, nsamepad)

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -157,6 +157,13 @@ class DolphinGenerator(Generator):
                 else:
                     dolphinSettings.set("Core", f"SIDevice{i}", "6")
 
+        # Triforce wheel: both ports must be GC Steering (8) for baseboard detection.
+        if system.name == "triforce" and system.config.use_wheels and wheels:
+            if not system.config.get("dolphin_port_1_type"):
+                dolphinSettings.set("Core", "SIDevice0", "8")
+            if not system.config.get("dolphin_port_2_type"):
+                dolphinSettings.set("Core", "SIDevice1", "8")
+
         # [Light Gun] HiResTextures for crosshair (part 1/2)
         if system.config.use_guns and guns and not system.config.get_bool('dolphin_crosshair'):
             dolphinSettings.set("General", "CustomTexturesPath", "/usr/share/DolphinCrosshairsPack")

--- a/package/batocera/emulators/dolphin-emu/013-fzeroax-steering-fix.patch
+++ b/package/batocera/emulators/dolphin-emu/013-fzeroax-steering-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/Source/Core/Core/HW/SI/SI_DeviceAMBaseboard.cpp b/Source/Core/Core/HW/SI/SI_DeviceAMBaseboard.cpp
+index 5532c06..f81108a 100644
+--- a/Source/Core/Core/HW/SI/SI_DeviceAMBaseboard.cpp
++++ b/Source/Core/Core/HW/SI/SI_DeviceAMBaseboard.cpp
+@@ -1758,8 +1758,9 @@ int CSIDevice_AMBaseboard::RunBuffer(u8* buffer, int request_length)
+                 }
+                 else
+                 {
+-                  // The center for the Y axis is expected to be 78h this adjusts that
+-                  message.AddData(pad_status.stickX - 12);
++                  // Clamp stickX - 12 to prevent u8 underflow at extreme left.
++                  const int steering = (int)pad_status.stickX - 12;
++                  message.AddData((u8)std::clamp(steering, 0, 255));
+                   message.AddData((u8)0);
+ 
+                   message.AddData(pad_status.stickY);

--- a/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
+++ b/package/batocera/emulators/dolphin-emu/dolphin-emu.mk
@@ -67,8 +67,8 @@ endef
 
 define DOLPHIN_EMU_INI
     mkdir -p $(TARGET_DIR)/usr/share/dolphin-emu/sys/GameSettings
-    # copy extra triforce ini files
-    cp -prn $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-emu/*.ini \
+    # copy extra triforce ini files - force overwrite
+    cp -pr $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/dolphin-emu/*.ini \
 		$(TARGET_DIR)/usr/share/dolphin-emu/sys/GameSettings
     cd $(TARGET_DIR)/usr/bin && ln -sf dolphin-emu dolphin-emu.desktopconfig
 endef


### PR DESCRIPTION
Fix F Zero AX steering
Add wheel support with proper controls for each driving games
Disable FFB by default (totally broken and unfinished upstream)
~~fix Test/Service controls (L3 and R3)~~
Force overwrite optimized game settings .ini (default ones from upstream are empty)

Need to fix ROM naming in emulationstation for wheel flags to work properly.
