### PR TITLE
fix: rpcs3: move VFS mounts to dedicated vfs.yml

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -16,7 +16,7 @@ from ...exceptions import BatoceraException
 from ...utils import vulkan
 from ..Generator import Generator
 from . import rpcs3Controllers
-from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG, RPCS3_DEV_HDD0
+from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG, RPCS3_DEV_HDD0, RPCS3_VFS
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -94,14 +94,13 @@ class Rpcs3Generator(Generator):
         if RPCS3_CONFIG.is_file():
             rpcs3ymlconfig = safe_load_yaml12(RPCS3_CONFIG, dict[str, dict[str, Any]]) or {}
 
+        # VFS is no longer stored in config.yml: RPCS3 reads it from a dedicated vfs.yml
+        # file. Drop any stale VFS section that older versions may have written here.
+        rpcs3ymlconfig.pop("VFS", None)
+
         # Add Nodes if not in the file
         if "Core" not in rpcs3ymlconfig:
             rpcs3ymlconfig["Core"] = {}
-        if "VFS" not in rpcs3ymlconfig:
-            rpcs3ymlconfig["VFS"] = {}
-        rpcs3ymlconfig["VFS"]["/dev_hdd0/"] = (str(rom / "dev_hdd0") + "/" if is_psn_squashfs
-                                               else f"{RPCS3_DEV_HDD0}/")
-
         if "Video" not in rpcs3ymlconfig:
             rpcs3ymlconfig["Video"] = {}
         if "Audio" not in rpcs3ymlconfig:
@@ -271,6 +270,38 @@ class Rpcs3Generator(Generator):
             yaml = YAML(pure=True)
             yaml.default_flow_style = False
             yaml.dump(rpcs3ymlconfig, file)
+
+        dev_hdd0 = str(rom / "dev_hdd0") + "/" if is_psn_squashfs else f"{RPCS3_DEV_HDD0}/"
+
+        # For a PSN squashfs, redirect /dev_hdd1/ to the overlay when it ships one.
+        if is_psn_squashfs and (rom / "dev_hdd1").is_dir():
+            dev_hdd1 = str(rom / "dev_hdd1") + "/"
+        else:
+            dev_hdd1 = "$(EmulatorDir)dev_hdd1/"
+
+        rpcs3vfsconfig: dict[str, Any] = {
+            "$(EmulatorDir)": "",
+            "/dev_hdd0/": dev_hdd0,
+            "/dev_hdd1/": dev_hdd1,
+            "/dev_flash/": "$(EmulatorDir)dev_flash/",
+            "/dev_flash2/": "$(EmulatorDir)dev_flash2/",
+            "/dev_flash3/": "$(EmulatorDir)dev_flash3/",
+            "/dev_bdvd/": "$(EmulatorDir)dev_bdvd/",
+            "/games/": "$(EmulatorDir)games/",
+            "/app_home/": "",
+            "/dev_usb***/": {
+                "/dev_usb000": {"Path": "$(EmulatorDir)dev_usb000/", "Serial": "", "VID": "", "PID": ""},
+                **{
+                    f"/dev_usb00{index}": {"Path": "", "Serial": "", "VID": "", "PID": ""}
+                    for index in range(1, 8)
+                },
+            },
+        }
+
+        with RPCS3_VFS.open("w") as file:
+            yaml = YAML(pure=True)
+            yaml.default_flow_style = False
+            yaml.dump(rpcs3vfsconfig, file)
 
         # copy icon files to config
         icon_target = RPCS3_CONFIG_DIR / 'Icons'

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
@@ -7,6 +7,7 @@ from ...batoceraPaths import CONFIGS
 
 RPCS3_CONFIG_DIR: Final = CONFIGS / 'rpcs3'
 RPCS3_CONFIG: Final = RPCS3_CONFIG_DIR / 'config.yml'
+RPCS3_VFS: Final = RPCS3_CONFIG_DIR / 'vfs.yml'
 RPCS3_CURRENT_CONFIG: Final = RPCS3_CONFIG_DIR / 'GuiConfigs' / 'CurrentSettings.ini'
 RPCS3_CONFIG_INPUT: Final = RPCS3_CONFIG_DIR / 'config_input.yml'
 RPCS3_CONFIG_EVDEV: Final = RPCS3_CONFIG_DIR / 'InputConfigs' / 'Evdev' / 'Default Profile.yml'


### PR DESCRIPTION
commit https://github.com/batocera-linux/batocera.linux/commit/0bffd22b738e8046b956e766e1d6163292e3e7c5 have introduced rewrite of path for dev_hdd0 in config.yml.

RPCS3 reads VFS mounts from vfs.yml, not the VFS section of config.yml.

With current implementation, gamelist is not displayed from the rpcs3 GUI anymore, and some psn game seem to not be able to read .rap files in dev_hdd1.

Strip any stale VFS section from config.yml and fully regenerate vfs.yml on each launch, redirecting /dev_hdd0/ (and /dev_hdd1/ for PSN squashfs overlays that ship one) while keeping RPCS3 defaults for the rest.