### PR TITLE
Debug boot [v44]

### DIFF
--- a/board/batocera/fsoverlay/etc/init.d/S02resize
+++ b/board/batocera/fsoverlay/etc/init.d/S02resize
@@ -128,16 +128,16 @@ if grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "${BOOTCONF}"; then
     )
 
     # --- BEGIN RESIZE ---
-    
+
     # Get /userdata partition details
     PART=$(batocera-part "share_internal")
     PARTNUM=$(batocera-part "share_internal_num")
     echo "Partition name: $PART & number: $PARTNUM" >> "$LOG"
-    
+
     # Check the initial partition size
     PARTSIZE=$(get_partition_size_mb "$PART")
     echo "Initial partition size: ${PARTSIZE} MB" >> "$LOG"
-    
+
     # Determine if we should format based on initial size
     FORMAT_ALLOWED=false
     if [ "$PARTSIZE" -eq 256 ] || [ "$PARTSIZE" -eq 512 ]; then
@@ -146,7 +146,7 @@ if grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "${BOOTCONF}"; then
     else
         echo "Initial partition size is ${PARTSIZE}MB, formatting will be skipped" >> "$LOG"
     fi
-    
+
     # boot disk
     DISK=$(batocera-part prefix "${PART}")
     echo "Disk = $DISK" >> "$LOG"
@@ -158,8 +158,8 @@ if grep -qE '^[ ]*autoresize[ ]*=[ ]*true[ ]*$' "${BOOTCONF}"; then
     PARTTYPE=$(blkid "${PART}" | sed -e s+'^.* TYPE="\([^"]*\)\".*'+'\1'+)
     test "${PARTTYPE}" != "ext4" && exit 0
     echo "Partition type = ${PARTTYPE}" >> "$LOG"
-    
-    # textoutput "Message" "percentage" "command call" 
+
+    # textoutput "Message" "percentage" "command call"
     for i in 1 3 5 7 9 11 13; do
     case $i in
         1)

