### PR TITLE
add-dolphin-battlergcpro

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -6,6 +6,7 @@
 
 ### Added
 - NanoBoyAdvance as an alternative GBA emulator
+- Dolphin GameCube Controller type BattlerGC Pro (x-input mode with analog+digital triggers)
 ### Fixed
 
 ### Changed / Improved

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinControllers.py
@@ -504,6 +504,13 @@ def get_AltMapping(system: Emulator, nplayer: int, anyMapping: Mapping[str, str 
         mapping['y'] = 'Buttons/B'
         mapping['x'] = 'Buttons/Y'
 
+    # BattlerGC Pro is a "real" GC style controller, plus full analog+digital analogs(x-input only, home+B turns on/off, digital triggers are mirrored l3/r3).
+    if system.config.get(f"dolphin_port_{nplayer}_type") == '6c':
+        mapping['a'] = 'Buttons/B'
+        mapping['b'] = 'Buttons/A'
+        mapping['l3'] = 'Triggers/L'
+        mapping['r3'] = 'Triggers/R'
+
     return mapping
 
 def generateControllerConfig_any(system: Emulator, playersControllers: Controllers, wheels: DeviceInfoMapping, filename: str, anyDefKey: str, anyMapping: Mapping[str, str | None], anyReverseAxes: Mapping[str | None, str], anyReplacements: Mapping[str, str] | None, extraOptions: Mapping[str, str] = {}, wheelMapping: Mapping[str, str | None] | None = None, wheelReverseAxes: Mapping[str | None, str] | None = None, wheelExtraOptions: Mapping[str, str] = {}) -> None:

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/dolphin/dolphinGenerator.py
@@ -147,7 +147,7 @@ class DolphinGenerator(Generator):
             key = f"dolphin_port_{i+1}_type"
             if value := system.config.get(key):
                 # Set value to 6 if it is 6a or 6b. This is to differentiate between Standard Controller and GameCube Controller type.
-                value = "6" if value in ["6a", "6b"] else value
+                value = "6" if value in ["6a", "6b", "6c"] else value
                 # Sub in the appropriate values from es_features, accounting for the 1 integer difference.
                 dolphinSettings.set("Core", f"SIDevice{i}", value)
             else:

--- a/package/batocera/emulators/dolphin-emu/dolphin.emulator.yml
+++ b/package/batocera/emulators/dolphin-emu/dolphin.emulator.yml
@@ -147,6 +147,7 @@ cores:
           None: 0
           Standard Controller: 6a
           GameCube Controller: 6b
+          BattlerGC Pro Controller: 6c
           GameCube Adapter for Wii U: 12
           Steering Wheel: 8
           Dance Mat: 9
@@ -161,6 +162,7 @@ cores:
           None: 0
           Standard Controller: 6a
           GameCube Controller: 6b
+          BattlerGC Pro Controller: 6c
           GameCube Adapter for Wii U: 12
           Steering Wheel: 8
           Dance Mat: 9
@@ -175,6 +177,7 @@ cores:
           None: 0
           Standard Controller: 6a
           GameCube Controller: 6b
+          BattlerGC Pro Controller: 6c
           GameCube Adapter for Wii U: 12
           Steering Wheel: 8
           Dance Mat: 9
@@ -189,6 +192,7 @@ cores:
           None: 0
           Standard Controller: 6a
           GameCube Controller: 6b
+          BattlerGC Pro Controller: 6c
           GameCube Adapter for Wii U: 12
           Steering Wheel: 8
           Dance Mat: 9


### PR DESCRIPTION
Adds support for battlergc-pro in dolphin.

By selecting controller type of "BattlerGC Pro" it will autocorrect the A<->B inputs and map L3+R3 as the digital inputs at the end of the analog trigger pulls.

The battlerGC Pro is one of very few controllers that have real full analog+digital triggers which is what a real gc controller had.