### PR TITLE
nfc: wait for es startup

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
+++ b/package/batocera/emulationstation/batocera-emulationstation/S31emulationstation
@@ -50,9 +50,10 @@ case "$1" in
 		    timeout -k 5 20 tail -q --pid=$(pidof emulationstation) -f /dev/null 2>/dev/null
 		fi
 		
-		# Clean up the communication pipe on a full system stop
+		# Clean up the communication pipe and the ready-flag on a full system stop
 		rm -f "${FIFO_PATH}"
 		rm -f "${SUSPEND_FLAG}"
+		rm -f "/tmp/emulationstation.ready"
 		;;
 
 	suspend)

--- a/package/batocera/utils/batocera-nfc/scripts/on-nfc-connect/default.sh
+++ b/package/batocera/utils/batocera-nfc/scripts/on-nfc-connect/default.sh
@@ -2,6 +2,10 @@
 
 TAG=$1
 
+# check for emulationstation.ready-file: https://stackoverflow.com/questions/70132359
+# watch dir tmp for creation of any file --include means only emulationstation.ready - regex-include always searches for full path so /file.name$ is valid
+! [ -e /tmp/emulationstation.ready ] && inotifywait -t 60 -e create --include '/emulationstation\.ready$' /tmp
+
 # start the game only if none is already running
 CURRENT=$(curl -s http://127.0.0.1:1234/runningGame | jq -r '.name')
 if test "${CURRENT}" = null


### PR DESCRIPTION
if a nfc token is on a reader at boot, the default nfc-on-connect script fails to start a game because emulationstation is not ready yet. This fix waits 60s to detect emulationstation.ready-file with inode tool This is a yet more solid solution as https://github.com/batocera-linux/batocera.linux/pull/15889