### PR TITLE
batocera-cpu-temp

### DIFF
--- a/batocera-Changelog.md
+++ b/batocera-Changelog.md
@@ -46,6 +46,7 @@
 - Mesa3D to 26.1.0
 - Nvidia Open Production driver to 595.71.05
 - Nvidia 580 Legacy driver to 580.159.03
+- New cpu temp helper script, batocera-cpu-temp
 
 # 2026/05/xx - batocera.linux 43.1
 - fix es for missing systems / collections disappearing

--- a/package/batocera/core/batocera-scripts/batocera-scripts.mk
+++ b/package/batocera/core/batocera-scripts/batocera-scripts.mk
@@ -88,6 +88,7 @@ define BATOCERA_SCRIPTS_INSTALL_TARGET_CMDS
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-storage-manager           $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-storage-udev              $(TARGET_DIR)/usr/bin/
     install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-keyboard                  $(TARGET_DIR)/usr/bin/
+    install -m 0755 $(BATOCERA_SCRIPTS_PATH)/scripts/batocera-cpu-temp                  $(TARGET_DIR)/usr/bin/
 endef
 
 define BATOCERA_SCRIPTS_INSTALL_MOUSE

--- a/package/batocera/core/batocera-scripts/scripts/batocera-cpu-temp
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-cpu-temp
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Find hottest likely candidate for cpu. Some handhelds use clusters.
+# Fallback to just reporting the hottest temp found, and if nothing is found report 0C.
+
+BEST_CPU=""
+BEST_ANY=""
+
+check_temp() {
+    label="$1"
+    file="$2"
+
+    IFS= read -r v < "$file" 2>/dev/null || return
+
+    case "$v" in
+        ''|*[!0-9-]*) return ;;
+    esac
+
+    c=$(( v / 1000 ))
+
+    [ "$c" -gt 0 ] 2>/dev/null || return
+    [ "$c" -lt 130 ] 2>/dev/null || return
+
+    if [ -z "$BEST_ANY" ] || [ "$c" -gt "$BEST_ANY" ]; then
+        BEST_ANY="$c"
+    fi
+
+    case "$label" in
+        *[Cc][Pp][Uu]*|*[Cc][Ll][Uu][Ss][Tt][Ee][Rr]*)
+            if [ -z "$BEST_CPU" ] || [ "$c" -gt "$BEST_CPU" ]; then
+                BEST_CPU="$c"
+            fi
+            ;;
+    esac
+}
+
+for z in /sys/class/thermal/thermal_zone* /sys/devices/virtual/thermal/thermal_zone*; do
+    [ -f "$z/temp" ] || continue
+    [ -f "$z/type" ] || continue
+
+    IFS= read -r label < "$z/type" 2>/dev/null || label=""
+    check_temp "$label" "$z/temp"
+done
+
+for h in /sys/class/hwmon/hwmon*; do
+    [ -d "$h" ] || continue
+
+    IFS= read -r name < "$h/name" 2>/dev/null || name=""
+
+    for t in "$h"/temp*_input; do
+        [ -f "$t" ] || continue
+
+        label_file="${t%_input}_label"
+        if [ -f "$label_file" ]; then
+            IFS= read -r label < "$label_file" 2>/dev/null || label=""
+        else
+            label=""
+        fi
+
+        check_temp "$name $label" "$t"
+    done
+done
+
+if [ -n "$BEST_CPU" ]; then
+    echo "${BEST_CPU}C"
+elif [ -n "$BEST_ANY" ]; then
+    echo "${BEST_ANY}C"
+else
+    echo "0C"
+fi
+
+exit 0

--- a/package/batocera/core/batocera-scripts/scripts/batocera-info
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-info
@@ -248,43 +248,7 @@ fi
 # ---------------------------------------------------------------------------
 # Temperature
 # ---------------------------------------------------------------------------
-get_temperature() {
-    local best=""
-    for zone in /sys/devices/virtual/thermal/thermal_zone*; do
-        local type
-        type=$(cat "${zone}/type" 2>/dev/null)
-        # Prefer known CPU zone types
-        case "${type}" in
-            cpu-thermal|x86_pkg_temp|cpu_thermal|arm-thermal|soc-thermal)
-                local t
-                t=$(cat "${zone}/temp" 2>/dev/null)
-                if [ -n "$t" ] && { [ -z "$best" ] || [ "$t" -gt "$best" ]; }; then
-                    best="$t"
-                fi
-                ;;
-        esac
-    done
-
-    # Fall back: hwmon temp*_input, excluding "in" (voltage) sensors
-    if [ -z "$best" ]; then
-        best=$(cat /sys/class/hwmon/hwmon*/temp*_input 2>/dev/null | \
-               sort -rn | head -1)
-    fi
-
-    # Still nothing: global thermal_zone max
-    if [ -z "$best" ]; then
-        best=$(cat /sys/devices/virtual/thermal/thermal_zone*/temp 2>/dev/null | \
-               sort -rn | head -1)
-    fi
-
-    # Trim trailing 3 digits (millidegree → degree)
-    echo "${best}" | sed -e 's/[0-9][0-9][0-9]$//'
-}
-
-TEMPE=$(get_temperature)
-if test -n "${TEMPE}"; then
-    echo "Temperature: ${TEMPE}°C"
-fi
+echo "Temperature: $(batocera-cpu-temp)"
 
 # ---------------------------------------------------------------------------
 # Memory


### PR DESCRIPTION
Add re-usable helper script that searches for hottest likely candidate for cpu, else reports hottest any, and fallback if nothing is found reports 0C.

This is a better deterministic approach vs just simply finding the hottest thing and assuming it's the cpu(it might not be).
This also can reduce a lot of duplicate code in various scripts, bcc, fan controllers, etc.