### PR TITLE
bsnes/bsnes-hd: add missing es_features for sgb-msu1 and SNES HD Mode 7

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroOptions.py
@@ -1535,6 +1535,20 @@ def _bsnes_options(
     # Video Filters
     _set_from_system(coreSettings, 'bsnes_video_filter', system, 'bsnes_video_filter', default='disabled')
 
+    # HD Mode 7 (bsnes_hd only, SNES systems)
+    if system.config.core == 'bsnes_hd' and system.name in ('snes', 'snes-msu1'):
+        _set_from_system(coreSettings, 'bsnes_mode7_scale',       system, 'bsnes_mode7_scale',       default='disable')
+        _set_from_system(coreSettings, 'bsnes_mode7_supersample', system, 'bsnes_mode7_supersample', default='none')
+        _set_from_system(coreSettings, 'bsnes_mode7_wsMode',         system, 'bsnes_mode7_wsMode',         default='Off')
+
+    # SGB options
+    if system.name == 'sgb-msu1':
+        # BIOS
+        _set_from_system(coreSettings, 'bsnes_sgb_bios', system, 'bsnes_sgb_bios', default='SGB1.sfc')
+        # Hide SGB border (bsnes only, not supported by bsnes_hd)
+        if system.config.core == 'bsnes':
+            _set_from_system(coreSettings, 'bsnes_hide_sgb_border', system, 'bsnes_hide_sgb_border', default='OFF')
+
 
 # Nintendo SNES/GB/GBC/SGB
 def _mesen_s_options(
@@ -2463,6 +2477,7 @@ _option_functions: dict[str, Callable[[UnixSettings, Emulator, Path, Guns, Devic
     'snes9x': _snes9x_options,
     'snes9x_next': _snes9x_next_options,
     'bsnes': _bsnes_options,
+    'bsnes_hd': _bsnes_options,
     'mesen-s': _mesen_s_options,
     'vb': _vb_options,
     'opera': _opera_options,

--- a/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/bsnes_hd.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bsnes-hd/bsnes_hd.libretro.core.yml
@@ -4,7 +4,106 @@ features:
 shared_features:
   - rewind
   - autosave
+custom_features:
+  bsnes_video_filter:
+    prompt: VIDEO FILTERS
+    description: Apply a video filter to mimic various NTSC TV signals.
+    choices:
+      'Off': None
+      NTSC (RF): NTSC (RF)
+      NTSC (RGB): NTSC (RGB)
+      NTSC (S-Video): NTSC (S-Video)
+      NTSC (Composite): NTSC (Composite)
 systems:
-  - sgb-msu1
-  - snes
-  - snes-msu1
+  - name: sgb-msu1
+    custom_features:
+      bsnes_sgb_bios:
+        group: ADVANCED OPTIONS
+        prompt: SUPER GAME BOY BIOS
+        description: Select the SGB BIOS. Requires SGB1.sfc or SGB2.sfc in the bios folder.
+        choices:
+          Super Game Boy: SGB1.sfc
+          Super Game Boy 2: SGB2.sfc
+
+  - name: snes
+    custom_features:
+      bsnes_mode7_scale:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 SCALE
+        description: Scale Mode 7 graphics at a higher resolution. Higher values require more GPU power.
+        choices:
+          'Off': disable
+          '240p (1x)': 1x
+          '480p (2x)': 2x
+          '720p (3x)': 3x
+          '960p (4x)': 4x
+          '1200p (5x)': 5x
+          '1440p (6x)': 6x
+          '1680p (7x)': 7x
+          '1920p (8x)': 8x
+          '2160p (9x)': 9x
+          '2400p (10x)': 10x
+      bsnes_mode7_supersample:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 SUPERSAMPLING
+        description: Supersample Mode 7 before scaling for smoother edges. Higher values require more GPU power.
+        choices:
+          'Off': none
+          2x: 2x
+          3x: 3x
+          4x: 4x
+          5x: 5x
+          6x: 6x
+          7x: 7x
+          8x: 8x
+          9x: 9x
+          10x: 10x
+      bsnes_mode7_wsMode:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 WIDESCREEN
+        description: Extend the horizontal field of view for widescreen displays.
+        choices:
+          'Off': Off
+          Only for Mode 7 scenes: Mode 7
+          Enable for all scenes: all
+  - name: snes-msu1
+    custom_features:
+      bsnes_mode7_scale:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 SCALE
+        description: Scale Mode 7 graphics at a higher resolution. Higher values require more GPU power.
+        choices:
+          'Off': disable
+          '240p (1x)': 1x
+          '480p (2x)': 2x
+          '720p (3x)': 3x
+          '960p (4x)': 4x
+          '1200p (5x)': 5x
+          '1440p (6x)': 6x
+          '1680p (7x)': 7x
+          '1920p (8x)': 8x
+          '2160p (9x)': 9x
+          '2400p (10x)': 10x
+      bsnes_mode7_supersample:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 SUPERSAMPLING
+        description: Supersample Mode 7 before scaling for smoother edges. Higher values require more GPU power.
+        choices:
+          'Off': none
+          2x: 2x
+          3x: 3x
+          4x: 4x
+          5x: 5x
+          6x: 6x
+          7x: 7x
+          8x: 8x
+          9x: 9x
+          10x: 10x
+      bsnes_mode7_wsMode:
+        group: ADVANCED OPTIONS
+        prompt: HD MODE 7 WIDESCREEN
+        description: Extend the horizontal field of view for widescreen displays.
+        choices:
+          'Off': Off
+          Only for Mode 7 scenes: Mode 7
+          Enable for all scenes: all

--- a/package/batocera/emulators/retroarch/libretro/libretro-bsnes/bsnes.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-bsnes/bsnes.libretro.core.yml
@@ -16,6 +16,21 @@ custom_features:
       NTSC (S-Video): NTSC (S-Video)
       NTSC (Composite): NTSC (Composite)
 systems:
-  - sgb-msu1
+  - name: sgb-msu1
+    custom_features:
+      bsnes_sgb_bios:
+        group: ADVANCED OPTIONS
+        prompt: SUPER GAME BOY BIOS
+        description: Select the SGB BIOS. Requires SGB1.sfc or SGB2.sfc in the bios folder.
+        choices:
+          Super Game Boy: SGB1.sfc
+          Super Game Boy 2: SGB2.sfc
+      bsnes_hide_sgb_border:
+        group: ADVANCED OPTIONS
+        prompt: HIDE SGB BORDER
+        description: Hide the Super Game Boy decorative border.
+        choices:
+          'Off': OFF
+          'On': ON
   - snes
   - snes-msu1


### PR DESCRIPTION
Add missing es_features for **sgb-msu1** and SNES **HD Mode 7**