### PR TITLE
batocera-steam-update: support both Desktop/ and .local/share/applications for game shortcuts

### DIFF
--- a/package/batocera/utils/batocera-steam/batocera-steam-update
+++ b/package/batocera/utils/batocera-steam/batocera-steam-update
@@ -59,11 +59,18 @@ if [ ! -f "$steam_file" ]; then
     echo "Steam app added to game list." >> $log
 fi
 
-# Check if the Steam applications directory exists
-steam_apps_dir="/userdata/saves/flatpak/data/Desktop/"
+# Steam may put .desktop files in different locations depending on Flatpak/Steam version:
+# - newer: $HOME/Desktop (via XDG Desktop portal)
+# - older: $HOME/.var/app/com.valvesoftware.Steam/.local/share/applications
+steam_search_dirs=()
+for dir in \
+    "/userdata/saves/flatpak/data/Desktop" \
+    "/userdata/saves/flatpak/data/.var/app/com.valvesoftware.Steam/.local/share/applications"; do
+    [ -d "$dir" ] && steam_search_dirs+=("$dir")
+done
 
-if [ ! -d "$steam_apps_dir" ]; then
-    echo "Steam applications directory not found: $steam_apps_dir" >> $log
+if [ ${#steam_search_dirs[@]} -eq 0 ]; then
+    echo "Steam applications directory not found" >> $log
 else
     # Define a blacklist of words to check in game names
     BLACKLIST=(
@@ -91,7 +98,7 @@ else
     }
 
     # Find and process applications
-    find "$steam_apps_dir" -name "*.desktop" | (
+    find "${steam_search_dirs[@]}" -name "*.desktop" | (
         N=0
         while read STEAMAPP; do
             if grep -qE '^[ ]*Categories[ ]*=.*Game.*$' "${STEAMAPP}"; then  # Check if it's a game


### PR DESCRIPTION
Steam Flatpak writes `.desktop` game shortcuts to different locations depending on the version:
- newer: `$HOME/Desktop/` via the XDG Desktop portal
- older: `$HOME/.var/app/com.valvesoftware.Steam/.local/share/applications/`

Instead of hardcoding one path, the script now searches both directories if they exist. Duplicates are already prevented by the existing `test -e "/userdata/roms/steam/${BASEAPP}.steam"` check.