### PR TITLE
 getLocalWayland and getLocalX return correct error code now 

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/getLocalWaylandDisplay
+++ b/package/batocera/core/batocera-scripts/scripts/getLocalWaylandDisplay
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-find /run -name "wayland-*.lock" 2>/dev/null | head -1 | sed -e s+"^.*/\([^/]*\)\.lock$"+"\1"+
+find /run/wayland-*.lock 2>/dev/null | head -1 | sed -e s+"^.*/\([^/]*\)\.lock$"+"\1"+
 exit ${PIPESTATUS[0]}

--- a/package/batocera/core/batocera-scripts/scripts/getLocalXDisplay
+++ b/package/batocera/core/batocera-scripts/scripts/getLocalXDisplay
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-find /tmp/.X11-unix -name "X*" 2>/dev/null | head -1 | sed -e s+"^.*/X"+":"+
+find /tmp/.X11-unix/X* 2>/dev/null | head -1 | sed -e s+"^.*/X"+":"+
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
before return was always 0, because find does not need to find a name

Now:

```
[root@BATOCERA /run]# getLocalWaylandDisplay
[root@BATOCERA /run]# echo $?
1
```