### PR TITLE
vpinball: fix binary path to use VPinballX_BGFX

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballGenerator.py
@@ -83,7 +83,7 @@ class VPinballGenerator(Generator):
 
         # set the config path to be sure
         commandArray = [
-            "/usr/bin/vpinball/VPinballX_GL",
+            "/usr/bin/vpinball/VPinballX_BGFX",
             "-PrefPath", vpinballConfigPath,
             "-Ini", vpinballConfigFile,
             "-Play", rom

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballOptions.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/vpinball/vpinballOptions.py
@@ -107,7 +107,7 @@ def configureOptions(vpinballSettings: CaseSensitiveConfigParser, system: Emulat
     vpinballSettings.set("Standalone", "AltSound", system.config.get_bool("vpinball_altsound", True, return_values=("1", "0")))
 
     # select which ID for sounddevices by running:
-    # /usr/bin/vpinball/VPinballX_GL -listsnd
+    # /usr/bin/vpinball/VPinballX_BGFX -listsnd
     vpinballSettings.set("Player", "SoundDevice", system.config.get("vpinball_sounddevice", ""))
     vpinballSettings.set("Player", "SoundDeviceBG", system.config.get("vpinball_sounddevicebg", ""))
 


### PR DESCRIPTION
The buildroot package builds VPinballX_BGFX, but the generator was launching the non-existent VPinballX_GL binary.