### PR TITLE
fix(shadps4): build against host-protobuf and protobuf

### DIFF
--- a/package/batocera/emulators/shadps4/0002-fix-protobuf.patch
+++ b/package/batocera/emulators/shadps4/0002-fix-protobuf.patch
@@ -1,13 +1,47 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index d38b447..41d672d 100644
+index d38b447..6bc0c3a 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
+@@ -246,6 +246,7 @@ if (ENABLE_SYSTEM_LIBRARIES)
+     find_package(miniz 3.1 CONFIG)
+     find_package(nlohmann_json 3.12 CONFIG)
+     find_package(PNG 1.6 MODULE)
++    find_package(Protobuf CONFIG REQUIRED)
+     find_package(OpenAL CONFIG)
+     find_package(LibreSSL 4.3.1 MODULE)
+     find_package(RenderDoc 1.6.0 MODULE)
 @@ -1208,7 +1208,7 @@ add_custom_command(
      OUTPUT
          "${SHADNET_PROTO_OUT}/shadnet.pb.cc"
          "${SHADNET_PROTO_OUT}/shadnet.pb.h"
 -    COMMAND protobuf::protoc
-+    COMMAND $<TARGET_FILE:protobuf::protoc>
++    COMMAND "${SHADPS4_PROTOC_EXECUTABLE}"
          "--proto_path=${CMAKE_CURRENT_SOURCE_DIR}/src/shadnet"
          "--cpp_out=${SHADNET_PROTO_OUT}"
          "${CMAKE_CURRENT_SOURCE_DIR}/src/shadnet/shadnet.proto"
+@@ -1256,5 +1256,5 @@ target_link_libraries(shadps4 PRIVATE Cpp_Httplib miniupnpc::miniupnpc)
+ target_link_libraries(shadps4 PRIVATE Freetype::Freetype)
+-target_link_libraries(shadps4 PRIVATE libprotobuf)
++target_link_libraries(shadps4 PRIVATE protobuf::libprotobuf)
+ target_link_libraries(shadps4 PRIVATE ZArchive::zarchive)
+ target_include_directories(shadps4 PRIVATE "${SHADNET_PROTO_OUT}")
+ 
+diff --git a/externals/CMakeLists.txt b/externals/CMakeLists.txt
+index 7b8175f..062582d 100644
+--- a/externals/CMakeLists.txt
++++ b/externals/CMakeLists.txt
+@@ -384,5 +384,6 @@ endif()
+ 
+ # protobuf
++if (NOT ENABLE_SYSTEM_LIBRARIES)
+ set(protobuf_BUILD_TESTS              OFF CACHE INTERNAL "")
+ set(protobuf_BUILD_EXAMPLES           OFF CACHE INTERNAL "")
+ set(protobuf_BUILD_PROTOC_BINARIES    ON  CACHE INTERNAL "")
+@@ -394,6 +395,7 @@ if(MSVC)
+ set(protobuf_MSVC_STATIC_RUNTIME OFF CACHE BOOL "" FORCE)
+ endif()
+ add_subdirectory(protobuf EXCLUDE_FROM_ALL)
++endif()
+ 
+ # zstd (dependency of ZArchive)
+ if (NOT TARGET libzstd_static)

--- a/package/batocera/emulators/shadps4/shadps4.mk
+++ b/package/batocera/emulators/shadps4/shadps4.mk
@@ -27,9 +27,9 @@ SHADPS4_SUPPORTS_IN_SOURCE_BUILD = NO
 
 SHADPS4_EMULATOR_INFO = shadps4.emulator.yml
 
-SHADPS4_DEPENDENCIES += alsa-lib boost ffmpeg fmt freetype glslang jack2 libedit
+SHADPS4_DEPENDENCIES += alsa-lib boost ffmpeg fmt freetype glslang host-protobuf jack2 libedit
 SHADPS4_DEPENDENCIES += libevdev libminiupnpc libzlib openal openssl pugixml
-SHADPS4_DEPENDENCIES += pulseaudio sdl3 udev vulkan-headers
+SHADPS4_DEPENDENCIES += protobuf pulseaudio sdl3 udev vulkan-headers
 SHADPS4_DEPENDENCIES += vulkan-validationlayers
 
 SHADPS4_CMAKE_BACKEND = ninja
@@ -44,6 +44,7 @@ SHADPS4_CONF_OPTS += -DENABLE_DISCORD_RPC=OFF
 SHADPS4_CONF_OPTS += -DENABLE_SYSTEM_LIBRARIES=ON
 SHADPS4_CONF_OPTS += -DENABLE_UPDATER=OFF
 SHADPS4_CONF_OPTS += -DVMA_ENABLE_INSTALL=ON
+SHADPS4_CONF_OPTS += -DSHADPS4_PROTOC_EXECUTABLE=$(HOST_DIR)/bin/protoc
 
 # Dear_ImGui_FontEmbed is a build-time code generator that runs on the host.
 # The following builds the binary to run on the host rather than adding a


### PR DESCRIPTION
- Use host-protobuf to generate protobuf files instead of building `protoc` from source.
- Dynamically link against the target's protobuf library instead of the version provided by shadps4 so there is no version mismatch.