### PR TITLE
generator: clk: try to load supported extension from zipped roms

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/clk/clkGenerator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/clk/clkGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shutil
+import xml.etree.ElementTree as ElementTree
 import zipfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Final
@@ -21,8 +22,38 @@ _SVIDEO_SYSTEMS: Final = { "colecovision", "mastersystem" }
 _RGB_SYSTEMS: Final = { "amstradcpc", "atarist", "electron", "enterprise", "msx1", "msx2",
     "oricatmos", "zxspectrum" }
 
+_ES_SYSTEMS_DIRS: Final = (
+    Path("/usr/share/emulationstation"),
+    Path("/userdata/system/configs/emulationstation"),
+)
 
-def _openzip_file(file_path: Path, /) -> Path | None:
+# Archive containers are never the loadable file we extract from a zip.
+_ARCHIVE_EXTENSIONS: Final = { "zip", "7z" }
+
+
+def _supported_extensions(system_name: str, /) -> set[str]:
+    """Loadable file extensions for a system, read from es_systems.cfg (honouring user
+    overrides). Empty if no config can be read, in which case no filtering is applied."""
+    extensions: set[str] = set()
+    for es_dir in _ES_SYSTEMS_DIRS:
+        for config in sorted(es_dir.glob("es_systems*.cfg")):
+            try:
+                root = ElementTree.parse(config).getroot()
+            except (ElementTree.ParseError, OSError):
+                continue
+            for system in root.iter("system"):
+                if system.findtext("name") != system_name:
+                    continue
+                found = {
+                    ext.lstrip(".").lower()
+                    for ext in (system.findtext("extension") or "").split()
+                } - _ARCHIVE_EXTENSIONS
+                if found:
+                    extensions = found  # later configs override earlier ones
+    return extensions
+
+
+def _openzip_file(file_path: Path, valid_extensions: set[str] | None = None, /) -> Path | None:
     if not file_path.is_file():
         return None
 
@@ -31,7 +62,9 @@ def _openzip_file(file_path: Path, /) -> Path | None:
 
     if str(file_path).lower().endswith('.zip'):
         with zipfile.ZipFile(file_path, 'r') as zip_ref:
-            # Choose the largest regular file in the archive
+            # Prefer the largest file with a loadable extension, so CLK can identify
+            # the target machine. Fall back to the largest file overall.
+            best_valid: zipfile.ZipInfo | None = None
             largest_info: zipfile.ZipInfo | None = None
             for info in zip_ref.infolist():
                 # Skip directories (names ending with '/')
@@ -41,9 +74,14 @@ def _openzip_file(file_path: Path, /) -> Path | None:
                 if largest_info is None or info.file_size > largest_info.file_size:
                     largest_info = info
 
-            if largest_info is not None:
+                if valid_extensions and Path(info.filename).suffix.lower().lstrip('.') in valid_extensions:
+                    if best_valid is None or info.file_size > best_valid.file_size:
+                        best_valid = info
+
+            chosen = best_valid or largest_info
+            if chosen is not None:
                 zip_ref.extractall(_TMP_DIR)
-                return _TMP_DIR / largest_info.filename
+                return _TMP_DIR / chosen.filename
 
         return None # if no files, just directories
 
@@ -53,7 +91,7 @@ def _openzip_file(file_path: Path, /) -> Path | None:
 class ClkGenerator(Generator):
 
     def generate(self, system, rom, playersControllers, metadata, guns, wheels, gameResolution):
-        romzip = _openzip_file(rom)
+        romzip = _openzip_file(rom, _supported_extensions(system.name))
 
         if romzip is None:
             raise BatoceraException(f'ROM is a directory: {rom}')


### PR DESCRIPTION
Currently, when a rom is zipped, the biggest file in the zip is choosen.

Prefer the largest file whose extension is loadable for the system, falling back to the largest file overall when none match. Extension lists mirror es_systems.yml for all systems using the clk emulator.