### PR TITLE
batocera-storage-manager: handle_disk_event : use udevadm settle inst…

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
@@ -436,8 +436,7 @@ handle_disk_event() {
     if [ -z "$(lsblk -no NAME "/dev/$devname" | grep -v "^$devname$")" ]; then
         log_msg "SAFETY: [$devname] No partitions seen. Probing for hidden tables..."
         partprobe "/dev/$devname" >/dev/null 2>&1
-        # Use a short sleep to let the kernel update /dev
-        sleep 0.2 
+        udevadm settle
     fi
 
     # Check if this disk contains any Android/Qualcomm/Critical labels


### PR DESCRIPTION
…ead sleep after partprobe

sleep 0.2 can be too short for some devices like usb

use a clean "udevadm settle" to wait udev populate the partitions