### PR TITLE
batocera-xtract: no need for additional switches in CLI [44]

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-xtract
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-xtract
@@ -19,7 +19,8 @@
 #           application/x-xz-compressed-tar;application/x-iso;application/zip;
 
 # inital idea and inspired by brunoeduardobrasil, 07/19/2025 cyperghost aka crcerror
-# ec-codes: ec-0 okay, ec-1 error, ec-10 parameter l used
+# ec-codes: ec-0 - okay, ec-10 parameter l,s or f used - okay
+# ec-1 - error, ec-2 parameter not found - error, ec-3 dest dir not found - error
 # ec-11 archives not supported for extraction, ec-12 archives not supported for showing content
 # ec-21 to 29 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz exe (only InnoSetup)
 
@@ -48,8 +49,8 @@ list_archive () {
     esac
 
     # Just output for CLI as list - usefull for further scripting
-    [[ "${2}" == "l" ]]  && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $2 }'; return 10; }
-    [[ "${2}" == "s" ]]  && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3 }'; return 10; }
+    [[ "${2}" == "l" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $2 }'; return 10; }
+    [[ "${2}" == "s" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3 }'; return 10; }
     [[ "${2}" == "f" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }'; return 10; }
 
     #Options needs to be added to PCmanFM "file-roller --open"
@@ -128,24 +129,32 @@ case "$1" in
         FILE=("${FILE[@]/*\/}")   #strip pathes this builds archives with relative pathes
         zip -q -r "$DEST" "${FILE[@]}" && { yad --title "Created zip" --text "Created '$(readlink -f $DEST)' and added ${#FILE[@]} files:\n$(printf '%s\n' "${FILE[@]}")"; exit 0; } || exit 1
     ;;
-   *) ret=2
+   *)   ret=2
+        if [[ -e "${1}" ]]; then
+          batocera-xtract clix "${@}"
+          ret=$?
+        fi
+        [[ $ret -ne 2 ]] && exit $ret # <- avoid second call of error message for unsupported parameters in CLI
 esac
 
 case $ret in
     0|1|10) true ;;
     2) # Action not defined
         [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Action: '$1' is unknown"; exit 2; }
-        echo "Usage: $(basename "$0") <SWITCHES> [ARCHIVEFILE] {DESTINATION-DIR}"; echo
+        echo "Usage: $(basename $0) <SWITCH> [ARCHIVEFILE] <DESTINATION-DIR>"; echo
         echo "    x: extraction of archiv with prompt if DESTINATION is missing"
         echo " clix: extraction of current archive without prompt (CLI)"
         echo "  pyx: extraction of single files: $(basename "$0") pyx <ARCHIVEFILE> <DESTINATION-DIR> <file1> ... <file{n}>"
         echo "    l: list files in archive content"
         echo "    s: list sizes in archive content"
         echo "    f: list size and files"; echo
+        echo "default usage: 'batocera-xtract archiv.zip' extracts archiv.zip to PWD"
+        echo "                Parameters in <> are optional"; echo
         echo "Supported archives for extraction: zip 7z rar tar gz iso tar.gz/tgz tar.xz exe"
         echo "Supported archives for list/open : zip 7z rar tar gz iso tar.gz/tgz tar.xz"; echo
         echo "error-codes/return codes:"
-        echo "  ec-0 no error, ec-10 parameter 'l' 's' or 'f', okay -- ec-1 general error -- ec-2 unknown action"
+        echo "  ec-0 no error, ec-10 parameter 'l' 's' or 'f' used -- okay"
+        echo "  ec-1 general error -- ec-2 unknown action -- ec-3 destination dir not found"
         echo "  ec-11 to 12 -- archive type not supported for extraction, listing"
         echo "  ec-21 to 28 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz"
         echo "  ec-29       -- file extraction error for exe-files (InnoSetup)" ;echo


### PR DESCRIPTION
`batocera-xtract archive-file.zip` is enough and should simplify usage for the average user. Just an idea out of an discord discussion