### PR TITLE
dxvk-nvapi: add missing nvofapi64.dll

### DIFF
--- a/package/batocera/wine/batocera-wine/batocera-wine
+++ b/package/batocera/wine/batocera-wine/batocera-wine
@@ -465,11 +465,11 @@ dxvk_install() {
         mkdir -p "${WINEPREFIX}/drive_c/windows/system32" "${WINEPREFIX}/drive_c/windows/syswow64" || return 1
         if [[ -e "/userdata/system/wine/dxvk" ]]; then
             echo "Creating links using /userdata, Linux File System required !!!"
-            ln -sf "/userdata/system/wine/dxvk/x64/"{d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi64.dll} "${WINEPREFIX}/drive_c/windows/system32" || return 1
+            ln -sf "/userdata/system/wine/dxvk/x64/"{d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi64.dll,nvofapi64.dll} "${WINEPREFIX}/drive_c/windows/system32" || return 1
             ln -sf "/userdata/system/wine/dxvk/x32/"{d3d8.dll,d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi.dll} "${WINEPREFIX}/drive_c/windows/syswow64" || return 1
         else
             echo "Creating links using /usr/wine/dxvk/, Linux File System required !!!"
-            ln -sf "/usr/wine/dxvk/x64/"{d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi64.dll} "${WINEPREFIX}/drive_c/windows/system32" || return 1
+            ln -sf "/usr/wine/dxvk/x64/"{d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi64.dll,nvofapi64.dll} "${WINEPREFIX}/drive_c/windows/system32" || return 1
             ln -sf "/usr/wine/dxvk/x32/"{d3d8.dll,d3d12.dll,d3d12core.dll,d3d11.dll,d3d10core.dll,d3d9.dll,dxgi.dll,nvapi.dll} "${WINEPREFIX}/drive_c/windows/syswow64" || return 1
         fi
     else

--- a/package/batocera/wine/dxvk-nvapi/dxvk-nvapi.mk
+++ b/package/batocera/wine/dxvk-nvapi/dxvk-nvapi.mk
@@ -18,6 +18,7 @@ define DXVK_NVAPI_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/wine/dxvk/x64
 	cp -a $(@D)/target/x32/nvapi.dll $(TARGET_DIR)/usr/wine/dxvk/x32
 	cp -a $(@D)/target/x64/nvapi64.dll $(TARGET_DIR)/usr/wine/dxvk/x64
+	cp -a $(@D)/target/x64/nvofapi64.dll $(TARGET_DIR)/usr/wine/dxvk/x64
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
it has been introduced in dxvk-nvapi 0.8 in 2014

https://github.com/jp7677/dxvk-nvapi/releases/tag/v0.8.0

"
Add implementation for nvofapi64.dll / NVIDIA Optical Flow API. This serves as a pass-through implementation for D3D12 and Vulkan backends to VK_NV_optical_flow for DLSS3 / Frame Generation. "