### PR TITLE
emulatorlauncher-niceness

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -586,7 +586,7 @@ def runCommand(command: Command) -> int:
     if not command.array:
         raise BadCommandLineArguments
 
-    proc = subprocess.Popen(command.array, env=command.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(["nice", "-n", "-4", *command.array], env=command.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     exitcode = 0
 
     try:


### PR DESCRIPTION
This may be more or less important depending on what other daemons, services, etc could be running. So it just ensures any application launched by ES has a slight priority. At the very least it causes absolutely no harm.


Knulli has been doing this for at least a year now.