### PR TITLE
mame: fix SUBTARGET mismatch between genie and build steps

### DIFF
--- a/package/batocera/emulators/mame/mame.mk
+++ b/package/batocera/emulators/mame/mame.mk
@@ -155,7 +155,7 @@ define MAME_BUILD_CMDS
 	$(MAKE) -j$(MAME_JOBS) -l$(MAME_JOBS) $(MAME_ARCH) \
 	TARGETOS=linux OSD=sdl \
 	TARGET=mame \
-	SUBTARGET=mame \
+	SUBTARGET=tiny \
 	OVERRIDE_CC="$(TARGET_CC)" \
 	OVERRIDE_CXX="$(TARGET_CXX)" \
 	OVERRIDE_LD="$(TARGET_LD)" \
@@ -200,7 +200,7 @@ define MAME_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)/usr/bin/mame/roms
 
 	# Install binaries and default distro
-	$(INSTALL) -D $(@D)/mame	$(TARGET_DIR)/usr/bin/mame/mame
+	$(INSTALL) -D $(@D)/mametiny	$(TARGET_DIR)/usr/bin/mame/mame
 	cp $(@D)/COPYING			$(TARGET_DIR)/usr/bin/mame/
 	cp $(@D)/README.md			$(TARGET_DIR)/usr/bin/mame/
 	cp $(@D)/uismall.bdf		$(TARGET_DIR)/usr/bin/mame/


### PR DESCRIPTION
## Summary

`MAME_GENIE` (the project-generation pre-build hook in `mame.mk`) runs with `SUBTARGET=tiny`, but `MAME_BUILD_CMDS` (the actual build) runs with `SUBTARGET=mame`. This means the driver list gets (re)generated against the full ~40,000+ driver catalog at build time, while only the tiny subset's sources were ever compiled by genie — causing link failures, found while building the rk3568 board:

```
undefined reference to `driver_gaelcods'
```

(any driver present in `mame.lst` but not `tiny.lst` will hit this)

## Fix

- `MAME_BUILD_CMDS`: `SUBTARGET=mame` → `SUBTARGET=tiny`, matching genie
- Since MAME names the produced binary after the subtarget, the build now produces `mametiny` instead of `mame`. Updated `MAME_INSTALL_TARGET_CMDS` to install `mametiny` under the same `mame` name Batocera expects everywhere else, so nothing downstream changes.

## Test plan

- [x] Built the rk3568 board (Docker build) with this patch — driver list now reports 59 drivers (the expected tiny subtarget count, vs 42880 before), links and installs successfully (`.stamp_target_installed` reached)
- [ ] Would appreciate confirmation on another board that also ships mame, and a maintainer weighing in on whether `SUBTARGET=tiny` was the intended behavior all along (this exact mismatch appears to date back to at least Feb 2025 in git history, so I'm not certain whether something else changed recently to turn a latent inconsistency into a hard failure, e.g. the recent MAME 0.288 bump)