### PR TITLE
bump solarus to v2.1.3

### DIFF
--- a/package/batocera/emulators/solarus-engine/Config.in
+++ b/package/batocera/emulators/solarus-engine/Config.in
@@ -7,7 +7,7 @@ config BR2_PACKAGE_SOLARUS_ENGINE
 	depends on BR2_TOOLCHAIN_HAS_THREADS_NPTL # openal
 	depends on !BR2_STATIC_LIBS # SDL2
 	depends on BR2_PACKAGE_HAS_LIBGL || BR2_PACKAGE_HAS_LIBGLES
-	
+
 	select BR2_PACKAGE_GLM
 	select BR2_PACKAGE_LIBMODPLUG
 	select BR2_PACKAGE_LIBOGG
@@ -24,7 +24,7 @@ config BR2_PACKAGE_SOLARUS_ENGINE
 	  in C++. It can run games scripted in Lua. This engine is used
 	  by our Zelda fangames. Solarus is licensed under GPL v3.
 
-	  http://www.solarus-games.org
+	  https://www.solarus-games.org
 	  https://github.com/solarus-games/solarus
 
 comment "solarus needs OpenGL and a toolchain w/ C++, gcc >= 4.9, NPTL, dynamic library, and luajit or lua 5.1"

--- a/package/batocera/emulators/solarus-engine/solarus-engine.mk
+++ b/package/batocera/emulators/solarus-engine/solarus-engine.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-SOLARUS_ENGINE_VERSION = v2.0.4
+SOLARUS_ENGINE_VERSION = v2.1.3
 SOLARUS_ENGINE_SITE = https://gitlab.com/solarus-games/solarus
 SOLARUS_ENGINE_SITE_METHOD=git
 SOLARUS_ENGINE_EMULATOR_INFO = solarus.emulator.yml


### PR DESCRIPTION
Link to release/tag: https://gitlab.com/solarus-games/solarus/-/releases/v2.1.3