### PR TITLE
feat: add post-processing display options for xenia-canary

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/xenia/xeniaGenerator.py
@@ -182,6 +182,10 @@ class XeniaGenerator(Generator):
         config['Display'] = {
             'fullscreen': True,
             'internal_display_resolution': system.config.get_int('xenia_resolution', 8)}
+        config['Display']['postprocess_scaling_and_sharpening'] = system.config.get('xenia_postprocess_scaling_and_sharpening', 'bilinear')
+        config['Display']['postprocess_antialiasing'] = system.config.get('xenia_postprocess_antialiasing', 'none')
+        config['Display']['postprocess_ffx_cas_additional_sharpness'] = float(system.config.get('xenia_postprocess_ffx_cas_additional_sharpness', '0'))
+        config['Display']['postprocess_ffx_fsr_sharpness_reduction'] = float(system.config.get('xenia_postprocess_ffx_fsr_sharpness_reduction', '0.2'))
         # add node GPU
         if 'GPU' not in config:
             config['GPU'] = {}

--- a/package/batocera/emulators/xenia-canary/xenia-canary.emulator.yml
+++ b/package/batocera/emulators/xenia-canary/xenia-canary.emulator.yml
@@ -12,6 +12,7 @@ custom_features:
       XBLA license enabled (Default): 1
       All possible licenses (Not recommended): -1
   xenia_resolution:
+    group: DISPLAY OPTIONS
     prompt: INTERNAL DISPLAY RESOLUTION
     description: Allow game that support different resolutions to be rendered in specific resolution.
     choices:
@@ -33,18 +34,21 @@ custom_features:
       1920x540: 15
       1920x1080: 16
   xenia_api:
+    group: DISPLAY OPTIONS
     prompt: GRAPHICS API
     description: Choose which graphics API library to use. D3D12 may yield better results with faster GPUs.
     choices:
       D3D12 (Default): D3D12
       Native Vulkan: Vulkan
   xenia_vsync:
+    group: DISPLAY OPTIONS
     prompt: VSYNC
     description: Fix screen tearing. With Some games you need to turn VSync on in the games options.
     choices:
       Disabled: false
       Enabled: true
   xenia_vsync_fps:
+    group: DISPLAY OPTIONS
     prompt: VSYNC FPS
     description: Manually set VSYNC frames per second. Ideally this should match your monitor refresh rate.
     choices:
@@ -285,5 +289,33 @@ custom_features:
     choices:
       Disabled: false
       Enabled: true
+  xenia_postprocess_scaling_and_sharpening:
+    group: DISPLAY OPTIONS
+    prompt: POST-PROCESSING SCALING AND SHARPENING
+    description: Upscaling and sharpening filter. CAS = AMD FidelityFX Contrast Adaptive Sharpening, FSR = AMD FidelityFX Super Resolution 1.0.
+    choices:
+      Bilinear (Default): bilinear
+      CAS: cas
+      FSR: fsr
+  xenia_postprocess_antialiasing:
+    group: DISPLAY OPTIONS
+    prompt: POST-PROCESSING ANTI-ALIASING
+    description: Post-processing anti-aliasing filter.
+    choices:
+      None (Default): none
+      FXAA: fxaa
+      FXAA Extreme: fxaa_extreme
+  xenia_postprocess_ffx_cas_additional_sharpness:
+    group: DISPLAY OPTIONS
+    prompt: CAS ADDITIONAL SHARPNESS
+    description: Additional sharpness for AMD FidelityFX CAS, from 0 to 1. Higher is sharper.
+    preset: sliderauto
+    preset_parameters: 0.0 1.0 0.1
+  xenia_postprocess_ffx_fsr_sharpness_reduction:
+    group: DISPLAY OPTIONS
+    prompt: FSR SHARPNESS REDUCTION
+    description: Sharpness reduction for AMD FidelityFX FSR 1.0, in stops. Lower is sharper.
+    preset: sliderauto
+    preset_parameters: 0.0 2.0 0.1
 systems:
   - xbox360


### PR DESCRIPTION
Add scaling/sharpening (CAS, FSR), anti-aliasing (FXAA), and sharpness sliders (CAS/FSR) to xenia-canary.
Group display-related options under a new DISPLAY OPTIONS section in the emulator yml.