### PR TITLE
add-pcsx2-es-settings

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/pcsx2/pcsx2Generator.py
@@ -312,6 +312,10 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
     if not pcsx2INIConfig.has_section("EmuCore/GS"):
         pcsx2INIConfig.add_section("EmuCore/GS")
 
+    ## [EMUCORE/Speedhacks]
+    if not pcsx2INIConfig.has_section("EmuCore/Speedhacks"):
+        pcsx2INIConfig.add_section("EmuCore/Speedhacks")
+
     # Renderer
     # Check Vulkan first to be sure
     if vulkan.is_available():
@@ -407,12 +411,26 @@ def configureINI(config_directory: Path, bios_directory: Path, system: Emulator,
     # OSD Performance Position
     pcsx2INIConfig.set("EmuCore/GS", "OsdPerformancePos", system.config.get("pcsx2_osd_performance_position", "0"))
 
+    # Crop Overscan
+    cropOverscan = "3" if system.config.get_bool("pcsx2_overscan") else "0"
+
+    pcsx2INIConfig.set("EmuCore/GS", "CropLeft", cropOverscan)
+    pcsx2INIConfig.set("EmuCore/GS", "CropTop", cropOverscan)
+    pcsx2INIConfig.set("EmuCore/GS", "CropRight", cropOverscan)
+    pcsx2INIConfig.set("EmuCore/GS", "CropBottom", cropOverscan)
+
     # TV Shader
     pcsx2INIConfig.set("EmuCore", "TVShader", system.config.get("pcsx2_shaderset", "0"))
 
     pcsx2INIConfig.set("EmuCore", "AutoIncrementSlot", system.config.get_bool('incrementalsavestates', True, return_values=("true", "false")))
 
     pcsx2INIConfig.set("EmuCore", "SaveStateOnShutdown", system.config.get_bool('autosave', return_values=("true", "false")))
+
+    # VU thread speedhack
+    pcsx2INIConfig.set("EmuCore/Speedhacks", "vuThread", system.config.get_bool("pcsx2_vuthread", return_values=("true", "false")))
+
+    # EE Cycle Rate speedhack
+    pcsx2INIConfig.set("EmuCore/Speedhacks", "EECycleRate", system.config.get("pcsx2_eecyclerate", "0"))
 
     ## [InputSources]
     if not pcsx2INIConfig.has_section("InputSources"):

--- a/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
+++ b/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
@@ -88,6 +88,11 @@ cores:
           Standard (4:3): 4:3
           Widescreen (16:9): 16:9
           10:7 (1.43:1 - custom): 10:7
+      pcsx2_crop_overscan:
+        submenu: DISPLAY
+        prompt: CROP OVERSCAN
+        description: Crops a small number of pixels from the screen edges to hide visual artifacts.
+        preset: switchauto
       pcsx2_deinterlacing:
         submenu: DISPLAY
         prompt: DEINTERLACING
@@ -262,6 +267,25 @@ cores:
           Maximum 2 Players (Default): 2
           Maximum 4 Players: 4
           Maximum 8 Players: 8
+      pcsx2_vuthread:
+        submenu: SPEEDHACKS
+        group: ADVANCED OPTIONS
+        prompt: MULTI-THREADED VU1
+        description: Runs VU1 emulation on a separate thread to improve performance on multi-core CPUs. May cause issues in some games.
+        preset: switchauto
+      pcsx2_eecyclerate:
+        submenu: SPEEDHACKS
+        group: ADVANCED OPTIONS
+        prompt: EE CYCLE RATE
+        description: Adjusts the emulated PS2 CPU speed. Lower or higher values may improve performance or game speed, but may cause issues.
+        choices:
+          "50%": -3
+          "60%": -2
+          "75%": -1
+          "100%(Default)": 0
+          "130%": 1
+          "180%": 2
+          "300%": 3
       pcsx2_texture_replacements:
         group: ADVANCED OPTIONS
         prompt: TEXTURE REPLACEMENTS


### PR DESCRIPTION
Adds new ES settings for pcsx2.

1. crop overscan. Some games have visual artifacts on the edge of the screen. I found 3 pixels is enough with all the games I tested so it's simple as a toggle on/off.

2. Speedhacks submenu for multi-threaded VU1 and EE cycle rate. Some games require EE cycle rate to be > 100% to run full speed. Shadow of the colossus is a good example. with EE cycle rate of 180% it gets and holds around 60 fps. Other games benefit as well like Killzone, etc. Lowering EE cycle rate can make performance better on lower end hardware with some games.