### PR TITLE
hid-nintendo : fix rumble of third-party bluetooth gamepad

### DIFF
--- a/board/batocera/allwinner/h616/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/allwinner/h616/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/allwinner/h616/linux_patches/series
+++ b/board/batocera/allwinner/h616/linux_patches/series
@@ -517,3 +517,4 @@ patches.armbian/arm64-dts-sun50i-h616-bigtreetech-cb1-emac1-ac300.patch
 linux-usbhid-quircks.patch
 linux-wiimote-abs-not-hat.patch
 uvc-bandwidth_cap_param-for-sinden.patch
+hid-nintendo-bt-rumble.patch

--- a/board/batocera/allwinner/h700/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/allwinner/h700/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/allwinner/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/allwinner/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,8 +1,7 @@
 diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
-index e7302ec..5033f3e 100644
 --- a/drivers/hid/hid-nintendo.c
 +++ b/drivers/hid/hid-nintendo.c
-@@ -609,6 +609,8 @@ struct joycon_ctlr {
+@@ -589,6 +589,8 @@
  	unsigned int last_input_report_msecs;
  	unsigned int last_subcmd_sent_msecs;
  	unsigned int consecutive_valid_report_deltas;
@@ -11,20 +10,17 @@ index e7302ec..5033f3e 100644
  
  	/* factory calibration data */
  	struct joycon_stick_cal left_stick_cal_x;
-@@ -841,10 +843,11 @@ static void joycon_wait_for_input_report(struct joycon_ctlr *ctlr)
- #define JC_SUBCMD_TX_OFFSET_MS		4
- #define JC_SUBCMD_VALID_DELTA_REQ	3
- #define JC_SUBCMD_RATE_MAX_ATTEMPTS	25
-+#define JC_SUBCMD_RATE_MAX_FAILURES	2
+@@ -823,7 +825,8 @@
  #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
  #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
  #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
 -static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
 +static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
  {
  	unsigned int current_ms;
  	unsigned long subcmd_delta;
-@@ -872,6 +875,14 @@ static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
+@@ -851,6 +854,14 @@
  
  	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
  		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
@@ -39,7 +35,7 @@ index e7302ec..5033f3e 100644
  		return;
  	}
  
-@@ -886,6 +897,32 @@ static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
+@@ -865,6 +876,32 @@
  	msleep(JC_SUBCMD_TX_OFFSET_MS);
  }
  

