### PR TITLE
emulatorlauncher: fix overlayfs save path for ROMs in subdirectories

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -103,7 +103,7 @@ def start_rom(args: argparse.Namespace, maxnbplayers: int, rom: Path, original_r
         generator = get_generator(system.config.emulator, system.config.core)
 
         with (
-            mount_overlayfs(rom, SAVES / original_rom.parent.name / original_rom.stem)
+            mount_overlayfs(rom, SAVES / system.name / original_rom.stem)
             if original_rom.suffix == ".squashfs" and generator.writesToRom(system.config)
             else contextlib.nullcontext(rom)
         ) as rom:


### PR DESCRIPTION
mount_overlayfs used original_rom.parent.name to build the writable save directory, which only equals the system name when the ROM sits directly in roms/<system>/.

For a ROM nested in a subdirectory like
roms/<system>/subdir/game.squashfs it wrongly became the subdir name, like  /userdata/saves/subdir/game.squashfs

Use system.name instead, matching the save-path convention.