--- a/board/batocera/fsoverlay/etc/init.d/S11share
+++ b/board/batocera/fsoverlay/etc/init.d/S11share
@@ -147,7 +147,7 @@ mountDevicesOrNetwork() {
         do
             XWAIT=4 # N seconds between each try
             XTRY=$((MAXTRY / XWAIT)) # X tries and give up
-            
+
             while [ "${XTRY}" -gt 0 ]
             do
                 XTRY=$((XTRY-1))
@@ -393,6 +393,28 @@ case "${MODE}" in
         fi
     ;;
 esac
+
+# Debug boot mode
+# We wait for userdata to be mounted normally so we can move and bind mount roms and bios later
+DEBUG_FLAG="/boot/boot/bootmode.debug"
+if [ -f "$DEBUG_FLAG" ]; then
+    echo "[DEBUG BOOT] Checking userdata..."
+
+    FSTYPE="$(awk '$2=="/userdata"{print $3}' /proc/mounts)"
+
+    if [ "$FSTYPE" = "tmpfs" ]; then
+        echo "[DEBUG BOOT] /userdata is already tmpfs. Nothing to do..."
+    else
+        mkdir -p /userdata.real
+
+        echo "[DEBUG BOOT] Moving /userdata to /userdata.real"
+        mount --move /userdata /userdata.real
+
+        echo "[DEBUG BOOT] Mounting new tmpfs as /userdata"
+
+        mountRAMDisk
+    fi
+fi
 
 # filesystem compression
 compressenabled="$(/usr/bin/batocera-settings-get system.fscompression.enabled)"

--- a/board/batocera/fsoverlay/etc/init.d/S12populateshare
+++ b/board/batocera/fsoverlay/etc/init.d/S12populateshare
@@ -69,7 +69,7 @@ then
             do
 		RELATIVE_PATH="${FILE#$IN/}"
 		DEST_FILE="$OUT/$RELATIVE_PATH"
-            
+
 		# Check if the source file is newer than the destination file
 		if [ "$FILE" -nt "$DEST_FILE" ]; then
                     echo "Updating $DEST_FILE"
@@ -151,6 +151,23 @@ ln -sf /userdata/system/machine-id /etc/machine-id
 
 # save to avoid to redo that all the times
 cp /usr/share/batocera/batocera.version /userdata/system/data.version
+
+# Debug boot mode:
+# Bind mount userdata.real/bios and userdata.real/roms to tmpfs userdata
+DEBUG_FLAG="/boot/boot/bootmode.debug"
+if [ -f "$DEBUG_FLAG" ]; then
+    if [ -d /userdata.real/roms ]; then
+        mkdir -p "${OUT}/roms"
+        mount --bind /userdata.real/roms "${OUT}/roms"
+        echo "[DEBUG BOOT] Binding /userdata.real/roms -> ${OUT}/roms"
+    fi
+
+    if [ -d /userdata.real/bios ]; then
+        mkdir -p "${OUT}/bios"
+        mount --bind /userdata.real/bios "${OUT}/bios"
+        echo "[DEBUG BOOT] Binding /userdata.real/bios -> ${OUT}/bios"
+    fi
+fi
 
 # call user script with start condition
 test -e /boot/postshare.sh && bash /boot/postshare.sh start

--- a/package/batocera/boot/batocera-initramfs/init
+++ b/package/batocera/boot/batocera-initramfs/init
@@ -105,12 +105,18 @@ do_root() {
     # fill the overlay with the stored one
     if test -f /boot_root/boot/overlay
     then
-	# the mount can fail if the fs was open in write and not correctly closed
-	if mount -o ro /boot_root/boot/overlay /overlay_root/saved
-	then
-	    cp -pr /overlay_root/saved/* /overlay_root/overlay || return 1
-	    umount /overlay_root/saved                         || return 1
-	fi
+        # check if debug boot is enabled, if so do not use saved overlay
+        if test -f /boot_root/boot/bootmode.debug
+        then
+            echo "[DEBUG BOOT] Skipping saved overlay restore" > /dev/kmsg
+        else
+            # the mount can fail if the fs was open in write and not correctly closed
+            if mount -o ro /boot_root/boot/overlay /overlay_root/saved
+            then
+                cp -pr /overlay_root/saved/* /overlay_root/overlay || return 1
+                umount /overlay_root/saved                         || return 1
+            fi
+        fi
     fi
 
     # mount the squashfs

--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -88,6 +88,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-storage-manager           $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-storage-udev              $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-keyboard                  $(TARGET_DIR)/usr/bin/
+    install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-boot-debug                $(TARGET_DIR)/usr/bin/
 endef
 
 define BATOCERA_SCRIPTS_INSTALL_MOUSE

--- a/package/batocera/core/batocera-scripts/scripts/batocera-boot-debug
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-boot-debug
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Debug flag file needed for initramfs, and anything else that might need to know if debug mode is active.
+
+DEBUG_FLAG="/boot/boot/bootmode.debug"
+
+case "$1" in
+    enable)
+        mount -o remount,rw /boot 2>/dev/null
+        touch "$DEBUG_FLAG"
+        echo "[DEBUG BOOT] enabled"
+        mount -o remount,ro /boot 2>/dev/null
+        exit 0
+        ;;
+    disable)
+        mount -o remount,rw /boot 2>/dev/null
+        rm -f "$DEBUG_FLAG"
+        echo "[DEBUG BOOT] disabled"
+        mount -o remount,ro /boot 2>/dev/null
+        exit 0
+        ;;
+esac
+
+exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-save-overlay
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-save-overlay
@@ -8,6 +8,13 @@ OVERLAYMOUNT="/overlay/saved"
 OVERLAYRAM="/overlay/overlay"
 OVERLAYSIZE=100 # M
 
+DEBUG_FLAG="/boot/boot/bootmode.debug"
+
+if [ -f "$DEBUGFLAG" ]; then
+    echo "[DEBUG BOOT] Overlay save disabled while in debug boot mode."
+    exit 0
+fi
+
 # fix for winscp running bash and then not sourcing /etc/profile
 PATH=$PATH:/sbin
 

--- a/package/batocera/core/batocera-scripts/scripts/batocera-version
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-version
@@ -36,6 +36,14 @@ test -n "${FIND_CUSTOMESSYSTEMS}"  && EXTRA=${EXTRA}s
 test -n "${FIND_CUSTOMSERVICES}"   && EXTRA=${EXTRA}u
 test -n "${FIND_USERSCRIPTS}"      && EXTRA=${EXTRA}v
 
+
+# Override EXTRA if debug boot mode
+DEBUG_FLAG="/boot/boot/bootmode.debug"
+
+if [ -f "${DEBUGFLAG}" ]; then
+    EXTRA="debug"
+fi
+
 if test "${1}" = "--extra"
 then
     if test -z "${EXTRA}"


### PR DESCRIPTION
Purpose of this PR is to allow users to easily reboot their machine into a debug mode, where any overlay file will be ignored, prevent any new overlay from being saved while in debug mode, and a new tmpfs userdata being mounted with bind mounts to existing userdata.real/bios+roms for testing purposes.

A follow up PR will be needed for ES toggle switch after this is merged.