### PR TITLE
batocera-wine: Installers carry the presetted values to the installed…

### DIFF
--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -1094,27 +1094,18 @@ case "${ACTION}" in
 
     "install")
         # Sync windows_installers and windows, so setting from installer section will be used for the installed program
-        # This method is very safe and can also be improved in time, but it syncs all settings between 2 systems - better then wild seds
+        # This method is very safe and but it syncs all settings between 2 systems, $INST_ROMGAMENAME is used for an unique filename
         INST_ROMGAMENAME="$(date +%y%m%d-%H%M%S)_${ROMGAMENAME%.*}.wine"
-        # get global keys of all windows_installers.value
-        readarray -t globalkeys < <(grep -o "^windows_installers\.[^=]*" /userdata/system/batocera.conf)
-        # get local keys with the gamename within
-        readarray -t localkeys < <(grep -o "^windows_installers\[.$ROMGAMENAME[^=]*" /userdata/system/batocera.conf)
 
-        for i in "${globalkeys[@]}"; do
+        while read i; do
             val_key=$(batocera-settings-get "$i")
-            batocera-settings-set "${i/windows_installers/windows}" "$val_key"
-        done
-        echo "Converted ${#globalkeys[@]} windows_installers -> windows as global keys"
-
-        for i in "${localkeys[@]}"; do
-            val_key=$(batocera-settings-get "$i")
-            i="${i/windows_installers/windows}"
-            batocera-settings-set "${i/$ROMGAMENAME/$INST_ROMGAMENAME}" "$val_key"
-        done
-        echo "Converted ${#localkeys[@]} windows_installers -> windows as local game specific keys"
-
-        unset i val_key globalkeys localkeys
+            printf "Converted ${i} -> "
+            i="${i/${SYSTEM}_installers/${SYSTEM}}"
+            i="${i/${ROMGAMENAME}/${INST_ROMGAMENAME}}"
+            batocera-settings-set "${i}" "$val_key"
+            echo "${i} with value ${val_key}"
+        done < <(grep -Eo "^${SYSTEM}_installers(\[\"${ROMGAMENAME}\"\])?[.][^=]*" /userdata/system/batocera.conf)
+        unset i val_key
 
         init_wine && requestFileSystem "${GAMENAME}"
 	case "${GAMEEXT,,}" in
@@ -1225,6 +1216,5 @@ case "${ACTION}" in
         echo "${0} windows stop"                                 >&2
         exit 1
 esac
-
 cleanAndExit $?
 exit $?

--- a/package/batocera/utils/batocera-wine/batocera-wine
+++ b/package/batocera/utils/batocera-wine/batocera-wine
@@ -293,7 +293,6 @@ wine_options() {
     # Nvidia variables
     [[ -e "/userdata/system/cache/nvidia" ]] || mkdir -p "/userdata/system/cache/nvidia"
     export XDG_CACHE_HOME="/userdata/system/cache"
-
     export __GL_SHADER_DISK_CACHE_SIZE=2147483648
     export __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1
     export __GL_SHADER_DISK_CACHE_PATH="${XDG_CACHE_HOME}"/nvidia
@@ -1094,15 +1093,38 @@ case "${ACTION}" in
 	;;
 
     "install")
-    init_wine && requestFileSystem "${GAMENAME}"
+        # Sync windows_installers and windows, so setting from installer section will be used for the installed program
+        # This method is very safe and can also be improved in time, but it syncs all settings between 2 systems - better then wild seds
+        INST_ROMGAMENAME="$(date +%y%m%d-%H%M%S)_${ROMGAMENAME%.*}.wine"
+        # get global keys of all windows_installers.value
+        readarray -t globalkeys < <(grep -o "^windows_installers\.[^=]*" /userdata/system/batocera.conf)
+        # get local keys with the gamename within
+        readarray -t localkeys < <(grep -o "^windows_installers\[.$ROMGAMENAME[^=]*" /userdata/system/batocera.conf)
+
+        for i in "${globalkeys[@]}"; do
+            val_key=$(batocera-settings-get "$i")
+            batocera-settings-set "${i/windows_installers/windows}" "$val_key"
+        done
+        echo "Converted ${#globalkeys[@]} windows_installers -> windows as global keys"
+
+        for i in "${localkeys[@]}"; do
+            val_key=$(batocera-settings-get "$i")
+            i="${i/windows_installers/windows}"
+            batocera-settings-set "${i/$ROMGAMENAME/$INST_ROMGAMENAME}" "$val_key"
+        done
+        echo "Converted ${#localkeys[@]} windows_installers -> windows as local game specific keys"
+
+        unset i val_key globalkeys localkeys
+
+        init_wine && requestFileSystem "${GAMENAME}"
 	case "${GAMEEXT,,}" in
 	    "exe"|"msi")
