### PR TITLE
feat(buildroot): improve rufomaculata generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,6 @@ endif
 		fi; \
 	done
 	@rm -rf $(TARGET_OUTPUT_DIR)/target
-	@rm -rf $(TARGET_OUTPUT_DIR)/target2
 
 %-refresh: %-clean-for-refresh | $(DOCKER_IMAGE_AVAILABLE)
 	@$(MAKE) $*-build

--- a/board/batocera/scripts/post-build-script.sh
+++ b/board/batocera/scripts/post-build-script.sh
@@ -127,29 +127,12 @@ fi
 
 # split target dir in 2 cause of the 4GB image size limit
 # in initrd, the 2 targets will be mounted as one
-TARGET2_DIR=${TARGET_DIR}2
-echo "Generating target2 (${TARGET2_DIR})..."
-mkdir -p "${TARGET2_DIR}" || exit 1
-for XDIR in usr/lib/libretro usr/wine usr/share/wine usr/share/lr-mame usr/bin/mame usr/bin/sonic3-air usr/pcsx2 usr/xenia
-do
-    echo -n "${XDIR}..."
-    if test -e "${TARGET_DIR}/${XDIR}"
-    then
-	mkdir -p "${TARGET2_DIR}/${XDIR}" || exit 1
-	rsync -a "${TARGET_DIR}/${XDIR}/" "${TARGET2_DIR}/${XDIR}/" || exit 1
-	rm -rf "${TARGET_DIR}/${XDIR}/" || exit 1
-	echo "OK."
-    elif test -d "${TARGET2_DIR}/${XDIR}"
-    then
-    echo "Already in target2. Continuing..."
-    else
-	echo "${TARGET_DIR}/${XDIR} not found. Skipping."
-    fi
-done
 
 # generate the image 2
 echo "Generating ${BINARIES_DIR}/rufomaculata..."
-"${HOST_DIR}/bin/mksquashfs" "${TARGET2_DIR}" "${BINARIES_DIR}/rufomaculata" -noappend -b 128K -comp zstd || exit 1
+set -o pipefail
+tar -C "${TARGET_DIR}" --ignore-failed-read -c ${BATOCERA_RUFOMACULATA_DIRS} \
+    | "${HOST_DIR}/bin/mksquashfs" - "${BINARIES_DIR}/rufomaculata" -tar -noappend -b 128K -comp zstd || exit 1
 
 # With PARALLEL_BUILD it is difficult to control which of two
 # conflicting files from different packages will be the one ending up

--- a/external.mk
+++ b/external.mk
@@ -1,3 +1,21 @@
+# Directories that are included in the rufomaculata squashfs image. These
+# are also excluded from the main squashfs image, so that they are only
+# included once in batocera. The variable is exported so it can be used in
+# post-build-script.sh.
+export BATOCERA_RUFOMACULATA_DIRS := \
+	usr/lib/libretro \
+	usr/wine \
+	usr/share/wine \
+	usr/share/lr-mame \
+	usr/bin/mame \
+	usr/bin/sonic3-air \
+	usr/pcsx2 \
+	usr/xenia
+
+# This variable needs to be here so that `-e ...` is the very last argument
+# appended to it
+ROOTFS_SQUASHFS_ARGS += -wildcards -e $(BATOCERA_RUFOMACULATA_DIRS)
+
 include $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/pkg-boot.mk
 include $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/pkg-emulator-info.mk
 include $(sort $(wildcard $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/*/*.mk $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/*/*/*.mk $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/*/*/*/*.mk $(BR2_EXTERNAL_BATOCERA_PATH)/package/batocera/*/*/*/*/*.mk))


### PR DESCRIPTION
Add rufomaculata directories to exclusion list when creating rootfs squashfs image and use a tar pipe to generate the rufomaculata squashfs image. This avoids the need to copy files to a separate directory and remove them from the target directory.