### PR TITLE
Add Sega Model 1 arcade platform

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -62,7 +62,7 @@ def generateMAMEConfigs(playersControllers: Controllers, system: Emulator, rom: 
     else:
         corePath = str(system.config.core)
 
-    if system.name in [ 'mame', 'neogeo', 'lcdgames', 'tvgames', 'vis', 'namco22', 'model2', 'cave3rd', 'gaelco', 'hikaru' ]:
+    if system.name in [ 'mame', 'neogeo', 'lcdgames', 'tvgames', 'vis', 'namco22', 'model1', 'model2', 'cave3rd', 'gaelco', 'hikaru' ]:
         # Set up command line for basic systems
         # ie. no media, softlists, etc.
         if system.config.get_bool("customcfg"):

--- a/package/batocera/core/batocera-configgen/configgen/configgen/utils/metadata.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/utils/metadata.py
@@ -20,6 +20,7 @@ _ARCADE_SYSTEMS: Final = {
     'neogeo',
     'triforce',
     'hypseus-singe',
+    'model1',
     'model2',
     'model3',
     'hikaru',

--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults.yml
@@ -395,6 +395,9 @@ megadrive-msu:
 megaduck:
   emulator: libretro
   core:     sameduck
+model1:
+  emulator: libretro
+  core:     mame
 model2:
   emulator: model2emu
   core:     model2emu

--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -3181,6 +3181,30 @@ sonicretro:
 
     A opção do menu de desenvolvimento é necessária para executar modificações (mods).
 
+model1:
+  name: Model 1
+  manufacturer: Sega
+  release: 1992
+  hardware: arcade
+  extensions: [zip]
+  platform: model1, arcade
+  emulators:
+    libretro:
+      archs_include: [x86_64, x86-64-v3]
+      mame: { requireAnyOf: [BR2_PACKAGE_LIBRETRO_MAME] }
+    mame:
+      archs_include: [x86_64, x86-64-v3]
+      mame: { requireAnyOf: [BR2_PACKAGE_MAME] }
+
+  comment_en: |
+    ## SEGA MODEL 1 ##
+
+    Put your Model 1 roms in this directory.
+
+    Rom files must have a ".zip" extension from a MAME ROM set.
+
+    Known games: Virtua Fighter, Virtua Racing, Wing War, Star Wars Arcade, Virtua Formula, Net Merc.
+
 model2:
   name: Model 2
   manufacturer: Sega

--- a/package/batocera/emulators/mame/sega-arcade.mame.emulator.yml
+++ b/package/batocera/emulators/mame/sega-arcade.mame.emulator.yml
@@ -1,5 +1,6 @@
 systems:
   - cave3rd
   - gaelco
+  - model1
   - model2
   - model3

--- a/package/batocera/emulators/retroarch/libretro/libretro-mame/sega-arcade.mame.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-mame/sega-arcade.mame.libretro.core.yml
@@ -1,5 +1,6 @@
 systems:
   - cave3rd
   - gaelco
+  - model1
   - model2
   - model3


### PR DESCRIPTION
## Summary
- Add Sega Model 1 as a standalone arcade system (released 1992)
- Emulators: MAME and libretro-mame (x86_64 only)
- Known games: Virtua Fighter, Virtua Racing, Wing War, Star Wars Arcade, Virtua Formula, Net Merc

## Changes
- `es_systems.yml` — new model1 system definition
- `configgen-defaults.yml` — default emulator: libretro mame
- `sega-arcade.mame.emulator.yml` / `sega-arcade.mame.libretro.core.yml` — add model1
- `libretroMAMEConfig.py` — model1 as basic MAME system (no softlists)
- `metadata.py` — model1 in arcade metadata list