### PR TITLE
fix-rpcs3-unresponsive-exit[v43.1?]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -28,7 +28,7 @@ class Rpcs3Generator(Generator):
     def getHotkeysContext(self) -> HotkeysContext:
         return {
             "name": "rpcs3",
-            "keys": { "exit": ["KEY_LEFTALT", "KEY_F4"] }
+            "keys": {}
         }
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):

--- a/package/batocera/emulators/rpcs3/ps3.rpcs3.keys
+++ b/package/batocera/emulators/rpcs3/ps3.rpcs3.keys
@@ -1,0 +1,9 @@
+{
+    "actions_player1": [
+        {
+            "trigger": ["hotkey", "start"],
+            "type": "exec",
+            "target": "pkill -KILL -f rpcs3"
+        }
+    ]
+}

--- a/package/batocera/emulators/rpcs3/rpcs3.mk
+++ b/package/batocera/emulators/rpcs3/rpcs3.mk
@@ -50,5 +50,12 @@ else
     RPCS3_CONF_OPTS += -DUSE_VULKAN=OFF
 endif
 
+define RPCS3_EVMAPY
+	# evmap config
+	mkdir -p $(TARGET_DIR)/usr/share/evmapy
+	cp $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/emulators/rpcs3/*.keys \
+	    $(TARGET_DIR)/usr/share/evmapy
+endef
+
 $(eval $(cmake-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
Fixes issue where the current method of exiting (ALT+F4) leaves rpcs3 unresponsive, causing it to hang for roughly 10 seconds or so and pop up an unresponsive error.

Solution: Instead just use a evmapy key file to pkill -KILL it, which cleanly terminates the process.