### PR TITLE
faster-game-launch[wip][don't merge-example]

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/emulatorlauncher.py
@@ -51,6 +51,8 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+GAME_LAUNCH_WAIT_FILE = Path("/tmp/es-gamelaunch.wait")
+
 # A lock to safely modify the active controller list from multiple threads
 _player_controllers_lock = threading.Lock()
 # A global variable to hold the current, up-to-date list of player controllers
@@ -717,6 +719,31 @@ def runCommand(command: Command) -> int:
 
     if not command.array:
         raise BadCommandLineArguments
+
+    if GAME_LAUNCH_WAIT_FILE.exists():
+        try:
+            subprocess.run(
+                [
+                    "inotifywait",
+                    "-q",
+                    "-t", "5",
+                    "-e", "delete_self",
+                    "-e", "move_self",
+                    str(GAME_LAUNCH_WAIT_FILE),
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=6,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+        if GAME_LAUNCH_WAIT_FILE.exists():
+            _logger.warning(
+                "EmulationStation launch transition wait did not complete normally. "
+                "Continuing game launch."
+            )
 
     proc = subprocess.Popen(["nice", "-n", "-4", *command.array], env=command.env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     exitcode = 0


### PR DESCRIPTION
This change, or something similar, is required for the faster-game-launch ES PR.

ES now starts emulatorlauncher.py as soon as the game launch begins, instead of waiting for the launch animation to finish. ES then creates a wait file, which is removed once the animation completes. emulatorlauncher.py waits for that file to be removed before starting the emulator.

This lets emulatorlauncher load options, generate configs, and do other setup work while the launch animation is playing. The result is a faster overall game launch because most of the animation time is no longer added on top of the launcher setup time.

See the ES PR for more details:
https://github.com/batocera-linux/batocera-emulationstation/pull/2193