### PR TITLE
Original English lines editing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ batocera-mok.key
 typescript
 .ruff_cache
 .coverage
+*.mo

--- a/package/batocera/emulationstation/batocera-es-system/_shared.emulator.yml
+++ b/package/batocera/emulationstation/batocera-es-system/_shared.emulator.yml
@@ -2,7 +2,7 @@ custom_features:
   powermode:
     group: POWER OPTIONS
     prompt: POWER MODE
-    description: Adjust the cpu power frequency profile whilst in-game. Some systems will benefit from improved voltage handling.
+    description: Adjust the CPU power frequency profile whilst in-game. Some systems will benefit from improved voltage handling.
     choices:
       High Performance: highperformance
       Balanced: balanced
@@ -10,7 +10,7 @@ custom_features:
   batterymode:
     group: POWER OPTIONS
     prompt: BATTERY MODE
-    description: Adjust the cpu power profile whist on battery. Overwrites previous Power Mode(s).
+    description: Adjust the CPU power profile whist on battery. Overwrites previous Power Mode(s).
     choices:
       High Performance: highperformance
       Balanced: balanced

--- a/package/batocera/emulationstation/batocera-es-system/locales/ar/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ar/batocera-es-system.po
@@ -2251,7 +2251,7 @@ msgstr "9x أساسي (~3240p)"
 
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
-msgid "A small  number of games will have compatibility problems with this enabled."
+msgid "A small number of games will have compatibility problems with this enabled."
 msgstr "سيواجه عدد قليل من الألعاب مشاكل في التوافق عند تفعيل هذا الخيار."
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2843,12 +2843,12 @@ msgstr "تعديل وضع رسم خطوط الشاشة."
 
 #. TRANSLATION: shared
 msgctxt "game_options"
-msgid "Adjust the cpu power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
+msgid "Adjust the CPU power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
 msgstr "تعديل ملف تعريف تردد طاقة المعالج أثناء اللعب. ستستفيد بعض الأنظمة من تحسين معالجة الجهد."
 
 #. TRANSLATION: shared
 msgctxt "game_options"
-msgid "Adjust the cpu power profile whist on battery. Overwrites previous Power Mode(s)."
+msgid "Adjust the CPU power profile whist on battery. Overwrites previous Power Mode(s)."
 msgstr "تعديل ملف تعريف طاقة المعالج أثناء استخدام البطارية. يستبدل وضع (أوضاع) الطاقة السابقة."
 
 #. TRANSLATION: vpinball
@@ -3050,7 +3050,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "شاشة نقطية ملونة بديلة (يتطلب ملف إضافي)."
 
 #. TRANSLATION: vpinball
@@ -4423,12 +4423,12 @@ msgstr "التلوين"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "عمق اللون"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "وضع اللون"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4753,7 +4753,7 @@ msgstr "حجم مؤشر التصويب"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "لون CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4778,7 +4778,7 @@ msgstr "مبدل دقة CRT (Switchres)"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "تكيف ألوان مشابه لـ CRT. يتطلب محرك 3D الجديد."
 
 #. TRANSLATION: citron
@@ -5300,7 +5300,7 @@ msgstr "اختر عمق جودة الملمس (Texture)."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "اختر عمق اللون المحاكى."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5365,7 +5365,7 @@ msgstr "اختر حجم واجهة العرض العلوية (HUD)."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "اختر عمق ألوان الملمس (Texture)."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5395,8 +5395,8 @@ msgstr "اختر الإبقاء على الجثث موجودة."
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "Choose to render high definition graphics textures. Requires OpenGL, True Colour and the enhanced.gob file."
-msgstr "اختر تصيير نسيج رسومات عالي الدقة. يتطلب OpenGL، True Colour وملف enhanced.gob."
+msgid "Choose to render high definition graphics textures. Requires OpenGL, True Color and the enhanced.gob file."
+msgstr "اختر تصيير نسيج رسومات عالي الدقة. يتطلب OpenGL، True Color وملف enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6460,7 +6460,7 @@ msgstr "صورة القرص"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "عرض معلومات على الشاشة مثل حالة الحفظ وتحذيرات الإعداد وغيرها..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7720,7 +7720,7 @@ msgstr "معدل نقل سريع للقرص"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "اللون المفضل"
 
 #. TRANSLATION: wine
@@ -9987,7 +9987,7 @@ msgstr "لوحة لعب (تلقائي)"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "حساسية لوحة اللعب للمجاديف. الافتراضي للنواة (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11388,7 +11388,7 @@ msgstr "التحرك للأمام"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "التحرك للأمام، يمكن استخدامه للضغط على W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12265,7 +12265,7 @@ msgstr "فتح وحدة تحكم LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "فتح القائمة"
 
 #. TRANSLATION: corsixth.keys
@@ -13462,7 +13462,7 @@ msgstr "RGB (صورة حادة)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "لون RGB بدقة منخفضة/متوسطة"
 
 #. TRANSLATION: citron
@@ -13612,7 +13612,7 @@ msgstr "تقليل التلعثم الذي يحدث عند تجميع المظل
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid "Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr "يقلل التدرجات اللونية المرئية ويحسن عمق الألوان المدرك."
 
 #. TRANSLATION: rpcs3
@@ -15993,7 +15993,7 @@ msgstr "نص"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "عمق لون النسيج"
 
 #. TRANSLATION: openmohaa
@@ -16173,7 +16173,7 @@ msgstr "التخزين المؤقت الثلاثي"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "تصيير الألوان الحقيقية"
 
 #. TRANSLATION: libretro/hatarib
@@ -16373,7 +16373,7 @@ msgstr "سيتم زيادة عدد عينات كل بلاطة في كل EVENT_WR
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr ".لون موضوع وحدة التحكم المحاكاة"
 
 #. TRANSLATION: ppsspp
@@ -16593,7 +16593,7 @@ msgstr "مثلث"
 
 #. TRANSLATION: model2emu
 msgctxt "game_options"
-msgid "Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly information (flat)."
+msgid "Tries to guess Per-vertex color (gouraud) from the Model2 per-poly information (flat)."
 msgstr "يحاول تخمين لون كل رأس (gouraud) من معلومات كل مضلع في Model2 (المستوي)."
 
 #. TRANSLATION: openjk, openmohaa
@@ -16623,7 +16623,7 @@ msgstr "التخزين المؤقت الثلاثي"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "اللون الحقيقي"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17238,7 +17238,7 @@ msgstr ".المستقل - لا يُنصح بذلك إذا كنت تستخدم ا
 
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
-msgid "Use the system mouse pointer as paddle controller 1.  Does not let you choose a specific mouse if you have several."
+msgid "Use the system mouse pointer as paddle controller 1. Does not let you choose a specific mouse if you have several."
 msgstr "استخدم مؤشر فأرة النظام كوحدة تحكم بدالة ١. لا يسمح لك باختيار فأرة محددة إذا كان لديك عدة فأرات."
 
 #. TRANSLATION: libretro/melondsds

--- a/package/batocera/emulationstation/batocera-es-system/locales/batocera-es-system.pot
+++ b/package/batocera/emulationstation/batocera-es-system/locales/batocera-es-system.pot
@@ -19,7 +19,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 
@@ -777,12 +777,12 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: libretro/cap32
@@ -1650,12 +1650,12 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds
@@ -2043,7 +2043,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 
@@ -4267,7 +4267,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr ""
 
 #. TRANSLATION: libretro/hatarib
@@ -6702,7 +6702,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/pcsx2
@@ -6865,7 +6865,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
@@ -8090,7 +8090,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/stella
@@ -10233,7 +10233,7 @@ msgstr ""
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr ""
 
 #. TRANSLATION: duckstation
@@ -11238,7 +11238,7 @@ msgstr ""
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 
 #. TRANSLATION: pcsx2
@@ -12908,12 +12908,12 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr ""
 
 #. TRANSLATION: supermodel
@@ -13850,7 +13850,7 @@ msgstr ""
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 
@@ -15849,7 +15849,7 @@ msgstr ""
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 
 #. TRANSLATION: vpinball
@@ -16242,7 +16242,7 @@ msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr ""
 
 #. TRANSLATION: theforceengine
@@ -16257,14 +16257,14 @@ msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 
 #. TRANSLATION: theforceengine
@@ -17518,12 +17518,12 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -18179,7 +18179,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr ""
 
 #. TRANSLATION: catacomb.keys
@@ -18204,7 +18204,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr ""
 
 #. TRANSLATION: catacomb.keys

--- a/package/batocera/emulationstation/batocera-es-system/locales/ca/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ca/batocera-es-system.po
@@ -1456,7 +1456,7 @@ msgstr "Natiu x3 (~1080p)"
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
 msgid "3x native (768 x 576)"
-msgstr "3x  nadiu (768 x 576)"
+msgstr "3x nadiu (768 x 576)"
 
 #. TRANSLATION: libretro/potator
 msgctxt "game_options"
@@ -2231,7 +2231,7 @@ msgstr "9x Nadiu (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Un petit nombre de jocs tindran problemes de compatibilitat amb aquesta "
 "opció habilitada."
@@ -2819,7 +2819,7 @@ msgid ""
 "Adjust mixing of CD audio. In MSU-MD, cartridge-sourced sound effects are "
 "not affected."
 msgstr ""
-"Ajustar barreja d’àudio de CD.  En el MSU-MD, no es veuen afectats els "
+"Ajustar barreja d’àudio de CD. En el MSU-MD, no es veuen afectats els "
 "efectes sonors del cartutx."
 
 #. TRANSLATION: amiberry
