### PR TITLE
emulators/ppsspp: fix Infrastructure DNS Server ES option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/ppsspp/ppssppConfig.py
@@ -227,10 +227,10 @@ def createPPSSPPConfig(iniConfig: CaseSensitiveConfigParser, system: Emulator):
             iniConfig.set("Network", "ForcedFirstConnect",   str(system.config.get_bool("adhoc_forced_connect", False)))
 
             # Infrastructure DNS
-            infra_auto_dns = system.config.get_bool("infra_auto_dns", True)
-            iniConfig.set("Network", "InfrastructureAutoDNS", str(infra_auto_dns))
-            if not infra_auto_dns:
+            if not iniConfig.has_option("Network", "PrimaryDNSServer"):
                 iniConfig.set("Network", "PrimaryDNSServer", "67.222.156.250")
+            infra_auto_dns = system.config.get_str("infra_auto_dns", "auto")
+            iniConfig.set("Network", "InfrastructureAutoDNS", "False" if infra_auto_dns == "manual" else "True")
 
     # Custom : allow the user to configure directly PPSSPP via batocera.conf via lines like : ppsspp.section.option=value
     for section_option, user_config_value in system.config.items(starts_with='ppsspp.'):

--- a/package/batocera/emulators/ppsspp/ppsspp.emulator.yml
+++ b/package/batocera/emulators/ppsspp/ppsspp.emulator.yml
@@ -249,11 +249,12 @@ custom_features:
       'On': true
   infra_auto_dns:
     submenu: NETWORKING
-    prompt: INFRASTRUCTURE AUTO DNS
-    description: "When disabled, PPSSPP uses 67.222.156.250 as DNS server for Infrastructure (online) mode."
+    prompt: INFRASTRUCTURE DNS SERVER
+    description: "Auto/On: PPSSPP handles DNS automatically. Manual: disables auto DNS, use PrimaryDNSServer in ppsspp.ini."
     choices:
-      'Off': false
-      'On': true
+      'Auto': "auto"
+      'On': "on"
+      'Manual': "manual"
 
 systems:
   - psp


### PR DESCRIPTION
Rename option to INFRASTRUCTURE DNS SERVER with three choices: Auto/On (InfrastructureAutoDNS=True) and Manual (InfrastructureAutoDNS=False). PrimaryDNSServer defaults to 67.222.156.250 on first run and is never overwritten automatically afterwards.