### PR TITLE
fix(shadps4): pre-build `Dear_ImGui_FontEmbed` on the host

### DIFF
--- a/package/batocera/emulators/shadps4/0001-imgui-renderer-allow-prebuilt-fontembed.patch
+++ b/package/batocera/emulators/shadps4/0001-imgui-renderer-allow-prebuilt-fontembed.patch
@@ -1,0 +1,17 @@
+diff --git a/src/imgui/renderer/CMakeLists.txt b/src/imgui/renderer/CMakeLists.txt
+--- a/src/imgui/renderer/CMakeLists.txt
++++ b/src/imgui/renderer/CMakeLists.txt
+@@ -3,7 +3,12 @@
+
+ project(ImGui_Resources)
+
+-add_executable(Dear_ImGui_FontEmbed ${CMAKE_SOURCE_DIR}/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp)
++if(Dear_ImGui_FontEmbed_EXECUTABLE)
++    add_executable(Dear_ImGui_FontEmbed IMPORTED GLOBAL)
++    set_target_properties(Dear_ImGui_FontEmbed PROPERTIES IMPORTED_LOCATION "${Dear_ImGui_FontEmbed_EXECUTABLE}")
++else()
++    add_executable(Dear_ImGui_FontEmbed ${CMAKE_SOURCE_DIR}/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp)
++endif()
+
+ set(FONT_LIST
+     NotoSansArabic-Regular.ttf

--- a/package/batocera/emulators/shadps4/shadps4.mk
+++ b/package/batocera/emulators/shadps4/shadps4.mk
@@ -43,5 +43,18 @@ SHADPS4_CONF_OPTS += -DENABLE_DISCORD_RPC=OFF
 SHADPS4_CONF_OPTS += -DENABLE_UPDATER=OFF
 SHADPS4_CONF_OPTS += -DVMA_ENABLE_INSTALL=ON
 
+# Dear_ImGui_FontEmbed is a build-time code generator that runs on the host.
+# The following builds the binary to run on the host rather than adding a
+# host- prefixed package just to compile Dear_ImGui_FontEmbed. After compiling
+# the binary, we tell CMake to use that executable via -DDear_ImGui_FontEmbed_EXECUTABLE
+# which is added in 0001-imgui-renderer-allow-prebuilt-fontembed.patch.
+define SHADPS4_BUILD_HOST_FONTEMBED
+	$(HOSTCXX) -O2 -o $(@D)/host-dear-imgui-fontembed \
+		$(@D)/externals/dear_imgui/misc/fonts/binary_to_compressed_c.cpp
+endef
+SHADPS4_PRE_CONFIGURE_HOOKS += SHADPS4_BUILD_HOST_FONTEMBED
+
+SHADPS4_CONF_OPTS += -DDear_ImGui_FontEmbed_EXECUTABLE=$(BUILD_DIR)/shadps4-$(SHADPS4_VERSION)/host-dear-imgui-fontembed
+
 $(eval $(cmake-package))
 $(eval $(emulator-info-package))


### PR DESCRIPTION
This not only avoids cross-compilation issues but is the proper way to use a build-time code generator.