### PR TITLE
bluetooth: auto pairing: don't try to connect to already paired controllers

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth-agent
+++ b/package/batocera/core/batocera-scripts/scripts/bluetooth/batocera-bluetooth-agent
@@ -479,7 +479,7 @@ def user_signal_start_discovery(userdata = None):
   start_discovery()
 
   filter = getBluetoothWantedAddr()
-  if filter is not None:
+  if filter is not None and filter != "input":
     for path in list(gdevices):
       connect_device(path, gdevices[path], False, filter)
 


### PR DESCRIPTION
If controllers are already paired and poweroff, the automatic pairing is currently trying to reconnect each controller, and timeout before trying to detect new controllers

This fix a regression introduce in my patch 
https://github.com/batocera-linux/batocera.linux/pull/16199

