### PR TITLE
feat(rpcs3): add options, safer dev_hdd0 migration

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from ruamel.yaml import YAML
 
 from batocera_common.configparser import CaseSensitiveConfigParser
+from batocera_common.fs import directory_differences
 from batocera_common.yaml import safe_load_yaml12
 
 from ... import Command
@@ -16,7 +17,14 @@ from ...exceptions import BatoceraException
 from ...utils import vulkan
 from ..Generator import Generator
 from . import rpcs3Controllers
-from .rpcs3Paths import RPCS3_BIN, RPCS3_CONFIG, RPCS3_CONFIG_DIR, RPCS3_CURRENT_CONFIG, RPCS3_DEV_HDD0, RPCS3_VFS
+from .rpcs3Paths import (
+    RPCS3_BIN,
+    RPCS3_CONFIG,
+    RPCS3_CONFIG_DIR,
+    RPCS3_CURRENT_CONFIG,
+    RPCS3_DEV_HDD0_DIR,
+    RPCS3_VFS_CONFIG,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -33,39 +41,56 @@ class Rpcs3Generator(Generator):
             "keys": { "exit": "/usr/bin/rpcs3-exit", "menu": ["KEY_LEFTSHIFT", "KEY_F10"] }
         }
 
-    def _migrateDevHdd0(self):
-        legacy_dev_hdd0 = RPCS3_CONFIG_DIR / 'dev_hdd0'
-
-        mkdir_if_not_exists(RPCS3_DEV_HDD0)
-
+    def _migrate_dev_hdd0(self) -> None:
+        legacy_dev_hdd0 = RPCS3_CONFIG_DIR / "dev_hdd0"
         if not legacy_dev_hdd0.exists():
+            # New install or fully migrated: nothing to do
             return
 
-        for source in legacy_dev_hdd0.rglob("*"):
-            relative_path = source.relative_to(legacy_dev_hdd0)
-            target = RPCS3_DEV_HDD0 / relative_path
+        if RPCS3_DEV_HDD0_DIR.exists():
+            # Partial or failed migration: leave it alone
+            _logger.warning(
+                "Skipping RPCS3 dev_hdd0 migration: target directory already exists at %s", RPCS3_DEV_HDD0_DIR
+            )
+            return
 
-            if source.is_dir():
-                mkdir_if_not_exists(target)
-                continue
+        mkdir_if_not_exists(RPCS3_DEV_HDD0_DIR.parent)
 
