### PR TITLE
Fix openjk cross-compilation

### DIFF
--- a/package/batocera/ports/openjk/001-cross-compile.patch
+++ b/package/batocera/ports/openjk/001-cross-compile.patch
@@ -1,13 +1,100 @@
-diff --git a/codemp/rd-rend2/CMakeLists.txt b/codemp/rd-rend2/CMakeLists.txt
-index 786cf25..44ecef9 100644
+From: Batocera build system
+Subject: [PATCH] Allow cross-compiling: import a pre-built compact_glsl and
+ keep its sources compilable without an OpenGL development package
+
+When cross-compiling, the rd-rend2 GLSL "compact_glsl" code-generator must run
+on the build host (not the target).  Two source-level changes let the
+build system pre-compile compact_glsl with the host toolchain and hand the
+resulting binary to the CMake cross build:
+
+  * codemp/rd-rend2/CMakeLists.txt:
+      - If -Dcompact_glsl_EXECUTABLE=<path> is passed, declare compact_glsl
+        as an IMPORTED GLOBAL executable target pointing at that path
+        instead of compiling it for the target architecture.
+      - The custom-command that invokes compact_glsl uses the bare target
+        name (resolved by CMake to either the in-tree binary or the imported
+        location) so the in-build relative path is no longer hard-coded;
+        this is the same branch used on Win32 / Apple.
+
+  * codemp/rd-rend2/qgl.h:
+      - Wraps the entire body of the header in #if !defined(GLSL_BUILDTOOL).
+        Under GLSL_BUILDTOOL we provide stubs for the seven GL types that
+        tr_local.h actually references (GLuint, GLenum, GLint, GLsizei,
+        GLfloat, GLboolean, GLsync) and the GL_UNSIGNED_INT macro, then
+        short-circuit before the qgl* function-pointer wrappers and the PFN*
+        extern declarations.  This lets compact_glsl be compiled directly by
+        the build system's HOSTCXX without an OpenGL development package on
+        the build machine.
+
 --- a/codemp/rd-rend2/CMakeLists.txt
 +++ b/codemp/rd-rend2/CMakeLists.txt
