### PR TITLE
Update batocera-xtract: list and sort archive content

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-xtract
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-xtract
@@ -19,8 +19,7 @@
 #           application/x-xz-compressed-tar;application/x-iso;application/zip;
 
 # inital idea and inspired by brunoeduardobrasil, 07/19/2025 cyperghost aka crcerror
-# ec-codes: ec-0 - okay, ec-10 parameter l,s or f used - okay
-# ec-1 - error, ec-2 parameter not found - error, ec-3 dest dir not found - error
+# ec-codes: ec-0 okay, ec-1 error, ec-10 parameter l,s,la,lt,ls used
 # ec-11 archives not supported for extraction, ec-12 archives not supported for showing content
 # ec-21 to 29 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz exe (only InnoSetup)
 
@@ -49,9 +48,27 @@ list_archive () {
     esac
 
     # Just output for CLI as list - usefull for further scripting
-    [[ "${2}" == "l" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $2 }'; return 10; }
-    [[ "${2}" == "s" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3 }'; return 10; }
-    [[ "${2}" == "f" ]] && { printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }'; return 10; }
+    if [[ "${#2}" -le 2 ]]; then
+        case "${2}" in
+            l) # List files
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $2 }'
+            ;;
+            s) # List filesize
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3 }'
+            ;;
+            la)# List file + size unsorted original archive content
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }'
+            ;;
+            lt)# List tallest to smallest file, reverse sort order, strip first column
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -nr | awk '{ $1=""; print substr($0,2) }'
+            ;;
+            ls)# List smallest to tallest file, reverse sort order, strip first column
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -n  | awk '{ $1=""; print substr($0,2) }'
+            ;;
+
+        esac
+        return 10
+    fi
 
     #Options needs to be added to PCmanFM "file-roller --open"
     readarray -t files <<< $(yad --title="Extract Files" --list --checklist --print-column=2 --separator= --column=Extract:chk --column=Filename:text --column=Size:text --column=Date:text "${array[@]}")
@@ -113,7 +130,7 @@ case "$1" in
         DEST="${2/file:\/\/}"; DEST=$(printf '%b' "${DEST//%/\\x}")
         extract_archive "${FILE,,}" || ret=$?
     ;;
-    --open|open|[lLsSfF])
+    --open|open|[lLsS]|[lL][aAsStT])
         FILE="$2"
         DEST="$(readlink -f "$(dirname "${FILE}")")"
         list_archive "$(basename "${FILE,,}")" "${1,,}" && extract_archive "$(basename "${FILE,,}")" || ret=$?
@@ -141,19 +158,21 @@ case $ret in
     0|1|10) true ;;
     2) # Action not defined
         [[ $TERMINAL -eq 0 ]] && { yad --title "Error" --text "Action: '$1' is unknown"; exit 2; }
-        echo "Usage: $(basename $0) <SWITCH> [ARCHIVEFILE] <DESTINATION-DIR>"; echo
+        echo "Usage: $(basename "$0") <SWITCH> [ARCHIVEFILE] <DESTINATION-DIR>"; echo
         echo "    x: extraction of archiv with prompt if DESTINATION is missing"
         echo " clix: extraction of current archive without prompt (CLI)"
         echo "  pyx: extraction of single files: $(basename "$0") pyx <ARCHIVEFILE> <DESTINATION-DIR> <file1> ... <file{n}>"
         echo "    l: list files in archive content"
         echo "    s: list sizes in archive content"
-        echo "    f: list size and files"; echo
-        echo "default usage: 'batocera-xtract archiv.zip' extracts archiv.zip to PWD"
+        echo "   la: list files and size (unsorted)"
+        echo "   ls: list files sorted from smallest to tallest"
+        echo "   lt: list files sorted from tallest to smallest"; echo
+        echo "default usage: '$(basename "$0") archiv.zip' extracts archiv.zip to PWD"
         echo "                Parameters in <> are optional"; echo
         echo "Supported archives for extraction: zip 7z rar tar gz iso tar.gz/tgz tar.xz exe"
         echo "Supported archives for list/open : zip 7z rar tar gz iso tar.gz/tgz tar.xz"; echo
         echo "error-codes/return codes:"
-        echo "  ec-0 no error, ec-10 parameter 'l' 's' or 'f' used -- okay"
+        echo "  ec-0 no error, ec-10 parameter l s la ls or lt, okay"
         echo "  ec-1 general error -- ec-2 unknown action -- ec-3 destination dir not found"
         echo "  ec-11 to 12 -- archive type not supported for extraction, listing"
         echo "  ec-21 to 28 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz"


### PR DESCRIPTION
la, ls, lt parameter added
la show size + archive content
lt sort from tallest to smallest file
```
[root@BATOCERA ~/v44_patches]# batocera-xtract la v44_patches.zip
8564    batocera-config
10344   batocera-settings-get
14472   batocera-settings-set
5046    batocera-steam-update
13829   batocera-upgrade
15783   batocera-upgrade-v2
13916   batocera-upgrade-v3
2785    batocera-version
50980   batocera-wine
50480   batocera-wine2
385     check-arch.sh
803     mausberry_service
469     read-conf.sh
34882   rpi_gpioswitch
250     test-conf.conf
806     x86_compat
Exit with code: 10
[root@BATOCERA ~/v44_patches]# batocera-xtract lt v44_patches.zip
batocera-wine
batocera-wine2
rpi_gpioswitch
batocera-upgrade-v2
batocera-settings-set
batocera-upgrade-v3
batocera-upgrade
batocera-settings-get
batocera-config
batocera-steam-update
batocera-version
x86_compat
mausberry_service
read-conf.sh
check-arch.sh
test-conf.conf
Exit with code: 10
[root@BATOCERA ~/v44_patches]#
```