### PR TITLE
wait for es startup in nfc-on-connect default script

### DIFF
--- a/package/batocera/utils/batocera-nfc/scripts/on-nfc-connect/default.sh
+++ b/package/batocera/utils/batocera-nfc/scripts/on-nfc-connect/default.sh
@@ -2,6 +2,18 @@
 
 TAG=$1
 
+# wait for ES webserver to be ready (up to 60 seconds)
+TRIES=0
+while [ $TRIES -lt 60 ]; do
+    curl -s http://127.0.0.1:1234/runningGame > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        break
+    fi
+    sleep 1
+    TRIES=$((TRIES + 1))
+done
+
+
 # start the game only if none is already running
 CURRENT=$(curl -s http://127.0.0.1:1234/runningGame | jq -r '.name')
 if test "${CURRENT}" = null


### PR DESCRIPTION
if a nfc token is on a reader at boot, the default nfc-on-connect script fails to start a game because emulationstation is not ready yet.
my fix waits until emulationstation is ready (or 60s at max) before starting the game