### PR TITLE
utils: syncthing: bump version to 2.0.15

### DIFF
--- a/package/batocera/utils/syncthing/syncthing.mk
+++ b/package/batocera/utils/syncthing/syncthing.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SYNCTHING_VERSION = v2.0.12
+SYNCTHING_VERSION = v2.0.15
 SYNCTHING_SITE = $(call github,syncthing,syncthing,$(SYNCTHING_VERSION))
 SYNCTHING_LICENSE = MPLv2
 SYNCTHING_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Fixes go dependencies at compile time.