-@@ -193,7 +193,7 @@ if (NOT WIN32 AND NOT APPLE)
- 	target_compile_definitions(compact_glsl PRIVATE "ARCH_STRING=\"${Architecture}\"")
+@@ -182,18 +182,25 @@
+ target_link_libraries(${MPRend2} ${MPRend2Libraries})
+ target_include_directories(${MPRend2} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+-# GLSL shader file generator
+-add_executable(compact_glsl
+-	${MPDir}/rd-rend2/glsl/compact.cpp
+-	${MPDir}/rd-rend2/tr_allocator.cpp
+-	${MPDir}/rd-rend2/tr_allocator.h
+-	${MPDir}/rd-rend2/tr_glsl_parse.cpp)
+-target_compile_definitions(compact_glsl PRIVATE "GLSL_BUILDTOOL" "NOMINMAX")
+-if (NOT WIN32 AND NOT APPLE)
+-	target_compile_definitions(compact_glsl PRIVATE "ARCH_STRING=\"${Architecture}\"")
++# GLSL shader file generator.  When cross-compiling, the build system can
++# supply a pre-built host binary via -Dcompact_glsl_EXECUTABLE=<path>, in
++# which case we import it instead of building one for the target.
++if(compact_glsl_EXECUTABLE)
++	add_executable(compact_glsl IMPORTED GLOBAL)
++	set_target_properties(compact_glsl PROPERTIES IMPORTED_LOCATION "${compact_glsl_EXECUTABLE}")
++else()
++	add_executable(compact_glsl
++		${MPDir}/rd-rend2/glsl/compact.cpp
++		${MPDir}/rd-rend2/tr_allocator.cpp
++		${MPDir}/rd-rend2/tr_allocator.h
++		${MPDir}/rd-rend2/tr_glsl_parse.cpp)
++	target_compile_definitions(compact_glsl PRIVATE "GLSL_BUILDTOOL" "NOMINMAX")
++	if (NOT WIN32 AND NOT APPLE)
++		target_compile_definitions(compact_glsl PRIVATE "ARCH_STRING=\"${Architecture}\"")
++	endif()
++	target_include_directories(compact_glsl PRIVATE "${MPRend2IncludeDirectories}")
  endif()
- target_include_directories(compact_glsl PRIVATE "${MPRend2IncludeDirectories}")
+-target_include_directories(compact_glsl PRIVATE "${MPRend2IncludeDirectories}")
 -if (WIN32 OR APPLE)
-+if (WIN32 OR APPLE OR CMAKE_CROSSCOMPILING)
++if (WIN32 OR APPLE OR compact_glsl_EXECUTABLE)
  add_custom_command(
  	OUTPUT
  		${CMAKE_CURRENT_BINARY_DIR}/glsl_shaders.cpp
+--- a/codemp/rd-rend2/qgl.h
++++ b/codemp/rd-rend2/qgl.h
+@@ -1,5 +1,24 @@
+ #pragma once
+ 
++#if defined(GLSL_BUILDTOOL)
++// The compact_glsl code-generator only includes this header transitively via
++// tr_local.h; it never calls OpenGL.  Provide the minimal subset of GL types
++// and macros referenced by tr_local.h so the tool can be compiled on a host
++// that has no OpenGL development files installed, and stop here -- the rest
++// of qgl.h (qgl* function-pointer wrappers and PFN externs) needs the full
++// glext.h definitions and is unused by the tool.
++typedef unsigned int    GLenum;
++typedef unsigned char   GLboolean;
++typedef unsigned int    GLuint;
++typedef int             GLint;
++typedef int             GLsizei;
++typedef float           GLfloat;
++typedef struct __GLsync *GLsync;
++#ifndef GL_UNSIGNED_INT
++#define GL_UNSIGNED_INT 0x1405
++#endif
++#else // GLSL_BUILDTOOL
++
+ #if defined( __LINT__ )
+ #	include <GL/gl.h>
+ #elif defined( _WIN32 )
+@@ -614,3 +633,5 @@
+ extern PFNGLQUERYCOUNTERPROC qglQueryCounter;
+ extern PFNGLGETQUERYOBJECTI64VPROC qglGetQueryObjecti64v;
+ extern PFNGLGETQUERYOBJECTUI64VPROC qglGetQueryObjectui64v;
++
++#endif // GLSL_BUILDTOOL

--- a/package/batocera/ports/openjk/openjk.mk
+++ b/package/batocera/ports/openjk/openjk.mk
@@ -25,7 +25,7 @@ OPENJK_LICENSE = GPL-2.0 license
 OPENJK_LICENSE_FILE = LICENSE.txt
 OPENJK_EMULATOR_INFO = openjk.emulator.yml
 
-OPENJK_DEPENDENCIES += host-openjk libjpeg-bato libpng sdl2 zlib
+OPENJK_DEPENDENCIES += libjpeg-bato libpng sdl2 zlib
 
 OPENJK_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
 OPENJK_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
@@ -35,16 +35,27 @@ OPENJK_CONF_OPTS += -DBuildJK2SPEngine=ON
 OPENJK_CONF_OPTS += -DBuildJK2SPGame=ON
 OPENJK_CONF_OPTS += -DBuildJK2SPRdVanilla=ON
 
-HOST_OPENJK_DEPENDENCIES = mesa3d
+# compact_glsl is a build-time code generator (it embeds .glsl shader files
+# into a C++ source file). When cross-compiling, the binary built with the
+# target toolchain cannot be executed on the build host, so pre-build it
+# with the host compiler and tell CMake to import it via the cache variable
+# added in 001-cross-compile.patch.
+OPENJK_COMPACT_GLSL_BIN = $(@D)/host-compact_glsl
+OPENJK_COMPACT_GLSL_SRCS = \
+	$(@D)/codemp/rd-rend2/glsl/compact.cpp \
+	$(@D)/codemp/rd-rend2/tr_allocator.cpp \
+	$(@D)/codemp/rd-rend2/tr_glsl_parse.cpp
 
-HOST_OPENJK_CONF_OPTS += -DCMAKE_BUILD_TYPE=Release
-HOST_OPENJK_CONF_OPTS += -DCMAKE_FIND_ROOT_PATH="$(HOST_DIR);$(STAGING_DIR)"
-HOST_OPENJK_CONF_OPTS += -DBUILD_SHARED_LIBS=OFF
-HOST_OPENJK_CONF_OPTS += -DUseInternalSDL2=ON
-HOST_OPENJK_CONF_OPTS += -DUseInternalJPEG=ON
-HOST_OPENJK_CONF_OPTS += -DUseInternalPNG=ON
+define OPENJK_BUILD_HOST_COMPACT_GLSL
+	$(HOSTCXX) -O2 -std=c++11 -DGLSL_BUILDTOOL -DNOMINMAX \
+		-DARCH_STRING='"host"' \
+		-I$(@D)/codemp -I$(@D)/codemp/rd-rend2 -I$(@D)/shared \
+		-I$(@D)/lib/gsl-lite/include \
+		-o $(OPENJK_COMPACT_GLSL_BIN) $(OPENJK_COMPACT_GLSL_SRCS)
+endef
+OPENJK_PRE_CONFIGURE_HOOKS += OPENJK_BUILD_HOST_COMPACT_GLSL
 
-HOST_OPENJK_BUILD_OPTS += --target compact_glsl
+OPENJK_CONF_OPTS += -Dcompact_glsl_EXECUTABLE=$(BUILD_DIR)/openjk-$(OPENJK_VERSION)/host-compact_glsl
 
 define OPENJK_EVMAPY
 	mkdir -p $(TARGET_DIR)/usr/share/evmapy
@@ -52,13 +63,7 @@ define OPENJK_EVMAPY
 	    $(TARGET_DIR)/usr/share/evmapy
 endef
 
-define HOST_OPENJK_INSTALL_CMDS
-	$(INSTALL) -D -m 0755 $(HOST_OPENJK_BUILDDIR)/compact_glsl \
-	    $(HOST_DIR)/usr/bin/compact_glsl
-endef
-
 OPENJK_POST_INSTALL_TARGET_HOOKS += OPENJK_EVMAPY
 
 $(eval $(cmake-package))
-$(eval $(host-cmake-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
Pre-build `compact_glsl` with the host compiler and tell CMake to import it instead of building one for the target, and let `compact_glsl` compile without an OpenGL development package on the build host by providing stubs for the GL types it references.