### PR TITLE
Create 007-disable-home-pause.patch

### DIFF
--- a/package/batocera/emulators/ppsspp/007-disable-home-pause.patch
+++ b/package/batocera/emulators/ppsspp/007-disable-home-pause.patch
@@ -1,0 +1,13 @@
+diff --git a/SDL/SDLJoystick.cpp b/SDL/SDLJoystick.cpp
+index 94a6f481ba..e7992e2f19 100644
+--- a/SDL/SDLJoystick.cpp
++++ b/SDL/SDLJoystick.cpp
+@@ -141,7 +141,7 @@ InputKeyCode SDLJoystick::getKeycodeForButton(SDL_GameControllerButton button) {
+ 	case SDL_CONTROLLER_BUTTON_BACK:
+ 		return NKCODE_BUTTON_9; // select button
+ 	case SDL_CONTROLLER_BUTTON_GUIDE:
+-		return NKCODE_BACK; // pause menu
++		return NKCODE_UNKNOWN; // pause menu
+ 	case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+ 		return NKCODE_BUTTON_THUMBL;
+ 	case SDL_CONTROLLER_BUTTON_RIGHTSTICK:


### PR DESCRIPTION
Disables the hard coded single press of hotkey that opens the PPSSPP pause menu. It can then allow hotkeys to be used like normal.