### PR TITLE
vpinball: bump libraries to latest

### DIFF
--- a/package/batocera/emulators/vpinball/vpinball.mk
+++ b/package/batocera/emulators/vpinball/vpinball.mk
@@ -3,8 +3,8 @@
 # vpinball
 #
 ################################################################################
-# Version: Commits on Jun 2, 2026
-VPINBALL_VERSION = 62c4238a224a8a5eced318a58fd6c530a45c7388
+# Version: Commits on Jun 10, 2026
+VPINBALL_VERSION = 892deb5c5a0530cf0b4713feae401ae266899921
 VPINBALL_SITE = $(call github,vpinball,vpinball,$(VPINBALL_VERSION))
 VPINBALL_LICENSE = GPLv3+
 VPINBALL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libaltsound/libaltsound.mk
+++ b/package/batocera/libraries/libaltsound/libaltsound.mk
@@ -3,8 +3,8 @@
 # libaltsound
 #
 ################################################################################
-# Version: Commits on May 31, 2026
-LIBALTSOUND_VERSION = b9c0ca1f0444a687a218c93d1c4d3ffa8680311f
+# Version: Commits on Jun 10, 2026
+LIBALTSOUND_VERSION = f4b790a19ae45a9f93ae0051df6933800c7a6446
 LIBALTSOUND_SITE = $(call github,vpinball,libaltsound,$(LIBALTSOUND_VERSION))
 LIBALTSOUND_LICENSE = BSD-3-Clause
 LIBALTSOUND_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libdmdutil/libdmdutil.mk
+++ b/package/batocera/libraries/libdmdutil/libdmdutil.mk
@@ -3,8 +3,8 @@
 # libdmdutil
 #
 ################################################################################
-# Version: Commits on Jun 2, 2026
-LIBDMDUTIL_VERSION = 9cb088f21eb43a688c6f55334c97702461c2f9ad
+# Version: Commits on Jun 10, 2026
+LIBDMDUTIL_VERSION = 5879c321e75c2ca3c5dd9cde5d7c49f0075d1f16
 LIBDMDUTIL_SITE = $(call github,vpinball,libdmdutil,$(LIBDMDUTIL_VERSION))
 LIBDMDUTIL_LICENSE = BSD-3-Clause
 LIBDMDUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libframeutil/libframeutil.mk
+++ b/package/batocera/libraries/libframeutil/libframeutil.mk
@@ -3,8 +3,8 @@
 # libframeutil
 #
 ################################################################################
-# Version: Commits on June 10, 2026
-LIBFRAMEUTIL_VERSION = 03d2483d5cded0bdef84bec24c9ddfdede324b5c
+# Version: Commits on Jun 10, 2026
+LIBFRAMEUTIL_VERSION = 28f2bae0dabcbd5c599e6f62211f009e078c1f96
 LIBFRAMEUTIL_SITE = $(call github,PPUC,libframeutil,$(LIBFRAMEUTIL_VERSION))
 LIBFRAMEUTIL_LICENSE = GPLv3
 LIBFRAMEUTIL_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libserum/libserum.mk
+++ b/package/batocera/libraries/libserum/libserum.mk
@@ -3,8 +3,8 @@
 # libserum
 #
 ################################################################################
-# Version: Commits on Jun 2, 2026
-LIBSERUM_VERSION = 4419fb55635f0adc6e674ea8d895e1d1e1531b8c
+# Version: Commits on Jun 10, 2026
+LIBSERUM_VERSION = 21b28325c4272724e719ab2d17481d851eaf9fd8
 LIBSERUM_SITE = $(call github,ppuc,libserum,$(LIBSERUM_VERSION))
 LIBSERUM_LICENSE = GPLv2+
 LIBSERUM_LICENSE_FILES = LICENSE.md

--- a/package/batocera/libraries/libvni/libvni.mk
+++ b/package/batocera/libraries/libvni/libvni.mk
@@ -3,8 +3,8 @@
 # libvni
 #
 ################################################################################
-# Version: Commits on May 8, 2026
-LIBVNI_VERSION = 99a4ce0c844af75604546d8a4d0a2f98a485e2db
+# Version: Commits on Jun 10, 2026
+LIBVNI_VERSION = 7258e2fa0d086e1224d6510d44a61879e6b344b1
 LIBVNI_SITE = $(call github,PPUC,libvni,$(LIBVNI_VERSION))
 LIBVNI_LICENSE = GPLv2
 LIBVNI_LICENSE_FILES = LICENSE.md

--- a/package/batocera/libraries/libwinevbs/libwinevbs.mk
+++ b/package/batocera/libraries/libwinevbs/libwinevbs.mk
@@ -3,8 +3,8 @@
 # libwinevbs
 #
 ################################################################################
-# Version: Commits on Jun 2, 2026
-LIBWINEVBS_VERSION = ff26b571d4060aaafb9e093d81a749b0897013ca
+# Version: Commits on Jun 10, 2026
+LIBWINEVBS_VERSION = 770447bae894a478fe84ebb21fc00d24beb4d230
 LIBWINEVBS_SITE = $(call github,vpinball,libwinevbs,$(LIBWINEVBS_VERSION))
 LIBWINEVBS_LICENSE = LGPL-2.1
 LIBWINEVBS_LICENSE_FILES = LICENSE

--- a/package/batocera/libraries/libzedmd/libzedmd.mk
+++ b/package/batocera/libraries/libzedmd/libzedmd.mk
@@ -3,8 +3,8 @@
 # libzedmd
 #
 ################################################################################
-# Version: Commits on May 8, 2026
-LIBZEDMD_VERSION = 24044222a83ffed33f93d9f0a0baa68fe9fa5a47
+# Version: Commits on Jun 10, 2026
+LIBZEDMD_VERSION = 5c44646f2af4b1419b4cdcaed3a2799ca9439221
 LIBZEDMD_SITE = $(call github,PPUC,libzedmd,$(LIBZEDMD_VERSION))
 LIBZEDMD_LICENSE = GPLv3
 LIBZEDMD_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Updated all dependent libraries after new `LIBFRAMEUTIL` package was made. 