### PR TITLE
[Bug] Update Kodi languages and H6 defaults

### DIFF
--- a/package/batocera/core/batocera-configgen/configs/configgen-defaults-h6.yml
+++ b/package/batocera/core/batocera-configgen/configs/configgen-defaults-h6.yml
@@ -22,3 +22,6 @@ systemsp:
 cdi:
   emulator: libretro
   core:     same_cdi
+oricatmos:
+  emulator: libretro
+  core:     mame

--- a/package/batocera/kodi/kodi21-resource-language-de_de/kodi21_resource_language_de_de.mk
+++ b/package/batocera/kodi/kodi21-resource-language-de_de/kodi21_resource_language_de_de.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION = 11.0.101
+KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION = 11.0.107
 KODI21_RESOURCE_LANGUAGE_DE_DE_SOURCE = \
     resource.language.de_de-$(KODI21_RESOURCE_LANGUAGE_DE_DE_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_DE_DE_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-el_gr/kodi21_resource_language_el_gr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-el_gr/kodi21_resource_language_el_gr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION = 11.0.75
+KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION = 11.0.81
 KODI21_RESOURCE_LANGUAGE_EL_GR_SOURCE = \
     resource.language.el_gr-$(KODI21_RESOURCE_LANGUAGE_EL_GR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_EL_GR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-es_es/kodi21_resource_language_es_es.mk
+++ b/package/batocera/kodi/kodi21-resource-language-es_es/kodi21_resource_language_es_es.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION = 11.0.97
+KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION = 11.0.104
 KODI21_RESOURCE_LANGUAGE_ES_ES_SOURCE = \
     resource.language.es_es-$(KODI21_RESOURCE_LANGUAGE_ES_ES_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_ES_ES_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-eu_es/kodi21_resource_language_eu_es.mk
+++ b/package/batocera/kodi/kodi21-resource-language-eu_es/kodi21_resource_language_eu_es.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION = 11.0.72
+KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION = 11.0.78
 KODI21_RESOURCE_LANGUAGE_EU_ES_SOURCE = \
     resource.language.eu_es-$(KODI21_RESOURCE_LANGUAGE_EU_ES_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_EU_ES_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-fr_fr/kodi21_resource_language_fr_fr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-fr_fr/kodi21_resource_language_fr_fr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION = 11.0.101
+KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION = 11.0.107
 KODI21_RESOURCE_LANGUAGE_FR_FR_SOURCE = resource.language.fr_fr-$(KODI21_RESOURCE_LANGUAGE_FR_FR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_FR_FR_SITE = https://mirrors.kodi.tv/addons/omega/resource.language.fr_fr
 KODI21_RESOURCE_LANGUAGE_FR_FR_PLUGINNAME=resource.language.fr_fr

--- a/package/batocera/kodi/kodi21-resource-language-it_it/kodi21_resource_language_it_it.mk
+++ b/package/batocera/kodi/kodi21-resource-language-it_it/kodi21_resource_language_it_it.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION = 11.0.100
+KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION = 11.0.106
 KODI21_RESOURCE_LANGUAGE_IT_IT_SOURCE = \
     resource.language.it_it-$(KODI21_RESOURCE_LANGUAGE_IT_IT_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_IT_IT_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-pt_br/kodi21_resource_language_pt_br.mk
+++ b/package/batocera/kodi/kodi21-resource-language-pt_br/kodi21_resource_language_pt_br.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION = 11.0.98
+KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION = 11.0.104
 KODI21_RESOURCE_LANGUAGE_PT_BR_SOURCE = \
     resource.language.pt_br-$(KODI21_RESOURCE_LANGUAGE_PT_BR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_PT_BR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-sv_se/kodi21_resource_language_sv_se.mk
+++ b/package/batocera/kodi/kodi21-resource-language-sv_se/kodi21_resource_language_sv_se.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION = 11.0.94
+KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION = 11.0.101
 KODI21_RESOURCE_LANGUAGE_SV_SE_SOURCE = \
     resource.language.sv_se-$(KODI21_RESOURCE_LANGUAGE_SV_SE_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_SV_SE_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-tr_tr/kodi21_resource_language_tr_tr.mk
+++ b/package/batocera/kodi/kodi21-resource-language-tr_tr/kodi21_resource_language_tr_tr.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION = 11.0.88
+KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION = 11.0.94
 KODI21_RESOURCE_LANGUAGE_TR_TR_SOURCE = \
     resource.language.tr_tr-$(KODI21_RESOURCE_LANGUAGE_TR_TR_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_TR_TR_SITE = \

--- a/package/batocera/kodi/kodi21-resource-language-zh_cn/kodi21_resource_language_zh_cn.mk
+++ b/package/batocera/kodi/kodi21-resource-language-zh_cn/kodi21_resource_language_zh_cn.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION = 11.0.93
+KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION = 11.0.100
 KODI21_RESOURCE_LANGUAGE_ZH_CN_SOURCE = resource.language.zh_cn-$(KODI21_RESOURCE_LANGUAGE_ZH_CN_VERSION).zip
 KODI21_RESOURCE_LANGUAGE_ZH_CN_SITE = https://mirrors.kodi.tv/addons/omega/resource.language.zh_cn
 KODI21_RESOURCE_LANGUAGE_ZH_CN_PLUGINNAME=resource.language.zh_cn


### PR DESCRIPTION
Hi,

I rebuilt the RK3399 image from scratch and encountered a couple of issues during the build process.

The first issue was 404 errors when downloading the Kodi language packages. The second was a missing default configuration for Oric Atmos.

Thanks.