--- a/board/batocera/amlogic/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/amlogic/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/amlogic/s812/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/amlogic/s812/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/amlogic/s922x/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/amlogic/s922x/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/broadcom/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/broadcom/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/qcs6490/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/qcs6490/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/sdm845/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/sdm845/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/sm6115/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/sm6115/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/sm8250/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/sm8250/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/sm8550/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/sm8550/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/qualcomm/sm8750/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/qualcomm/sm8750/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3326/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3326/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3328/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3328/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3399/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3399/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3568/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3568/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3576/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3576/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/rockchip/rk3588-mainline/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/rockchip/rk3588-mainline/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/samsung/exynos5422/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/samsung/exynos5422/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/x86/linux_patches/27-hid-nintendo-bt-rumble.patch
+++ b/board/batocera/x86/linux_patches/27-hid-nintendo-bt-rumble.patch
@@ -1,0 +1,74 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+index e7302ec..5033f3e 100644
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -609,6 +609,8 @@ struct joycon_ctlr {
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -841,10 +843,11 @@ static void joycon_wait_for_input_report(struct joycon_ctlr *ctlr)
+ #define JC_SUBCMD_TX_OFFSET_MS		4
+ #define JC_SUBCMD_VALID_DELTA_REQ	3
+ #define JC_SUBCMD_RATE_MAX_ATTEMPTS	25
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -872,6 +875,14 @@ static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -886,6 +897,32 @@ static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {

--- a/board/batocera/x86/linux_patches/hid-nintendo-bt-rumble.patch
+++ b/board/batocera/x86/linux_patches/hid-nintendo-bt-rumble.patch
@@ -1,0 +1,70 @@
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -589,6 +589,8 @@
+ 	unsigned int last_input_report_msecs;
+ 	unsigned int last_subcmd_sent_msecs;
+ 	unsigned int consecutive_valid_report_deltas;
++	unsigned int subcmd_rate_exhaustions;
++	bool subcmd_rate_relaxed;
+ 
+ 	/* factory calibration data */
+ 	struct joycon_stick_cal left_stick_cal_x;
+@@ -823,7 +825,8 @@
+ #define JC_SUBCMD_RATE_LIMITER_USB_MS	20
+ #define JC_SUBCMD_RATE_LIMITER_BT_MS	60
+ #define JC_SUBCMD_RATE_LIMITER_MS(ctlr)	((ctlr)->hdev->bus == BUS_USB ? JC_SUBCMD_RATE_LIMITER_USB_MS : JC_SUBCMD_RATE_LIMITER_BT_MS)
+-static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++#define JC_SUBCMD_RATE_MAX_FAILURES	2
++static void joycon_enforce_subcmd_rate_strict(struct joycon_ctlr *ctlr)
+ {
+ 	unsigned int current_ms;
+ 	unsigned long subcmd_delta;
+@@ -851,6 +854,14 @@
+ 
+ 	if (attempts >= JC_SUBCMD_RATE_MAX_ATTEMPTS) {
+ 		hid_warn(ctlr->hdev, "%s: exceeded max attempts", __func__);
++
++		if (++ctlr->subcmd_rate_exhaustions == JC_SUBCMD_RATE_MAX_FAILURES) {
++			ctlr->subcmd_rate_relaxed = true;
++			hid_info(ctlr->hdev,
++				 "input report cadence does not fit the %d-%dms window; using the legacy subcommand throttle\n",
++				 JC_INPUT_REPORT_MIN_DELTA,
++				 JC_INPUT_REPORT_MAX_DELTA);
++		}
+ 		return;
+ 	}
+ 
+@@ -865,6 +876,32 @@
+ 	msleep(JC_SUBCMD_TX_OFFSET_MS);
+ }
+ 
++/* The rate limiter as it was before commit d750d1480362, without the report
++ * cadence requirement.
++ */
++static void joycon_enforce_subcmd_rate_legacy(struct joycon_ctlr *ctlr)
++{
++	static const unsigned int max_subcmd_rate_ms = 25;
++	unsigned int current_ms = jiffies_to_msecs(jiffies);
++	unsigned int delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++
++	while (delta_ms < max_subcmd_rate_ms &&
++	       ctlr->ctlr_state == JOYCON_CTLR_STATE_READ) {
++		joycon_wait_for_input_report(ctlr);
++		current_ms = jiffies_to_msecs(jiffies);
++		delta_ms = current_ms - ctlr->last_subcmd_sent_msecs;
++	}
++	ctlr->last_subcmd_sent_msecs = current_ms;
++}
++
++static void joycon_enforce_subcmd_rate(struct joycon_ctlr *ctlr)
++{
++	if (ctlr->subcmd_rate_relaxed)
++		joycon_enforce_subcmd_rate_legacy(ctlr);
++	else
++		joycon_enforce_subcmd_rate_strict(ctlr);
++}
++
+ static int joycon_hid_send_sync(struct joycon_ctlr *ctlr, u8 *data, size_t len,
+ 				u32 timeout)
+ {


### PR DESCRIPTION
I have submitted this patch to kernel mailing
(and it's applied to linux-input branch currently) https://lore.kernel.org/linux-input/8q45nos3-s5q2-0028-7o72-po920q5892q3@xreary.bet/T/#t

Third-party controller like 8bitdo pro2 or other chineses clones have broken rumble currently in bluetooth because their report interval implementation is different than undocumented official nintendo controller.