### PR TITLE
rpcs3: generator: remove old gun config when gun is not present

### DIFF
--- a/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
+++ b/package/batocera/core/batocera-configgen/configgen/configgen/generators/rpcs3/rpcs3Generator.py
@@ -690,6 +690,10 @@ class Rpcs3Generator(Generator):
             rpcs3ymlconfig["Input/Output"]["Camera"] = "Fake"
             rpcs3ymlconfig["Input/Output"]["Camera type"] = "PS Eye"
             self._generateGunConfig()
+        elif rpcs3ymlconfig["Input/Output"].get("Move") == "Gun":
+            rpcs3ymlconfig["Input/Output"]["Move"] = "Null"
+            rpcs3ymlconfig["Input/Output"]["Camera"] = "Null"
+            rpcs3ymlconfig["Input/Output"]["Camera type"] = "Unknown"
         # Gun crosshairs
         rpcs3ymlconfig["Input/Output"]["Show move cursor"] = system.config.get_bool("rpcs3_crosshairs")
 


### PR DESCRIPTION
some games are crashing if gun is defined from previous run, and the gun is not present anymore

```
RPCS3: PPU[0x1000011] Thread (MoveKitUpdateThread) [HLE:0x01e91b9c, LR:0x00b9ffcc]: SIG: Thread terminated due to fatal error: Range check failed (index: 0, container_size: 0)
(in file /x86_64/build/rpcs3-v0.0.41/rpcs3/Emu/Io/evdev_gun_handler.cpp:114[:34], in function 'int evdev_gun_handler::get_axis_x(u32) const') (PPU: cellGemGetImageState)
tcache_thread_shutdown(): unaligned tcache chunk detected
```