### PR TITLE
dmd-simulator: play numbered image sequences on game selection

### DIFF
--- a/package/batocera/screens/dmd-simulator/scripts/game-selected.sh
+++ b/package/batocera/screens/dmd-simulator/scripts/game-selected.sh
@@ -10,9 +10,35 @@ txt2http() {
     sed -e s+"&"+"%26"+g
 }
 
+# stop any running sequence loop from a previous game selection
+DMD_SEQ_PID="/tmp/dmd-sequence.pid"
+if [ -f "$DMD_SEQ_PID" ]; then
+    kill "$(cat "$DMD_SEQ_PID")" 2>/dev/null
+    rm -f "$DMD_SEQ_PID"
+fi
+
 DMDOPT=
 DMDFORMAT=$(batocera-settings-get dmd.format)
 test "${DMDFORMAT}" = "hd" && DMDOPT="--hd"
+
+# Play files matching a glob pattern in sequence (name_1.gif, name_2.gif, ...)
+# Returns 0 if at least one file was found, 1 otherwise
+play_sequence() {
+    FILES=$(find "/userdata/system/dmd/games/${GSYSTEM}" -maxdepth 1 -name "$1" 2>/dev/null | sort)
+    test -z "$FILES" && return 1
+    N=$(echo "$FILES" | wc -l)
+    if [ "$N" -le 1 ]; then
+	dmd-play ${DMDOPT} -f "$FILES"
+    else
+	(while true; do
+	    echo "$FILES" | while read F; do
+		dmd-play ${DMDOPT} --once -f "$F"
+	    done
+	done) &
+	echo $! > "$DMD_SEQ_PID"
+    fi
+    return 0
+}
 
 # custom
 # exact matching
@@ -27,7 +53,15 @@ do
     fi
 done
 
-# exact matching
+# sequence matching (name_1.gif, name_2.gif, ...)
+for EXT in gif png
+do
+    if play_sequence "${ROMBASE}_*.${EXT}"; then
+	exit 0
+    fi
+done
+
+# exact matching (normalized)
 ROMMIN=$(echo "${ROMBASE}" | sed -e s+"([^)]*)"+""+g -e s+"[^A-Za-z0-9]"+""+g | tr A-Z a-z) # lowercase and remove any but a-z and 0-9, remove things in parenthesis
 for EXT in gif png
 do
@@ -35,6 +69,14 @@ do
     if test -e "${CUS}"
     then
 	dmd-play ${DMDOPT} -f "${CUS}"
+	exit 0
+    fi
+done
+
+# sequence matching (normalized)
+for EXT in gif png
+do
+    if play_sequence "${ROMMIN}_*.${EXT}"; then
 	exit 0
     fi
 done
@@ -60,4 +102,3 @@ else
     dmd-play ${DMDOPT} --clear
     exit 0
 fi
-


### PR DESCRIPTION
If `supermarioworld_1.gif`, `supermarioworld_2.gif`, ... are present in `/userdata/system/dmd/games/<system>/`, they are played in sequence on the DMD instead of requiring a single file match.

The sequence loops in background using `--once` per file (which blocks for the duration of each animation). A PID file ensures the previous loop is killed at each new game-selected event. Works for both raw and normalized rom names, and for gif and png.