### PR TITLE
v44: bump Amiberry to 8.1.5 && improve generator

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/amiberry/amiberryGenerator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final
 
 from ... import Command
-from ...batoceraPaths import CONFIGS, mkdir_if_not_exists
+from ...batoceraPaths import CONFIGS, ROMS, mkdir_if_not_exists
 from ...controller import generate_sdl_game_controller_config, write_sdl_controller_db
 from ...settings.unixSettings import UnixSettings
 from ..Generator import Generator
@@ -64,13 +64,20 @@ class AmiberryGenerator(Generator):
         amiberryconf.save('default_vkbd_language', system.config.get('amiberry_vkbd_language', 'US'))
         amiberryconf.save('default_vkbd_toggle', 'leftstick')
         amiberryconf.save('default_fullscreen_mode', '2')
+        amiberryconf.save('default_auto_crop', system.config.get_bool('amiberry_auto_crop', return_values=('true', 'false')))
+        amiberryconf.save('default_keep_aspect', system.config.get_bool('amiberry_keep_aspect', return_values=('true', 'false')))
+        amiberryconf.save('shader', system.config.get('amiberry_shader', 'none'))
+
+
         amiberryconf.save('write_logfile', 'yes')
         amiberryconf.write()
 
         romType = self.getRomType(rom)
         _logger.debug("romType: %s", romType)
+
         if romType != 'UNKNOWN' :
             commandArray: list[str | Path] = [ _AMIBERRY_BIN ]
+
             if romType != 'WHDL' :
                 commandArray.append("--model")
                 commandArray.append(system.config.core)
@@ -79,9 +86,9 @@ class AmiberryGenerator(Generator):
                 commandArray.append(rom)
             elif romType == 'HDF' :
                 commandArray.append("-s")
-                commandArray.append(f"hardfile2=rw,DH0:{rom},32,1,2,512,0,,uae0")
+                commandArray.append(f"hardfile2=rw,DH0:\"{rom}\",32,1,2,512,0,,uae0")
                 commandArray.append("-s")
-                commandArray.append(f"uaehf0=hdf,rw,DH0:{rom},32,1,2,512,0,,uae0")
+                commandArray.append(f"uaehf0=hdf,rw,DH0:\"{rom}\",32,1,2,512,0,,uae0")
             elif romType == 'UAE' :
                 commandArray.append("-f")
                 commandArray.append(rom)
@@ -105,6 +112,7 @@ class AmiberryGenerator(Generator):
             mkdir_if_not_exists(_RETROARCH_INPUTS_DIR)
             write_sdl_controller_db(playersControllers, _RETROARCH_INPUTS_DIR / "gamecontrollerdb.txt")
 
+            is_player2 = None
             for pad in playersControllers:
                 replacements = {f'_player{pad.player_number}_':'_'}
                 # amiberry remove / included in pads names like "USB Downlo01.80 PS3/USB Corded Gamepad"
@@ -118,13 +126,33 @@ class AmiberryGenerator(Generator):
                                 outfile.write(newline)
                 if pad.player_number == 1: # 1 = joystick port
                     commandArray.append("-s")
+                    commandArray.append(f"joyport1=joy0")
+                    commandArray.append("-s")
                     commandArray.append(f"joyport1_friendlyname={padfilename}")
+                    commandArray.append("-s")
+                    commandArray.append(f"joyportname1=")
                     if romType == 'CD' :
                         commandArray.append("-s")
                         commandArray.append("joyport1_mode=cd32joy")
                 if pad.player_number == 2: # 0 = mouse for the player 2
+                    is_player2 = 1
                     commandArray.append("-s")
-                    commandArray.append(f"joyport0_friendlyname={padfilename}")
+                    commandArray.append(f"joyport0=joy1")
+                    commandArray.append("-s")
+                    commandArray.append(f"joyport0_friendlyname=\"{padfilename}\"")
+                    commandArray.append("-s")
+                    commandArray.append(f"joyportname0=")
+
+
+            #set default mouse if no player2 gamepad is configured
+            #when gamepad is configured on joyport0, autoswitch between gamepad<->mouse is enabled by default
+            if not is_player2:
+                commandArray.append("-s")
+                commandArray.append(f"joyport0=mouse")
+                commandArray.append("-s")
+                commandArray.append(f"joyport0_friendlyname=\"System mouse\"")
+                commandArray.append("-s")
+                commandArray.append(f"joyportname0=MOUSE0")
 
             # fps
             if system.config.show_fps:
@@ -135,49 +163,72 @@ class AmiberryGenerator(Generator):
             commandArray.append("-s")
             commandArray.append("joyport2=")
 