@@ -2830,7 +2830,7 @@ msgstr "Ajusta el mode de dibuixat de les línies de pantalla."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajusta el perfil de freqüència de potència de la CPU mentre jugues. Alguns "
@@ -2839,7 +2839,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajusta el perfil de potència de la CPU mentre estàs amb la bateria. "
@@ -3060,7 +3060,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Pantalla de matriu de punts (DMD) en color alternativa (cal un fitxer "
 "addicional)."
@@ -4467,12 +4467,12 @@ msgstr "COLORITZACIÓ"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFUNDITAT DE COLOR"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODE COLOR"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4796,7 +4796,7 @@ msgstr "TAMANY DEL PUNT DE MIRA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "TRC (CRT) A COLOR"
 
 #. TRANSLATION: libretro/o2em
@@ -4821,7 +4821,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptació de color simulant una TRC (CRT). Requereix Nou motor 3D."
 
 #. TRANSLATION: citron
@@ -5007,7 +5007,7 @@ msgstr "Pot prevenir salts d’àudio al prémer botons quan s’usa pre-avança
 #. TRANSLATION: rpcs3
 msgctxt "game_options"
 msgid "Can reduce crackle and stutter but increases audio latency."
-msgstr "Pot reduïr els salts  però incrementa la latència d'àudio."
+msgstr "Pot reduïr els salts però incrementa la latència d'àudio."
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
@@ -5384,7 +5384,7 @@ msgstr "Tria la profunditat de la qualitat de textura."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Tria la profunditat de color emulada."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5452,7 +5452,7 @@ msgstr "Tria el tamany dels avisos en pantalla."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Tria la profunditat de color de la textura."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5486,7 +5486,7 @@ msgstr "Tria per mantenir els cadàvers presents."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Tria per renderitzar textures de gràfics d’alta definició. Requereix OpenGL, "
 "Color veritable i l’arxiu enhanced.gob."
@@ -6607,7 +6607,7 @@ msgstr "Imatge de disc"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Mostra en pantalla informació com estat desats, configuració, avisos, etc…"
 
@@ -8009,7 +8009,7 @@ msgstr "MOSTRATGE DE TRANFERÈNCIA DE DISC RÀPIDA"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COLOR FAVORIT"
 
 #. TRANSLATION: wine
@@ -10390,7 +10390,7 @@ msgstr "Joypad Automàtic"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 "Sensibilitat el comandament per botons giratoris (paddles). Per defecte "
 "nucli (3)."
@@ -11845,7 +11845,7 @@ msgstr "Moure Endavant"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Moure Endavant, Pot ser usat pulsant W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12757,7 +12757,7 @@ msgstr "Obrir consola LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Obrir Menú"
 
 #. TRANSLATION: corsixth.keys
@@ -13976,7 +13976,7 @@ msgstr "RGB (imatge nítida)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB Color Resolució Mitjana/Baixa"
 
 #. TRANSLATION: citron
@@ -14130,7 +14130,7 @@ msgstr "Redueix la quequesa que es produeix al compilar shaders."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Redueix el banding entre colors i millora la percepció de la profunditat de "
 "color."
@@ -16637,7 +16637,7 @@ msgstr "TEXT"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "PROFUNDITAT DEL COLOR DE LA TEXTURA"
 
 #. TRANSLATION: openmohaa
@@ -16817,7 +16817,7 @@ msgstr "TRIPLE MEMÒRIA CAU"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDERITZACIÓ AMB COLOR REAL"
 
 #. TRANSLATION: libretro/hatarib
@@ -17035,7 +17035,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "El color del tema de la consola emulada."
 
 #. TRANSLATION: ppsspp
@@ -17271,7 +17271,7 @@ msgstr "Triangle"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Intenta obtenir el color per-vèrtex (gouraud) a partir de la informació per "
@@ -17304,7 +17304,7 @@ msgstr "Memòria intermèdia triple"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Color Real"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17965,7 +17965,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Usa el punter del ratolí com a botó rotatori (paddle) 1. No permet escollir "
@@ -19435,7 +19435,7 @@ msgstr "groc/blau"
 #~ msgstr "Activar la vibració en comandaments que ho suporten."
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Ajusta el perfil de potència de la CPU durant el joc."
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/cs_CZ/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/cs_CZ/batocera-es-system.po
@@ -2226,7 +2226,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2820,7 +2820,7 @@ msgstr "Nastavení režimu kreslení čar na obrazovce."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Nastavení profilu frekvence výkonu procesoru ve hře. Některé systémy budou "
@@ -2829,7 +2829,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Nastavení profilu napájení procesoru při napájení z baterie. Přepíše "
@@ -3045,7 +3045,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternativní barevný matrixový displej (potřebuje další soubor)."
 
 #. TRANSLATION: vpinball
@@ -4444,12 +4444,12 @@ msgstr "VYBARVENÍ"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "HLOUBKA BARVY"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "BAREVNÝ REŽIM"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4540,7 +4540,7 @@ msgstr "OVLADAČ 3"
 #. TRANSLATION: flycast
 msgctxt "game_options"
 msgid "CONTROLLER 3 FEATURE PACK"
-msgstr "BALÍČEK FUNKCÍ OVLADAČE  3"
+msgstr "BALÍČEK FUNKCÍ OVLADAČE 3"
 
 #. TRANSLATION: libretro/genesisplusgx, libretro/genesisplusgx-expanded, libretro/picodrive
 msgctxt "game_options"
@@ -4560,7 +4560,7 @@ msgstr "OVLADAČ 4"
 #. TRANSLATION: flycast
 msgctxt "game_options"
 msgid "CONTROLLER 4 FEATURE PACK"
-msgstr "BALÍČEK FUNKCÍ OVLADAČE  4"
+msgstr "BALÍČEK FUNKCÍ OVLADAČE 4"
 
 #. TRANSLATION: libretro/genesisplusgx, libretro/genesisplusgx-expanded, libretro/picodrive
 msgctxt "game_options"
@@ -4771,7 +4771,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "BARVA CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4796,7 +4796,7 @@ msgstr "PŘEPÍNAČE CRT"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Přizpůsobení barev jako u CRT. Vyžaduje nový 3D engine."
 
 #. TRANSLATION: citron
@@ -5354,7 +5354,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Zvolte emulovanou barevnou hloubku."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5420,7 +5420,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openjk, openmohaa
@@ -5455,10 +5455,10 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Zvolte vykreslování grafických textur ve vysokém rozlišení. Vyžaduje OpenGL, "
-"True Colour a soubor enhanced.gob."
+"True Color a soubor enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6572,7 +6572,7 @@ msgstr "Obraz Disku"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Zobrazení informací na obrazovce, jako je uložení pozice, upozornění na "
 "konfiguraci atd..."
@@ -7966,7 +7966,7 @@ msgstr "RYCHLÁ PŘENOSOVÁ RYCHLOST DISKU"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "Oblíbená barva"
 
 #. TRANSLATION: wine
@@ -10329,7 +10329,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11779,7 +11779,7 @@ msgstr "Pohyb vpřed"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Posun vpřed, lze použít ke stisknutí tlačítka W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12686,7 +12686,7 @@ msgstr "Otevření konzoly LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Otevřít menu"
 
 #. TRANSLATION: corsixth.keys
@@ -13901,7 +13901,7 @@ msgstr "RGB (ostrý obrázek)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Barvy RGB s nízkým/středním rozlišením"
 
 #. TRANSLATION: citron
@@ -14055,7 +14055,7 @@ msgstr "Snížení zadrhávání, ke kterému dochází při kompilaci shaderů.
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Snižuje pruhování mezi barvami a zlepšuje vnímanou hloubku barev."
 
 #. TRANSLATION: rpcs3
@@ -16547,7 +16547,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -16727,7 +16727,7 @@ msgstr "TROJITÝ BUFFERING"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "VĚRNÉ PODÁNÍ BAREV"
 
 #. TRANSLATION: libretro/hatarib
@@ -16941,7 +16941,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Barva motivu emulované konzole."
 
 #. TRANSLATION: ppsspp
@@ -17173,7 +17173,7 @@ msgstr "Trojúhelník"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Pokusí se odhadnout barvu na-vertex (gouraud) z informací (flat) na-poly "
@@ -17206,7 +17206,7 @@ msgstr "Trojitá vyrovnávací paměť"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Věrná barva"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17857,7 +17857,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 
@@ -19485,7 +19485,7 @@ msgstr "žlutá/modrá"
 #~ msgstr "Aktivace funkce vibrace na podporovaných ovladačích."
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Nastavení profilu výkonu cpu ve hře."
 
 #~ msgctxt "game_options"
@@ -19858,7 +19858,7 @@ msgstr "žlutá/modrá"
 #~ msgstr "POVOLIT OSD"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "POVOLIT VĚRNÉ BARVY"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/de/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/de/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9x Nativ (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Einige wenige Spiele haben bei aktivierter Option Kompatibilitätsprobleme."
 
@@ -2826,7 +2826,7 @@ msgstr "Modus für Bildschirmzeilen-Aufbau anpassen."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Passen Sie das Frequenzprofil der CPU-Leistung im Spiel an. Einige Systeme "
@@ -2835,7 +2835,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Passt das Leistungsprofil des Prozessors im Akkubetrieb an. Überschreibt die "
@@ -3056,7 +3056,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternative farbige Dot-Matrix-Anzeige (benötigt zusätzliche Datei)."
 
 #. TRANSLATION: vpinball
@@ -4462,12 +4462,12 @@ msgstr "FARBGEBUNG"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "FARBTIEFE"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "FARBMODUS"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4791,7 +4791,7 @@ msgstr "FADENKREUZ-GRÖSSE"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT-FARBE"
 
 #. TRANSLATION: libretro/o2em
@@ -4816,7 +4816,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT-ähnliche Farbanpassung. Erfordert neue 3D-Engine."
 
 #. TRANSLATION: citron
@@ -5385,7 +5385,7 @@ msgstr "Tiefe der Texturqualität wählen."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Wählen Sie die emulierte Farbtiefe."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5451,7 +5451,7 @@ msgstr "Größe des HUD wählen."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Farbtiefe der Texturen wählen."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5483,10 +5483,10 @@ msgstr "Leichen beibehalten."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Wählen Sie diese Option, um hochauflösende Grafiktexturen zu rendern. "
-"Erfordert OpenGL, True Colour und die Datei enhanced.gob."
+"Erfordert OpenGL, True Color und die Datei enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6604,7 +6604,7 @@ msgstr "Disk-Image"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Zeigt auf dem Bildschirm Informationen wie Speicherstatus, "
 "Konfigurationswarnungen usw. an."
@@ -8029,7 +8029,7 @@ msgstr "SCHNELLE DATENTRÄGER-TRANSFERRATE"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "BEVORZUGTE FARBE"
 
 #. TRANSLATION: wine
@@ -10430,7 +10430,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Joypad-Empfindlichkeit für Paddles. Standardwert: (3)"
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11896,7 +11896,7 @@ msgstr "Vorwärts"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Vorwärts bewegen, durch Drücken der Taste W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12813,7 +12813,7 @@ msgstr "LUA Konsole öffnen"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Menü öffnen"
 
 #. TRANSLATION: corsixth.keys
@@ -14037,7 +14037,7 @@ msgstr "RGB (scharfes Bild)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB Farben mit niedriger/mittlerer Auflösung"
 
 #. TRANSLATION: citron
@@ -14191,7 +14191,7 @@ msgstr "Ruckler beim Shader-Kompilieren reduzieren."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Reduktion von Banding-Effekten bei Farbverläufen und Verbesserung der "
 "wahrgenommenen Farbtiefe."
@@ -16716,7 +16716,7 @@ msgstr "TEXT"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TEXTUREN FARBTIEFE"
 
 #. TRANSLATION: openmohaa
@@ -16896,7 +16896,7 @@ msgstr "DREIFACHE PUFFERUNG"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "TRUE-COLOR RENDERING"
 
 #. TRANSLATION: libretro/hatarib
@@ -17117,7 +17117,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Die Themenfarbe der emulierten Konsole."
 
 #. TRANSLATION: ppsspp
@@ -17355,7 +17355,7 @@ msgstr "Triangle"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Versucht die Farben mit Per-Vertex (Gouraud) aus der Model2 Per-Poly "
@@ -17388,8 +17388,8 @@ msgstr "Dreifache Pufferung"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -18055,7 +18055,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Systemmauszeiger als Schieberegler 1 nutzen. Auswahl einer spezifischen Maus "

--- a/package/batocera/emulationstation/batocera-es-system/locales/de/batocera-es-system_de_DE.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/de/batocera-es-system_de_DE.po
@@ -156,7 +156,7 @@ msgstr ""
 #. TRANSLATION: libretro/atari800
 msgctxt "game_options"
 msgid "Emulate NTSC quirks to show more colors in hi-res mode."
-msgstr "Emulate NTSC quirks to show more colours in hi-res mode."
+msgstr "Emulate NTSC quirks to show more colors in hi-res mode."
 
 #. TRANSLATION: libretro/atari800
 msgctxt "game_options"
@@ -1316,22 +1316,22 @@ msgstr ""
 #. TRANSLATION: libretro/fceumm, libretro/nestopia, libretro/vice_x64, libretro/vice_x64sc, libretro/vice_x128, ...
 msgctxt "game_options"
 msgid "COLOR FILTER"
-msgstr "COLOUR FILTER"
+msgstr "COLOR FILTER"
 
 #. TRANSLATION: libretro/fceumm, libretro/nestopia, libretro/vice_x64, libretro/vice_x64sc, libretro/vice_x128, ...
 msgctxt "game_options"
 msgid "Can be used to simulate colors of particular displays."
-msgstr "Can be used to simulate colours of particular displays."
+msgstr "Can be used to simulate colors of particular displays."
 
 #. TRANSLATION: libretro/fceumm, libretro/genesisplusgx, libretro/genesisplusgx, libretro/nestopia
 msgctxt "game_options"
 msgid "Composite (color bleeding + artifacts)"
-msgstr "Composite (colour bleeding + artifacts)"
+msgstr "Composite (color bleeding + artifacts)"
 
 #. TRANSLATION: libretro/fceumm, libretro/genesisplusgx, libretro/genesisplusgx, libretro/nestopia
 msgctxt "game_options"
 msgid "SVideo (color bleeding only)"
-msgstr "SVideo (colour bleeding only)"
+msgstr "SVideo (color bleeding only)"
 
 #. TRANSLATION: libretro/fceumm, libretro/genesisplusgx, libretro/genesisplusgx, libretro/nestopia
 msgctxt "game_options"
@@ -1586,22 +1586,22 @@ msgstr ""
 #. TRANSLATION: libretro/gambatte, libretro/mgba, libretro/mgba, libretro/vba-m, libretro/vba-m
 msgctxt "game_options"
 msgid "COLOR CORRECTION"
-msgstr "COLOUR CORRECTION"
+msgstr "COLOR CORRECTION"
 
 #. TRANSLATION: libretro/gambatte, libretro/mgba, libretro/mgba, libretro/vba-m, libretro/vba-m
 msgctxt "game_options"
 msgid "Simulate LCD color inaccuracy."
-msgstr "Simulate LCD colour inaccuracy."
+msgstr "Simulate LCD color inaccuracy."
 
 #. TRANSLATION: libretro/gambatte
 msgctxt "game_options"
 msgid "Set the color palette to use."
-msgstr "Set the colour palette to use."
+msgstr "Set the color palette to use."
 
 #. TRANSLATION: libretro/gambatte
 msgctxt "game_options"
 msgid "GB - Smart Coloring"
-msgstr "GB - Smart Colouring"
+msgstr "GB - Smart Coloring"
 
 #. TRANSLATION: libretro/gambatte, libretro/potator
 msgctxt "game_options"
@@ -1991,7 +1991,7 @@ msgstr ""
 #. TRANSLATION: libretro/mrboom
 msgctxt "game_options"
 msgid "TEAM COLOR MODE"
-msgstr "TEAM COLOUR MODE"
+msgstr "TEAM COLOR MODE"
 
 #. TRANSLATION: libretro/mrboom
 msgctxt "game_options"
@@ -2001,7 +2001,7 @@ msgstr ""
 #. TRANSLATION: libretro/mrboom
 msgctxt "game_options"
 msgid "Color"
-msgstr "Colour"
+msgstr "Color"
 
 #. TRANSLATION: libretro/mrboom
 msgctxt "game_options"
@@ -2633,7 +2633,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx_rearmed
 msgctxt "game_options"
 msgid "Lunar Ignore Brightness Color Fix"
-msgstr "Lunar Ignore Brightness Colour Fix"
+msgstr "Lunar Ignore Brightness Color Fix"
 
 #. TRANSLATION: libretro/pcsx_rearmed
 msgctxt "game_options"
@@ -2668,7 +2668,7 @@ msgstr ""
 #. TRANSLATION: libretro/potator
 msgctxt "game_options"
 msgid "COLOR PALETTE"
-msgstr "COLOUR PALETTE"
+msgstr "COLOR PALETTE"
 
 #. TRANSLATION: libretro/potator
 msgctxt "game_options"
@@ -3675,7 +3675,7 @@ msgstr ""
 #. TRANSLATION: libretro/vb
 msgctxt "game_options"
 msgid "COLOR PALETTE (2D)"
-msgstr "COLOUR PALETTE (2D)"
+msgstr "COLOR PALETTE (2D)"
 
 #. TRANSLATION: libretro/vb
 msgctxt "game_options"
@@ -3750,12 +3750,12 @@ msgstr ""
 #. TRANSLATION: libretro/vba-m
 msgctxt "game_options"
 msgid "GB COLORIZATION"
-msgstr "GB COLOURISATION"
+msgstr "GB COLORISATION"
 
 #. TRANSLATION: libretro/vba-m
 msgctxt "game_options"
 msgid "Add color to Game Boy games."
-msgstr "Add colour to Game Boy games."
+msgstr "Add color to Game Boy games."
 
 #. TRANSLATION: libretro/vba-m
 msgctxt "game_options"
@@ -6407,7 +6407,7 @@ msgstr ""
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 

--- a/package/batocera/emulationstation/batocera-es-system/locales/en_GB/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/en_GB/batocera-es-system.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-12-16 08:24+0100\n"
-"PO-Revision-Date: 2024-07-03 11:51+0300\n"
+"PO-Revision-Date: 2026-08-13 00:37+0200\n"
 "Last-Translator: Mihai Vasiliu <mihai.vasiliu.93@gmail.com>\n"
 "Language-Team: \n"
 "Language: en_GB\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.4\n"
+"X-Generator: Poedit 3.9\n"
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
 msgctxt "game_options"
@@ -2231,7 +2231,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2362,7 +2362,7 @@ msgstr ""
 #. TRANSLATION: vpinball
 msgctxt "game_options"
 msgid "ALTCOLOR"
-msgstr ""
+msgstr "ALTCOLOUR"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -2824,14 +2824,14 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 
@@ -3038,8 +3038,8 @@ msgstr ""
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
-msgstr ""
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
+msgstr "Alternative Coloured Dot Matrix Display (needs additional file)."
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -4423,13 +4423,13 @@ msgstr "COLOURISATION"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
-msgstr ""
+msgid "COLOR DEPTH"
+msgstr "COLOUR DEPTH"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
-msgstr ""
+msgid "COLOR MODE"
+msgstr "COLOUR MODE"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
 msgctxt "game_options"
@@ -4750,8 +4750,8 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
-msgstr ""
+msgid "CRT COLOR"
+msgstr "CRT COLOUR"
 
 #. TRANSLATION: libretro/o2em
 msgctxt "game_options"
@@ -4775,8 +4775,8 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
-msgstr ""
+msgid "CRT-like color adaption. Requires New 3D engine."
+msgstr "CRT-like colour adaption. Requires New 3D engine."
 
 #. TRANSLATION: citron
 msgctxt "game_options"
@@ -5313,8 +5313,8 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
-msgstr ""
+msgid "Choose the emulated color depth."
+msgstr "Choose the emulated colour depth."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
 msgctxt "game_options"
@@ -5379,8 +5379,8 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
-msgstr ""
+msgid "Choose the texture color depth."
+msgstr "Choose the texture colour depth."
 
 #. TRANSLATION: openjk, openmohaa
 msgctxt "game_options"
@@ -5411,8 +5411,10 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
+"Choose to render high definition graphics textures. Requires OpenGL, True "
+"Colour and the enhanced.gob file."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6496,7 +6498,7 @@ msgstr ""
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 
 #. TRANSLATION: nds.drastic.keys
@@ -7814,8 +7816,8 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
-msgstr ""
+msgid "FAVORITE COLOR"
+msgstr "FAVOURITE COLOUR"
 
 #. TRANSLATION: wine
 msgctxt "game_options"
@@ -10128,7 +10130,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11002,7 +11004,7 @@ msgstr "Mac II (2Mb RAM, Colour, 2 HD Floppies/CD/HDD)"
 #. TRANSLATION: mame
 msgctxt "game_options"
 msgid "Mac IIx (2Mb RAM, Color, 2 HD Floppies/CD/HDD, Image Reader)"
-msgstr ""
+msgstr "Mac IIx (2Mb RAM, Colour, 2 HD Floppies/CD/HDD, Image Reader)"
 
 #. TRANSLATION: libretro/mame
 msgctxt "game_options"
@@ -11551,7 +11553,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr ""
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12439,7 +12441,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr ""
 
 #. TRANSLATION: corsixth.keys
@@ -12650,7 +12652,7 @@ msgstr ""
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
 msgid "PALETTE COLORS"
-msgstr ""
+msgstr "PALETTE COLOURS"
 
 #. TRANSLATION: redream
 msgctxt "game_options"
@@ -13349,8 +13351,8 @@ msgstr ""
 #. TRANSLATION: vpinball
 msgctxt "game_options"
 msgid ""
-"Presets which can improve performance without manually editing the VPinballX."
-"ini file to fine tune performance."
+"Presets which can improve performance without manually editing the "
+"VPinballX.ini file to fine tune performance."
 msgstr ""
 
 #. TRANSLATION: catacomb.keys
@@ -13642,8 +13644,8 @@ msgstr ""
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
-msgstr ""
+msgid "RGB Color Low/Medium-Resolution"
+msgstr "RGB Colour Low/Medium-Resolution"
 
 #. TRANSLATION: citron
 msgctxt "game_options"
@@ -13793,9 +13795,9 @@ msgstr ""
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr ""
+"Reduces banding between coloUrs and improves the preceived color depth."
 
 #. TRANSLATION: rpcs3
 msgctxt "game_options"
@@ -14918,7 +14920,7 @@ msgstr "Select the model of Colour Computer to emulate"
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
 msgid "Select the palette used to render colors."
-msgstr ""
+msgstr "Select the palette used to render colours."
 
 #. TRANSLATION: libretro/np2kai
 msgctxt "game_options"
@@ -16223,8 +16225,8 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
-msgstr ""
+msgid "TEXTURE COLOR DEPTH"
+msgstr "TEXTURE COLOUR DEPTH"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
@@ -16403,8 +16405,8 @@ msgstr ""
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
-msgstr ""
+msgid "TRUE COLOR RENDERING"
+msgstr "TRUE COLOUR RENDERING"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
@@ -16611,8 +16613,8 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
-msgstr ""
+msgid "The theme color of the emulated console."
+msgstr "The theme colour of the emulated console."
 
 #. TRANSLATION: ppsspp
 msgctxt "game_options"
@@ -16839,9 +16841,11 @@ msgstr ""
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
+"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"information (flat)."
 
 #. TRANSLATION: openjk, openmohaa
 msgctxt "game_options"
@@ -16870,8 +16874,8 @@ msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr ""
+msgid "True Color"
+msgstr "True Colour"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17501,8 +17505,8 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
-"choose a specific mouse if you have several."
+"Use the system mouse pointer as paddle controller 1. Does not let you choose "
+"a specific mouse if you have several."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds
@@ -18020,7 +18024,7 @@ msgstr ""
 #. TRANSLATION: rpcs3
 msgctxt "game_options"
 msgid "WRITE COLOR BUFFERS"
-msgstr ""
+msgstr "WRITE COLOUR BUFFERS"
 
 #. TRANSLATION: rpcs3
 msgctxt "game_options"
@@ -18767,7 +18771,7 @@ msgstr ""
 #. TRANSLATION: libretro/vba-m
 msgctxt "game_options"
 msgid "weird colors"
-msgstr ""
+msgstr "weird colours"
 
 #. TRANSLATION: libretro/vice_xpet
 msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/es/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/es/batocera-es-system.po
@@ -2225,7 +2225,7 @@ msgstr "Nativo x9 (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Una pequeña cantidad de juegos tendrán problemas de compatibilidad con esta "
 "opción habilitada."
@@ -2824,7 +2824,7 @@ msgstr "Ajusta el modo de dibujado de líneas en la pantalla."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajusta el perfil de energía de la CPU mientras estás en el juego. Algunos "
@@ -2833,7 +2833,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajusta el perfil de energía de la CPU mientras la batería está encendida. "
@@ -3055,7 +3055,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Pantalla de matriz de puntos de color alternativo (se necesita un archivo "
 "adicional)."
@@ -4468,12 +4468,12 @@ msgstr "COLORIZACIÓN"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "INTENSIDAD DE COLOR"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODO DE COLOR"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4797,7 +4797,7 @@ msgstr "TAMAÑO DE PUNTO DE MIRA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COLOR CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4822,7 +4822,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr ""
 "Adaptación de color similar a la de un monitor CRT. Requiere un nuevo motor "
 "3D."
@@ -5395,7 +5395,7 @@ msgstr "Elige la profundidad de calidad de la textura."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Elige la profundidad de color emulada."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5463,7 +5463,7 @@ msgstr "Elige el tamaño de la pantalla de visualización frontal."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Elige la profundidad del color de la textura."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5497,10 +5497,10 @@ msgstr "Elige mantener los cadáveres presentes."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Elige para renderizar texturas de gráficos en alta definición. Requiere "
-"OpenGL, True Colour y el archivo enhanced.gob ."
+"OpenGL, True Color y el archivo enhanced.gob ."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6623,7 +6623,7 @@ msgstr "Imagen de disco"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Muestra información en pantalla como estados de guardado, advertencia de "
 "configuración, etc."
@@ -8048,7 +8048,7 @@ msgstr "TASA DE TRANSFERENCIA DE DISCO RÁPIDA"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COLOR FAVORITO"
 
 #. TRANSLATION: wine
@@ -10441,7 +10441,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensibilidad del joystick para las palancas. Valor predeterminado (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11898,7 +11898,7 @@ msgstr "Avanzar"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Avanzar, puede utilizar pulsar W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12815,7 +12815,7 @@ msgstr "Abrir consola LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Abrir menú"
 
 #. TRANSLATION: corsixth.keys
@@ -14036,7 +14036,7 @@ msgstr "RGB (imagen nítida)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Color RGB de resolución baja/media"
 
 #. TRANSLATION: citron
@@ -14190,7 +14190,7 @@ msgstr "Reduce el parpadeo que ocurre al compilar shaders."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Reduce las bandas entre colores y mejora la profundidad de color percibida."
 
@@ -16711,7 +16711,7 @@ msgstr "TEXTO"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "PROFUNDIDAD DE COLOR DE LA TEXTURA"
 
 #. TRANSLATION: openmohaa
@@ -16891,7 +16891,7 @@ msgstr "TRIPLE ALMACENAMIENTO EN BÚFER"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDERIZADO DE COLOR ORIGINAL"
 
 #. TRANSLATION: libretro/hatarib
@@ -17111,7 +17111,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "El tema de color de la consola emulada."
 
 #. TRANSLATION: ppsspp
@@ -17351,7 +17351,7 @@ msgstr "Triángulo"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Intenta adivinar el color por vértice (gouraud) a partir de la información "
@@ -17384,7 +17384,7 @@ msgstr "Triple almacenamiento en búfer"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Color Verdadero"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -18046,7 +18046,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Utiliza el puntero del ratón del sistema como paddle controller 1. No le "

--- a/package/batocera/emulationstation/batocera-es-system/locales/eu_ES/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/eu_ES/batocera-es-system.po
@@ -2229,7 +2229,7 @@ msgstr "9x Jatorrizkoa (~3240p)"
 
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
-msgid "A small  number of games will have compatibility problems with this enabled."
+msgid "A small number of games will have compatibility problems with this enabled."
 msgstr "Joku kopuru txiki batek konpatibilidade arazoak izango ditu hau aktibatuta."
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2820,14 +2820,14 @@ msgstr "Doitu pantaila lerro marrazte modua."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
+"Adjust the CPU power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
 msgstr ""
 "Doitu puz potentzia maiztasun profila joko barruan. Sistema batzuk onura izango dute boltaia hobetuaren "
 "kudeaketarengatik"
 
 #. TRANSLATION: shared
 msgctxt "game_options"
-msgid "Adjust the cpu power profile whist on battery. Overwrites previous Power Mode(s)."
+msgid "Adjust the CPU power profile whist on battery. Overwrites previous Power Mode(s)."
 msgstr "Doitu puz potentzia profila joko barruan. Aurreko Potentzia Modua(k) gainidazten du"
 
 #. TRANSLATION: vpinball
@@ -3031,7 +3031,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Koloreztatze alternatiboko Puntu Matrize Bistaratzea (fitxategi gehigarria behar du)"
 
 #. TRANSLATION: vpinball
@@ -4365,7 +4365,7 @@ msgstr "AUKERATU KONTSOLAREN ORDU EREMUA"
 #. TRANSLATION: citron
 msgctxt "game_options"
 msgid "CHOOSE SOUND OUTPUT MODE"
-msgstr "AUKERATU SOINU IRTEERA  MODUA"
+msgstr "AUKERATU SOINU IRTEERA MODUA"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -4409,12 +4409,12 @@ msgstr "KOLOREZTATZEA"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "KOLORE SAKONERA"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "KOLORE MODUA"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4734,7 +4734,7 @@ msgstr "MIRA TAMAINA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT KOLOREA"
 
 #. TRANSLATION: libretro/o2em
@@ -4759,7 +4759,7 @@ msgstr "CRT BEREIZMEN ALDAKETA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT moduko kolore egokitzapena. 3D motore Berria behar du"
 
 #. TRANSLATION: citron
@@ -5076,7 +5076,7 @@ msgstr "Aldatu jokoaren hizkuntza"
 msgctxt "game_options"
 msgid "Change the game's language. Game files require the supported language strings in the .pk4 files."
 msgstr ""
-"Aldatu jokuaren hizkuntza. Jokuaren fitxategiek euskarria duten  hizkuntzen string-an .pk4 fitxategietan behar "
+"Aldatu jokuaren hizkuntza. Jokuaren fitxategiek euskarria duten hizkuntzen string-an .pk4 fitxategietan behar "
 "dute."
 
 #. TRANSLATION: bigpemu, cannonball, cemu, citron, duckstation, ...
@@ -5242,7 +5242,7 @@ msgstr "Aukeratu Wayland driver modua eramangarri gailu batean badago. XWayland-
 msgctxt "game_options"
 msgid "Choose the amount of Gamma which changes how light or dark mid-range tones appear."
 msgstr ""
-"Aukeratu Gamma-ren zenbatekoa, argi eta erdi-mailako ilunpean agertzen diren  tonuak nola agertzen diren "
+"Aukeratu Gamma-ren zenbatekoa, argi eta erdi-mailako ilunpean agertzen diren tonuak nola agertzen diren "
 "aldatzen du."
 
 #. TRANSLATION: openmohaa
@@ -5291,7 +5291,7 @@ msgstr "Aukeratu testuen kalitate sakonera"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Aukeratu emulatutako kolore sakonera"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5356,7 +5356,7 @@ msgstr "Aukeratu HUD-aren tamaina"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Aukeratu testuraren kolore sakontasuna."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5386,7 +5386,7 @@ msgstr "Aukeratu hilotzak presente mantentzea."
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "Choose to render high definition graphics textures. Requires OpenGL, True Colour and the enhanced.gob file."
+msgid "Choose to render high definition graphics textures. Requires OpenGL, True Color and the enhanced.gob file."
 msgstr ""
 "Aukeratu definizio handiko testura grafikoak renderizatzea. OpenGL behar du, True Color eta enhanced.gob "
 "fitxategia."
@@ -6467,7 +6467,7 @@ msgstr "Disko Irudia"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "Erakutsi pantaila informazioan gordetze egoerak bezala, konfigurazioa, oharrak, etabar..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7192,7 +7192,7 @@ msgstr "Gaitu argisable auto-kamera"
 msgctxt "game_options"
 msgid "Enable mouse input for trackballs, spinners, lightguns (if no gun connected), and similar controls"
 msgstr ""
-"Gaitu  xagu sarrera trackball, spinner, argizko pistola (Pistolarik ez badago konektatuta), eta antzeko "
+"Gaitu xagu sarrera trackball, spinner, argizko pistola (Pistolarik ez badago konektatuta), eta antzeko "
 "kontrolentzat"
 
 #. TRANSLATION: cemu
@@ -7748,7 +7748,7 @@ msgstr "DISKO TRANSFERENTZIA TASA ALDUTA"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "GOGOKO KOLOREA"
 
 #. TRANSLATION: wine
@@ -9669,7 +9669,7 @@ msgstr "Hobetu abiadura, zehaztasun kostu txiki batekin"
 #. TRANSLATION: cannonball
 msgctxt "game_options"
 msgid "Improves both sprite scaling and road rendering. Does not affect the car sprite."
-msgstr "Sprite eta errepide renderizazioa  hobetzen du. Ez dio autoa spriteari  eragiten."
+msgstr "Sprite eta errepide renderizazioa hobetzen du. Ez dio autoa spriteari eragiten."
 
 #. TRANSLATION: flycast, libretro/flycast
 msgctxt "game_options"
@@ -9755,7 +9755,7 @@ msgstr "Indonesiera"
 #. TRANSLATION: libretro/mame, mame
 msgctxt "game_options"
 msgid "Insert a disk into the floppy drive, a blank will be used if one doesn't exist"
-msgstr "Sartu diska bat floppy disko irakurgailuan, huts bat erabilikok da batek  existitzen ez badu."
+msgstr "Sartu diska bat floppy disko irakurgailuan, huts bat erabilikok da batek existitzen ez badu."
 
 #. TRANSLATION: vpinball.keys
 msgctxt "keys_files"
@@ -10053,7 +10053,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Joypad sentsibilitatea arrauntxoentzat. Nukeoaren lehenetsia (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11471,7 +11471,7 @@ msgstr "Mugitu aurrera"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Mugitu Aurrera, W zapaltzeko erabili daiteke"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12356,7 +12356,7 @@ msgstr "Ireki LUA kontsola"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Ireki Menua"
 
 #. TRANSLATION: corsixth.keys
@@ -13560,7 +13560,7 @@ msgstr "RGB (irudi markatua)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB Kolorea Baxu/Ertain Bereizmena"
 
 #. TRANSLATION: citron
@@ -13710,7 +13710,7 @@ msgstr "Gutxitu shader-ak konpilatzean ematen den toteltzea."
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid "Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr "Bandak sortzea gutxitzen du kolore artean eta antzemandako kolore sakonera hobetzen du."
 
 #. TRANSLATION: rpcs3
@@ -15598,7 +15598,7 @@ msgid ""
 "Sound generator. MAME is faster and Nuked is cycle accurate. Original model used YM2612 while later revisions "
 "used YM3438."
 msgstr ""
-"sorgailu. MAME azkarragoa da eta Nuked ziklo zehatza da. Jatorrizko ereduak  YM2612 erabili zuen, eta geroagoko "
+"sorgailu. MAME azkarragoa da eta Nuked ziklo zehatza da. Jatorrizko ereduak YM2612 erabili zuen, eta geroagoko "
 "berrikuspenek YM3438 erabili zuten"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -16120,7 +16120,7 @@ msgstr "TESTUA"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TESTURA KOLORE SAKONTASUNA"
 
 #. TRANSLATION: openmohaa
@@ -16300,7 +16300,7 @@ msgstr "BUFFER HIRUKOITZA"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "BENETAKO KOLORE RENDERIZATZEA"
 
 #. TRANSLATION: libretro/hatarib
@@ -16454,7 +16454,7 @@ msgid ""
 "The PSP will cull triangles that are outside a 4096x4096 clipping box, and also triangles crossing the Z=1 plane "
 "if clipping is enabled."
 msgstr ""
-"PSP-k 4096x4096ko mozketa-koadrotik kanpo dauden triangeluak kenduko ditu,  eta Z=1 planoa zeharkatzen duten "
+"PSP-k 4096x4096ko mozketa-koadrotik kanpo dauden triangeluak kenduko ditu, eta Z=1 planoa zeharkatzen duten "
 "triangeluak ere mozketa gaituta badago."
 
 #. TRANSLATION: mupen64plus
@@ -16508,12 +16508,12 @@ msgid ""
 "The sample count of every tile will be incremented on every EVENT_WRITE_ZPD by this number. Setting this to 0 "
 "means everything is reported as occluded."
 msgstr ""
-"Sanple bakoitzaren lagin-kopurua EVENT_WRITE_ZPD guztietan handituko da zenbaki  honekin. Hau 0-an ezartzeak "
+"Sanple bakoitzaren lagin-kopurua EVENT_WRITE_ZPD guztietan handituko da zenbaki honekin. Hau 0-an ezartzeak "
 "dena itxita dagoela esan nahi du."
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Emulatutako kontsolaren gaiaren kolorea."
 
 #. TRANSLATION: ppsspp
@@ -16533,7 +16533,7 @@ msgid ""
 "This option enables the ability to play Xbox Live Arcade games. May cause compatibility issues with non-XBLA "
 "games."
 msgstr ""
-"Aukera honek Xbox Live Arcade jokoetara jolasteko aukera ematen du. XBLA  ez diren jokoekin bateragarritasun "
+"Aukera honek Xbox Live Arcade jokoetara jolasteko aukera ematen du. XBLA ez diren jokoekin bateragarritasun "
 "arazoak sor ditzake"
 
 #. TRANSLATION: hypseus-singe
@@ -16549,7 +16549,7 @@ msgstr "Ezarpen honek hizkuntza lehenetsiaren disposizioa kontrolatzen du teklat
 #. TRANSLATION: vpinball
 msgctxt "game_options"
 msgid "This should not be necessary, unless you are not using the default pad2key mapping."
-msgstr "Ez litzateke honen beharrik izan beharko, defektuzko pad2key mapeoa erabiltzen  ari ez bazara behintzat."
+msgstr "Ez litzateke honen beharrik izan beharko, defektuzko pad2key mapeoa erabiltzen ari ez bazara behintzat."
 
 #. TRANSLATION: libretro/mame, mame
 msgctxt "game_options"
@@ -16738,8 +16738,8 @@ msgstr "Hirukia"
 
 #. TRANSLATION: model2emu
 msgctxt "game_options"
-msgid "Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly information (flat)."
-msgstr "Erpin bakoitzeko kolorea (gouraud) asmatzen saiatzen da Model2-ko poligonoko  informaziotik (laua)."
+msgid "Tries to guess Per-vertex color (gouraud) from the Model2 per-poly information (flat)."
+msgstr "Erpin bakoitzeko kolorea (gouraud) asmatzen saiatzen da Model2-ko poligonoko informaziotik (laua)."
 
 #. TRANSLATION: openjk, openmohaa
 msgctxt "game_options"
@@ -16768,7 +16768,7 @@ msgstr "Buffer hirukoitza"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Benetazko Kolorea"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17257,7 +17257,7 @@ msgstr "Erabili"
 msgctxt "game_options"
 msgid "Use 16 bit audio samples for audio drivers that don't support 32bit. Only use if you get no audio."
 msgstr ""
-"Erabili 16 biteko audio sanpleak 32bit onartzen ez dituzten audio  kontrolatzaileetarako. Audiorik ez baduzu "
+"Erabili 16 biteko audio sanpleak 32bit onartzen ez dituzten audiokontrolatzaileetarako. Audiorik ez baduzu "
 "bakarrik erabili."
 
 #. TRANSLATION: openjkdf2
@@ -17392,7 +17392,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you choose a specific mouse if you have "
+"Use the system mouse pointer as paddle controller 1. Does not let you choose a specific mouse if you have "
 "several."
 msgstr ""
 "Erabili saguaren erakuslea 1. kontrolatzaile gisa. Ez utzi sagu zehatz bat aukeratzen bat baino gehiago badituzu."
@@ -17439,7 +17439,7 @@ msgstr "Erabilgarria N64 estiloko kontrolatzaileentzat."
 msgctxt "game_options"
 msgid "Useful for N64 style controllers. Limited hotkeys for controllers without dedicated hotkey."
 msgstr ""
-"Erabilgarri N64 moduko kontrolatzaileentzat. Hotkey mugatuak horretarako botoi berezirik  ez duten "
+"Erabilgarri N64 moduko kontrolatzaileentzat. Hotkey mugatuak horretarako botoi berezirik ez duten "
 "kontrolatzaileetan."
 
 #. TRANSLATION: libretro/flycast
@@ -18902,7 +18902,7 @@ msgstr "horia/urdina"
 #~ msgstr "GAITU MIPMAPPING-A"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "GAITU BENETAZKO KOLOREA"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/fi_FI/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/fi_FI/batocera-es-system.po
@@ -2231,7 +2231,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2824,14 +2824,14 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 
@@ -3038,7 +3038,7 @@ msgstr ""
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 
 #. TRANSLATION: vpinball
@@ -4423,12 +4423,12 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr ""
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4750,7 +4750,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr ""
 
 #. TRANSLATION: libretro/o2em
@@ -4775,7 +4775,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr ""
 
 #. TRANSLATION: citron
@@ -5313,7 +5313,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr ""
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5379,7 +5379,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openjk, openmohaa
@@ -5411,7 +5411,7 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 
 #. TRANSLATION: ymir
@@ -6499,7 +6499,7 @@ msgstr ""
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 
 #. TRANSLATION: nds.drastic.keys
@@ -7820,7 +7820,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr ""
 
 #. TRANSLATION: wine
@@ -10136,7 +10136,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11561,7 +11561,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr ""
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12449,7 +12449,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr ""
 
 #. TRANSLATION: corsixth.keys
@@ -13652,7 +13652,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr ""
 
 #. TRANSLATION: citron
@@ -13804,7 +13804,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 
 #. TRANSLATION: rpcs3
@@ -16239,7 +16239,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -16419,7 +16419,7 @@ msgstr ""
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr ""
 
 #. TRANSLATION: libretro/hatarib
@@ -16627,7 +16627,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr ""
 
 #. TRANSLATION: ppsspp
@@ -16855,7 +16855,7 @@ msgstr ""
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 
@@ -16886,7 +16886,7 @@ msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr ""
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17518,7 +17518,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 

--- a/package/batocera/emulationstation/batocera-es-system/locales/fr/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/fr/batocera-es-system.po
@@ -16,7 +16,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajustez le profil de fréquence d'alimentation du processeur pendant le jeu. "
@@ -50,7 +50,7 @@ msgstr "Économie d'énergie"
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajustez le profil d'alimentation du processeur lorsque la batterie est "
@@ -814,12 +814,12 @@ msgstr "576+Ko"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Choisir la profondeur de couleurs emulées."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFONDEUR DE COULEURS"
 
 #. TRANSLATION: libretro/cap32
@@ -1711,12 +1711,12 @@ msgstr "Anglais"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "La couleur du thème de la console émulée."
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COULEUR PRÉFÉRÉE"
 
 #. TRANSLATION: libretro/melondsds
@@ -2109,8 +2109,8 @@ msgstr "AFFICHER L'ETAT LID"
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
-"choose a specific mouse if you have several."
+"Use the system mouse pointer as paddle controller 1. Does not let you choose "
+"a specific mouse if you have several."
 msgstr ""
 "Utilisez le pointeur de la souris du système comme contrôleur de manette 1. "
 "Ne vous permet pas de choisir une souris spécifique si vous en avez "
@@ -4383,7 +4383,7 @@ msgstr "Monochrome Haute-Résolution"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Couleur RGB Basse/Moyenne-Résolution"
 
 #. TRANSLATION: libretro/hatarib
@@ -6844,7 +6844,7 @@ msgstr "BOOT RAPIDE DU BIOS"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Un petit nombre de jeux présenteront des problèmes avec ce mode activé."
 
@@ -7009,8 +7009,7 @@ msgstr "Trilinéaire (Forcé)"
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Reduire le bandage entre les couleurs pour améliorer la profondeur des "
 "couleurs."
@@ -8258,7 +8257,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 "Sensibilité des manettes pour les palettes. Valeur par défaut du noyau (3)."
 
@@ -10461,7 +10460,7 @@ msgstr "24-bit, désactive le tramage."
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDU DE VRAIES COULEURS"
 
 #. TRANSLATION: duckstation
@@ -11500,7 +11499,7 @@ msgstr "nxagss"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Afficher les informations à l'écran telles que les sauvegardes, les messages "
 "d'erreur, etc."
@@ -13263,12 +13262,12 @@ msgstr "RENDU QUADRUPLE"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptation des couleurs de type CRT. Nécessite un nouveau moteur 3D."
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COULEUR CRT"
 
 #. TRANSLATION: supermodel
@@ -14266,7 +14265,7 @@ msgstr "ACTIVER FILTRE DE BALAYAGE"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Essayer de deviner la couleur Par-vertex (gouraud) du Model2 par-poly "
@@ -16366,7 +16365,7 @@ msgstr "Ordinateur puissant"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "DMD coloré alternatif (nécessite un fichier supplémentaire)."
 
 #. TRANSLATION: vpinball
@@ -16782,7 +16781,7 @@ msgstr "GPU / OpenGL (par défaut)"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODE COULEUR"
 
 #. TRANSLATION: theforceengine
@@ -16797,14 +16796,14 @@ msgstr "8 bits interpolés"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Couleur vraie"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Choisir de restituer des textures graphiques haute définition. Nécessite "
 "OpenGL, True Color et le fichier .gob amélioré."
@@ -18091,12 +18090,12 @@ msgstr "MODE NEW 3DS"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Choisissez la profondeur de couleur de la texture."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TEXTURE PROFONDEUR DE COULEUR"
 
 #. TRANSLATION: openmohaa
@@ -18754,7 +18753,7 @@ msgstr "Prochaine arme"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Avancer, peut être utilisé pour appuyer sur W"
 
 #. TRANSLATION: catacomb.keys
@@ -18779,8 +18778,8 @@ msgstr "Démarrer / Entrer"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
-msgstr "Menu Ouvrir"
+msgid "Open menu"
+msgstr "Ouvrir le menu"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
@@ -19675,7 +19674,7 @@ msgstr "Bouton C"
 #~ msgstr "Activer les vibrations sur les contrôleurs pris en charge."
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Ajuster le profil énergétique du CPU en jeu."
 
 #~ msgctxt "game_options"
@@ -20050,7 +20049,7 @@ msgstr "Bouton C"
 #~ msgstr "ACTIVER\tL'OSD"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "ACTIVER LES VRAIES COULEURS"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/gl_ES/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/gl_ES/batocera-es-system.po
@@ -2231,7 +2231,7 @@ msgstr "9x Nativo (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Algúns xogos poden ter problemas de compatibilidade con esta opción activada."
 
@@ -2829,7 +2829,7 @@ msgstr "Axuste o modo de debuxo da liñas da pantalla."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Axusta o perfil de frecuencia de enerxía da CPU mentres estás no xogo. Algúns "
@@ -2838,7 +2838,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Axusta o perfil de enerxía da CPU mentres está ca batería. Sobrescribe os "
@@ -3056,7 +3056,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Visualización de matriz de puntos de cores alternativa (necesita un ficheiro "
 "adicional)."
@@ -4467,12 +4467,12 @@ msgstr "COLORIZACIÓN"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFUNDIDADE DE COR"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODO DE COR"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4795,7 +4795,7 @@ msgstr "TAMAÑO DO PUNTEIRO"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COR CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4820,7 +4820,7 @@ msgstr "SWITCHRES CRT"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptación de cores similar a CRT. Require un motor 3D novo."
 
 #. TRANSLATION: citron
@@ -5014,7 +5014,7 @@ msgstr "Pode reducir o crepitar e o tartamudeo pero aumenta a latencia de audio.
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
 msgid "Can sharpen images in lower resolutions."
-msgstr "Pode mellorar a  nitedez das imaxes en resolucións máis baixas."
+msgstr "Pode mellorar a nitedez das imaxes en resolucións máis baixas."
 
 #. TRANSLATION: sonic2013, soniccd
 msgctxt "game_options"
@@ -5387,7 +5387,7 @@ msgstr "Elixe a profundidade da calidade das texturas."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Escolla a profundidade de cor emulada."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5455,7 +5455,7 @@ msgstr "Elixe o tamaño da pantalla de información."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Elixe a profundidade de cor das texturas."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5488,7 +5488,7 @@ msgstr "Choose to keep corpses present."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Escolla para renderizar texturas de gráficos de alta definición. Require "
 "OpenGL, True Color e o ficheiro enhanced.gob."
@@ -6605,10 +6605,10 @@ msgstr "Imaxe de disco"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Amosa información en pantalla como partidas gardadas, aviso de configuración, "
-"etc..."
+"etc."
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
@@ -8003,7 +8003,7 @@ msgstr "TASA RÁPIDA DE TRANSFERENCIA DE DISCO"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COR PREFERIDA"
 
 #. TRANSLATION: wine
@@ -10387,10 +10387,10 @@ msgstr "Mando Básico Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 "Sensibilidade do mando básico para os mandos de roda. Valor predeterminado do "
-"núcleo  (3)."
+"núcleo (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
 msgctxt "game_options"
@@ -11842,7 +11842,7 @@ msgstr "Avanzar"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Avanzar, pódese usarse para premer W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12752,7 +12752,7 @@ msgstr "Abre a consola LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Abrir o menú"
 
 #. TRANSLATION: corsixth.keys
@@ -13970,7 +13970,7 @@ msgstr "RGB (imaxe nítida)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Cor RGB Resolución baixa/media"
 
 #. TRANSLATION: citron
@@ -14122,7 +14122,7 @@ msgstr "Reduce o pestanexo que ocorre ao compilar sombreadores."
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid "Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr "Reduce as bandas entre cores e mellora a profundidade da cor percibida."
 
 #. TRANSLATION: rpcs3
@@ -16626,7 +16626,7 @@ msgstr "TEXTO"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "PROFUNDIDADE DE COR DAS TEXTURAS"
 
 #. TRANSLATION: openmohaa
@@ -16806,7 +16806,7 @@ msgstr "BUFFERING TRIPLE"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDERIZADO ORIXINAL DA COR"
 
 #. TRANSLATION: libretro/hatarib
@@ -17024,7 +17024,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "O tema de cor da consola emulada."
 
 #. TRANSLATION: ppsspp
@@ -17264,7 +17264,7 @@ msgstr "Triángulo"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Intenta adiviñar a cor por vértice (gouraud) a partir da información per-poly "
@@ -17297,7 +17297,7 @@ msgstr "Búfer triple"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Cor verdadeira"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17955,7 +17955,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you choose "
+"Use the system mouse pointer as paddle controller 1. Does not let you choose "
 "a specific mouse if you have several."
 msgstr ""
 "Emprega o punteiro do rato do sistema como controlador do mando de roda 1. Non "

--- a/package/batocera/emulationstation/batocera-es-system/locales/hu/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/hu/batocera-es-system.po
@@ -2226,7 +2226,7 @@ msgstr "9x Native (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Néhány játéknál kompatibilitási problémák adódhatnak, ha ez engedélyezve van."
 
@@ -2824,7 +2824,7 @@ msgstr "A képernyővonal rajzolási módjának beállítása."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "A cpu teljesítményfrekvencia profiljának beállítása játék közben. Egyes "
@@ -2833,7 +2833,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Állítsa be a cpu teljesítményprofilját, miközben az akkumulátoron van. "
@@ -3056,7 +3056,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternatív színes pontmátrix kijelző (további fájl szükséges)."
 
 #. TRANSLATION: vpinball
@@ -4462,12 +4462,12 @@ msgstr "SZÍNEZET"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "SZÍNMÉRET"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "SZÍNES MÓD"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4791,7 +4791,7 @@ msgstr "CÉLKERÉSZ MÉRET"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT SZÍN"
 
 #. TRANSLATION: libretro/o2em
@@ -4816,7 +4816,7 @@ msgstr "CRT KAPCSOLÓK"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT-szerű színadaptáció. Új 3D motorra van szükség."
 
 #. TRANSLATION: citron
@@ -5383,7 +5383,7 @@ msgstr "Válassza ki a textúra minőségének mélységét."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Válassza ki az emulált színmélységet."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5451,7 +5451,7 @@ msgstr "Válaszd ki a head-up kijelző méretét."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Válassza ki a textúra színmélységét."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5486,10 +5486,10 @@ msgstr "Válaszd a holttestek jelenlétét."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Válassza a nagyfelbontású grafikai textúrák renderelését. OpenGL, True "
-"Colour és az enhanced.gob fájl szükséges hozzá."
+"Color és az enhanced.gob fájl szükséges hozzá."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6606,7 +6606,7 @@ msgstr "Lemezkép"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Információk megjelenítése a képernyőn, például mentési állapot, "
 "konfigurációs figyelmeztetés stb."
@@ -8033,7 +8033,7 @@ msgstr "GYORS LEMEZÁTVITELI SEBESSÉG"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "KEDVENC SZÍN"
 
 #. TRANSLATION: wine
@@ -10424,7 +10424,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Joypad érzékenység a pedálokhoz. Alapértelmezés (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11885,7 +11885,7 @@ msgstr "Mozgás előre"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Mozgás előre, a W megnyomásával használható"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12796,7 +12796,7 @@ msgstr "Nyissa meg a LUA konzolt"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Menü megnyitása"
 
 #. TRANSLATION: corsixth.keys
@@ -12953,7 +12953,7 @@ msgstr "ANALÓG LAPATKAR ÉRZÉKENYSÉGE"
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid "PADDLE D-PAD SENSITIVITY"
-msgstr "D-PAD LAPÁT  ÉRZÉKENYSÉGE"
+msgstr "D-PAD LAPÁT ÉRZÉKENYSÉGE"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
@@ -14014,7 +14014,7 @@ msgstr "RGB (crisp image)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB szín alacsony/közepes felbontású"
 
 #. TRANSLATION: citron
@@ -14168,7 +14168,7 @@ msgstr "Csökkentse az árnyékolók összeállítása során előforduló dadog
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Csökkenti a színek közötti sávosodást és javítja a színmélységet."
 
 #. TRANSLATION: rpcs3
@@ -16075,7 +16075,7 @@ msgstr "Egyes játékok a 2-es portról fogadják a bemenetet az 1-es helyett."
 #. TRANSLATION: libretro/vice_x128, libretro/vice_x64, libretro/vice_x64sc
 msgctxt "game_options"
 msgid "Some games and homebrews require more RAM"
-msgstr "Egyes játékokhoz és házi készítésű programokhoz  több RAM szükséges"
+msgstr "Egyes játékokhoz és házi készítésű programokhoz több RAM szükséges"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
@@ -16683,7 +16683,7 @@ msgstr "SZÖVEG"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TEXTÚRA SZÍN MÉLYSÉG"
 
 #. TRANSLATION: openmohaa
@@ -16863,7 +16863,7 @@ msgstr "HÁRMAS PUFFERELÉS"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "SZÍNHŰ SZÍNVISSZAADÁS"
 
 #. TRANSLATION: libretro/hatarib
@@ -17082,7 +17082,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Az emulált konzol témaszíne."
 
 #. TRANSLATION: ppsspp
@@ -17321,7 +17321,7 @@ msgstr "Háromszög"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Megpróbálja kitalálni a csúcsonkénti színt (gouraud) a Model2 per-poli "
@@ -17354,7 +17354,7 @@ msgstr "Háromszoros pufferelés"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Valódi színek"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -18015,7 +18015,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "A rendszer egérmutatójának használata lapátvezérlőként 1. Nem engedi "
@@ -19450,7 +19450,7 @@ msgstr "sárga/kék"
 #~ msgstr "ASCI"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Állítsa be a processzor teljesítményprofilját játék közben."
 
 #~ msgctxt "game_options"
@@ -19621,7 +19621,7 @@ msgstr "sárga/kék"
 #~ msgstr "MIPMAPPING ENGEDÉLYEZÉSE"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "A VALÓDI SZÍN ENGEDÉLYEZÉSE"
 
 #~ msgctxt "game_options"
@@ -19654,7 +19654,7 @@ msgstr "sárga/kék"
 
 #~ msgctxt "keys_files"
 #~ msgid "Exit Dosbox-X"
-#~ msgstr "Kilépés a  Dosbox-X-ből"
+#~ msgstr "Kilépés a Dosbox-X-ből"
 
 #~ msgctxt "keys_files"
 #~ msgid "Exit Drastic"

--- a/package/batocera/emulationstation/batocera-es-system/locales/id_ID/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/id_ID/batocera-es-system.po
@@ -1161,7 +1161,7 @@ msgstr "2nd VMU (Default / Bawaan)"
 #. TRANSLATION: redream
 msgctxt "game_options"
 msgid "2x (1280x960) (Default)"
-msgstr "2x (1280x960)  (Default / Bawaan)"
+msgstr "2x (1280x960) (Default / Bawaan)"
 
 #. TRANSLATION: citron, ryujinx
 msgctxt "game_options"
@@ -1206,7 +1206,7 @@ msgstr "2x SSAA"
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
 msgid "2x native (512 x 384)"
-msgstr "2x native  / asli (512 x 384)"
+msgstr "2x native / asli (512 x 384)"
 
 #. TRANSLATION: libretro/fceumm
 msgctxt "game_options"
@@ -2226,7 +2226,7 @@ msgstr "9x Native / Asli (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Sebagian kecil game akan mengalami masalah kompatibilitas jika fitur ini diaktifkan."
 
@@ -2822,7 +2822,7 @@ msgstr "Sesuaikan mode gambar garis layar."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Atur profil frekuensi daya CPU saat di dalam game."
@@ -2831,7 +2831,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Atur profil daya CPU saat menggunakan baterai."
@@ -3047,7 +3047,7 @@ msgstr "AltWFC (172.104.88.237) - (Layanan server alternatif)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Tampilan Dot Matrix Berwarna Alternatif (butuh file tambahan)."
 
 #. TRANSLATION: vpinball
@@ -4067,7 +4067,7 @@ msgstr "Kedua-nya"
 #. TRANSLATION: libretro/dosbox_pure
 msgctxt "game_options"
 msgid "Both Joysticks (4 Axes, 4 Btns)"
-msgstr "Joysticks Kedua-nya(4 Sumbu, 4  Tombol)"
+msgstr "Joysticks Kedua-nya(4 Sumbu, 4 Tombol)"
 
 #. TRANSLATION: soniccd
 msgctxt "game_options"
@@ -4449,12 +4449,12 @@ msgstr "PEWARNAAN"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "KEDALAMAN WARNA"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "Mode Warna"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4778,7 +4778,7 @@ msgstr "Ukuran Bidikan"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "Warna TV Tabung (CRT)"
 
 #. TRANSLATION: libretro/o2em
@@ -4803,7 +4803,7 @@ msgstr "PERALIHAN CRT"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Penyesuaian warna ala TV tabung jadul. Memerlukan mesin 3D baru."
 
 #. TRANSLATION: citron
@@ -5366,7 +5366,7 @@ msgstr "Pilih kedalaman kualitas tekstur."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Pilih Kedalaman Warna yang akan ditiru"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5433,7 +5433,7 @@ msgstr "Pilih ukuran tampilan menu info di layar (HUD)."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Pilih kedalaman warna tekstur."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5465,10 +5465,10 @@ msgstr "Pilih untuk membiarkan mayat tetap terlihat (tidak hilang)."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Pilih untuk menampilkan tekstur grafis definisi tinggi (HD)."
-"Memerlukan OpenGL, True Colour, dan file enhanced.gob."
+"Memerlukan OpenGL, True Color, dan file enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6581,7 +6581,7 @@ msgstr "Disk Image"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "Tampilkan informasi di layar seperti status penyimpanan (savestate), peringatan konfigurasi, dll."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7974,7 +7974,7 @@ msgstr "RATA-RATA KECEPATAN TRANSFER DISK"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "Warna Favorit"
 
 #. TRANSLATION: wine
@@ -9738,7 +9738,7 @@ msgctxt "game_options"
 msgid ""
 "How much RAM the emulated Mac will have installed (Mac IIx & Mac LC 3 only)"
 msgstr ""
-"Berapa banyak emulasi RAM  Mac yang sudah terpasang (hanya Mac IIx & Mac LC "
+"Berapa banyak emulasi RAM Mac yang sudah terpasang (hanya Mac IIx & Mac LC "
 "3)"
 
 #. TRANSLATION: melonds
@@ -10352,7 +10352,7 @@ msgstr "joypad Otomatis"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensitivitas stik untuk kontroler paddle. Bawaan sistem (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -10516,7 +10516,7 @@ msgid ""
 "Konami Justifier P2 is daisy chained from controller 2, appears as port 3 to "
 "system."
 msgstr ""
-"Konami Justifier P2 terkait pada  pengontrol 2, muncul sebagai port ke 3 "
+"Konami Justifier P2 terkait pada pengontrol 2, muncul sebagai port ke 3 "
 "sistem."
 
 #. TRANSLATION: libretro/genesisplusgx-expanded
@@ -11805,7 +11805,7 @@ msgstr "Bergerak Maju"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Bergerak Maju, Bisa digunakan untuk menekan tombol W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12714,7 +12714,7 @@ msgstr "Buka konsol LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Buka Menu"
 
 #. TRANSLATION: corsixth.keys
@@ -12985,7 +12985,7 @@ msgstr "PCjr"
 #. TRANSLATION: libretro/mame, mame
 msgctxt "game_options"
 msgid "PDP-1 Paper Tape Reader Images"
-msgstr "PDP-1  Tape kertas pembaca gambar (image reader)"
+msgstr "PDP-1 Tape kertas pembaca gambar (image reader)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -13929,7 +13929,7 @@ msgstr "RGB (gambar crisp)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Warna RGB Resolusi Rendah/Sedang"
 
 #. TRANSLATION: citron
@@ -14083,7 +14083,7 @@ msgstr "Mengurangi kegagapan saat membuat shader"
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Mengurangi efek garis gradasi warna (banding) dan meningkatkan kedalaman warna yang terlihat."
 
@@ -16583,7 +16583,7 @@ msgstr "TEKS"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "KEDALAMAN WARNA TEKSTUR"
 
 #. TRANSLATION: openmohaa
@@ -16763,7 +16763,7 @@ msgstr "TRIPLE BUFFERING (Fitur sinkronisasi bingkai gambar)"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "PERUPAAN WARNA ASLI (TRUE COLOR RENDERING)"
 
 #. TRANSLATION: libretro/hatarib
@@ -16983,7 +16983,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Warna tema dari konsol yang diemulasikan."
 
 #. TRANSLATION: ppsspp
@@ -17219,7 +17219,7 @@ msgstr "Segitiga / Triangle"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Mencoba menebak warna setiap-vertex(gouraud) dari model2 tiap-poly informasi "
@@ -17252,7 +17252,7 @@ msgstr "Triple buffering"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Warna Asli (True Color)"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17902,7 +17902,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Gunakan penunjuk mouse sistem sebagai kontroler paddle 1."
@@ -19778,7 +19778,7 @@ msgstr "kuning/biru"
 
 #~ msgctxt "game_options"
 #~ msgid "mVU Flag Hack + MTVU"
-#~ msgstr "mVU Flag  + MTVU"
+#~ msgstr "mVU Flag + MTVU"
 
 #~ msgctxt "game_options"
 #~ msgid "mVU Flag Hack. May cause bad graphics (recommended)"

--- a/package/batocera/emulationstation/batocera-es-system/locales/it/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/it/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9x Nativo (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Un numero minore di giochi avra' problemi di compatibilita' con questo "
 "abilitato."
@@ -2825,7 +2825,7 @@ msgstr "Aggiusta la modalità disegno linee a video."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Regola il profilo della frequenza di alimentazione della CPU durante il "
@@ -2834,7 +2834,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Regola il profilo della frequenza della cpu con solo la batteria. "
@@ -3051,7 +3051,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Schermo a Dot Matrix Colorato Alternativo (necessita file aggiuntivo)."
 
 #. TRANSLATION: vpinball
@@ -3797,7 +3797,7 @@ msgstr "TRASMISSIONE"
 #. TRANSLATION: supermodel
 msgctxt "game_options"
 msgid "BT601_525/D65 (recommended for all US developed games)"
-msgstr "BT601_525/D65  (raccomandato per tutto i giochi sviluppati US)"
+msgstr "BT601_525/D65 (raccomandato per tutto i giochi sviluppati US)"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
@@ -4453,12 +4453,12 @@ msgstr "COLORIZZAZIONE"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFONDITÀ COLORE"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODALITÀ COLORE"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4782,7 +4782,7 @@ msgstr "DIMENSIONE MIRINO"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COLORE CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4807,7 +4807,7 @@ msgstr "SWITCHRES CRT"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Colori tipo-CRT. Richiede un nuovo motore 3D."
 
 #. TRANSLATION: citron
@@ -5369,7 +5369,7 @@ msgstr "Scegli la profondita' delle texture."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Scegli la profondità di colore emulata."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5436,7 +5436,7 @@ msgstr "Scegli la dimensione del display a tendina."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Scegli la profondita' colore delle texture."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5468,10 +5468,10 @@ msgstr "Scegli di mantenere i cadaveri presenti."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Scegli di rendere le texture grafiche in alta definizione. Richiede OpenGL, "
-"True Colour e il file enhanced.gob."
+"True Color e il file enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6590,8 +6590,8 @@ msgstr "Disco Immagine"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
-msgstr "Mostra informazioni a schermo tipo savestate, avvertenze etc..."
+msgid "Display on screen information like savestate, config warning, etc."
+msgstr "Mostra informazioni a schermo tipo savestate, avvertenze etc."
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
@@ -7984,7 +7984,7 @@ msgstr "VELOCITA; DI TRASFERIMENTO DISCO"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COLORE PREFERITO"
 
 #. TRANSLATION: wine
@@ -10368,7 +10368,7 @@ msgstr "Auto Joypad"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensibilita' Joypad per i paddles. Valore di default (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11820,7 +11820,7 @@ msgstr "Muovi Avanti"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Muovi Avanti, Puoi anche premere W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12730,7 +12730,7 @@ msgstr "Apri la console LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Apri Menu"
 
 #. TRANSLATION: corsixth.keys
@@ -13949,7 +13949,7 @@ msgstr "RGB (immagine chiara)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Colore RGC Bassa/Media-Risoluzione"
 
 #. TRANSLATION: citron
@@ -14104,7 +14104,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Riduce il bandeggio tra i colori e migliora la profondità colore percepita."
 
@@ -15194,7 +15194,7 @@ msgid ""
 "Select how much graphics memory is allocated for the GPU, may need modifying "
 "for some games / systems."
 msgstr ""
-"Seleziona quanta memoria grafica allocare per la GPU, può essere necessario  "
+"Seleziona quanta memoria grafica allocare per la GPU, può essere necessario "
 "modificarla per alcuni giochi/sistemi."
 
 #. TRANSLATION: libretro/melonds
@@ -16604,7 +16604,7 @@ msgstr "TESTO"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "PROFONDITA' COLORE TEXTURE"
 
 #. TRANSLATION: openmohaa
@@ -16784,7 +16784,7 @@ msgstr "BUFFERING TRIPLO"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDERING IN TRUE COLOR"
 
 #. TRANSLATION: libretro/hatarib
@@ -17003,7 +17003,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Il tema colori della console emulata."
 
 #. TRANSLATION: ppsspp
@@ -17241,7 +17241,7 @@ msgstr "Triangolo"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Prova a predirre il colore per-vertice (gouraud) dalle informazioni per-poly "
@@ -17274,8 +17274,8 @@ msgstr "Triplo buffering"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17925,7 +17925,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Usa il puntatore mouse di sistema come controller paddle 1. Non ti "
@@ -19361,7 +19361,7 @@ msgstr "giallo/blu"
 #~ msgstr "ASCI"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Imposta il profilo energetico cpu in-gioco."
 
 #~ msgctxt "game_options"
@@ -19555,7 +19555,7 @@ msgstr "giallo/blu"
 #~ msgstr "ABILITA MIPMAPPING"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "ABILITA TRUE COLOR"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/ja_JP/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ja_JP/batocera-es-system.po
@@ -16,7 +16,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "ゲーム中に CPU電力周波数プロファイルを調整します。 一部のシステムでは、電圧処"
@@ -50,7 +50,7 @@ msgstr "パワーセーバー"
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "バッテリーを使用しながら CPU電力プロファイルを調整します。 以前の電力モードを"
@@ -797,12 +797,12 @@ msgstr "576+KB"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "エミュレートする色深度を選択します"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "色深度"
 
 #. TRANSLATION: libretro/cap32
@@ -1683,12 +1683,12 @@ msgstr "英語"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "エミュレートするコンソールのテーマカラー"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "好きな色"
 
 #. TRANSLATION: libretro/melondsds
@@ -2079,7 +2079,7 @@ msgstr "開閉の状態を表示"
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "マウス ポインターをパドル 1 として使用します。複数のマウスがある場合、特定の"
@@ -4331,7 +4331,7 @@ msgstr "モノクロ高解像度"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB カラー低/中解像度"
 
 #. TRANSLATION: libretro/hatarib
@@ -6779,7 +6779,7 @@ msgstr "BIOS 高速起動(ロゴスキップ)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr "これを有効にすると、少数のゲームで互換性の問題が発生します"
 
 #. TRANSLATION: libretro/pcsx2
@@ -6944,7 +6944,7 @@ msgstr "トライリニア (強制)"
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "色間の分解を減らし、表示する為の色の深さを改善します"
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
@@ -7292,7 +7292,7 @@ msgstr "A500+ (1MB チップ)"
 #. TRANSLATION: libretro/puae, libretro/puae2021
 msgctxt "game_options"
 msgid "A600 (2MB Chip + 8MB Fast)"
-msgstr "A600  (2MB チップ+ 8MB[速])"
+msgstr "A600 (2MB チップ+ 8MB[速])"
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
 msgctxt "game_options"
@@ -8173,7 +8173,7 @@ msgstr "パドルのマウス感度（コアの標準=10）"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "ジョイパッドのパドル感度（コアの標準=3）"
 
 #. TRANSLATION: libretro/stella
@@ -10342,7 +10342,7 @@ msgstr "24 ビット, ディザリング無効"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "トゥルー カラー (レンダリング)"
 
 #. TRANSLATION: duckstation
@@ -10499,7 +10499,7 @@ msgstr "メモリ使用量の目安の表示; ( RAM| VRAM)"
 #. TRANSLATION: duckstation
 msgctxt "game_options"
 msgid "Per 0.05s, 5s total (550MB|100MB)"
-msgstr "0.05 秒間隔、合計  5秒 (550MB|100MB)"
+msgstr "0.05 秒間隔、合計 5秒 (550MB|100MB)"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
@@ -11356,7 +11356,7 @@ msgstr "NxAGSS"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "ステートセーブ、設定警告などの情報を画面に表示します"
 
 #. TRANSLATION: pcsx2
@@ -13087,12 +13087,12 @@ msgstr "クワッド レンダリング"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT のような色適応。新しい 3D エンジンが必要"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT の色"
 
 #. TRANSLATION: supermodel
@@ -14066,7 +14066,7 @@ msgstr "スキャンラインを有効"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Model2 のポリゴンごとのフラット情報から頂点ごとの色(グーロー)を推測しようとし"
@@ -16136,7 +16136,7 @@ msgstr "ハイエンドコンピュータ"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "代替カラードットマトリックス表示 (追加ファイルが必要)"
 
 #. TRANSLATION: vpinball
@@ -16542,7 +16542,7 @@ msgstr "GPU / OpenGL (標準)"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "カラーモード"
 
 #. TRANSLATION: theforceengine
@@ -16557,14 +16557,14 @@ msgstr "8ビット補間"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "トゥルーカラー"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "高解像度のグラフィック テクスチャで表示することを選択します\n"
 "OpenGL、トゥルーカラー、およびenhanced.gobファイルが必要です"
@@ -17842,12 +17842,12 @@ msgstr "New 3DS モード"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "テクスチャの色の深さを選択します"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "テクスチャカラーの深さ"
 
 #. TRANSLATION: openmohaa
@@ -18503,7 +18503,7 @@ msgstr "次の武器"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "前進、W を押すと可能"
 
 #. TRANSLATION: catacomb.keys
@@ -18528,7 +18528,7 @@ msgstr "開始 / 有効"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "メニューを開く"
 
 #. TRANSLATION: catacomb.keys
@@ -23372,7 +23372,7 @@ msgstr "ボタン C"
 #~ msgstr "ハンドヘルド タテモード"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "ゲーム中に CPU 電力プロファイルを調整します"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/ko/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ko/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9배 실기 (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr "일부 게임에서는 이 기능을 활성화하면 호환성 문제가 발생할 수 있습니다."
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2823,7 +2823,7 @@ msgstr "화면 선 그리기 모드를 조정합니다."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "게임 중에 CPU 전원 주파수 프로파일 조정합니다. 일부 시스템은 향상된 전압 처리"
@@ -2832,7 +2832,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "배터리 사용 중에 CPU 전원 프로을 조정합니다. 이전 전원 모드를 덮어씁니다."
@@ -3046,7 +3046,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "대체 컬러 도트 매트릭스 디스플레이(추가 파일 필요)."
 
 #. TRANSLATION: vpinball
@@ -4443,12 +4443,12 @@ msgstr "색상화"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "색심도"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "색상 모드"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4772,7 +4772,7 @@ msgstr "십자선 크기"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT 색상"
 
 #. TRANSLATION: libretro/o2em
@@ -4797,7 +4797,7 @@ msgstr "CRT 스위치"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT와 유사한 색상 적응. 새로운 3D 엔진이 필요합니다."
 
 #. TRANSLATION: citron
@@ -5359,7 +5359,7 @@ msgstr "텍스처 품질의 깊이를 선택하세요."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "에뮬레이트된 색심도를 선택하세요."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5425,7 +5425,7 @@ msgstr "헤드업 디스플레이의 크기를 선택하세요."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "텍스처 색상 깊이를 선택하세요."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5457,9 +5457,9 @@ msgstr "시체를 그대로 두는 것을 선택하세요."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
-"고화질 그래픽 텍스처를 렌더링하도록 선택합니다. OpenGL, True Colour, 향상"
+"고화질 그래픽 텍스처를 렌더링하도록 선택합니다. OpenGL, True Color, 향상"
 "된 .gob 파일이 필요합니다."
 
 #. TRANSLATION: ymir
@@ -6569,7 +6569,7 @@ msgstr "디스크 이미지"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "저장 상태, 구성 경고 등의 정보를 화면에 표시합니다..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7951,7 +7951,7 @@ msgstr "빠른 디스크 전송 속도"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "즐겨찾기 색상"
 
 #. TRANSLATION: wine
@@ -10321,7 +10321,7 @@ msgstr "조이패드 자동"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "패들에 대한 조이패드 감도입니다. 코어 기본값 (3)입니다."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11767,7 +11767,7 @@ msgstr "앞으로 이동"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "앞으로 이동, W를 누를 때 사용할 수 있ㅇ"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12673,7 +12673,7 @@ msgstr "LUA 콘솔 열기"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "메뉴 열기"
 
 #. TRANSLATION: corsixth.keys
@@ -13884,7 +13884,7 @@ msgstr "RGB (선명한 이미지)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB 색상 저해상도/중간해상도"
 
 #. TRANSLATION: citron
@@ -14037,7 +14037,7 @@ msgstr "셰이더를 컴파일할 때 발생하는 끊김을 줄입니다."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "색상 간 밴딩 현상을 줄이고, 인식되는 색상 깊이를 향상시킵니다."
 
 #. TRANSLATION: rpcs3
@@ -16518,7 +16518,7 @@ msgstr "텍스트"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "텍스처 색상 깊이"
 
 #. TRANSLATION: openmohaa
@@ -16698,7 +16698,7 @@ msgstr "트리플 버퍼링"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "트루 컬러 렌더링"
 
 #. TRANSLATION: libretro/hatarib
@@ -16914,7 +16914,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "에뮬레이션된 콘솔의 테마 색상입니다."
 
 #. TRANSLATION: ppsspp
@@ -17147,7 +17147,7 @@ msgstr "삼각형"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "모델2 폴리당 정보 (평면)에서 꼭짓점별 색상(구로)을 추측하려고 시도합니다."
@@ -17179,7 +17179,7 @@ msgstr "트리플 버퍼링"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "트루 컬러"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17826,7 +17826,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "시스템 마우스 포인터를 패들 컨트롤러 1로 사용합니다. 마우스가 여러 개 있는 경"
@@ -19162,7 +19162,7 @@ msgstr "노란색/파란색"
 
 #~ msgctxt "game_options"
 #~ msgid ""
-#~ "A small  number of games will ahve compatibility problems with this "
+#~ "A small number of games will ahve compatibility problems with this "
 #~ "enabled."
 #~ msgstr ""
 #~ "일부 게임에서는 이 기능을 활성화하면 호환성 문제가 발생할 수 있습니다."

--- a/package/batocera/emulationstation/batocera-es-system/locales/nb_NO/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/nb_NO/batocera-es-system.po
@@ -2225,7 +2225,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2819,7 +2819,7 @@ msgstr "Juster modusen for skjermlinjetegning."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Juster CPU-strømfrekvensprofilen mens du er i spillet. Noen systemer vil dra "
@@ -2828,7 +2828,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Juster cpu-strømprofilen på batteriet. Overskriver tidligere strømmodus(er)."
@@ -3043,7 +3043,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternativ farget punktmatriseskjerm (krever ekstra fil)."
 
 #. TRANSLATION: vpinball
@@ -4444,12 +4444,12 @@ msgstr "FARGEGIVNING"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "FARGEDYBDE"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "FARGEMODUS"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4771,7 +4771,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT FARGE"
 
 #. TRANSLATION: libretro/o2em
@@ -4796,7 +4796,7 @@ msgstr "CRT-BRYTERE"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT-lignende fargetilpasning. Krever ny 3D-motor."
 
 #. TRANSLATION: citron
@@ -5348,7 +5348,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Velg emulert fargedybde."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5414,7 +5414,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openjk, openmohaa
@@ -5447,7 +5447,7 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Velg å gjengi høydefinisjonsgrafikkteksturer. Krever OpenGL, True Color og "
 "filen enhanced.gob."
@@ -6566,7 +6566,7 @@ msgstr "Diskavbildning"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Vis informasjon på skjermen, f.eks. savestate, konfigurasjonsadvarsel osv..."
 
@@ -7956,7 +7956,7 @@ msgstr "RASK DISKOVERFØRINGSHASTIGHET"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "FAVORITTFARGE"
 
 #. TRANSLATION: wine
@@ -10322,7 +10322,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11773,7 +11773,7 @@ msgstr "Gå Frem"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Flytt fremover, kan brukes til å trykke på W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12675,7 +12675,7 @@ msgstr "Åpne LUA-konsollen"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Åpne Meny"
 
 #. TRANSLATION: corsixth.keys
@@ -13890,7 +13890,7 @@ msgstr "RGB (skarpt bilde)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB-farge med lav/middels oppløsning"
 
 #. TRANSLATION: citron
@@ -14044,7 +14044,7 @@ msgstr "Reduser hakking som oppstår ved kompilering av shaders."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Reduserer bånd mellom fargene og forbedrer den opplevde fargedybden."
 
 #. TRANSLATION: rpcs3
@@ -15186,7 +15186,7 @@ msgstr "Velg inndatatype for å navigere på berøringsskjermen"
 #. TRANSLATION: libretro/mame, mame
 msgctxt "game_options"
 msgid "Select the model of Color Computer to emulate"
-msgstr "Velg hvilken modell av Color Computer  som skal emuleres"
+msgstr "Velg hvilken modell av Color Computer som skal emuleres"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
@@ -16531,7 +16531,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -16711,7 +16711,7 @@ msgstr "TRIPPEL BUFRING"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "EKTE FARGEGJENGIVELSE"
 
 #. TRANSLATION: libretro/hatarib
@@ -16928,7 +16928,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Temafargen til den emulerte konsollen."
 
 #. TRANSLATION: ppsspp
@@ -17161,7 +17161,7 @@ msgstr "Triangel"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Prøver å gjette farge per vertex (gouraud) ut fra Model2 per-poly-"
@@ -17194,8 +17194,8 @@ msgstr "Trippel bufring"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17846,7 +17846,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 
@@ -18601,7 +18601,7 @@ msgstr ""
 #. TRANSLATION: libretro/vice_x128, libretro/vice_xpet, libretro/vice_xplus4, libretro/vice_xvic
 msgctxt "game_options"
 msgid "Y = Fire"
-msgstr "Y =  Skyt"
+msgstr "Y = Skyt"
 
 #. TRANSLATION: libretro/vice_x128, libretro/vice_xpet, libretro/vice_xplus4, libretro/vice_xvic
 msgctxt "game_options"
@@ -19272,7 +19272,7 @@ msgstr "gul/blå"
 #~ msgstr "ASCI"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Juster cpu-strømprofilen mens du spiller."
 
 #~ msgctxt "game_options"
@@ -19426,7 +19426,7 @@ msgstr "gul/blå"
 #~ msgstr "AKTIVERE MIPMAPPING"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "AKTIVERE EKTE FARGER"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/nl/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/nl/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9x Native (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Een klein aantal games zal compatibiliteitsproblemen ondervinden als deze "
 "optie ingeschakeld is."
@@ -2826,7 +2826,7 @@ msgstr "Pas de scherm lijn-opbouw modus aan."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Pas het CPU-vermogensprofiel aan tijdens het gamen. Sommige systemen zullen "
@@ -2835,7 +2835,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Pas het CPU-voedingsprofiel aan terwijl de batterij is ingeschakeld. "
@@ -3058,7 +3058,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternatief Colored Dot Matrix Display (vereist extra bestand)."
 
 #. TRANSLATION: vpinball
@@ -4464,12 +4464,12 @@ msgstr "COLORISATIE"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "KLEURDIEPTE"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "KLEURENMODUS"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4793,7 +4793,7 @@ msgstr "RICHTKRUISGROOTTE"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT KLEUR"
 
 #. TRANSLATION: libretro/o2em
@@ -4818,7 +4818,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT-achtige kleuraanpassing. Vereist nieuwe 3D-engine."
 
 #. TRANSLATION: citron
@@ -5386,7 +5386,7 @@ msgstr "Kies de diepte van de textuurkwaliteit."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Kies de geëmuleerde kleurdiepte."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5454,7 +5454,7 @@ msgstr "Kies de grootte van het heads-up scherm."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Kies de kleurdiepte van de textuur."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5489,7 +5489,7 @@ msgstr "Kies ervoor om de lijken aanwezig te houden."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Kies ervoor om grafische texturen in hoge definitie weer te geven. Vereist "
 "OpenGL, True Color en het enhanced.gob bestand."
@@ -6607,7 +6607,7 @@ msgstr "SCHIJFIMAGE"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Informatieweergave op het scherm zoals savestate, configuratiewaarschuwing "
 "enz..."
@@ -8024,7 +8024,7 @@ msgstr "FAST DISK TRANSFER RATE"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "FAVORIETE KLEUR"
 
 #. TRANSLATION: wine
@@ -10418,7 +10418,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Joypadgevoeligheid voor paddles. Standaardinstelling van de kern (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11873,7 +11873,7 @@ msgstr "Ga vooruit"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Ga vooruit, kan worden gebruikt door op W te drukken"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12788,8 +12788,8 @@ msgstr "Open de LUA console"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
-msgstr "Open Menu"
+msgid "Open menu"
+msgstr "Open menu"
 
 #. TRANSLATION: corsixth.keys
 msgctxt "keys_files"
@@ -14007,7 +14007,7 @@ msgstr "RGB (scherp beeld)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB Kleur Lage/Gemiddelde resolutie"
 
 #. TRANSLATION: citron
@@ -14160,7 +14160,7 @@ msgstr "Verminder stotteren wanneer shaderes gecompileerd worden."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Vermindert banding tussen kleuren en verbetert de waargenomen kleurdiepte."
 
@@ -16672,7 +16672,7 @@ msgstr "TEKST"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TEXTUUR KLEURDIEPTE"
 
 #. TRANSLATION: openmohaa
@@ -16852,7 +16852,7 @@ msgstr "Drievoudige Buffering"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "WARE KLEURWEERGAVE"
 
 #. TRANSLATION: libretro/hatarib
@@ -17073,7 +17073,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "De themakleur van de geëmuleerde console."
 
 #. TRANSLATION: ppsspp
@@ -17311,7 +17311,7 @@ msgstr "Driehoek"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Probeert de Per-vertex (gouraud) te raden van de Model2 per-poly informatie "
@@ -17344,7 +17344,7 @@ msgstr "Drievoudige buffering"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Ware Kleur"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -18004,7 +18004,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Gebruik de systeem muisaanwijzer als paddle controller 1. U kunt geen "

--- a/package/batocera/emulationstation/batocera-es-system/locales/pl/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/pl/batocera-es-system.po
@@ -1452,7 +1452,7 @@ msgstr "3x natywnej (1920x1584) dla 1080p"
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid "3x Native (~1080p)"
-msgstr "3x natywnej  (~1080p)"
+msgstr "3x natywnej (~1080p)"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
@@ -2232,7 +2232,7 @@ msgstr "9x natywnej (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Niewielka liczba gier będzie miała problemy z kompatybilnością po włączeniu "
 "tej opcji."
@@ -2830,7 +2830,7 @@ msgstr "Dostosuj tryb rysowania linii na ekranie."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Dostosuj profil częstotliwości zasilania CPU w grze. Niektóre systemy "
@@ -2839,7 +2839,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Dostosowuje profil zasilania CPU podczas pracy na baterii. Nadpisuje "
@@ -3059,8 +3059,8 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
-msgstr "Alternative Coloured Dot Matrix Display (wymaga dodatkowego pliku)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
+msgstr "Alternative Colored Dot Matrix Display (wymaga dodatkowego pliku)."
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -4463,12 +4463,12 @@ msgstr "KOLOROWANIE"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "GŁĘBOKOŚĆ KOLORU"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "TRYB KOLORU"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4792,7 +4792,7 @@ msgstr "ROZMIAR CELOWNIKA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "KOLOR CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4817,7 +4817,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptacja kolorów podobna do CRT. Wymaga Nowego Silnika 3D."
 
 #. TRANSLATION: citron
@@ -5383,7 +5383,7 @@ msgstr "Wybierz głębokość jakości tekstury."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Wybierz emulowaną głębię kolorów."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5451,7 +5451,7 @@ msgstr "Wybierz rozmiar wyświetlacza heads-up."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Wybierz głębię koloru tekstur."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5486,10 +5486,10 @@ msgstr "Wybierz, aby zwłoki pozostawały."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Umożliwia renderowanie tekstur graficznych w wysokiej rozdzielczości. Wymaga "
-"OpenGL, True Colour i pliku enhanced.gob."
+"OpenGL, True Color i pliku enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6608,7 +6608,7 @@ msgstr "Obraz dysku"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Wyświetlaj na ekranie informacje, takie jak stan zapisu, ostrzeżenie o "
 "konfiguracji itp."
@@ -7315,7 +7315,7 @@ msgstr "Włącz dla większej płynności, wyłącz w przypadku zrywania ekranu.
 #. TRANSLATION: lindbergh-loader
 msgctxt "game_options"
 msgid "Enable free play for supported games."
-msgstr "Włącz Free Play  w obsługiwanych grach."
+msgstr "Włącz Free Play w obsługiwanych grach."
 
 #. TRANSLATION: openjkdf2
 msgctxt "game_options"
@@ -8022,7 +8022,7 @@ msgstr "SZYBKI TRANSFER DYSKU"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "ULUBIONY KOLOR"
 
 #. TRANSLATION: wine
@@ -10418,7 +10418,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Czułość kontrolera dla paddle. Domyślna wartość (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11875,7 +11875,7 @@ msgstr "Ruch do przodu"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Ruch do przodu, może być użyty do naciśnięcia W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12788,7 +12788,7 @@ msgstr "Otwórz konsolę LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Otwarcie menu"
 
 #. TRANSLATION: corsixth.keys
@@ -14007,7 +14007,7 @@ msgstr "RGB (wyraźny obraz)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Kolor RGB w niskiej/średniej rozdzielczości"
 
 #. TRANSLATION: citron
@@ -14161,7 +14161,7 @@ msgstr "Redukuje zacinanie się programu podczas kompilacji shaderów."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Zmniejsza pasma między kolorami i poprawia postrzeganą głębię kolorów."
 
 #. TRANSLATION: rpcs3
@@ -15603,7 +15603,7 @@ msgstr "Strzał"
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
 msgid "Shoot Xterm"
-msgstr "Strzał  Xterm'a"
+msgstr "Strzał Xterm'a"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
@@ -16666,7 +16666,7 @@ msgstr "TEKST"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "GŁĘBIA KOLORU TEKSTUR"
 
 #. TRANSLATION: openmohaa
@@ -16846,7 +16846,7 @@ msgstr "POTRÓJNE BUFOROWANIE"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "WIERNE ODWZOROWANIE KOLORÓW"
 
 #. TRANSLATION: libretro/hatarib
@@ -17065,7 +17065,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Kolor motywu emulowanej konsoli."
 
 #. TRANSLATION: ppsspp
@@ -17303,7 +17303,7 @@ msgstr "Trójkąt"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Próbuje odgadnąć kolor wierzchołków (gouraud) na podstawie informacji Model2 "
@@ -17336,8 +17336,8 @@ msgstr "Potrójne buforowanie"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17992,10 +17992,10 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
-"Używanie wskaźnika myszy systemowej jako kontrolera paddle 1.  Nie pozwala "
+"Używanie wskaźnika myszy systemowej jako kontrolera paddle 1. Nie pozwala "
 "wybrać konkretnej myszy, jeśli masz ich kilka."
 
 #. TRANSLATION: libretro/melondsds
@@ -19581,7 +19581,7 @@ msgstr "żółty/niebieski"
 
 #~ msgctxt "game_options"
 #~ msgid ""
-#~ "A small  number of games will ahve compatibility problems with this "
+#~ "A small number of games will ahve compatibility problems with this "
 #~ "enabled."
 #~ msgstr ""
 #~ "Niewielka liczba gier będzie miała problemy z kompatybilnością po "
@@ -19628,7 +19628,7 @@ msgstr "żółty/niebieski"
 #~ msgstr "Włącz wibracje na obsługiwanych kontrolerach."
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Dostosuj moc procesora kiedy w grze."
 
 #~ msgctxt "game_options"
@@ -20091,7 +20091,7 @@ msgstr "żółty/niebieski"
 #~ msgstr "WŁĄCZ OSD"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "WŁĄCZ TRUE KOLOR"
 
 #~ msgctxt "game_options"
@@ -21443,7 +21443,7 @@ msgstr "żółty/niebieski"
 #~ msgstr "POPRAWKI SZEROKOEKRANOWE"
 
 #~ msgctxt "game_options"
-#~ msgid "WRITE COLOUR BUFFERS"
+#~ msgid "WRITE COLOR BUFFERS"
 #~ msgstr "ZAPIS BUFORA KOLORU"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/pt_BR/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/pt_BR/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9x Nativo (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Um pequeno número de jogos terá problemas de compatibilidade com esta opção "
 "ativada."
@@ -2826,7 +2826,7 @@ msgstr "Ajusta o modo de desenho da linha da tela."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajuste o perfil de frequência de potência da CPU durante o jogo. Alguns "
@@ -2835,7 +2835,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajuste o perfil de energia da CPU enquanto estiver na bateria. Sobrescreve "
@@ -3054,7 +3054,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Tela matricial de pontos colorida alternativa (precisa de arquivo adicional)."
 
@@ -4469,12 +4469,12 @@ msgstr "COLORIZAÇÃO"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFUNDIDADE DE COR"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODO COR"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4798,7 +4798,7 @@ msgstr "TAMANHO DA MIRA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COR CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4823,7 +4823,7 @@ msgstr "INTERRUPTORES DE TELA DE TUBO (CRT )"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptação de cores semelhante a CRT. Requer novo mecanismo 3D."
 
 #. TRANSLATION: citron
@@ -5387,7 +5387,7 @@ msgstr "Escolha a profunidade da qualidade da textura."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Escolha a profundidade de cor emulada."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5455,7 +5455,7 @@ msgstr "Escolha o tamanho da interface (HUD)."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Escolha a profundidade de cor da textura."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5487,10 +5487,10 @@ msgstr "Escolha manter cadáveres visíveis."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Escolha renderizar texturas gráficas de alta definição. Requer OpenGL, True "
-"Colour e o arquivo enhanced.gob."
+"Color e o arquivo enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6611,7 +6611,7 @@ msgstr "Imagem do Disco"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Exibe informações na tela como estado de salvamento, aviso de configuração "
 "etc."
@@ -8025,7 +8025,7 @@ msgstr "TAXA DE TRANSFERÊNCIA DE DISCO RÁPIDO"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COR FAVORITA"
 
 #. TRANSLATION: wine
@@ -10418,7 +10418,7 @@ msgstr "Controle Automático"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensibilidade do controle para paddles. Padrão do core (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11877,7 +11877,7 @@ msgstr "Mover adiante"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Avançar, pode ser usado para pressionar W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12790,7 +12790,7 @@ msgstr "Abra o terminal LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Abrir Menu"
 
 #. TRANSLATION: corsixth.keys
@@ -14010,7 +14010,7 @@ msgstr "RGB (imagem nítida)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Cor RGB de Baixa/Média Resolução"
 
 #. TRANSLATION: citron
@@ -14164,7 +14164,7 @@ msgstr "Reduz a gagueira que acontece ao compilar sombreamentos."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Reduz as faixas entre as cores e melhora a profundidade de cor percebida."
 
@@ -16677,7 +16677,7 @@ msgstr "TEXTO"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "PROFUNIDIDADE DE COR DE TEXTURA"
 
 #. TRANSLATION: openmohaa
@@ -16857,7 +16857,7 @@ msgstr "TRIPLICAR MEMÓRIA TEMPORÁRIA DE RESERVA"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "REPRESENTACAO DE CORES VERDADEIRAS"
 
 #. TRANSLATION: libretro/hatarib
@@ -17076,7 +17076,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "A cor do tema do videogame emulado."
 
 #. TRANSLATION: ppsspp
@@ -17085,7 +17085,7 @@ msgid ""
 "There is generally no point in going beyond 4x texture scaling unless you "
 "are running at very high resolutions."
 msgstr ""
-"Geralmente não faz sentido ir além da escala de textura 4x, a não ser que  "
+"Geralmente não faz sentido ir além da escala de textura 4x, a não ser que "
 "estejam rodando em resoluções muito altas."
 
 #. TRANSLATION: openmsx
@@ -17317,7 +17317,7 @@ msgstr "Triângulo"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Tenta adivinhar a cor por vértice (gouraud) das informações por polígono "
@@ -17350,7 +17350,7 @@ msgstr "Triplicar memória temporária de reserva"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Cor Verdadeira"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -18009,7 +18009,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Usar o ponteiro de mouse do sistema como um controle paddle 1. Não deixa "

--- a/package/batocera/emulationstation/batocera-es-system/locales/pt_PT/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/pt_PT/batocera-es-system.po
@@ -2228,7 +2228,7 @@ msgstr "9x Nativo (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Um pequeno número de jogos terá problemas de compatibilidade com esta opção "
 "ativada."
@@ -2825,7 +2825,7 @@ msgstr "Ajustar o modo de desenho da linha do ecrã."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajustar o perfil de frequência de energia da CPU durante o jogo. Alguns "
@@ -2834,7 +2834,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajustar o perfil de energia da CPU enquanto estiver na bateria. Substitui o "
@@ -3052,7 +3052,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Display alternativo de matriz de pontos coloridos (precisa de arquivo "
 "adicional)."
@@ -4462,12 +4462,12 @@ msgstr "COLORIZAÇÃO"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "PROFUNDIDADE DE COR"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MODO DE COR"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4791,7 +4791,7 @@ msgstr "TAMANHO DA MIRA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "COR CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4816,7 +4816,7 @@ msgstr "INTERRUPTORES DE ECRÃ DE TUBO (CRT)"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptação de cores semelhante ao CRT. Requer novo motor 3D."
 
 #. TRANSLATION: citron
@@ -5381,7 +5381,7 @@ msgstr "Escolha a profundidade da qualidade da textura."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Escolha a profundidade de cor emulada."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5449,7 +5449,7 @@ msgstr "Escolha o tamanho do ecrã heads-up."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Escolha a profundidade da cor da textura."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5481,7 +5481,7 @@ msgstr "Escolha manter os cadáveres presentes."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Escolha renderizar texturas gráficas de alta definição. Requer OpenGL, "
 "verdadeiro Cor e o arquivo aprimorado.gob."
@@ -6603,9 +6603,9 @@ msgstr "Imagem do Disco"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
-"Mostrar informção no ecrã como savestates, avisos de configuração, etc..."
+"Mostrar informção no ecrã como savestates, avisos de configuração, etc."
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
@@ -8002,7 +8002,7 @@ msgstr "TAXA DE TRANSFERÊNCIA RÁPIDA DO DISCO"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "COR FAVORITA"
 
 #. TRANSLATION: wine
@@ -10390,7 +10390,7 @@ msgstr "Comando Automático"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensibilidade do comando para paddles. Padrão do core (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11846,7 +11846,7 @@ msgstr "Mover para frente"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Avançar, pode ser usado para pressionar W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12759,7 +12759,7 @@ msgstr "Abrir a consola da LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Abrir Menu"
 
 #. TRANSLATION: corsixth.keys
@@ -13979,7 +13979,7 @@ msgstr "RGB (imagem nítida)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Cor RGB de baixa/média resolução"
 
 #. TRANSLATION: citron
@@ -14133,7 +14133,7 @@ msgstr "Reduza o ruído que ocorre ao compilar shaders."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Reduz as faixas entre as cores e melhora a profundidade de cor."
 
 #. TRANSLATION: rpcs3
@@ -16638,7 +16638,7 @@ msgstr "TEXTO"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "TEXTURA PROFUNDIDADE DA COR"
 
 #. TRANSLATION: openmohaa
@@ -16818,7 +16818,7 @@ msgstr "BUFFER TRIPLO"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RENDERIZAÇÃO DE CORES REAIS"
 
 #. TRANSLATION: libretro/hatarib
@@ -17037,7 +17037,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "A cor do tema da consola emulado."
 
 #. TRANSLATION: ppsspp
@@ -17046,7 +17046,7 @@ msgid ""
 "There is generally no point in going beyond 4x texture scaling unless you "
 "are running at very high resolutions."
 msgstr ""
-"Geralmente não faz sentido ir além da escala de textura 4x, a não ser que  "
+"Geralmente não faz sentido ir além da escala de textura 4x, a não ser que "
 "estejam a ser executados em resoluções muito elevadas."
 
 #. TRANSLATION: openmsx
@@ -17277,7 +17277,7 @@ msgstr "Triângulo"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Tenta adivinhar a cor por vértice (gouraud) das informações por polígono do "
@@ -17310,7 +17310,7 @@ msgstr "Triplo buffering"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Cor Verdadeira"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17969,7 +17969,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Usar o ponteiro do rato do sistema como comando de paddle 1. Não lhe permite "

--- a/package/batocera/emulationstation/batocera-es-system/locales/ro_RO/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ro_RO/batocera-es-system.po
@@ -2225,7 +2225,7 @@ msgstr "9x nativ (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Un mic număr de jocuri vor avea probleme de compatibilitate când acesta este "
 "activat."
@@ -2826,7 +2826,7 @@ msgstr "Ajustează modul de desenare a liniei de ecran."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Ajustează profilul de putere și frecvență al CPU-ului în timpul jocului. "
@@ -2835,7 +2835,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Ajustează profilul de putere al CPU-ului când rulează pe baterie. Suprascrie "
@@ -3053,7 +3053,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Ecran matricial de culoare alternativă (necesită fișier adițional)."
 
 #. TRANSLATION: vpinball
@@ -4457,12 +4457,12 @@ msgstr "COLORARE"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "ADÂNCIME DE CULOARE"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "MOD CULOARE"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4786,7 +4786,7 @@ msgstr "MĂRIME RETICUL"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CULOARE CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4811,7 +4811,7 @@ msgstr "SWITCHRES CRT"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Adaptarea culorilor similară cu un CRT. Necesită motorul 3D nou."
 
 #. TRANSLATION: citron
@@ -5375,7 +5375,7 @@ msgstr "Alege adâncimea de calitate a texturii."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Alege adâncimea de culoare emulată."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5442,7 +5442,7 @@ msgstr "Alege mărimea informațiilor de pe ecran."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Alege adâncimea de culoare a texturilor."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5474,7 +5474,7 @@ msgstr "Alege să păstrezi cadavrele prezente."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Alege pentru a reda texturi de înaltă definiție. Necesită OpenGL, True Color "
 "și fișierul enhanced.gob."
@@ -6594,10 +6594,10 @@ msgstr "Imagine de disc"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Afișează informații pe ecran cum ar fi starea salvării, atenționări de "
-"configurație etc..."
+"configurație etc."
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
@@ -8014,7 +8014,7 @@ msgstr "RATĂ MARE DE TRANSFER DISC"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "CULOAREA FAVORITĂ"
 
 #. TRANSLATION: wine
@@ -10410,7 +10410,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Sensibilitate joypad pentru padele. Implicit nucleu (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11868,7 +11868,7 @@ msgstr "Mișcă înainte"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Mișcă înainte, poate fi folosit pentru a apăsa W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12779,7 +12779,7 @@ msgstr "Deschide consola LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Deschide meniul"
 
 #. TRANSLATION: corsixth.keys
@@ -14000,7 +14000,7 @@ msgstr "RGB (imagine clară)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB color de rezoluție joasă/medie"
 
 #. TRANSLATION: citron
@@ -14154,7 +14154,7 @@ msgstr "Redu bâlbâielile care apar în timpul compilării shaderelor."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Reduce benzile dintre culori și îmbunătățește adâncimea de culoare percepută."
 
@@ -16665,7 +16665,7 @@ msgstr "TEXT"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "ADÂNCIME DE CULORI TEXTURĂ"
 
 #. TRANSLATION: openmohaa
@@ -16845,7 +16845,7 @@ msgstr "BUFFERING TRIPLU"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "RANDARE LA CULOAREA REALĂ"
 
 #. TRANSLATION: libretro/hatarib
@@ -17063,7 +17063,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Culoarea temei consolei emulate."
 
 #. TRANSLATION: ppsspp
@@ -17303,7 +17303,7 @@ msgstr "Triunghi"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Încearcă să ghicească culoarea per vertex (gouraud) din informația per "
@@ -17336,7 +17336,7 @@ msgstr "Buffering triplu"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Culoare adevărată"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17999,7 +17999,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Folosește cursorul masului sistemului ca controler pentru paddle 1. Nu "

--- a/package/batocera/emulationstation/batocera-es-system/locales/ru_RU/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/ru_RU/batocera-es-system.po
@@ -2227,7 +2227,7 @@ msgstr "9x Native (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Небольшое количество игр может иметь проблемы с совместимостью при включении "
 "этой функции."
@@ -2826,7 +2826,7 @@ msgstr "Настраивает режим рисования линий экра
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Настройте профиль частоты питания процессора во время игры. Некоторые "
@@ -2835,7 +2835,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Отрегулируйте профиль мощности процессора при работе от батареи. "
@@ -3052,7 +3052,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 "Альтернативный цветной матричный дисплей (требуется дополнительный файл)."
 
@@ -4456,12 +4456,12 @@ msgstr "КОЛОРИЗАЦИЯ"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "ГЛУБИНА ЦВЕТА"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "ЦВЕТОВОЙ РЕЖИМ"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4785,8 +4785,8 @@ msgstr "РАЗМЕР ПРИЦЕЛА"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
-msgstr "CRT COLOUR"
+msgid "CRT COLOR"
+msgstr "CRT COLOR"
 
 #. TRANSLATION: libretro/o2em
 msgctxt "game_options"
@@ -4810,7 +4810,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Адаптация цвета, как у ЭЛТ. Требуется новый 3D-движок."
 
 #. TRANSLATION: citron
@@ -5369,7 +5369,7 @@ msgstr "Выберите детализацию текстур."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Выберите эмулируемую глубину цвета."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5437,7 +5437,7 @@ msgstr "Выберите размер интерфейса."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Выберите глубину цвета текстур."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5469,10 +5469,10 @@ msgstr "Выберите отображение трупов."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Выбрать для рендера графических текстур высокого разрешения. Требуется "
-"OpenGL, True Colour и файл enhanced.gob."
+"OpenGL, True Color и файл enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6589,7 +6589,7 @@ msgstr "Образа диска"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Отображать на экране такой информации, как состояние сохранения, "
 "предупреждение о конфигурации и т.д.."
@@ -7988,7 +7988,7 @@ msgstr "УСКОРИТЬ ЧТЕНИЕ С ДИСКА"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "ЛЮБИМЫЙ ЦВЕТ"
 
 #. TRANSLATION: wine
@@ -10374,7 +10374,7 @@ msgstr "Джойстик Авто"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Чувствительность джойпада для Paddle-контроллеров. По умолчанию: 3."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11830,7 +11830,7 @@ msgstr "Двигайтесь вперед"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Двигаться вперед. Можно нажать W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12740,7 +12740,7 @@ msgstr "Открыть консоль LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Открыть меню"
 
 #. TRANSLATION: corsixth.keys
@@ -13956,7 +13956,7 @@ msgstr "RGB (чёткое изображение)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Цвет RGB низкое/среднее разрешение"
 
 #. TRANSLATION: citron
@@ -14110,7 +14110,7 @@ msgstr "Уменьшает заикание, возникающее при ко�
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Уменьшить полосатость между цветами и улучшить глубину цвета."
 
 #. TRANSLATION: rpcs3
@@ -16615,7 +16615,7 @@ msgstr "ТЕКСТ"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "ГЛУБИНА ЦВЕТА ТЕКСТУР"
 
 #. TRANSLATION: openmohaa
@@ -16795,8 +16795,8 @@ msgstr "ТРОЙНАЯ БУФЕРИЗАЦИЯ"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
-msgstr "TRUE COLOUR РЕНДЕРИНГ"
+msgid "TRUE COLOR RENDERING"
+msgstr "TRUE COLOR РЕНДЕРИНГ"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
@@ -17013,7 +17013,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Цвет темы эмулируемой консоли."
 
 #. TRANSLATION: ppsspp
@@ -17250,7 +17250,7 @@ msgstr "Треугольник"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Пытается угадать цвет каждой вершины (гуро) из информации о полигоне Model2 "
@@ -17283,8 +17283,8 @@ msgstr "Тройная буферизация"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17938,7 +17938,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Использовать курсор мыши для управления paddle 1. Не позволяет выбрать "
@@ -21093,8 +21093,8 @@ msgstr "жёлтая/синяя"
 #~ msgstr "ШИРОКОЭКРАННЫЕ ПАТЧИ (WIDESCREEN)"
 
 #~ msgctxt "game_options"
-#~ msgid "WRITE COLOUR BUFFERS"
-#~ msgstr "WRITE COLOUR BUFFERS"
+#~ msgid "WRITE COLOR BUFFERS"
+#~ msgstr "WRITE COLOR BUFFERS"
 
 #~ msgctxt "game_options"
 #~ msgid "WRITE DEPTH BUFFER"

--- a/package/batocera/emulationstation/batocera-es-system/locales/sk_SK/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/sk_SK/batocera-es-system.po
@@ -890,7 +890,7 @@ msgstr "2.25x (1440x1080)"
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
 msgid "2.25x Native"
-msgstr "2.25x  natívme"
+msgstr "2.25x natívme"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
@@ -1660,7 +1660,7 @@ msgstr "4x SSAA"
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
 msgid "4x native (1024 x 768)"
-msgstr "4x natívne  (1024 x 768)"
+msgstr "4x natívne (1024 x 768)"
 
 #. TRANSLATION: cgenius, x16emu
 msgctxt "game_options"
@@ -2229,7 +2229,7 @@ msgstr "9x Natívne (~3240p)"
 
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
-msgid "A small  number of games will have compatibility problems with this enabled."
+msgid "A small number of games will have compatibility problems with this enabled."
 msgstr "Malý počet hier bude mať problémy s kompatibilitou keď je toto povolené."
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2819,12 +2819,12 @@ msgstr "Upraviť režim kreslenia riadkov obrazovky."
 
 #. TRANSLATION: shared
 msgctxt "game_options"
-msgid "Adjust the cpu power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
+msgid "Adjust the CPU power frequency profile whilst in-game. Some systems will benefit from improved voltage handling."
 msgstr "Upravte profil frekvencie napájania CPU počas hry. Niektoré systémy budú mať úžitok z vylepšeného spracovania napätia."
 
 #. TRANSLATION: shared
 msgctxt "game_options"
-msgid "Adjust the cpu power profile whist on battery. Overwrites previous Power Mode(s)."
+msgid "Adjust the CPU power profile whist on battery. Overwrites previous Power Mode(s)."
 msgstr "Upravte profil napájania CPU pri behu na batérii. Prepíše predchádzajúce režimy napájania."
 
 #. TRANSLATION: vpinball
@@ -3024,7 +3024,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternatívny farebný bodový maticový displej (potrebuje dodatočný súbor)."
 
 #. TRANSLATION: vpinball
@@ -4394,12 +4394,12 @@ msgstr "Zafarbenie"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "Farebná hĺbka"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "Farebný režim"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4719,7 +4719,7 @@ msgstr "VEĽKOSŤ ZAMERIAVAČA"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT farba"
 
 #. TRANSLATION: libretro/o2em
@@ -4744,7 +4744,7 @@ msgstr "CRT prepínače"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Farebná adaptácia ako CRT. Vyžaduje nový 3D engine."
 
 #. TRANSLATION: citron
@@ -5264,7 +5264,7 @@ msgstr "Vyberte hĺbku kvality textúr."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Vyberte emulovanú farebnú hĺbku."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5329,7 +5329,7 @@ msgstr "Vyberte veľkosť HUD displeja."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Vyberte farebnú hĺbku textúr."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5359,8 +5359,8 @@ msgstr "Vyberte či ponechať mŕtvoly."
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "Choose to render high definition graphics textures. Requires OpenGL, True Colour and the enhanced.gob file."
-msgstr "Vyberte vykresľovanie textúr s vysokým rozlíšením. Vyžaduje OpenGL, True Colour a súbor enhanced.gob."
+msgid "Choose to render high definition graphics textures. Requires OpenGL, True Color and the enhanced.gob file."
+msgstr "Vyberte vykresľovanie textúr s vysokým rozlíšením. Vyžaduje OpenGL, True Color a súbor enhanced.gob."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6419,7 +6419,7 @@ msgstr "Obraz disku"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "Zobraziť informácie na obrazovke ako stav uloženia, varovania konfigurácie atď...Zobrazenie informácií na obrazovke, ako je stav uloženia, varovanie konfigurácie atď."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7674,7 +7674,7 @@ msgstr "Rýchla prenosová rýchlosť disku"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "Obľúbená farba"
 
 #. TRANSLATION: wine
@@ -9878,12 +9878,12 @@ msgstr "Joy2Pad dolu"
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
 msgid "Joy2Pad Left"
-msgstr "Joy2Pad  vľavo"
+msgstr "Joy2Pad vľavo"
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
 msgid "Joy2Pad Right"
-msgstr "Joy2Pad  vpravo"
+msgstr "Joy2Pad vpravo"
 
 #. TRANSLATION: nds.drastic.keys
 msgctxt "keys_files"
@@ -9942,7 +9942,7 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr "Citlivosť joypadu pre paddle. Predvolená hodnota jadra (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11342,7 +11342,7 @@ msgstr "Pohyb vpred"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Pohyb vpred, môže sa použiť na stlačenie W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12217,7 +12217,7 @@ msgstr "Otvoriť konzolu LUA"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Otvoriť menu"
 
 #. TRANSLATION: corsixth.keys
@@ -13412,7 +13412,7 @@ msgstr "RGB (ostrý obraz)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB farebné nízke/stredné rozlíšenie"
 
 #. TRANSLATION: citron
@@ -13562,7 +13562,7 @@ msgstr "Znížiť zasekávanie, ku ktorému dochádza pri kompilácii shaderov."
 
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
-msgid "Reduces banding between colours and improves the preceived colour depth."
+msgid "Reduces banding between colors and improves the preceived color depth."
 msgstr "Redukuje pruhy medzi farbami a zlepšuje vnímanú farebnú hĺbku."
 
 #. TRANSLATION: rpcs3
@@ -15932,7 +15932,7 @@ msgstr "TEXT"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "FAREBNÁ HĹBKA TEXTÚR"
 
 #. TRANSLATION: openmohaa
@@ -16112,7 +16112,7 @@ msgstr "Trojité bufferovanie"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "Renderovanie v pravých farbách"
 
 #. TRANSLATION: libretro/hatarib
@@ -16312,7 +16312,7 @@ msgstr "Počet vzoriek každej dlaždice sa zvýši pri každom EVENT_WRITE_ZPD 
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Farba témy emulovanej konzoly."
 
 #. TRANSLATION: ppsspp
@@ -16532,7 +16532,7 @@ msgstr "Trojuholník"
 
 #. TRANSLATION: model2emu
 msgctxt "game_options"
-msgid "Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly information (flat)."
+msgid "Tries to guess Per-vertex color (gouraud) from the Model2 per-poly information (flat)."
 msgstr "Pokúsi sa uhádnuť farbu na vrchol (gouraud) z informácií o modeli2 (flat)."
 
 #. TRANSLATION: openjk, openmohaa
@@ -16562,7 +16562,7 @@ msgstr "Trojité bufferovanie"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Pravé farby"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17177,7 +17177,7 @@ msgstr "Použiť rovnaké cesty grafiky ako samostatná MAME – neodporúča sa
 
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
-msgid "Use the system mouse pointer as paddle controller 1.  Does not let you choose a specific mouse if you have several."
+msgid "Use the system mouse pointer as paddle controller 1. Does not let you choose a specific mouse if you have several."
 msgstr "Použite systémový kurzor myši ako paddle ovládač 1. Neumožňuje vybrať konkrétnu myš, ak máte viacero."
 
 #. TRANSLATION: libretro/melondsds
@@ -18566,7 +18566,7 @@ msgstr "žltá/modrá"
 #~ msgstr "ASCI"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "Prispôsobiť silový profil CPU počas hry."
 
 #~ msgctxt "game_options"
@@ -18758,7 +18758,7 @@ msgstr "žltá/modrá"
 #~ msgstr "Povoliť mipmapping"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "Povoliť pravé farby"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/sv_SE/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/sv_SE/batocera-es-system.po
@@ -2230,7 +2230,7 @@ msgstr "9x inbyggd (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Ett litet antal spel kommer att ha kompatibilitetsproblem med detta "
 "aktiverat."
@@ -2827,7 +2827,7 @@ msgstr "Justera skärmlinjens ritningsläge."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Justera frekvensprofilen för cpu-effekt i spelet. Vissa system kommer att "
@@ -2836,7 +2836,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Justera cpu:ns energiprofil medan batteriet är på. Skriver över tidigare "
@@ -3052,7 +3052,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternativ färgad punktmatrisdisplay (kräver ytterligare fil)."
 
 #. TRANSLATION: vpinball
@@ -4452,12 +4452,12 @@ msgstr "FÄRGLÄGGNING"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "FÄRGDJUP"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "FÄRGLÄGE"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4781,7 +4781,7 @@ msgstr "STORLEK FÖR HÅRKORS"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT-FÄRG"
 
 #. TRANSLATION: libretro/o2em
@@ -4806,7 +4806,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT-liknande färganpassning. Kräver ny 3D-motor."
 
 #. TRANSLATION: citron
@@ -5369,7 +5369,7 @@ msgstr "Välj djupet för texturkvaliteten."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Välj det emulerade färgdjupet."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5437,7 +5437,7 @@ msgstr "Välj storleken för översiktsskärmen."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Välj texturens färgdjup."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5471,9 +5471,9 @@ msgstr "Välj att behålla döda kroppar."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
-"Välj att rendera högupplösta grafiktexturer. Kräver OpenGL, True Colour och "
+"Välj att rendera högupplösta grafiktexturer. Kräver OpenGL, True Color och "
 "filen enhanced.gob."
 
 #. TRANSLATION: ymir
@@ -6590,7 +6590,7 @@ msgstr "Diskavbildning"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Visa information på skärmen, t.ex. sparade tillstånd, konfigurationsvarning "
 "etc."
@@ -7985,7 +7985,7 @@ msgstr "SNABB DISKÖVERFÖRINGSHASTIGHET"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "FAVORITFÄRG"
 
 #. TRANSLATION: wine
@@ -10368,8 +10368,8 @@ msgstr "Joypad Auto"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
-msgstr "Joypad-känslighet för paddlar. Standardinställning  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
+msgstr "Joypad-känslighet för paddlar. Standardinställning (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
 msgctxt "game_options"
@@ -11806,7 +11806,7 @@ msgstr "Musaxel för spelare 4, vertikal skärmrörelse."
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
 msgid "Mouse sensitivity for paddles. Core default (10)."
-msgstr "Musens känslighet för paddlar. Standardinställning  (10)."
+msgstr "Musens känslighet för paddlar. Standardinställning (10)."
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
@@ -11820,7 +11820,7 @@ msgstr "Gå framåt"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Flytta framåt, kan användas för att trycka på W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12724,7 +12724,7 @@ msgstr "Öppna LUA-konsolen"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Öppna meny"
 
 #. TRANSLATION: corsixth.keys
@@ -13940,7 +13940,7 @@ msgstr "RGB (skarp bild)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB-färg Låg/Medelhög upplösning"
 
 #. TRANSLATION: citron
@@ -14093,7 +14093,7 @@ msgstr "Minska hackande som uppstår vid kompilering av shaders."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Minskar bandningen mellan färgerna och förbättrar det upplevda färgdjupet."
 
@@ -16592,7 +16592,7 @@ msgstr "TEXT"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "FÄRGDJUP FÖR TEXTUR"
 
 #. TRANSLATION: openmohaa
@@ -16772,8 +16772,8 @@ msgstr "TRIPPELBUFFRING"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
-msgstr "TRUE COLOUR-RENDERING"
+msgid "TRUE COLOR RENDERING"
+msgstr "TRUE COLOR-RENDERING"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
@@ -16990,7 +16990,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Temafärg för den emulerade konsolen."
 
 #. TRANSLATION: ppsspp
@@ -17226,7 +17226,7 @@ msgstr "Triangel"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Försöker gissa Per-vertexfärg (gouraud) från Model2 per-poly-information "
@@ -17259,8 +17259,8 @@ msgstr "Trippelbuffring"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
-msgstr "True Colour"
+msgid "True Color"
+msgstr "True Color"
 
 #. TRANSLATION: xenia, xenia-canary
 msgctxt "game_options"
@@ -17911,7 +17911,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "Använd systemets muspekare som paddelkontroll 1. Låter dig inte välja en "

--- a/package/batocera/emulationstation/batocera-es-system/locales/tr/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/tr/batocera-es-system.po
@@ -2232,7 +2232,7 @@ msgstr "9x Doğal (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 "Bu özellik etkinleştirildiğinde, az sayıda oyunda uyumluluk sorunları "
 "yaşanabilir."
@@ -2829,7 +2829,7 @@ msgstr "Ekran çizgisi çizme modunu ayarla."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Oyun sırasında CPU güç frekans profilini ayarlayın. Bazı sistemler "
@@ -2838,7 +2838,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Pildeyken CPU güç profilini ayarlayın. Önceki Güç Modlarını geçersiz kılar."
@@ -3058,7 +3058,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Alternatif Renkli Nokta Matris Ekranı (ek dosya gerektirir)."
 
 #. TRANSLATION: vpinball
@@ -4462,12 +4462,12 @@ msgstr "RENKLENDİRME"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "RENK DERİNLİĞİ"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "RENK MODU"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4791,7 +4791,7 @@ msgstr "NİŞANGAH BOYUTU"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT RENKLERİ"
 
 #. TRANSLATION: libretro/o2em
@@ -4816,7 +4816,7 @@ msgstr "CRT ANAHTARLARI"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "CRT gibi renk uyumu. Yeni 3D motoru gerektirir."
 
 #. TRANSLATION: citron
@@ -5381,7 +5381,7 @@ msgstr "Doku kalitesinin derinliğini seçin."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Taklit edilmiş renk derinliğini seçin."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5448,7 +5448,7 @@ msgstr "Anlık bilgi ekranı boyutunu seçin."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "Doku renk derinliğini seçin."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5482,7 +5482,7 @@ msgstr "Cesetler tutuldu."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Yüksek çözünürlüklü grafik dokuları işlemeyi seçin. OpenGL, Gerçek Renk ve "
 "enhanced.gob dosyası gerektirir."
@@ -6603,7 +6603,7 @@ msgstr "Disk Kalıbı"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "Ekranda durum kaydı, yapılandırma uyarısı vb. gibi bilgileri göster..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -8019,7 +8019,7 @@ msgstr "HIZLI DİSK AKTARIM HIZI"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "FAVORİ RENK"
 
 #. TRANSLATION: wine
@@ -10396,7 +10396,7 @@ msgstr "Joypad Otomatik"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11852,7 +11852,7 @@ msgstr "İleri Git"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "İleri Git, W tuşuna basmak için kullanılabilir"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12764,7 +12764,7 @@ msgstr "LUA konsolunu aç"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Menüyü Aç"
 
 #. TRANSLATION: corsixth.keys
@@ -13978,7 +13978,7 @@ msgstr "RGB (net görüntü)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB Renk Az/Orta-Çözünürlük"
 
 #. TRANSLATION: citron
@@ -14132,7 +14132,7 @@ msgstr "Gölgelendiricileri derlerken oluşan takılmaları azalt."
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 "Renkler arasındaki şeritlenmeyi azaltın ve algılanan renk derinliğini "
 "artırın."
@@ -16635,7 +16635,7 @@ msgstr "METİN"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "DOKU RENK DERİNLİĞİ"
 
 #. TRANSLATION: openmohaa
@@ -16816,7 +16816,7 @@ msgstr "ÜÇLÜ ARABELLEK"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "GERÇEK RENK İLE İŞLE"
 
 #. TRANSLATION: libretro/hatarib
@@ -17034,7 +17034,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Taklit edilmiş konsolun tema rengi."
 
 #. TRANSLATION: ppsspp
@@ -17268,7 +17268,7 @@ msgstr "Üçgen"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Per-poly Model2 bilgisinden Per-vertex rengini (gouraud) tahmin etmeye "
@@ -17301,7 +17301,7 @@ msgstr "Üçlü arabellek"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Gerçek Renk"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17958,10 +17958,10 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
-"1. sistem fare işaretçisini pedal kontrolcüsü olarak kullan.  Birden fazla "
+"1. sistem fare işaretçisini pedal kontrolcüsü olarak kullan. Birden fazla "
 "fareniz varsa belirli bir fareyi seçmenize izin vermez."
 
 #. TRANSLATION: libretro/melondsds

--- a/package/batocera/emulationstation/batocera-es-system/locales/uk_UA/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/uk_UA/batocera-es-system.po
@@ -2227,7 +2227,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2820,14 +2820,14 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 
@@ -3034,7 +3034,7 @@ msgstr ""
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr ""
 
 #. TRANSLATION: vpinball
@@ -4419,12 +4419,12 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr ""
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4746,7 +4746,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr ""
 
 #. TRANSLATION: libretro/o2em
@@ -4771,7 +4771,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr ""
 
 #. TRANSLATION: citron
@@ -5309,7 +5309,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr ""
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5375,7 +5375,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openjk, openmohaa
@@ -5407,7 +5407,7 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 
 #. TRANSLATION: ymir
@@ -6492,7 +6492,7 @@ msgstr ""
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 
 #. TRANSLATION: nds.drastic.keys
@@ -7810,7 +7810,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr ""
 
 #. TRANSLATION: wine
@@ -10124,7 +10124,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11547,7 +11547,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr ""
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12435,7 +12435,7 @@ msgstr ""
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr ""
 
 #. TRANSLATION: corsixth.keys
@@ -13638,7 +13638,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr ""
 
 #. TRANSLATION: citron
@@ -13790,7 +13790,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr ""
 
 #. TRANSLATION: rpcs3
@@ -16217,7 +16217,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -16397,7 +16397,7 @@ msgstr ""
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr ""
 
 #. TRANSLATION: libretro/hatarib
@@ -16605,7 +16605,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr ""
 
 #. TRANSLATION: ppsspp
@@ -16833,7 +16833,7 @@ msgstr ""
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 
@@ -16864,7 +16864,7 @@ msgstr ""
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr ""
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17495,7 +17495,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 

--- a/package/batocera/emulationstation/batocera-es-system/locales/vi_VN/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/vi_VN/batocera-es-system.po
@@ -2226,7 +2226,7 @@ msgstr ""
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr ""
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2821,7 +2821,7 @@ msgstr "Điều chỉnh chế độ vẽ đường màn hình."
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr ""
 "Điều chỉnh tần số nguồn CPU trong khi chơi game. Một số hệ thống sẽ được "
@@ -2830,7 +2830,7 @@ msgstr ""
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr ""
 "Điều chỉnh cấu hình nguồn CPU khi sử dụng pin. Ghi đè lên Chế độ nguồn trước "
@@ -3049,7 +3049,7 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "Hiển thị ma trận điểm màu thay thế (cần thêm tệp)."
 
 #. TRANSLATION: vpinball
@@ -4453,12 +4453,12 @@ msgstr "MÀU SẮC"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "ĐỘ SÂU MÀU"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "CHẾ ĐỘ MÀU"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4780,7 +4780,7 @@ msgstr ""
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "MÀU CRT"
 
 #. TRANSLATION: libretro/o2em
@@ -4805,7 +4805,7 @@ msgstr "CRT SWITCHRES"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "Điều chỉnh màu giống như CRT. Yêu cầu công cụ 3D mới."
 
 #. TRANSLATION: citron
@@ -5363,7 +5363,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "Chọn độ sâu màu mô phỏng."
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5429,7 +5429,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr ""
 
 #. TRANSLATION: openjk, openmohaa
@@ -5461,7 +5461,7 @@ msgstr ""
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr ""
 "Chọn để hiển thị kết cấu đồ họa độ nét cao. Yêu cầu OpenGL, True Color và "
 "tệp nâng cao.gob."
@@ -6578,7 +6578,7 @@ msgstr "Disk Image"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr ""
 "Hiển thị thông tin lên màn hình như savestate, cảnh báo, cấu hình, v.v..."
 
@@ -7837,7 +7837,7 @@ msgstr "Tăng cường. Họa tiết mượt mà/cao cấp trên các đối tư
 #. TRANSLATION: libretro/duckstation, libretro/swanstation
 msgctxt "game_options"
 msgid "Enhancement. Smooth/upscale textures."
-msgstr "Tăng cường.  Mượt/Nâng cấp textures."
+msgstr "Tăng cường. Mượt/Nâng cấp textures."
 
 #. TRANSLATION: libretro/mesen-s
 msgctxt "game_options"
@@ -7982,7 +7982,7 @@ msgstr "FAST DISK TRANSFER RATE"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "MÀU YÊU THÍCH"
 
 #. TRANSLATION: wine
@@ -9136,7 +9136,7 @@ msgstr "GameBlaster"
 #. TRANSLATION: dolphin
 msgctxt "game_options"
 msgid "GameCube Adapter for Wii U"
-msgstr "GameCube Adapter cho  Wii U"
+msgstr "GameCube Adapter cho Wii U"
 
 #. TRANSLATION: dolphin, libretro/dolphin
 msgctxt "game_options"
@@ -10344,7 +10344,7 @@ msgstr "Joypad tự động"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11798,7 +11798,7 @@ msgstr "Tiến về phía trước"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "Tiến về phía trước, có thể được sử dụng để nhấn W"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12707,7 +12707,7 @@ msgstr "Mở bảng điều khiển Lua"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "Mở menu"
 
 #. TRANSLATION: corsixth.keys
@@ -13920,7 +13920,7 @@ msgstr "RGB (hình ảnh sắc nét)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "Màu RGB Độ phân giải thấp/trung bình"
 
 #. TRANSLATION: citron
@@ -14072,7 +14072,7 @@ msgstr "Giảm tình trạng giật hình xảy ra khi biên dịch trình đổ
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "Giảm dải giữa các màu và cải thiện độ sâu màu nhận được."
 
 #. TRANSLATION: rpcs3
@@ -14948,7 +14948,7 @@ msgstr "PHỤ ĐỀ"
 #. TRANSLATION: libretro/mesen-s, libretro/snes9x, libretro/snes9x_next
 msgctxt "game_options"
 msgid "SUPER FX OVERCLOCK"
-msgstr "SIÊU  FX OVERCLOCK"
+msgstr "SIÊU FX OVERCLOCK"
 
 #. TRANSLATION: libretro/mesen-s
 msgctxt "game_options"
@@ -16568,7 +16568,7 @@ msgstr ""
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr ""
 
 #. TRANSLATION: openmohaa
@@ -16748,7 +16748,7 @@ msgstr "TRIPLE BUFFERING"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "KẾT XUẤT MÀU SẮC THẬT"
 
 #. TRANSLATION: libretro/hatarib
@@ -16963,7 +16963,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "Màu chủ đề của bảng điều khiển mô phỏng."
 
 #. TRANSLATION: ppsspp
@@ -17196,7 +17196,7 @@ msgstr "Triangle"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr ""
 "Cố gắng đoán màu Per-vertex (gouraud) từ Model2 per-poly information (flat)."
@@ -17228,7 +17228,7 @@ msgstr "Bộ đệm ba"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "Màu thật"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17876,7 +17876,7 @@ msgstr ""
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 

--- a/package/batocera/emulationstation/batocera-es-system/locales/zh_CN/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/zh_CN/batocera-es-system.po
@@ -2230,7 +2230,7 @@ msgstr "9x 原生 (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr "启用此功能后少数游戏将出现兼容性问题."
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2823,16 +2823,16 @@ msgstr "调整屏幕线条绘制模式。"
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
-msgstr "在游戏中调整cpu电源频率配置文件. 一些系统将受益于改进的电压处理."
+msgstr "在游戏中调整CPU电源频率配置文件. 一些系统将受益于改进的电压处理."
 
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
-msgstr "在使用电池的情况下调整cpu功率配置文件. 覆盖以前的电源模式."
+msgstr "在使用电池的情况下调整CPU功率配置文件. 覆盖以前的电源模式."
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -3039,7 +3039,7 @@ msgstr "AltWFC（172.104.88.237）"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
 msgstr "可选彩色点阵显示器（需要额外文件）。"
 
 #. TRANSLATION: vpinball
@@ -4426,12 +4426,12 @@ msgstr "彩色化"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "颜色深度"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "色彩模式"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4662,7 +4662,7 @@ msgstr "CPU核心方式"
 #. TRANSLATION: dosbox
 msgctxt "game_options"
 msgid "CPU CYCLES"
-msgstr "cpu周期"
+msgstr "CPU周期"
 
 #. TRANSLATION: dosbox
 msgctxt "game_options"
@@ -4753,7 +4753,7 @@ msgstr "十字准线尺寸"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT色彩"
 
 #. TRANSLATION: libretro/o2em
@@ -4778,7 +4778,7 @@ msgstr "CRT低解开关"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "类似CRT的色彩适应, 需要新的3D引擎."
 
 #. TRANSLATION: citron
@@ -5317,7 +5317,7 @@ msgstr "选择纹理质量的深度."
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "选择模拟颜色深度。"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5383,7 +5383,7 @@ msgstr "选择平视显示器的大小."
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "选择纹理颜色深度."
 
 #. TRANSLATION: openjk, openmohaa
@@ -5415,8 +5415,8 @@ msgstr "保留尸体在场状态."
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
-msgstr "选择渲染高清晰度图形纹理. 需要OpenGL、True Colour和enhanced.gob文件."
+"Color and the enhanced.gob file."
+msgstr "选择渲染高清晰度图形纹理. 需要OpenGL、True Color和enhanced.gob文件."
 
 #. TRANSLATION: ymir
 msgctxt "game_options"
@@ -6507,7 +6507,7 @@ msgstr "磁盘镜像"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "在屏幕上显示保存状态、配置警告等信息..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7834,7 +7834,7 @@ msgstr "快速磁盘传输速率"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "最喜欢的颜色"
 
 #. TRANSLATION: wine
@@ -10153,7 +10153,7 @@ msgstr "6键手柄 + 4-WayPlay"
 #. TRANSLATION: libretro/genesisplusgx-expanded
 msgctxt "game_options"
 msgid "Joypad 6 Button + Teamplayer"
-msgstr "6键手柄  + Teamplayer"
+msgstr "6键手柄 + Teamplayer"
 
 #. TRANSLATION: libretro/genesisplusgx-expanded
 msgctxt "game_options"
@@ -10162,8 +10162,8 @@ msgstr "手柄（自动）"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
-msgstr "摇杆的灵敏度. 核心默认值  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
+msgstr "摇杆的灵敏度. 核心默认值 (3)."
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
 msgctxt "game_options"
@@ -11593,7 +11593,7 @@ msgstr "向前移动"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "向前移动，可用于按W键"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12484,7 +12484,7 @@ msgstr "打开LUA控制台"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "打开菜单"
 
 #. TRANSLATION: corsixth.keys
@@ -13689,7 +13689,7 @@ msgstr "RGB（清晰干净的图像）"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
 msgstr "RGB颜色低/中分辨率"
 
 #. TRANSLATION: citron
@@ -13841,7 +13841,7 @@ msgstr "减少编译着色器时发生的卡顿。"
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "减少颜色之间的条纹，并提高预先设定的颜色深度。"
 
 #. TRANSLATION: rpcs3
@@ -16287,7 +16287,7 @@ msgstr "文本"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "纹理颜色深度"
 
 #. TRANSLATION: openmohaa
@@ -16467,7 +16467,7 @@ msgstr "三重缓冲"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "真彩色渲染"
 
 #. TRANSLATION: libretro/hatarib
@@ -16679,7 +16679,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "模拟主机的主题颜色。"
 
 #. TRANSLATION: ppsspp
@@ -16908,7 +16908,7 @@ msgstr "三角"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr "尝试根据Model2逐多边形信息（平面）猜测逐顶点颜色（gouraud）。"
 
@@ -16939,7 +16939,7 @@ msgstr "三重缓冲"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "真彩色"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17574,10 +17574,10 @@ msgstr "使用与独立MAME相同的艺术路径 - 如果使用装饰或着色�
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
-"将系统鼠标指针用作摇杆控制器1.  若连接多个鼠标则此设置不允许选择特定设备."
+"将系统鼠标指针用作摇杆控制器1. 若连接多个鼠标则此设置不允许选择特定设备."
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
@@ -18973,7 +18973,7 @@ msgstr "黄色/蓝色"
 
 #~ msgctxt "game_options"
 #~ msgid ""
-#~ "A small  number of games will ahve compatibility problems with this "
+#~ "A small number of games will ahve compatibility problems with this "
 #~ "enabled."
 #~ msgstr "启用此功能后少数游戏将出现兼容性问题."
 
@@ -18990,7 +18990,7 @@ msgstr "黄色/蓝色"
 #~ msgstr "ASCI"
 
 #~ msgctxt "game_options"
-#~ msgid "Adjust the cpu power profile while in-game."
+#~ msgid "Adjust the CPU power profile while in-game."
 #~ msgstr "游玩中调整CPU功率配置文件。"
 
 #~ msgctxt "game_options"
@@ -19162,7 +19162,7 @@ msgstr "黄色/蓝色"
 #~ msgstr "启用MIPMAPPING"
 
 #~ msgctxt "game_options"
-#~ msgid "ENABLE TRUE COLOUR"
+#~ msgid "ENABLE TRUE COLOR"
 #~ msgstr "启用真彩色"
 
 #~ msgctxt "game_options"

--- a/package/batocera/emulationstation/batocera-es-system/locales/zh_TW/batocera-es-system.po
+++ b/package/batocera/emulationstation/batocera-es-system/locales/zh_TW/batocera-es-system.po
@@ -2230,7 +2230,7 @@ msgstr "9x 原生解析度 (~3240p)"
 #. TRANSLATION: libretro/pcsx2
 msgctxt "game_options"
 msgid ""
-"A small  number of games will have compatibility problems with this enabled."
+"A small number of games will have compatibility problems with this enabled."
 msgstr "啟用此功能後，少部分遊戲可能會出現相容性問題。"
 
 #. TRANSLATION: libretro/puae, libretro/puae2021
@@ -2823,14 +2823,14 @@ msgstr "調整螢幕線繪模式。"
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power frequency profile whilst in-game. Some systems will "
+"Adjust the CPU power frequency profile whilst in-game. Some systems will "
 "benefit from improved voltage handling."
 msgstr "遊戲中調整CPU頻率功耗，部分系統會因電壓處理改善而得益。"
 
 #. TRANSLATION: shared
 msgctxt "game_options"
 msgid ""
-"Adjust the cpu power profile whist on battery. Overwrites previous Power "
+"Adjust the CPU power profile whist on battery. Overwrites previous Power "
 "Mode(s)."
 msgstr "電池模式下調整CPU頻率功耗，將覆蓋之前的電源模式。"
 
@@ -3038,8 +3038,8 @@ msgstr "AltWFC (172.104.88.237)"
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
-msgid "Alternative Coloured Dot Matrix Display (needs additional file)."
-msgstr "Alternative Coloured Dot Matrix Display (需額外檔案)."
+msgid "Alternative Colored Dot Matrix Display (needs additional file)."
+msgstr "Alternative Colored Dot Matrix Display (需額外檔案)."
 
 #. TRANSLATION: vpinball
 msgctxt "game_options"
@@ -4426,12 +4426,12 @@ msgstr "彩色化"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "COLOUR DEPTH"
+msgid "COLOR DEPTH"
 msgstr "色深度"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "COLOUR MODE"
+msgid "COLOR MODE"
 msgstr "色彩模式"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -4753,7 +4753,7 @@ msgstr "十字準星尺寸"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT COLOUR"
+msgid "CRT COLOR"
 msgstr "CRT顏色"
 
 #. TRANSLATION: libretro/o2em
@@ -4778,7 +4778,7 @@ msgstr "CRT解析度切換"
 
 #. TRANSLATION: supermodel
 msgctxt "game_options"
-msgid "CRT-like colour adaption. Requires New 3D engine."
+msgid "CRT-like color adaption. Requires New 3D engine."
 msgstr "類似 CRT 的色彩調整，需要新的 3D 引擎。"
 
 #. TRANSLATION: citron
@@ -5317,7 +5317,7 @@ msgstr "選擇紋理品質的深度。"
 
 #. TRANSLATION: libretro/cap32, openjk, openmohaa
 msgctxt "game_options"
-msgid "Choose the emulated colour depth."
+msgid "Choose the emulated color depth."
 msgstr "選擇模擬色深度。"
 
 #. TRANSLATION: fallout1-ce, fallout2-ce
@@ -5383,7 +5383,7 @@ msgstr "選擇平視顯示器的尺寸。"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "Choose the texture colour depth."
+msgid "Choose the texture color depth."
 msgstr "選擇紋理顏色深度。"
 
 #. TRANSLATION: openjk, openmohaa
@@ -5415,7 +5415,7 @@ msgstr "選擇保留屍體。"
 msgctxt "game_options"
 msgid ""
 "Choose to render high definition graphics textures. Requires OpenGL, True "
-"Colour and the enhanced.gob file."
+"Color and the enhanced.gob file."
 msgstr "選擇算繪高解析圖形紋理。需要 OpenGL、真彩色和增強型.gob 檔案。"
 
 #. TRANSLATION: ymir
@@ -6506,7 +6506,7 @@ msgstr "磁片鏡像"
 
 #. TRANSLATION: pcsx2
 msgctxt "game_options"
-msgid "Display on screen information like savestate, config warning etc..."
+msgid "Display on screen information like savestate, config warning, etc."
 msgstr "在螢幕上顯示訊息，如儲存狀態、設定警告等..."
 
 #. TRANSLATION: nds.drastic.keys
@@ -7836,7 +7836,7 @@ msgstr "快速磁碟傳輸速率"
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "FAVOURITE COLOUR"
+msgid "FAVORITE COLOR"
 msgstr "最喜歡的顏色"
 
 #. TRANSLATION: wine
@@ -10165,7 +10165,7 @@ msgstr "手把自動"
 
 #. TRANSLATION: libretro/stella
 msgctxt "game_options"
-msgid "Joypad sensitivity for paddles. Core default  (3)."
+msgid "Joypad sensitivity for paddles. Core default (3)."
 msgstr ""
 
 #. TRANSLATION: libretro/melondsds, libretro/puae, libretro/puae2021, libretro/vice_x128, libretro/vice_x64, ...
@@ -11595,7 +11595,7 @@ msgstr "向前移動"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Move Forward, Can be use to press W"
+msgid "Move forward, can be use to press W"
 msgstr "向前移動，可按W鍵"
 
 #. TRANSLATION: 3ds.azahar.keys
@@ -12483,7 +12483,7 @@ msgstr "開啟 LUA 主機"
 
 #. TRANSLATION: catacomb.keys
 msgctxt "keys_files"
-msgid "Open Menu"
+msgid "Open menu"
 msgstr "開啟選單"
 
 #. TRANSLATION: corsixth.keys
@@ -13690,8 +13690,8 @@ msgstr "RGB (crisp image)"
 
 #. TRANSLATION: libretro/hatarib
 msgctxt "game_options"
-msgid "RGB Colour Low/Medium-Resolution"
-msgstr "RGB Colour Low/Medium-Resolution"
+msgid "RGB Color Low/Medium-Resolution"
+msgstr "RGB Color Low/Medium-Resolution"
 
 #. TRANSLATION: citron
 msgctxt "game_options"
@@ -13842,7 +13842,7 @@ msgstr "減少編譯著色器時發生的卡頓。"
 #. TRANSLATION: libretro/pcsx2, pcsx2
 msgctxt "game_options"
 msgid ""
-"Reduces banding between colours and improves the preceived colour depth."
+"Reduces banding between colors and improves the preceived color depth."
 msgstr "減少顏色之間的條帶並提高感知的色彩深度。"
 
 #. TRANSLATION: rpcs3
@@ -16282,7 +16282,7 @@ msgstr "文字"
 
 #. TRANSLATION: openmohaa
 msgctxt "game_options"
-msgid "TEXTURE COLOUR DEPTH"
+msgid "TEXTURE COLOR DEPTH"
 msgstr "紋理顏色深度"
 
 #. TRANSLATION: openmohaa
@@ -16462,7 +16462,7 @@ msgstr "三重緩衝"
 
 #. TRANSLATION: duckstation
 msgctxt "game_options"
-msgid "TRUE COLOUR RENDERING"
+msgid "TRUE COLOR RENDERING"
 msgstr "真彩色再現"
 
 #. TRANSLATION: libretro/hatarib
@@ -16672,7 +16672,7 @@ msgstr ""
 
 #. TRANSLATION: libretro/melondsds
 msgctxt "game_options"
-msgid "The theme colour of the emulated console."
+msgid "The theme color of the emulated console."
 msgstr "模擬主機的主題顏色。"
 
 #. TRANSLATION: ppsspp
@@ -16900,7 +16900,7 @@ msgstr "三角形"
 #. TRANSLATION: model2emu
 msgctxt "game_options"
 msgid ""
-"Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly "
+"Tries to guess Per-vertex color (gouraud) from the Model2 per-poly "
 "information (flat)."
 msgstr "嘗試從模型2的每多邊形資訊(平面)中猜測每頂點顏色(gouraud)。"
 
@@ -16931,7 +16931,7 @@ msgstr "三重緩衝"
 
 #. TRANSLATION: theforceengine
 msgctxt "game_options"
-msgid "True Colour"
+msgid "True Color"
 msgstr "真實的色彩"
 
 #. TRANSLATION: xenia, xenia-canary
@@ -17563,7 +17563,7 @@ msgstr "使用與獨立MAME相同的藝術路徑-如果使用裝飾或著色器�
 #. TRANSLATION: libretro/dice
 msgctxt "game_options"
 msgid ""
-"Use the system mouse pointer as paddle controller 1.  Does not let you "
+"Use the system mouse pointer as paddle controller 1. Does not let you "
 "choose a specific mouse if you have several."
 msgstr ""
 "使用系統滑鼠指針作為踏板控制器1。如果您有多個滑鼠，不會讓您選擇特定的滑鼠。"

--- a/package/batocera/emulators/duckstation-common/duckstation.emulator.yml
+++ b/package/batocera/emulators/duckstation-common/duckstation.emulator.yml
@@ -152,7 +152,7 @@ custom_features:
       xBR (Very Slow, No Edge Blending): xBRBinAlpha
   duckstation_truecolour:
     submenu: RENDERING
-    prompt: TRUE COLOUR RENDERING
+    prompt: TRUE COLOR RENDERING
     description: 24-bit, disables dithering.
     choices:
       Disabled (Default): "false"

--- a/package/batocera/emulators/model2emu/model2emu.emulator.yml
+++ b/package/batocera/emulators/model2emu/model2emu.emulator.yml
@@ -35,7 +35,7 @@ custom_features:
   model2_fakeGouraud:
     group: ADVANCED OPTIONS
     prompt: FAKE GOURAUD
-    description: Tries to guess Per-vertex colour (gouraud) from the Model2 per-poly information (flat).
+    description: Tries to guess Per-vertex color (gouraud) from the Model2 per-poly information (flat).
     choices:
       'Off': 0
       'On': 1

--- a/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
+++ b/package/batocera/emulators/pcsx2/pcsx2.emulator.yml
@@ -35,7 +35,7 @@ cores:
       pcsx2_osd_messages:
         submenu: DISPLAY
         prompt: OSD MESSAGES
-        description: Display on screen information like savestate, config warning etc...
+        description: Display on screen information like savestate, config warning, etc.
         choices:
           Enabled (Default): "true"
           Disabled: "false"
@@ -216,7 +216,7 @@ cores:
       pcsx2_dithering:
         submenu: RENDERING
         prompt: DITHERING
-        description: Reduces banding between colours and improves the preceived colour depth.
+        description: Reduces banding between colors and improves the preceived color depth.
         choices:
           "Off": 0
           Unscaled (Default): 1

--- a/package/batocera/emulators/pcsx2x6/pcsx2x6.emulator.yml
+++ b/package/batocera/emulators/pcsx2x6/pcsx2x6.emulator.yml
@@ -35,7 +35,7 @@ cores:
       pcsx2x6_osd_messages:
         submenu: DISPLAY
         prompt: OSD MESSAGES
-        description: Display on screen information like savestate, config warning etc...
+        description: Display on screen information like savestate, config warning, etc.
         choices:
           Enabled (Default): "true"
           Disabled: "false"
@@ -216,7 +216,7 @@ cores:
       pcsx2x6_dithering:
         submenu: RENDERING
         prompt: DITHERING
-        description: Reduces banding between colours and improves the preceived colour depth.
+        description: Reduces banding between colors and improves the preceived color depth.
         choices:
           "Off": 0
           Unscaled (Default): 1

--- a/package/batocera/emulators/retroarch/libretro/libretro-cap32/cap32.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-cap32/cap32.libretro.core.yml
@@ -22,8 +22,8 @@ custom_features:
       512KB: 512
       576+KB: 576
   cap32_colour:
-    prompt: COLOUR DEPTH
-    description: Choose the emulated colour depth.
+    prompt: COLOR DEPTH
+    description: Choose the emulated color depth.
     choices:
       16 bit: 16bit
       24 bit (Default): 24bit

--- a/package/batocera/emulators/retroarch/libretro/libretro-dice/dice.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-dice/dice.libretro.core.yml
@@ -2,7 +2,7 @@ custom_features:
   ttl_use_mouse_pointer_for_paddle_1:
     group: CONTROLS
     prompt: USE MOUSE POINTER FOR PADDLE 1
-    description: Use the system mouse pointer as paddle controller 1.  Does not let you choose a specific mouse if you have several.
+    description: Use the system mouse pointer as paddle controller 1. Does not let you choose a specific mouse if you have several.
     choices:
       'Off': disabled
       'On': enabled

--- a/package/batocera/emulators/retroarch/libretro/libretro-hatarib/hatarib.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-hatarib/hatarib.libretro.core.yml
@@ -48,7 +48,7 @@ custom_features:
     description: Choose your desired Atari Monitor.
     choices:
       Monochrome High-Resolution: "0"
-      RGB Colour Low/Medium-Resolution: "1"
+      RGB Color Low/Medium-Resolution: "1"
       VGA: "2"
       TV: "3"
   hatarib_ratio:

--- a/package/batocera/emulators/retroarch/libretro/libretro-melonds-ds/melondsds.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-melonds-ds/melondsds.libretro.core.yml
@@ -98,8 +98,8 @@ custom_features:
       Don't Override: default
   melondsds_colour:
     submenu: FIRMWARE SETTINGS
-    prompt: FAVOURITE COLOUR
-    description: The theme colour of the emulated console.
+    prompt: FAVORITE COLOR
+    description: The theme color of the emulated console.
     choices:
       Gray: 0
       Brown: 1

--- a/package/batocera/emulators/retroarch/libretro/libretro-ps2/pcsx2.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-ps2/pcsx2.libretro.core.yml
@@ -14,7 +14,7 @@ custom_features:
   lr_pcsx2_fast_cdvd:
     submenu: SYSTEM
     prompt: FAST CD/DVD ACCESS
-    description: A small  number of games will have compatibility problems with this enabled.
+    description: A small number of games will have compatibility problems with this enabled.
     choices:
       Disabled: disabled
       Enabled: enabled
@@ -83,7 +83,7 @@ custom_features:
   lr_pcsx2_dithering:
     submenu: GRAPHICS
     prompt: DITHERING
-    description: Reduces banding between colours and improves the preceived colour depth.
+    description: Reduces banding between colors and improves the preceived color depth.
     choices:
       'OFF': false
       Scaled: Scaled

--- a/package/batocera/emulators/retroarch/libretro/libretro-stella/stella.libretro.core.yml
+++ b/package/batocera/emulators/retroarch/libretro/libretro-stella/stella.libretro.core.yml
@@ -93,7 +93,7 @@ custom_features:
   stella_paddle_joypad_sensitivity:
     group: CONTROLS
     prompt: PADDLE JOYPAD SENSITIVITY
-    description: Joypad sensitivity for paddles. Core default  (3).
+    description: Joypad sensitivity for paddles. Core default (3).
     preset: sliderauto
     preset_parameters: 1 20 1
   stella_paddle_analog_sensitivity:

--- a/package/batocera/emulators/supermodel/supermodel.emulator.yml
+++ b/package/batocera/emulators/supermodel/supermodel.emulator.yml
@@ -88,8 +88,8 @@ custom_features:
       'On (57.524Hz)': 1
   crt_colour:
     group: GRAPHICS
-    prompt: CRT COLOUR EMULATION
-    description: CRT-like colour adaptation. Requires New 3D engine.
+    prompt: CRT COLOR EMULATION
+    description: CRT-like color adaptation. Requires New 3D engine.
     choices:
       None (Default): 0
       ARI/D93 (recommended for all JP developed games): 1

--- a/package/batocera/emulators/vpinball/vpinball.emulator.yml
+++ b/package/batocera/emulators/vpinball/vpinball.emulator.yml
@@ -70,7 +70,7 @@ custom_features:
   vpinball_altcolor:
     group: DISPLAY
     prompt: ALTCOLOR
-    description: Alternative Coloured Dot Matrix Display (needs additional file).
+    description: Alternative Colored Dot Matrix Display (needs additional file).
     preset: switchauto
   vpinball_playfield:
     group: WINDOWS POSITIONS

--- a/package/batocera/emulators/xroar/xroar.emulator.yml
+++ b/package/batocera/emulators/xroar/xroar.emulator.yml
@@ -57,7 +57,7 @@ custom_features:
     prompt: TV Input
     description: Select the video signal type.
     choices:
-      Composite (Colour): svideo
+      Composite (Color): svideo
       Composite (Mono): mono
       RGB: rgb
   xroar_kbd_translate:

--- a/package/batocera/ports/cannonball/cannonball.emulator.yml
+++ b/package/batocera/ports/cannonball/cannonball.emulator.yml
@@ -43,8 +43,8 @@ custom_features:
       'Manual (Separate Buttons)': 2
       'Automatic': 3
   car_colour:
-    prompt: FERRARI COLOUR
-    description: Customize the colour palette of your Ferrari.
+    prompt: FERRARI COLOR
+    description: Customize the color palette of your Ferrari.
     choices:
       'Red': 0
       'Blue': 1

--- a/package/batocera/ports/catacombgl/catacomb.keys
+++ b/package/batocera/ports/catacombgl/catacomb.keys
@@ -4,25 +4,25 @@
             "trigger": "up",
             "type": "key",
             "target": "KEY_W",
-            "description": "Move Forward, Can be use to press W"
+            "description": "Move forward, can be use to press W"
         },
         {
             "trigger": "down",
             "type": "key",
             "target": "KEY_S",
-            "description": "Move Backward"
+            "description": "Move backward"
         },
         {
             "trigger": "left",
             "type": "key",
             "target": "KEY_LEFT",
-            "description": "Turn Left"
+            "description": "Turn left"
         },
         {
             "trigger": "right",
             "type": "key",
             "target": "KEY_RIGHT",
-            "description": "Turn Right"
+            "description": "Turn right"
         },
         {
             "trigger": "start",
@@ -34,7 +34,7 @@
             "trigger": "select",
             "type": "key",
             "target": "KEY_ESC",
-            "description": "Open Menu"
+            "description": "Open menu"
         },
         {
             "trigger": "a",
@@ -58,31 +58,31 @@
             "trigger": "x",
             "type": "key",
             "target": "KEY_SPACE",
-            "description": "Use Potion"
+            "description": "Use potion"
         },
         {
             "trigger": "joystick1up",
             "type": "key",
             "target": "KEY_UP",
-            "description": "Move Forward"
+            "description": "Move forward"
         },
         {
             "trigger": "joystick1down",
             "type": "key",
             "target": "KEY_DOWN",
-            "description": "Move Backward"
+            "description": "Move backward"
         },
         {
             "trigger": "joystick1left",
             "type": "key",
             "target": "KEY_A",
-            "description": "Strafe Left"
+            "description": "Strafe left"
         },
         {
             "trigger": "joystick1right",
             "type": "key",
             "target": "KEY_D",
-            "description": "Strafe Right"
+            "description": "Strafe right"
         },
         {
             "trigger": "pageup",
@@ -100,13 +100,13 @@
             "trigger": "joystick2left",
             "type": "key",
             "target": "KEY_LEFT",
-            "description": "Turn Left"
+            "description": "Turn left"
         },
         {
             "trigger": "joystick2right",
             "type": "key",
             "target": "KEY_RIGHT",
-            "description": "Turn Right"
+            "description": "Turn right"
         },
         {
             "trigger": "joystick2up",

--- a/package/batocera/ports/etlegacy/etlegacy.emulator.yml
+++ b/package/batocera/ports/etlegacy/etlegacy.emulator.yml
@@ -22,8 +22,8 @@ custom_features:
       3 Posts (T-Shape): '2'
       Center Dot Only: '3'
   etlegacy_scope_color:
-    prompt: SCOPE RETICLE COLOUR
-    description: Custom colour for the sniper scope reticle and center dot.
+    prompt: SCOPE RETICLE COLOR
+    description: Custom color for the sniper scope reticle and center dot.
     choices:
       Default (Black): '#000000FF'
       Red: '#FF0000FF'

--- a/package/batocera/ports/openjk/openjk.emulator.yml
+++ b/package/batocera/ports/openjk/openjk.emulator.yml
@@ -15,8 +15,8 @@ shared_features:
 custom_features:
   openjk_colour:
     submenu: VIDEO
-    prompt: COLOUR DEPTH
-    description: Choose the emulated colour depth.
+    prompt: COLOR DEPTH
+    description: Choose the emulated color depth.
     choices:
       Default: None
       16-bit: 16

--- a/package/batocera/ports/openmohaa/openmohaa.emulator.yml
+++ b/package/batocera/ports/openmohaa/openmohaa.emulator.yml
@@ -15,8 +15,8 @@ shared_features:
 custom_features:
   mohaa_colour:
     submenu: VIDEO
-    prompt: COLOUR DEPTH
-    description: Choose the emulated colour depth.
+    prompt: COLOR DEPTH
+    description: Choose the emulated color depth.
     choices:
       Default: 0
       16-bit: 16
@@ -31,8 +31,8 @@ custom_features:
       High: 0
   mohaa_texture_colour:
     submenu: VIDEO
-    prompt: TEXTURE COLOUR DEPTH
-    description: Choose the texture colour depth.
+    prompt: TEXTURE COLOR DEPTH
+    description: Choose the texture color depth.
     choices:
       Default: 0
       16-bit: 16

--- a/package/batocera/ports/theforceengine/theforceengine.emulator.yml
+++ b/package/batocera/ports/theforceengine/theforceengine.emulator.yml
@@ -68,15 +68,15 @@ custom_features:
       GPU / OpenGL (Default): 1
   force_colour:
     submenu: GRAPHICS
-    prompt: COLOUR MODE
+    prompt: COLOR MODE
     choices:
       8-bit (Classic): 0
       8-bit Interpolated: 1
-      True Colour: 2
+      True Color: 2
   force_hd:
     submenu: GRAPHICS
     prompt: HD TEXTURES
-    description: Choose to render high definition graphics textures. Requires OpenGL, True Colour and the enhanced.gob file.
+    description: Choose to render high definition graphics textures. Requires OpenGL, True Color and the enhanced.gob file.
     choices:
       Disabled (Default): 0
       Enabled: 1


### PR DESCRIPTION
- `.mo` added to `.gitignore`
- "etc..." to "etc."
- Normalize to American spelling: EN GB keeps its favourite colour
- Remove double spacing in UI strings
- CPU capitalization (shared emulator)
- Catacomb capitalization In the locale files, there is both "Strafe left" (bstone.keys, mohaa.keys, openjkdf2.keys, quake2.keys, rott.keys) and "Strafe Left", Catacomb being the only menu Capitalizing All Words. So Catacomb gets decapitilized for ease of localization, with two lines untouched in `.po` files to avoid duplicate strings errors.

Merging is even less fun when vscodium decides that its merge tool should stop loading anything.