### PR TITLE
thextech: fix asset pack not loading due to missing trailing slash

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/thextech/thextechGenerator.py
@@ -25,7 +25,7 @@ class TheXTechGenerator(Generator):
 
         commandArray.extend([system.config.get_bool('frameskip', True, return_values=("--frameskip", "--no-frameskip"))])
 
-        commandArray.extend(["-c", rom])
+        commandArray.extend(["-c", str(rom) + "/"])
 
         return Command.Command(array=commandArray)
 


### PR DESCRIPTION
https://discord.com/channels/357518249883205632/357518249883205633/1505104668316139620
<img width="705" height="152" alt="grafik" src="https://github.com/user-attachments/assets/4c7dd433-0aa0-4cd6-8157-acf39d706ab5" />