-            # remove interlace artifacts
-            commandArray.append("-s")
-            commandArray.append(f'gfx_flickerfixer={system.config.get_bool("amiberry_flickerfixer", return_values=("true", "false"))}')
 
-            # auto height
-            commandArray.append("-s")
-            commandArray.append(f'amiberry.gfx_auto_height={system.config.get_bool("amiberry_auto_height", return_values=("true", "false"))}')
+            # remove interlace artifacts
+            if amiberry_scandoubler := system.config.get('amiberry_scandoubler'):
+                commandArray.append("-s")
+                commandArray.append(f'gfx_scandoubler={amiberry_scandoubler}')
+
+            # auto_crop (previously auto_height)
+            if amiberry_auto_crop := system.config.get('amiberry_auto_crop'):
+                commandArray.append("-s")
+                commandArray.append(f"gfx_auto_crop={amiberry_auto_crop}")
 
             # line mode
-            commandArray.append("-s")
-            commandArray.append(f"gfx_linemode={system.config.get('amiberry_linemode', 'double')}")
+            if amiberry_linemode := system.config.get('amiberry_linemode'):
+                commandArray.append("-s")
+                commandArray.append(f"gfx_linemode={amiberry_linemode}")
 
             # video resolution
-            commandArray.append("-s")
-            commandArray.append(f"gfx_resolution={system.config.get('amiberry_resolution', 'hires')}")
+            if amiberry_resolution := system.config.get('amiberry_resolution'):
+                commandArray.append("-s")
+                commandArray.append(f"gfx_resolution={amiberry_resolution}")
+
 
             # Scaling method
             match system.config.get("amiberry_scalingmethod"):
-                case "smooth":
-                    commandArray.append("-s")
-                    commandArray.append("gfx_lores_mode=true")
-                    commandArray.append("-s")
-                    commandArray.append("amiberry.scaling_method=1")
-                case "pixelated":
-                    commandArray.append("-s")
-                    commandArray.append("gfx_lores_mode=true")
-                    commandArray.append("-s")
-                    commandArray.append("amiberry.scaling_method=0")
-                case _:
-                    commandArray.append("-s")
-                    commandArray.append("gfx_lores_mode=false")
+                case "none":
                     commandArray.append("-s")
                     commandArray.append("amiberry.scaling_method=-1")
+                case "pixelated":
+                    commandArray.append("-s")
+                    commandArray.append("amiberry.scaling_method=0")
+                case "smooth":
+                    commandArray.append("-s")
+                    commandArray.append("amiberry.scaling_method=1")
+                case "integer":
+                    commandArray.append("-s")
+                    commandArray.append("amiberry.scaling_method=2")
+
 
             # display vertical centering
             commandArray.append("-s")
             commandArray.append("gfx_center_vertical=smart")
+
+            # force ntsc
+            amiberry_default_ntsc = False
+            # detect ntsc from rom filename hint
+            if 'ntsc' in rom.stem.lower():
+                amiberry_default_ntsc = True
+
+            amiberry_ntsc = system.config.get_bool('amiberry_ntsc', amiberry_default_ntsc)
+            if amiberry_ntsc:
+                commandArray.append("-s")
+                commandArray.append("ntsc=true")
+                commandArray.append("-s")
+                commandArray.append("chipset_refreshrate=60.000000")
+
+            # memory
+            commandArray.append("-F 8")
+
+
 
             # fix sound buffer and frequency
             commandArray.append("-s")
             commandArray.append("sound_max_buff=4096")
             commandArray.append("-s")
             commandArray.append("sound_frequency=48000")
+
 
             # Disable GUI at launch
             if not commandArray or commandArray[-1] != "-G":

--- a/package/batocera/emulators/amiberry/003-fix-sdl-build.patch
+++ b/package/batocera/emulators/amiberry/003-fix-sdl-build.patch
@@ -5,7 +5,7 @@ index 45d7cae..2a399b0 100644
 @@ -2,7 +2,8 @@
  
  #include <png.h>
- #include <SDL_image.h>
+ #include <SDL3_image/SDL_image.h>
 -
 +#include <fsdb_host.h>
 +#include <drawing.h>

--- a/package/batocera/emulators/amiberry/Config.in
+++ b/package/batocera/emulators/amiberry/Config.in
@@ -1,8 +1,8 @@
 config BR2_PACKAGE_AMIBERRY
     bool "amiberry"
-    select BR2_PACKAGE_SDL2
-    select BR2_PACKAGE_SDL2_IMAGE
-    select BR2_PACKAGE_SDL2_TTF
+    select BR2_PACKAGE_SDL3
+    select BR2_PACKAGE_SDL3_IMAGE
+    select BR2_PACKAGE_SDL3_TTF
     select BR2_PACKAGE_MPG123
     select BR2_PACKAGE_LIBXML2
     select BR2_PACKAGE_LIBMPEG2

