### PR TITLE
aic8800: fix firmware paths for USB chips

### DIFF
--- a/package/batocera/network/aic8800/aic8800.mk
+++ b/package/batocera/network/aic8800/aic8800.mk
@@ -49,13 +49,13 @@ endef
 
 define AIC8800_FIRMWARE_ETC_USB
     mkdir -p $(TARGET_DIR)/lib/firmware/aic8800_fw/USB
-	cp -f $(@D)/src/USB/driver_fw/fw/aic8800/* \
+	cp -rf $(@D)/src/USB/driver_fw/fw/aic8800/ \
 	    $(TARGET_DIR)/lib/firmware/aic8800_fw/USB/
-	cp -f $(@D)/src/USB/driver_fw/fw/aic8800D80/* \
+	cp -rf $(@D)/src/USB/driver_fw/fw/aic8800D80/ \
 	    $(TARGET_DIR)/lib/firmware/aic8800_fw/USB/
-	cp -f $(@D)/src/USB/driver_fw/fw/aic8800D80X2/* \
+	cp -rf $(@D)/src/USB/driver_fw/fw/aic8800D80X2/ \
 	    $(TARGET_DIR)/lib/firmware/aic8800_fw/USB/
-	cp -f $(@D)/src/USB/driver_fw/fw/aic8800DC/* \
+	cp -rf $(@D)/src/USB/driver_fw/fw/aic8800DC/ \
 	    $(TARGET_DIR)/lib/firmware/aic8800_fw/USB/
 endef
 


### PR DESCRIPTION
USB driver appends the chip name to the firmware path, so the subdirectory is needed.