### PR TITLE
Fix retroarch build

### DIFF
--- a/package/batocera/emulators/retroarch/retroarch/026-fix-gl-common-include.patch
+++ b/package/batocera/emulators/retroarch/retroarch/026-fix-gl-common-include.patch
@@ -1,0 +1,16 @@
+diff --git a/gfx/drivers_context/drm_go2_ctx.c b/gfx/drivers_context/drm_go2_ctx.c
+index daf5ff8fdb..104fe05ee0 100644
+--- a/gfx/drivers_context/drm_go2_ctx.c
++++ b/gfx/drivers_context/drm_go2_ctx.c
+@@ -51,6 +51,10 @@
+ #include "../common/egl_common.h"
+ #endif
+ 
++#ifdef HAVE_OPENGL
++#include "../common/gl_common.h"
++#endif
++
+ #ifdef HAVE_MENU
+ #include "../../menu/menu_driver.h"
+ #endif
+


### PR DESCRIPTION
When building rk3326 images, retroarch fails to build due to an undefined function:

```
gfx/drivers_context/drm_go2_ctx.c: In function ‘gfx_ctx_go2_drm_set_video_mode’:
gfx/drivers_context/drm_go2_ctx.c:260:4: error: implicit declaration of function ‘gl_clear’ [-Wimplicit-function-declaration]
  260 |    gl_clear();
      |    ^~~~~~~~
gfx/drivers_context/drm_go2_ctx.c: In function ‘gfx_ctx_go2_drm_swap_buffers’:
gfx/drivers_context/drm_go2_ctx.c:336:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
  336 |        out_w = (out_w > drm->native_width) ? drm->native_width : out_w;
      |                       ^
gfx/drivers_context/drm_go2_ctx.c:336:66: warning: operand of ‘?:’ changes signedness from ‘int’ to ‘unsigned int’ due to unsignedness of other operand [-Wsign-compare]
  336 |        out_w = (out_w > drm->native_width) ? drm->native_width : out_w;
      |                                                                  ^~~~~
make[1]: *** [Makefile:234: obj-unix/release/gfx/drivers_context/drm_go2_ctx.o] Error 1
make[1]: *** Waiting for unfinished jobs....
input/drivers_joypad/udev_joypad.c: In function ‘isNumber’:
input/drivers_joypad/udev_joypad.c:594:13: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  594 |   for(n=0; n<strlen(s); n++) {
      |             ^
input/drivers_joypad/udev_joypad.c: In function ‘udev_joypad_init’:
input/drivers_joypad/udev_joypad.c:692:18: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
  692 |    for (i = 0; i < sorted_count; i++)
      |                  ^
input/drivers/udev_input.c: In function ‘event_isNumber’:
input/drivers/udev_input.c:4079:13: warning: comparison of integer expressions of different signedness:  int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
 4079 |   for(n=0; n<strlen(s); n++) {
      |             ^
gfx/drivers_context/drm_ctx.c: In function ‘gfx_ctx_drm_set_video_mode’:
gfx/drivers_context/drm_ctx.c:799:10: warning: variable ‘refresh_mod’ set but not used [-Wunused-but-set-variable]
  799 |    float refresh_mod;
      |          ^~~~~~~~~~~
gfx/common/drm_common.c: In function ‘drm_get_connector’:
gfx/common/drm_common.c:95:12: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
   95 |       if(i != drmConn) continue;
      |            ^~
gfx/common/drm_common.c:118:12: warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]
  118 |       if(i != drmConn) continue;
      |            ^~
gfx/drivers/gl2.c: In function ‘gl2_renderchain_read_viewport’:
gfx/drivers/gl2.c:2126:24: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
 2126 |          for (y = 0; y < gl->vp.height; y++)
      |                        ^
make[1]: Leaving directory '/rk3326/build/retroarch-4b74434a30c534c763b60ba4cc16f6a94a611c5f'
make: *** [package/pkg-generic.mk:273: /rk3326/build/retroarch-4b74434a30c534c763b60ba4cc16f6a94a611c5f/.stamp_built] Error 2
make: Leaving directory '/build/buildroot'
make: *** [Makefile:323: rk3326-build] Error 2
```

The symbol is compiled so ignoring the warning and linking at the end produces the binary

I'll open a PR with retroarch, but for now this patch fixes the build on batocera's side