### PR TITLE
batocera-systems: align ColecoVision BIOS path with actual emulator location

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-systems
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-systems
@@ -510,7 +510,7 @@ systems = {
                                                 { "md5": "3cdf2fe48ac4224b56f26c03f6c68982", "zippedFile": "printer.u2", "file": "bios/adam_prn.zip"}, ] },
 
     # ---------- ColecoVision ---------- #
-    "colecovision": { "name": "ColecoVision", "biosFiles": [ { "md5": "2c66f5911e5b42b8ebe113403548eee7", "file": "bios/colecovision.rom" } ] },
+    "colecovision": { "name": "ColecoVision", "biosFiles": [ { "md5": "2c66f5911e5b42b8ebe113403548eee7", "file": "bios/Machines/COL - ColecoVision/coleco.rom" } ] },
 
      # ---------- BBC Micro ---------- #
     "bbc":   { "name": "BBC Micro", "biosFiles":  [ { "md5": "", "file": "bios/bbcb.zip"  },


### PR DESCRIPTION
## Summary

The Missing-BIOS check (Main Menu → System Settings → Missing BIOS) reports the ColecoVision BIOS as missing even when the user has set it up correctly per the [wiki](https://wiki.batocera.org/systems:colecovision).

### Root cause

`batocera-systems` lists the required file as `bios/colecovision.rom`, but no emulator packaged in Batocera reads from that path:

| Emulator | Path it actually reads from |
|---|---|
| **libretro: bluemsx** (default core) | `bios/Machines/COL - ColecoVision/coleco.rom` |
| libretro: gearcoleco | no BIOS file required |
| OpenMSX | `bios/openmsx/coleco.rom` (filepool registered by `openmsxGenerator.py`; `bios/Machines` also works) |
| CLK | `bios/ColecoVision/coleco.rom` (per CLK's own ROMCatalogue) |

The "canonical" path `bios/colecovision.rom` is only referenced in `batocera-systems`; nothing else in the repo reads from it. Users who place the file at the BlueMSX path the wiki documents have a working setup but the check still complains.

### Change

Point the check at the BlueMSX path, since BlueMSX is the default core for ColecoVision. Same MD5 (`2c66f5911e5b42b8ebe113403548eee7`), same 8 KB boot ROM — just at the path that actually corresponds to a working setup.

```diff
- "colecovision": { "name": "ColecoVision", "biosFiles": [ { "md5": "...", "file": "bios/colecovision.rom" } ] },
+ "colecovision": { "name": "ColecoVision", "biosFiles": [ { "md5": "...", "file": "bios/Machines/COL - ColecoVision/coleco.rom" } ] },
```

Other emulators continue to read from their own paths and are independent of this check.