### PR TITLE
es_systems: triforce: limit supported extensions to iso and rvz

### DIFF
--- a/package/batocera/emulationstation/batocera-es-system/es_systems.yml
+++ b/package/batocera/emulationstation/batocera-es-system/es_systems.yml
@@ -2229,7 +2229,7 @@ triforce:
   manufacturer: Namco, Sega, Nintendo
   release: 2003
   hardware: arcade
-  extensions: [gcm, iso, gcz, ciso, wbfs, elf, dol, m3u]
+  extensions: [iso, rvz]
   platform: triforce, arcade
   emulators:
     dolphin:


### PR DESCRIPTION
gcm, gcz, ciso, wbfs, elf, dol and m3u formats don't make sense for Triforce arcade dumps.

Add. rvz (supported)