-            mkdir_if_not_exists(target.parent)
+        try:
+            shutil.copytree(legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
+        except Exception:
+            _logger.exception("Failed to copy RPCS3 dev_hdd0 from %s to %s", legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
+            return
 
-            if not target.exists():
-                shutil.move(str(source), str(target))
-            else:
-                _logger.warning("Skipping RPCS3 dev_hdd0 migration conflict: %s -> %s", source, target)
+        _logger.debug("Successfully copied RPCS3 dev_hdd0 from %s to %s", legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
+
+        differences = directory_differences(legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
+        if differences:
+            _logger.error("RPCS3 dev_hdd0 migration verification failed:\n%s", differences.report())
+            return
+
+        _logger.debug("Verified RPCS3 dev_hdd0 migration from %s to %s", legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
+
+        shutil.rmtree(legacy_dev_hdd0)
+
+        _logger.debug("Completed RPCS3 dev_hdd0 migration from %s to %s", legacy_dev_hdd0, RPCS3_DEV_HDD0_DIR)
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
 
-        self._migrateDevHdd0()
+        self._migrate_dev_hdd0()
+
+        mkdir_if_not_exists(RPCS3_DEV_HDD0_DIR)
+
+        rom_dev_hdd0 = rom / "dev_hdd0"
+        rom_dev_hdd1 = rom / "dev_hdd1"
+        rom_game_dir = rom_dev_hdd0 / "game"
 
         rpcs3Controllers.generateControllerConfig(system, playersControllers, rom)
 
         # Detect PSN game packed as a squashfs: emulatorlauncher has already mounted the
         # squashfs and (via writesToRom=True) created a writable overlayfs, so rom is
         # /var/run/overlays/<stem> mirroring the dev_hdd0 layout.
-        is_psn_squashfs = rom.is_dir() and str(rom).startswith("/var/run/") and (rom / "dev_hdd0" / "game").is_dir()
+        is_psn_squashfs = rom.is_dir() and str(rom).startswith("/var/run/") and rom_game_dir.is_dir()
 
         # Taking care of the CurrentSettings.ini file
         mkdir_if_not_exists(RPCS3_CURRENT_CONFIG.parent)
@@ -192,6 +217,8 @@ class Rpcs3Generator(Generator):
                 rpcs3ymlconfig["Video"]["Frame limit"] = "Off"
         # Write Color Buffers
         rpcs3ymlconfig["Video"]["Write Color Buffers"] = system.config.get_bool("rpcs3_colorbuffers")
+        # Read Color Buffers
+        rpcs3ymlconfig["Video"]["Read Color Buffers"] = system.config.get_bool("rpcs3_read_colorbuffers")
         # Disable Vertex Cache
         rpcs3ymlconfig["Video"]["Disable Vertex Cache"] = system.config.get_bool("rpcs3_vertexcache")
         # Anisotropic Filtering
@@ -216,17 +243,24 @@ class Rpcs3Generator(Generator):
         rpcs3ymlconfig["Video"]["Resolution"] = "1280x720"
         # Resolution scaling
         rpcs3ymlconfig["Video"]["Resolution Scale"] = system.config.get_int("rpcs3_resolution_scale", 100)
+        # Resolution scale threshold
+        rpcs3ymlconfig["Video"]["Minimum Scalable Dimension"] = int(system.config.get_float("rpcs3_resolution_scale_threshold", 16))
         # Output Scaling
         rpcs3ymlconfig["Video"]["Output Scaling Mode"] = system.config.get("rpcs3_scaling", "Bilinear")
         # Number of Shader Compilers
         rpcs3ymlconfig["Video"]["Shader Compiler Threads"] = system.config.get_int("rpcs3_num_compilers", 0)
         # Multithreaded RSX
         rpcs3ymlconfig["Video"]["Multithreaded RSX"] = system.config.get_bool("rpcs3_rsx")
-        # Async Texture Streaming
-        rpcs3ymlconfig["Video"]["Asynchronous Texture Streaming 2"] = system.config.get_bool("rpcs3_async_texture")
         # Write Depth Buffer
         rpcs3ymlconfig["Video"]["Write Depth Buffer"] = system.config.get_bool("rpcs3_write_depth_buffers")
+        # Force CPU blit emulation
+        rpcs3ymlconfig["Video"]["Force CPU Blit"] = system.config.get_bool("rpcs3_force_cpu_blit_emulation")
 
+        if "Vulkan" not in rpcs3ymlconfig["Video"]:
+            rpcs3ymlconfig["Video"]["Vulkan"] = {}
+
+        # Async Texture Streaming
+        rpcs3ymlconfig["Video"]["Vulkan"]["Asynchronous Texture Streaming 2"] = system.config.get_bool("rpcs3_async_texture")
 
         # -= [Audio] =-
         # defaults
@@ -271,13 +305,9 @@ class Rpcs3Generator(Generator):
             yaml.default_flow_style = False
             yaml.dump(rpcs3ymlconfig, file)
 
-        dev_hdd0 = str(rom / "dev_hdd0") + "/" if is_psn_squashfs else f"{RPCS3_DEV_HDD0}/"
-
+        dev_hdd0 = f"{rom_dev_hdd0 if is_psn_squashfs else RPCS3_DEV_HDD0_DIR}/"
         # For a PSN squashfs, redirect /dev_hdd1/ to the overlay when it ships one.
-        if is_psn_squashfs and (rom / "dev_hdd1").is_dir():
-            dev_hdd1 = str(rom / "dev_hdd1") + "/"
-        else:
-            dev_hdd1 = "$(EmulatorDir)dev_hdd1/"
+        dev_hdd1 = f"{rom_dev_hdd1 if is_psn_squashfs and rom_dev_hdd1.is_dir() else '$(EmulatorDir)dev_hdd1'}/"
 
         rpcs3vfsconfig: dict[str, Any] = {
             "$(EmulatorDir)": "",
@@ -298,7 +328,7 @@ class Rpcs3Generator(Generator):
             },
         }
 
-        with RPCS3_VFS.open("w") as file:
+        with RPCS3_VFS_CONFIG.open("w") as file:
             yaml = YAML(pure=True)
             yaml.default_flow_style = False
             yaml.dump(rpcs3vfsconfig, file)
@@ -316,24 +346,22 @@ class Rpcs3Generator(Generator):
             with rom.open() as fp:
                 for line in fp:
                     if len(line) >= 9:
-                        romName = RPCS3_DEV_HDD0 / "game" / line.strip().upper() / "USRDIR" / "EBOOT.BIN"
+                        romName = RPCS3_DEV_HDD0_DIR / "game" / line.strip().upper() / "USRDIR" / "EBOOT.BIN"
 
             if romName is None:
                 raise BatoceraException(f'No game ID found in {rom}')
-
 
         elif is_psn_squashfs:
             # rom is /var/run/overlays/<stem>; dev_hdd0 is redirected there via vfs.yml.
             # Scan for the game ID directory and pass EBOOT.BIN directly to RPCS3.
             romName = None
-            for game_id_dir in (rom / "dev_hdd0" / "game").iterdir():
+            for game_id_dir in rom_game_dir.iterdir():
                 eboot = game_id_dir / "USRDIR" / "EBOOT.BIN"
                 if eboot.exists():
                     romName = eboot
                     break
             if romName is None:
                 raise BatoceraException(f'No PSN game found in squashfs {rom}')
-
 
         elif rom.suffix.lower() == ".iso":
             romName = rom

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Paths.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Final
 
-from ...batoceraPaths import CONFIGS
+from ...batoceraPaths import CONFIGS, SAVES
 
 RPCS3_CONFIG_DIR: Final = CONFIGS / 'rpcs3'
 RPCS3_CONFIG: Final = RPCS3_CONFIG_DIR / 'config.yml'
-RPCS3_VFS: Final = RPCS3_CONFIG_DIR / 'vfs.yml'
+RPCS3_VFS_CONFIG: Final = RPCS3_CONFIG_DIR / 'vfs.yml'
 RPCS3_CURRENT_CONFIG: Final = RPCS3_CONFIG_DIR / 'GuiConfigs' / 'CurrentSettings.ini'
 RPCS3_CONFIG_INPUT: Final = RPCS3_CONFIG_DIR / 'config_input.yml'
 RPCS3_CONFIG_EVDEV: Final = RPCS3_CONFIG_DIR / 'InputConfigs' / 'Evdev' / 'Default Profile.yml'
-RPCS3_DEV_HDD0: Final = Path('/userdata/saves/ps3/rpcs3/dev_hdd0')
+RPCS3_DEV_HDD0_DIR: Final = SAVES / 'ps3' / 'rpcs3' / 'dev_hdd0'
 RPCS3_BIN: Final = Path('/usr/bin/rpcs3')

--- a/package/batocera/emulators/rpcs3/rpcs3.emulator.yml
+++ b/package/batocera/emulators/rpcs3/rpcs3.emulator.yml
@@ -162,6 +162,12 @@ custom_features:
       3840x2160: 250
       4480x2520: 275
       5120x2880: 300
+  rpcs3_resolution_scale_threshold:
+    submenu: VIDEO
+    prompt: RENDER RESOLUTION SCALE THRESHOLD
+    description: "Only framebuffers greater than this size will be upscaled. May fix problems with missing graphics. (Default: 16)"
+    preset: sliderauto
+    preset_parameters: 1 1024 1
   rpcs3_scaling:
     submenu: RENDER
     prompt: OUTPUT SCALING
@@ -204,6 +210,13 @@ custom_features:
     submenu: RENDER
     prompt: WRITE COLOR BUFFERS
     description: May fix missing graphics and broken lighting at the cost of performance.
+    choices:
+      Off (Default): false
+      'On': true
+  rpcs3_read_colorbuffers:
+    submenu: RENDER
+    prompt: READ COLOR BUFFERS
+    description: Initializes render target memory using vm memory. Some games need this to fix broken graphics.
     choices:
       Off (Default): false
       'On': true
@@ -256,6 +269,13 @@ custom_features:
     choices:
       Off (Default): false
       On (Vulkan Only): true
+  rpcs3_force_cpu_blit_emulation:
+    submenu: RENDER
+    prompt: FORCE CPU BLIT EMULATION
+    description: Forces emulation of all blit and image manipulation operations on the CPU. Can fix some graphical issues at the cost of performance.
+    choices:
+      Off (Default): false
+      'On': true
   rpcs3_audio_format:
     submenu: AUDIO
     prompt: AUDIO FORMAT

--- a/python-src/batocera-common/batocera_common/fs.py
+++ b/python-src/batocera-common/batocera_common/fs.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import filecmp
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+type Difference = tuple[None, Path] | tuple[Path, None] | tuple[Path, Path]
+
+
+def _dircmp_differences(comparison: filecmp.dircmp[str], /) -> Iterator[Difference]:
+    left = Path(comparison.left)
+    right = Path(comparison.right)
+
+    yield from ((left / name, None) for name in comparison.left_only)
+    yield from ((None, right / name) for name in comparison.right_only)
+    yield from (
+        (left / name, right / name) for name in comparison.diff_files + comparison.funny_files + comparison.common_funny
+    )
+
+    for sub in comparison.subdirs.values():
+        yield from _dircmp_differences(sub)
+
+
+@dataclass(slots=True)
+class directory_differences:
+    left: Path
+    right: Path
+
+    _differences: tuple[Difference, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        comparison = filecmp.dircmp(self.left, self.right, shallow=False)
+        self._differences = tuple(_dircmp_differences(comparison))
+
+    def __bool__(self) -> bool:
+        return bool(self._differences)
+
+    def report(self) -> str:
+        if not self._differences:
+            return 'Directories are identical'
+
+        left_only: list[Path] = []
+        right_only: list[Path] = []
+        different: list[Path] = []
+
+        for difference in self._differences:
+            if difference[0] is not None:
+                if difference[1] is None:
+                    left_only.append(difference[0])
+                else:
+                    different.append(difference[0])
+            else:
+                right_only.append(difference[1])
+
+        report: list[str] = []
+
+        if left_only:
+            report.append(f'Missing in {self.right}:')
+            report.extend(f'  {path.relative_to(self.left)}' for path in left_only)
+
+        if right_only:
+            report.append(f'Extra in {self.right}:')
+            report.extend(f'  {path.relative_to(self.right)}' for path in right_only)
+
+        if different:
+            report.append('Different files:')
+            report.extend(f'  {path.relative_to(self.left)}' for path in different)
+
+        return '\n'.join(report)

--- a/python-src/batocera-common/tests/test_fs.py
+++ b/python-src/batocera-common/tests/test_fs.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from batocera_common.fs import directory_differences
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, content: str = '') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+class TestDirectoryDifferencesBool:
+    def test_identical_directories_are_falsy(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'a.txt', 'same')
+        _write(right / 'a.txt', 'same')
+
+        assert bool(directory_differences(left, right)) is False
+
+    def test_empty_directories_are_falsy(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        left.mkdir()
+        right.mkdir()
+
+        assert bool(directory_differences(left, right)) is False
+
+    def test_differing_directories_are_truthy(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'a.txt', 'one')
+        _write(right / 'a.txt', 'two')
+
+        assert bool(directory_differences(left, right)) is True
+
+    def test_left_only_file_is_truthy(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'extra.txt', 'x')
+        right.mkdir()
+
+        assert bool(directory_differences(left, right)) is True
+
+
+class TestDirectoryDifferencesReport:
+    def test_identical_directories_report(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'a.txt', 'same')
+        _write(right / 'a.txt', 'same')
+
+        assert directory_differences(left, right).report() == 'Directories are identical'
+
+    def test_empty_directories_report(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        left.mkdir()
+        right.mkdir()
+
+        assert directory_differences(left, right).report() == 'Directories are identical'
+
+    def test_reports_file_missing_in_right(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'only_left.txt', 'x')
+        right.mkdir()
+
+        report = directory_differences(left, right).report()
+
+        assert report == f'Missing in {right}:\n  only_left.txt'
+
+    def test_reports_file_extra_in_right(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        left.mkdir()
+        _write(right / 'only_right.txt', 'x')
+
+        report = directory_differences(left, right).report()
+
+        assert report == f'Extra in {right}:\n  only_right.txt'
+
+    def test_reports_different_file(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'changed.txt', 'one')
+        _write(right / 'changed.txt', 'two')
+
+        report = directory_differences(left, right).report()
+
+        assert report == 'Different files:\n  changed.txt'
+
+    def test_reports_same_size_different_content(self, tmp_path: Path) -> None:
+        # shallow=False means same-size files are still compared by content
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'changed.txt', 'aaa')
+        _write(right / 'changed.txt', 'bbb')
+
+        report = directory_differences(left, right).report()
+
+        assert report == 'Different files:\n  changed.txt'
+
+    def test_reports_all_categories_together(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'gone.txt', 'x')
+        _write(left / 'changed.txt', 'one')
+        _write(right / 'changed.txt', 'two')
+        _write(right / 'added.txt', 'y')
+
+        report = directory_differences(left, right).report()
+
+        assert report == (
+            f'Missing in {right}:\n  gone.txt\nExtra in {right}:\n  added.txt\nDifferent files:\n  changed.txt'
+        )
+
+    def test_reports_nested_differences_with_relative_paths(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'sub' / 'deep' / 'file.txt', 'one')
+        _write(right / 'sub' / 'deep' / 'file.txt', 'two')
+
+        report = directory_differences(left, right).report()
+
+        assert report == 'Different files:\n  sub/deep/file.txt'
+
+    def test_reports_subdirectory_only_in_left(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'sub' / 'file.txt', 'x')
+        right.mkdir()
+
+        report = directory_differences(left, right).report()
+
+        assert report == f'Missing in {right}:\n  sub'
+
+    def test_report_can_be_called_multiple_times(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'changed.txt', 'one')
+        _write(right / 'changed.txt', 'two')
+
+        differences = directory_differences(left, right)
+
+        assert differences.report() == differences.report()
+
+    def test_report_is_unaffected_by_prior_bool_check(self, tmp_path: Path) -> None:
+        left = tmp_path / 'left'
+        right = tmp_path / 'right'
+        _write(left / 'changed.txt', 'one')
+        _write(right / 'changed.txt', 'two')
+
+        differences = directory_differences(left, right)
+
+        assert bool(differences) is True
+        assert differences.report() == 'Different files:\n  changed.txt'


### PR DESCRIPTION
- Add three new RPCS3 video options:
  - `rpcs3_resolution_scale_threshold` (Minimum Scalable Dimension)
  - `rpcs3_read_colorbuffers` (Read Color Buffers)
  - `rpcs3_force_cpu_blit_emulation` (Force CPU Blit)
- Move "Asynchronous Texture Streaming 2" under the `Video`/`Vulkan` node to match RPCS3's config schema.
- Rewrite the legacy `dev_hdd0` migration to copy-verify-delete instead of moving files one by one: it copies the tree, verifies the result with the new `directory_differences` helper, and only then removes the source, bailing out safely on any conflict or mismatch. The saves `dev_hdd0` directory is created unconditionally so fresh installs work.
- Rename `RPCS3_VFS` -> `RPCS3_VFS_CONFIG` and `RPCS3_DEV_HDD0` -> `RPCS3_DEV_HDD0_DIR` (now derived from `SAVES`) for clarity.
- Add `batocera_common.fs.directory_differences`, a `filecmp`-based directory comparison helper with a human-readable `report()`, plus tests.