### PR TITLE
minor update of SSH welcome screen and bato-xtract

### DIFF
--- a/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/20-alias.sh
@@ -1,4 +1,4 @@
 # ---- ALIAS VALUES ----
 alias mc='mc -xc'
-alias batocera-check-updates='batocera-upgrade --check-update'
+alias batocera-check-updates='batocera-upgrade --check-upgrade'
 alias which='command -v'

--- a/board/batocera/fsoverlay/etc/profile.d/30-welcome.sh
+++ b/board/batocera/fsoverlay/etc/profile.d/30-welcome.sh
@@ -7,8 +7,8 @@ echo '
                  R E A D Y   T O   R E T R O
 '
 echo
-echo "-- type 'batocera-check-updates' to check for stable branch --"
-echo "-- add 'butterfly' switch to check for latest arch developments  --"
+echo "-- type 'batocera-check-updates' to check the system setted branch --"
+echo "-- usage of 'butterfly' or 'stable' switch will force-check branch --"
 echo
 batocera-info 2>/dev/null
 echo "OS version: $(batocera-version)"

--- a/package/batocera/core/batocera-scripts/scripts/batocera-xtract
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-xtract
@@ -19,7 +19,8 @@
 #           application/x-xz-compressed-tar;application/x-iso;application/zip;
 
 # inital idea and inspired by brunoeduardobrasil, 07/19/2025 cyperghost aka crcerror
-# ec-codes: ec-0 okay, ec-1 error, ec-10 parameter l,s,la,lt,ls used
+# ec-codes: ec-0 okay, ec-10 parameter l,s,la,lt,ls used
+# ec-1 general error -- ec-2 unknown action -- ec-3 destination dir not found
 # ec-11 archives not supported for extraction, ec-12 archives not supported for showing content
 # ec-21 to 29 -- file extraction error zip rar 7z gz iso tar tar.xz tar.gz exe (only InnoSetup)
 
@@ -59,13 +60,12 @@ list_archive () {
             la)# List file + size unsorted original archive content
                printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }'
             ;;
-            lt)# List tallest to smallest file, reverse sort order, strip first column
-               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -nr | awk '{ $1=""; print substr($0,2) }'
+            lt)# List tallest to smallest file, strip first column and ignore entries with / at the end are directories
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -nr | awk '!/\/$/ { $1=""; print substr($0,2) }'
             ;;
-            ls)# List smallest to tallest file, reverse sort order, strip first column
-               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -n  | awk '{ $1=""; print substr($0,2) }'
+            ls)# List smallest to tallest file, reverse sort order, strip first column and ignore entries with ending with / are DIRs
+               printf '%s\t%s\t%s\t%s\n' "${array[@]}" | awk -F'\t' '{ print $3"\t"$2 }' | sort -n  | awk '!/\/$/ { $1=""; print substr($0,2) }'
             ;;
-
         esac
         return 10
     fi


### PR DESCRIPTION
alias uses the correct batocera-upgrade --check-upgrade now correct description of how the switches are used
batocera-xtract strips DIRS from list
nothing ground breaking