--- a/package/batocera/emulators/amiberry/amiberry.emulator.yml
+++ b/package/batocera/emulators/amiberry/amiberry.emulator.yml
@@ -33,22 +33,44 @@ custom_features:
     prompt: SCALING METHOD
     description: Change pixel scaling and filtering method.
     choices:
-      Automatic: automatic
+      None (default) : none
       Pixelated (Nearest): pixelated
       Smooth (Linear): smooth
-  amiberry_flickerfixer:
+      Integer: integer
+  amiberry_scandoubler:
     group: ADVANCED OPTIONS
     prompt: REMOVE INTERLACE ARTIFACTS
     description: Fix flickering in a static screen like Workbench.
     choices:
       "OFF": false
       "ON": true
-  amiberry_auto_height:
-    prompt: AUTO HEIGHT
+  amiberry_auto_crop:
+    prompt: AUTO CROP
     description: Resize automatically screen height.
     choices:
       "OFF": false
       "ON": true
+  amiberry_keep_aspect:
+    prompt: KEEP ASPECT RATIO
+    description: Keep original aspect ratio when stretching.
+    choices:
+      "OFF (Default)": False
+      "ON": True
+  amiberry_ntsc:
+    prompt: FORCE NTSC
+    description: Force NTSC instead PAL.
+    choices:
+      "ON (Default)": False
+      "OFF": True
+  amiberry_shader:
+    prompt: SHADER
+    description: CRT Shader.
+    choices:
+      "None (Default)": none
+      "TV CRT effect with heaver scanlines and curvature": tv
+      "PC monitor effect with lighter scanlines": pc
+      "Lightweight CRT effect": lite
+      "Commodore 1084 monitor": 1084
   amiberry_virtual_keyboard:
     group: KEYBOARD OPTIONS
     prompt: VIRTUAL KEYBOARD
@@ -76,7 +98,7 @@ custom_features:
     group: KEYBOARD OPTIONS
     prompt: KEYBOARD TRANSPARENCY
     description: Set the on-screen keyboard transparency (0-100%).
-    preset: slider
+    preset: sliderauto
     preset_parameters: 0 100 5 60
 systems:
   - name: amiga500

--- a/package/batocera/emulators/amiberry/amiberry.mk
+++ b/package/batocera/emulators/amiberry/amiberry.mk
@@ -4,12 +4,12 @@
 #
 ################################################################################
 
-AMIBERRY_VERSION = facaaeb13d996e8fa4e5f391c767a07183ab19e3
+AMIBERRY_VERSION = v8.1.5
 AMIBERRY_SITE = $(call github,BlitterStudio,amiberry,$(AMIBERRY_VERSION))
 AMIBERRY_LICENSE = GPLv3
 AMIBERRY_SUPPORTS_IN_SOURCE_BUILD = NO
 
-AMIBERRY_DEPENDENCIES += sdl2 sdl2_image sdl2_ttf mpg123 libpcap libxml2 libmpeg2
+AMIBERRY_DEPENDENCIES += sdl3 sdl3_image sdl3_ttf mpg123 libpcap libxml2 libmpeg2 libcurl json-for-modern-cpp
 AMIBERRY_DEPENDENCIES += flac libpng libserialport libportmidi libzlib libenet
 AMIBERRY_EMULATOR_INFO = amiberry.emulator.yml
 
@@ -38,7 +38,6 @@ define AMIBERRY_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/share/amiberry
 	cp -pr $(@D)/buildroot-build/whdboot $(TARGET_DIR)/usr/share/amiberry/
 	cp -pr $(@D)/buildroot-build/data $(TARGET_DIR)/usr/share/amiberry/
-	cp -p $(@D)/data/AmigaTopaz.ttf $(TARGET_DIR)/usr/share/amiberry/data
 endef
 
 define AMIBERRY_EVMAP


### PR DESCRIPTION
bump amiberry to 8.1.5
   major change : sdl2 -> sdl3

amiberry: improve generator
  - .hdf files must be quoted  ( file with , character for example)
  - rename deprecated auto_height -> auto_crop
  - rename deprecated flicker_free -> scandoubler
  - don't force default values to command line. (This is overriding .uae files)
  - add keep_aspect_ratio option
  - add crt shaders options
  - set default mouse0 when player2 is not defined
  - add integer scaling option value
  - add 8MB fast ram by default to improve compat with whdload
  - add force_ntsc option. (+auto detect from filename like P-UAE)