### PR TITLE
rpcs3-fixes[43.1]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -28,7 +28,7 @@ class Rpcs3Generator(Generator):
     def getHotkeysContext(self) -> HotkeysContext:
         return {
             "name": "rpcs3",
-            "keys": { "exit": ["KEY_LEFTALT", "KEY_F4"] }
+            "keys": { "exit": "/usr/bin/rpcs3-exit", "menu": ["KEY_LEFTSHIFT", "KEY_F10"] }
         }
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):

--- a/package/batocera/emulators/rpcs3/009-disable-psbutton.patch
+++ b/package/batocera/emulators/rpcs3/009-disable-psbutton.patch
@@ -1,0 +1,39 @@
+diff --git a/rpcs3/Input/pad_thread.cpp b/rpcs3/Input/pad_thread.cpp
+index 55652bc22..3626e8df8 100644
+--- a/rpcs3/Input/pad_thread.cpp
++++ b/rpcs3/Input/pad_thread.cpp
+@@ -673,20 +673,20 @@ void pad_thread::operator()()
+ 
+ 				// Check if an LDD pad pressed the PS button (bit 0 of the first button)
+ 				// NOTE: Rock Band 3 doesn't seem to care about the len. It's always 0.
+-				if (pad->ldd /*&& pad->ldd_data.len >= 1 */&& !!(pad->ldd_data.button[0] & CELL_PAD_CTRL_LDD_PS))
+-				{
+-					ps_button_pressed = true;
+-					break;
+-				}
+-
+-				for (const Button& button : pad->m_buttons)
+-				{
+-					if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1 && button.m_outKeyCode == CELL_PAD_CTRL_PS && button.m_pressed)
+-					{
+-						ps_button_pressed = true;
+-						break;
+-					}
+-				}
++				//if (pad->ldd /*&& pad->ldd_data.len >= 1 */&& !!(pad->ldd_data.button[0] & CELL_PAD_CTRL_LDD_PS))
++				//{
++				//	ps_button_pressed = true;
++				//	break;
++				//}
++
++				//for (const Button& button : pad->m_buttons)
++				//{
++				//	if (button.m_offset == CELL_PAD_BTN_OFFSET_DIGITAL1 && button.m_outKeyCode == CELL_PAD_CTRL_PS && button.m_pressed)
++				//	{
++				//		ps_button_pressed = true;
++				//		break;
++				//	}
++				//}
+ 			}
+ 
+ 			// Make sure we call this function only once per button press

--- a/package/batocera/emulators/rpcs3/rpcs3-exit
+++ b/package/batocera/emulators/rpcs3/rpcs3-exit
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+pkill -TERM -x rpcs3 >/dev/null 2>&1
+
+exit 0

--- a/package/batocera/emulators/rpcs3/rpcs3.mk
+++ b/package/batocera/emulators/rpcs3/rpcs3.mk
@@ -50,5 +50,11 @@ else
     RPCS3_CONF_OPTS += -DUSE_VULKAN=OFF
 endif
 
+define RPCS3_INSTALL_RPCS3_EXIT
+	$(INSTALL) -D -m 0755 $(RPCS3_PKGDIR)/rpcs3-exit $(TARGET_DIR)/usr/bin/rpcs3-exit
+endef
+
+RPCS3_POST_INSTALL_TARGET_HOOKS += RPCS3_INSTALL_RPCS3_EXIT
+
 $(eval $(cmake-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
Patch file disables the hard coded psbutton action to hotkey which brings up the rpcs3 menu. Instead it uses hotkeygen to open menu with hotkey+south(like most other emulators).

rpcs3-exit is used instead of alt+f4 to exit because it seems on wayland builds there's some kind of race condition happening which leaves a hanging process. pkill -TERM -x rpcs3 fixes this. So we do that in a script (rpcs3-exit) which hotkeygen calls with the normal exit action (hotkey+start).

@nadenislamarre how does this look?