-		#Winepoint with stripped extension, add current date_time to avoid duplicates
-		install_exe_msi "${GAMEEXT,,}" "${GAMENAME}" "${G_ROMS_DIR}/$(date +%y%m%d-%H%M%S)_${ROMGAMENAME%.*}.wine"
+		#INST_ROMGAMENAME -> Winepoint with stripped extension, add current date_time to avoid duplicates
+		install_exe_msi "${GAMEEXT,,}" "${GAMENAME}" "${G_ROMS_DIR}/${INST_ROMGAMENAME}"
 		;;
 	    "iso")
-		#Parsing Gamename, Winepoint with stripped extension, add current date_time to avoid duplicates
-		install_iso "${GAMENAME}" "${G_ROMS_DIR}/$(date +%y%m%d-%H%M%S)_${ROMGAMENAME%.*}.wine"
+		#INST_ROMGAMENAME -> Parsing Gamename, Winepoint with stripped extension, add current date_time to avoid duplicates
+		install_iso "${GAMENAME}" "${G_ROMS_DIR}/${INST_ROMGAMENAME}"
 		;;
 	    *)
 		echo "unknown extension ${GAMEEXT}" >&2
@@ -1110,6 +1132,8 @@ case "${ACTION}" in
 	;;
 
     "tricks"|"createprefix")
+        [[ "${GAMENAME}" == "." ]] && { GAMENAME="$PWD"; GAMEEXT="${GAMENAME##*.}"; }
+        [[ -e "${GAMENAME}" ]] && GAMENAME="$(realpath "${GAMENAME}")" || exit 1
         init_wine && requestFileSystem "${GAMENAME}"
         case "${GAMEEXT,,}" in
             "wine")
@@ -1122,6 +1146,7 @@ case "${ACTION}" in
                 setPrefixArch "${l_PREFIX}" "${WINE_VERSION}" "${ACTION}"
                 test -d "${l_PREFIX}" && echo "WINEPREFIX: '$_' already found!" || { createWineDirectory "$_" && echo "WINEPREFIX: '$_' created!"; }
                 ;;
+             *) echo "Fullpath for game needed, or extension is unknown ... Exit now!"; exit 1
         esac
 
         if [[ -n "${TRICK}" && "${ACTION}" == "tricks" ]]; then
@@ -1200,5 +1225,6 @@ case "${ACTION}" in
         echo "${0} windows stop"                                 >&2
         exit 1
 esac
+
 cleanAndExit $?
 exit $?


### PR DESCRIPTION
… game

Installers lost all presetted values setted from windows_installers menu. This copies now all detected values from windows_installers to windows config keys.

Also keeps track of individial setted game changes.

So `game1,exe` will be installed to `20260517-121315-game1.wine` and will get the same settings as defined for the game1.exe (Runners, DVVK etc etc....)

EDIT:
Optimized code and also better log output
```
Converted windows_installers.wine-runner -> windows.wine-runner with value win32-wine-tkg
Converted windows_installers["HiBitSysInfo-setup-2.1.30.exe"].enable_win32 -> windows["260518-212505_HiBitSysInfo-setup-2.1.30.wine"].enable_win32 with value 1
*** Chosen WINE runner is win32-wine-tkg ***
*** Directory checks complete, WINE runner is win32-wine-tkg ***
------ requestFileSystem called from main ------
main: File      /userdata/roms/windows_installers/HiBitSysInfo-setup-2.1.30.exe uses filesystem ext4
setPrefixArch: Environment Prefix setted -> RUNNER carries 'win32' value
```