### PR TITLE
fix: Add sys lang ES Option for Wii

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinSYSCONF.py
@@ -133,8 +133,14 @@ def getSensorBarPosition(config: SystemConfig) -> int:
     return 0
 
 def update(config: SystemConfig, filepath: Path, gameResolution: Resolution) -> None:
+    wii_lang_str = config.get_str("wii_language")
+    if wii_lang_str is not None:
+        wii_lang = int(wii_lang_str)
+    else:
+        wii_lang = getWiiLangFromEnvironment()
+
     arg_setval = {
-        "IPL.LNG": getWiiLangFromEnvironment(),
+        "IPL.LNG": wii_lang,
         "IPL.AR": getRatioFromConfig(config, gameResolution),
         "BT.BAR": getSensorBarPosition(config)
     }

--- a/package/batocera/emulators/dolphin-emu/dolphin.emulator.yml
+++ b/package/batocera/emulators/dolphin-emu/dolphin.emulator.yml
@@ -344,6 +344,21 @@ cores:
         shared_features:
           - use_guns
         custom_features:
+          wii_language:
+            submenu: EMULATION
+            prompt: WII LANGUAGE
+            description: Change the Wii system language.
+            choices:
+              Japanese: 0
+              English: 1
+              German: 2
+              French: 3
+              Spanish: 4
+              Italian: 5
+              Dutch: 6
+              Simplified Chinese: 7
+              Traditional Chinese: 8
+              Korean: 9
           tv_mode:
             submenu: DISPLAY
             prompt: WII TV MODE


### PR DESCRIPTION
Add Wii language option to standalone Dolphin emulator. The language is now configurable from EmulationStation instead of always defaulting to the system locale.