### PR TITLE
Fix Libretro-MAME "offscreenreload" light gun option

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -81,6 +81,12 @@ def generateMAMEConfigs(playersControllers: Controllers, system: Emulator, rom: 
             pluginsToLoad += [ "hiscore" ]
         if system.config.get_bool("coindropplugin"):
             pluginsToLoad += [ "coindrop" ]
+        if system.config.core == 'mame' and system.config.get_bool('offscreenreload'):
+            # -offscreen_reload was removed from MAME's core options; the modern
+            # equivalent is the bundled offscreenreload Lua plugin. Restricted to
+            # libretro-mame itself (not mess/mamevirtual/same_cdi, which also route
+            # through this generator).
+            pluginsToLoad += [ "offscreenreload" ]
         if pluginsToLoad:
             commandLine += [ "-plugins", "-plugin", ",".join(pluginsToLoad) ]
         messMode = -1
@@ -419,10 +425,6 @@ def generateMAMEConfigs(playersControllers: Controllers, system: Emulator, rom: 
                     commandLine += [ '-flop1', f'"{lr_mess_dsk}"' ]
                 else:
                     commandLine += [ '-flop2', f'"{lr_mess_dsk}"' ]
-
-    # Lightgun reload option
-    if system.config.get_bool('offscreenreload'):
-        commandLine += [ "-offscreen_reload" ]
 
     # Art paths - lr-mame displays artwork in the game area and not in the bezel area, so using regular MAME artwork + shaders is not recommended.
     # By default, will ignore standalone MAME's art paths.

--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/libretro/libretroMAMEConfig.py
@@ -82,10 +82,6 @@ def generateMAMEConfigs(playersControllers: Controllers, system: Emulator, rom: 
         if system.config.get_bool("coindropplugin"):
             pluginsToLoad += [ "coindrop" ]
         if system.config.core == 'mame' and system.config.get_bool('offscreenreload'):
-            # -offscreen_reload was removed from MAME's core options; the modern
-            # equivalent is the bundled offscreenreload Lua plugin. Restricted to
-            # libretro-mame itself (not mess/mamevirtual/same_cdi, which also route
-            # through this generator).
             pluginsToLoad += [ "offscreenreload" ]
         if pluginsToLoad:
             commandLine += [ "-plugins", "-plugin", ",".join(pluginsToLoad) ]


### PR DESCRIPTION
Disclosure, the fix was found using Claude code.

Light guns work fine in Libretro-MAME as long as the "offscreen reload" option is turned off.
If it's turned on however the game will fail to launch with this error -

```
[libretro INFO] Game description: The House of the Dead (Revision A)
[INFO] [Environ] SET_ROTATION: "0" (0 deg).
[libretro ERROR] Error: unknown option: -offscreen_reload
[ERROR] [Content] Failed to load content.
```

As that option has been removed from standalone, and Libretro MAME now.
Instead the offscreen reload is loaded as a helper plugin now, which was already done for standalone MAME in it's generator, so fix is just to apply the same here.

I kept the more conservative fix to only apply it if its MAME system specifically given Claudes comment about the other systems also potentially picking up from this generator as I don't have any of them to test with to be sure if they need this or not.

Tested in a custom build of Batocera v44 source on x86 build with Sinden light gun, offscreen button now working fine in addition to actual shooting off screen still.