### PR TITLE
fix wrong dsi_bios path

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/melonds/melondsGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/melonds/melondsGenerator.py
@@ -64,8 +64,8 @@ class MelonDSGenerator(Generator):
             "DSi": {
                 "FullBIOSBoot": False,
                 "FirmwarePath": str(BIOS / "dsi_firmware.bin"),
-                "BIOS9Path": str(BIOS / "bios9.bin"),
-                "BIOS7Path": str(BIOS / "bios7.bin"),
+                "BIOS9Path": str(BIOS / "dsi_bios9.bin"),
+                "BIOS7Path": str(BIOS / "dsi_bios7.bin"),
                 "NANDPath": str(BIOS / "dsi_nand.bin"),
                 "SD": {
                     "FolderPath": str(_MELONDS_SAVES),


### PR DESCRIPTION
Fix the incorrect path for Melon DS standalone. Games were not launching with the original path.