### PR TITLE
batocera-storage-manager: don't trigger partitions detect from disk d…

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -1,3 +1,18 @@
+# 2026/xx/xx - batocera.linux 44 - xxxx
+### Special Notes
+
+### Hardware
+
+### Added
+
+### Fixed
+
+### Changed / Improved
+
+### Updated
+
+### System
+
 # 2026/05/08 - batocera.linux 43 - Glasswing
 ### Special Notes
 - x86_64 Handhelds with AMD and Intel graphics will be supported on the preferred x86_64-v3 image using Wayland and the LabWC compositor.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/bigpemu/bigpemuGenerator.py
@@ -240,10 +240,21 @@ class BigPEmuGenerator(Generator):
 
         mkdir_if_not_exists(bigPemuConfig.parent)
 
-        # Delete the config file to update controllers
-        # As it doesn't like to be updated
-        # ¯\_(ツ)_/¯
+        # Preserve user-configured keys that BigPEmu writes in-game and that
+        # are not managed by the generator (BIOS paths, screen shader).
+        _PRESERVED_KEYS = ("BootROM", "CDBIOS", "ScreenEffect")
+        preserved: dict[str, Any] = {}
         if bigPemuConfig.exists():
+            try:
+                existing = json.loads(bigPemuConfig.read_text())
+                for key in _PRESERVED_KEYS:
+                    if key in existing.get("BigPEmuConfig", {}):
+                        preserved[key] = existing["BigPEmuConfig"][key]
+            except Exception:
+                pass
+            # Delete the config file to update controllers
+            # As it doesn't like to be updated
+            # ¯\_(ツ)_/¯
             bigPemuConfig.unlink()
 
         config: dict[str, Any] = {}
@@ -402,6 +413,8 @@ class BigPEmuGenerator(Generator):
         # Close off input
         config["BigPEmuConfig"]["Input"]["InputVer"] = 2
         config["BigPEmuConfig"]["Input"]["InputPluginVer"] = 666
+
+        config["BigPEmuConfig"].update(preserved)
 
         bigPemuConfig.write_text(json.dumps(config, indent=4))
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
@@ -38,20 +38,20 @@ log_initial_info() {
         
         if [ -n "$major_disks" ]; then
             for disk in $major_disks; do
-                
+
                 # Check if the device actually exists as a block device
                 if [ -b "/dev/$disk" ]; then
-                    parted_output=$(parted -s "/dev/$disk" unit MiB print 2>&1)
-                    
+                    sgdisk_output=$(sfdisk -d "/dev/$disk" 2>&1)
+
                     if [ $? -eq 0 ]; then
                         log_msg "SYSTEM: DISK: /dev/$disk"
-                        # Log each line of the parted output
-                        echo "$parted_output" | while IFS= read -r line; do
-                            log_msg "PARTED:   $line"
+                        # Log each line of the sgdisk output
+                        echo "$sgdisk_output" | while IFS= read -r line; do
+                            log_msg "SGDISK:   $line"
                         done
                     else
-                        # Log the disk but note that parted failed to read it.
-                        log_msg "SYSTEM: DISK: /dev/$disk - WARNING: parted failed to read the disk partition table. Skipping detailed dump."
+                        # Log the disk but note that sgdisk failed to read it.
+                        log_msg "SYSTEM: DISK: /dev/$disk - WARNING: sgdisk failed to read the disk partition table. Skipping detailed dump."
                     fi
                 else
                     log_msg "SYSTEM: DISK: /dev/$disk - WARNING: Device not found (block file missing)."

--- a/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
@@ -436,8 +436,7 @@ handle_disk_event() {
     if [ -z "$(lsblk -no NAME "/dev/$devname" | grep -v "^$devname$")" ]; then
         log_msg "SAFETY: [$devname] No partitions seen. Probing for hidden tables..."
         partprobe "/dev/$devname" >/dev/null 2>&1
-        # Use a short sleep to let the kernel update /dev
-        sleep 0.2 
+        udevadm settle
     fi
 
     # Check if this disk contains any Android/Qualcomm/Critical labels

--- a/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-storage-manager
@@ -462,14 +462,7 @@ handle_disk_event() {
         done
 
         if [ "$has_parts" = true ]; then
-            log_msg "INFO: [$devname] Partition table ($pttype) with partitions found. Triggering child partition scans..."
-            for p in /sys/class/block/$parent/$parent*; do
-                 [ -e "$p" ] || continue
-                 PNAME=$(basename "$p")
-                 [ "$PNAME" == "$parent" ] && continue
-                 log_msg "TRIGGER: Executing detection for child partition $PNAME"
-                 $0 detect "$PNAME" &
-            done
+            log_msg "INFO: [$devname] Partition table ($pttype) with partitions found. Partition events handled by udev."
             exit 0
         fi
         


### PR DESCRIPTION
…etect

the udev rule is already triggering partition detection.

They are a race in current code, where "batocera-storage detect partition" is called twice, 1 in the disk detect itself
and
1 by the udev rule

The first call to "detect /dev/sda1" from disk "detect /dev/sda" is wrong, and also, all partition infos are not seen by kernel at this moment, and "udevadm info" on partition (to detect GPT hidden,recovery,.. for example) is failing with empty result

race log:

```
[2026-05-13 13:48:48] ENTRY: [sda] Detect event triggered.
[2026-05-13 13:48:48] INFO: [sda] Partition table (gpt) with partitions found. Triggering child partition scans...
[2026-05-13 13:48:48] TRIGGER: Executing detection for child partition sda1
[2026-05-13 13:48:48] ENTRY: [sda1] Detect event triggered.
[2026-05-13 13:48:48] SKIP: [sda1] System/Recovery GUID detected for /dev/sda1 ().
[2026-05-13 13:48:48] ENTRY: [sda1] Detect event triggered.
[2026-05-13 13:48:48] MOUNT: [/dev/sda1] Attempting ext4 mount...
[2026-05-13 13:48:48] MOUNT: [/dev/sda1] Success at /media/sda1_2
```

with this fix:

```
[2026-05-13 14:04:01] ENTRY: [sda] Detect event triggered.
[2026-05-13 14:04:01] INFO: [sda] Partition table (gpt) with partitions found. Partition events handled by udev.
[2026-05-13 14:04:01] ENTRY: [sda1] Detect event triggered.
[2026-05-13 14:04:01] MOUNT: [/dev/sda1] Attempting ext4 mount...
[2026-05-13 14:04:01] MOUNT: [/dev/sda1] Success at /media/sda1_2
```