### PR TITLE
batocera-battery-checker: fix false unplugged on boards with no power_supply

### DIFF
--- a/package/batocera/utils/batocera-battery-checker/batocera-battery-checker
+++ b/package/batocera/utils/batocera-battery-checker/batocera-battery-checker
@@ -17,7 +17,13 @@ getBattery() {
 
 # Function to check if the ayn power supply is connected
 is_power_connected() {
-    PLUGGED=$(cat /sys/class/power_supply/*/online 2>/dev/null | grep -E "^1")
+    if compgen -G "/sys/class/power_supply/*/online" > /dev/null; then
+        PLUGGED=$(cat /sys/class/power_supply/*/online 2>/dev/null | grep -E "^1")
+    else
+        # No power_supply devices at all (e.g. desktop SBCs) - treat as
+        # AC-connected instead of falsely reporting "on battery".
+        PLUGGED="1"
+    fi
     if [ -n "${PLUGGED}" ]; then
         echo 1  # Power supply is connected
     else


### PR DESCRIPTION
`is_power_connected()` treats zero `/sys/class/power_supply/*/online` matches as "not connected". On boards with no power_supply devices at all (e.g. desktop-style SBCs with no battery/AC node), this always reports "on battery", which triggers `batocera-power-mode battery` at boot and overrides the CPU governor `S18governor` just set.

Fix: treat "no power_supply devices found" as always connected. Boards with real power_supply devices are unaffected.
