### PR TITLE
Fix shadps4 build when cross-compiling

### DIFF
--- a/package/batocera/emulators/shadps4/0001-imgui-renderer-allow-prebuilt-fontembed.patch
+++ b/package/batocera/emulators/shadps4/0001-imgui-renderer-allow-prebuilt-fontembed.patch
@@ -1,0 +1,17 @@
+diff --git a/src/imgui/renderer/CMakeLists.txt b/src/imgui/renderer/CMakeLists.txt
+--- a/src/imgui/renderer/CMakeLists.txt
++++ b/src/imgui/renderer/CMakeLists.txt
+@@ -3,7 +3,12 @@
+
+ project(ImGui_Resources)
+
+-add_executable(Dear_ImGui_FontEmbed ${CMAKE_SOURCE_DIR}/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp)
++if(Dear_ImGui_FontEmbed_EXECUTABLE)
++    add_executable(Dear_ImGui_FontEmbed IMPORTED GLOBAL)
++    set_target_properties(Dear_ImGui_FontEmbed PROPERTIES IMPORTED_LOCATION "${Dear_ImGui_FontEmbed_EXECUTABLE}")
++else()
++    add_executable(Dear_ImGui_FontEmbed ${CMAKE_SOURCE_DIR}/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp)
++endif()
+
+ set(FONT_LIST
+     NotoSansJP-Regular.ttf

--- a/package/batocera/emulators/shadps4/shadps4.mk
+++ b/package/batocera/emulators/shadps4/shadps4.mk
@@ -45,5 +45,17 @@ SHADPS4_CONF_OPTS += -DENABLE_DISCORD_RPC=OFF
 SHADPS4_CONF_OPTS += -DENABLE_UPDATER=OFF
 SHADPS4_CONF_OPTS += -DVMA_ENABLE_INSTALL=ON
 
+# Dear_ImGui_FontEmbed is a build-time code generator. When cross-compiling
+# (e.g. aarch64 host -> x86_64 target) the binary built with the target
+# toolchain cannot be executed on the build host, so pre-build it with the
+# host compiler and tell CMake to import it (see 0001-imgui-renderer-*.patch).
+define SHADPS4_BUILD_HOST_FONTEMBED
+	$(HOSTCXX) -O2 -o $(@D)/host-dear-imgui-fontembed \
+		$(@D)/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp
+endef
+SHADPS4_PRE_CONFIGURE_HOOKS += SHADPS4_BUILD_HOST_FONTEMBED
+
+SHADPS4_CONF_OPTS += -DDear_ImGui_FontEmbed_EXECUTABLE=$(BUILD_DIR)/shadps4-$(SHADPS4_VERSION)/host-dear-imgui-fontembed
+
 $(eval $(cmake-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
Pre-build `Dear_ImGui_FontEmbed` binary with the host compiler and tell CMake to import it, since the binary built with the target toolchain cannot be executed on the build host when cross-compiling (e.g. aarch64 host -> x86_64 target).