### PR TITLE
fix for hotd4 games + harley tweak

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/lindbergh/lindberghGenerator.py
@@ -30,7 +30,7 @@ from ... import Command
 from ...batoceraPaths import SAVES, mkdir_if_not_exists
 from ...controller import Controller, Controllers, generate_sdl_game_controller_config
 from ...exceptions import BatoceraException, InvalidConfiguration
-from ...utils import bezels as bezelsUtil, hotkeygen, videoMode
+from ...utils import bezels as bezelsUtil, hotkeygen
 from ...utils.download import download
 from ..Generator import Generator
 
@@ -193,11 +193,6 @@ class LindberghGenerator(Generator):
         
         if system.config.get_bool("lindbergh_test"):
             commandArray.append("-t")
-
-        # temp workaround - load MESA 25.1.x for hotd4 games
-        if "hotd4" in romName.lower() and videoMode.getGLVendor() in ("amd", "intel", "unknown"):
-            environment["LIBGL_DRIVERS_PATH"] = "/lib32/dri-legacy"
-            environment["LD_LIBRARY_PATH"] = f"/lib32/dri-legacy:{environment['LD_LIBRARY_PATH']}"
 
         return Command.Command(array=commandArray, env=environment)
 

--- a/package/batocera/emulators/lindbergh-loader/010-mesa-shaders-fix.patch
+++ b/package/batocera/emulators/lindbergh-loader/010-mesa-shaders-fix.patch
@@ -1,0 +1,90 @@
+diff --git a/src/lindbergh/shaderPatches.c b/src/lindbergh/shaderPatches.c
+index 25ce447..822418a 100644
+--- a/src/lindbergh/shaderPatches.c
++++ b/src/lindbergh/shaderPatches.c
+@@ -8,7 +8,9 @@
+ #include <fcntl.h>
+ #include <libgen.h>
+ #include <stdbool.h>
++#include <stdio.h>
+ #include <stdlib.h>
++#include <string.h>
+ #include <sys/mman.h>
+ #include <unistd.h>
+ 
+@@ -716,8 +718,60 @@ char *cgCreateProgram(uint32_t context, int program_type, const char *program, i
+     return _cgCreateProgram(context, program_type, program, profile, entry, args);
+ }
+ 
++// HOTD4/SP: Mesa 25.2+ NIR linker fix for NNGLD varyings
++
++static __GLXextFuncPtr (*_real_glXGetProcAddressARB)(const GLubyte *) = NULL;
++
++static void *real_glXGetProcAddress(const char *name)
++{
++    if (!_real_glXGetProcAddressARB)
++        _real_glXGetProcAddressARB = (__GLXextFuncPtr (*)(const GLubyte *))dlsym(RTLD_NEXT, "glXGetProcAddressARB");
++    return (void *)_real_glXGetProcAddressARB((const GLubyte *)name);
++}
++
++static bool hotd4_is_active(void)
++{
++    return (gGrp == GROUP_HOD4 || gGrp == GROUP_HOD4_TEST ||
++            gGrp == GROUP_HOD4_SP || gGrp == GROUP_HOD4_SP_TEST);
++}
++
+ void gl_ShaderSourceARB(GLhandleARB shaderObj, GLsizei count, const GLcharARB **const string, const GLint *length)
+ {
++    // HOTD4/SP: zero-init NNGLD varyings in vertex shaders for Mesa 25.2+
++    if (hotd4_is_active() && count > 0 && string[0])
++    {
++        int src_len = (length && length[0] > 0) ? length[0] : (int)strlen(string[0]);
++        if (strstr(string[0], "gl_Position") && strstr(string[0], "nnglvTexCoord01"))
++        {
++            const char *main_str = strstr(string[0], "void main");
++            const char *open_brace = main_str ? strchr(main_str, '{') : NULL;
++            if (open_brace)
++            {
++                static const char *varying_init =
++                    "\n"
++                    "nnglvTexCoord01 = vec4(0.0);\n"
++                    "nnglvTexCoord23 = vec4(0.0);\n"
++                    "nnglvTexCoord45 = vec4(0.0);\n"
++                    "nnglvTexCoord67 = vec4(0.0);\n";
++                int fix_len = strlen(varying_init);
++                int insert_pos = (int)(open_brace - string[0]) + 1;
++                int new_len = src_len + fix_len;
++                char *patched = malloc(new_len + 1);
++                if (patched)
++                {
++                    memcpy(patched, string[0], insert_pos);
++                    memcpy(patched + insert_pos, varying_init, fix_len);
++                    memcpy(patched + insert_pos + fix_len, string[0] + insert_pos, src_len - insert_pos);
++                    patched[new_len] = '\0';
++                    GLint patched_len = new_len;
++                    glShaderSourceARB(shaderObj, 1, (const GLcharARB **)&patched, &patched_len);
++                    free(patched);
++                    return;
++                }
++            }
++        }
++    }
++
+     if (gGrp != GROUP_HUMMER && gId != SEGA_RACE_TV)
+     {
+         glShaderSourceARB(shaderObj, count, string, length);
+@@ -933,7 +987,13 @@ void *gl_XGetProcAddressARB(const unsigned char *procName)
+         return (void *)gl_ShaderSourceARB;
+     }
+ 
+-    return glXGetProcAddressARB(procName);
++    return real_glXGetProcAddress((const char *)procName);
++}
++
++// LD_PRELOAD override to intercept GL lookups from NNGLD
++__GLXextFuncPtr glXGetProcAddressARB(const GLubyte *procName)
++{
++    return (__GLXextFuncPtr)gl_XGetProcAddressARB(procName);
+ }
+ 
+ /**

--- a/package/batocera/emulators/lindbergh-loader/lindbergh-loader.mk
+++ b/package/batocera/emulators/lindbergh-loader/lindbergh-loader.mk
@@ -22,9 +22,6 @@ LINDBERGH_LOADER_SITE = $(call github,lindbergh-loader,lindbergh-loader,$(LINDBE
 LINDBERGH_LOADER_LICENSE = ShareAlike 4.0 International
 LINDBERGH_LOADER_LICENSE_FILES = LICENSE.md
 LINDBERGH_LOADER_EMULATOR_INFO = lindbergh-loader.emulator.yml
-LINDBERGH_LOADER_MESA_LEGACY_SOURCE = mesa-legacy-25.1.9-lib32.tar.xz
-LINDBERGH_LOADER_EXTRA_DOWNLOADS = \
-    https://github.com/Tovarichtch/lindbergh-mesa-legacy/releases/download/v25.1.9/$(LINDBERGH_LOADER_MESA_LEGACY_SOURCE)
 
 ifeq ($(BR2_x86_64),y)
 LINDBERGH_LOADER_DEPENDENCIES = wine-x86 dmidecode ossp
@@ -75,14 +72,7 @@ define LINDBERGH_LOADER_CROSSHAIRS
 	    $(TARGET_DIR)/usr/bin/lindbergh/crosshairs/
 endef
 
-# temp workaround for HOTD4 games (radeonsi regression in Mesa 25.2+)
-define LINDBERGH_LOADER_MESA_LEGACY
-    mkdir -p $(TARGET_DIR)/lib32/dri-legacy
-    tar xf $(DL_DIR)/$(LINDBERGH_LOADER_DL_SUBDIR)/$(LINDBERGH_LOADER_MESA_LEGACY_SOURCE) \
-        -C $(TARGET_DIR)/lib32/dri-legacy/
-endef
-
-LINDBERGH_LOADER_POST_INSTALL_TARGET_HOOKS += LINDBERGH_LOADER_CROSSHAIRS LINDBERGH_LOADER_MESA_LEGACY
+LINDBERGH_LOADER_POST_INSTALL_TARGET_HOOKS += LINDBERGH_LOADER_CROSSHAIRS
 
 $(eval $(generic-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
~~This is the simplest alternative I found for now. Not the best one. A regression happened in MESA between 25.1.9 and 25.3.x but I can't find it where. This should be temporary for v43, not permanent.~~ **check bottom comment**

and add more detection for harley game because not everyone follow batocera convention for lindbergh ROM naming...
