### PR TITLE
change-rpcs3-hdd0-location

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -16,7 +16,7 @@ from ...exceptions import BatoceraException
 from ...utils import vulkan
 from ..Generator import Generator
 from . import rpcs3Controllers
-from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG
+from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG, RPCS3_DEV_HDD0
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -33,7 +33,32 @@ class Rpcs3Generator(Generator):
             "keys": { "exit": "/usr/bin/rpcs3-exit", "menu": ["KEY_LEFTSHIFT", "KEY_F10"] }
         }
 
+    def _migrateDevHdd0(self):
+        legacy_dev_hdd0 = RPCS3_CONFIG_DIR / 'dev_hdd0'
+
+        mkdir_if_not_exists(RPCS3_DEV_HDD0)
+
+        if not legacy_dev_hdd0.exists():
+            return
+
+        for source in legacy_dev_hdd0.rglob("*"):
+            relative_path = source.relative_to(legacy_dev_hdd0)
+            target = RPCS3_DEV_HDD0 / relative_path
+
+            if source.is_dir():
+                mkdir_if_not_exists(target)
+                continue
+
+            mkdir_if_not_exists(target.parent)
+
+            if not target.exists():
+                shutil.move(str(source), str(target))
+            else:
+                _logger.warning("Skipping RPCS3 dev_hdd0 migration conflict: %s -> %s", source, target)
+
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
+
+        self._migrateDevHdd0()
 
         rpcs3Controllers.generateControllerConfig(system, playersControllers, rom)
 
@@ -69,6 +94,9 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Core"] = {}
         if "VFS" not in rpcs3ymlconfig:
             rpcs3ymlconfig["VFS"] = {}
+        # Set new save location for hdd0
+        rpcs3ymlconfig["VFS"]["/dev_hdd0/"] = f"{RPCS3_DEV_HDD0}/"
+
         if "Video" not in rpcs3ymlconfig:
             rpcs3ymlconfig["Video"] = {}
         if "Audio" not in rpcs3ymlconfig:
@@ -252,7 +280,7 @@ class Rpcs3Generator(Generator):
             with rom.open() as fp:
                 for line in fp:
                     if len(line) >= 9:
-                        romName = RPCS3_CONFIG_DIR / "dev_hdd0" / "game" / line.strip().upper() / "USRDIR" / "EBOOT.BIN"
+                        romName = RPCS3_DEV_HDD0 / "game" / line.strip().upper() / "USRDIR" / "EBOOT.BIN"
 
             if romName is None:
                 raise BatoceraException(f'No game ID found in {rom}')

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
@@ -10,4 +10,5 @@ RPCS3_CONFIG: Final = RPCS3_CONFIG_DIR / 'config.yml'
 RPCS3_CURRENT_CONFIG: Final = RPCS3_CONFIG_DIR / 'GuiConfigs' / 'CurrentSettings.ini'
 RPCS3_CONFIG_INPUT: Final = RPCS3_CONFIG_DIR / 'config_input.yml'
 RPCS3_CONFIG_EVDEV: Final = RPCS3_CONFIG_DIR / 'InputConfigs' / 'Evdev' / 'Default Profile.yml'
+RPCS3_DEV_HDD0: Final = Path('/userdata/saves/ps3/rpcs3/dev_hdd0')
 RPCS3_BIN: Final = Path('/usr/bin/rpcs3')


### PR DESCRIPTION
Changes rpcs3 default location for hdd0, to userdata/saves/ps3/rpcs3/dev_hdd0

This is where the virtual hdd resides which contains save game data, dlc, updates, and installed psn games, etc.

Also migrates pre-existing data to new location automatically.