### PR TITLE
batocera-splash: fix rotation from wrong connector

### DIFF
--- a/package/batocera/core/batocera-splash/scripts/Ssystem-splash
+++ b/package/batocera/core/batocera-splash/scripts/Ssystem-splash
@@ -47,7 +47,18 @@ do_start () {
     if [ -z "${video_rotation}" ]; then
         MODEL_CONF="/usr/share/batocera/sysconfigs/batocera.conf.${V_BOARD_MODEL}"
         if [ -f "${MODEL_CONF}" ]; then
-            video_rotation=$(awk -F'=' '/^display\.rotate\.[^=-]+=/{print $2; exit}' "${MODEL_CONF}" | tr -d '[:space:]')
+            # Match the active connector's own rotate key, not the first one.
+            effectiveDrmOutput=$(for GPU in /dev/dri/card*; do batocera-drminfo "${GPU}" "current" 2>/dev/null; done | grep -oP '^[0-9]+\.[0-9]+:\K[^ ]+' | head -1)
+            rotation_line=""
+            if [ -n "${effectiveDrmOutput}" ]; then
+                rotation_line=$(grep -E "^display\.rotate\.${effectiveDrmOutput}=" "${MODEL_CONF}" | head -1)
+            fi
+            if [ -z "${rotation_line}" ]; then
+                rotation_line=$(grep -E '^display\.rotate=' "${MODEL_CONF}" | head -1)
+            fi
+            if [ -n "${rotation_line}" ]; then
+                video_rotation=$(echo "${rotation_line}" | cut -d'=' -f2)
+            fi
         fi
     fi
 

--- a/package/batocera/core/batocera-splash/scripts/Ssystem-splash
+++ b/package/batocera/core/batocera-splash/scripts/Ssystem-splash
@@ -9,7 +9,7 @@ do_start () {
     LOG_DIR="${LOG_FILE%/*}"
     [ -d "${LOG_DIR}" ] || mkdir -p "${LOG_DIR}"
     exec >> "${LOG_FILE}" 2>&1
-    
+
     if [ ! -e /dev/fb0 ]; then
         i=0
         while [ ! -e /dev/fb0 ] && [ $i -lt 50 ]; do
@@ -21,50 +21,47 @@ do_start () {
             exit 1
         fi
     fi
-    
+
     # Default image
     image="/usr/share/batocera/splash/boot-logo.png"
     # Standard FBV options
-    FBV_OPTS="-f -e -i -y"   
+    FBV_OPTS="-f -e -i -y"
     # Variables for screen dimensions
     WIDTH=""
     HEIGHT=""
 
-    # Resolve video rotation first so we know how to crop the image
+    # Detect active DRM connector type (batocera-drminfo returns "EDP", "DSI", "HDMIA", etc.)
+    effectiveDrmOutput=$(for GPU in /dev/dri/card*; do batocera-drminfo "${GPU}" "current" 2>/dev/null | grep -oP '^[0-9]+\.[0-9]+:\K[^ ]+'; done | head -1)
+
     V_BOARD_MODEL=$(batocera-model)
     video_rotation=""
     BOOT_CONF="/boot/batocera-boot.conf"
+    MODEL_CONF="/usr/share/batocera/sysconfigs/batocera.conf.${V_BOARD_MODEL}"
 
-    if [ -f "${BOOT_CONF}" ]; then
-        specific_key=$(awk -F'=' '/^[[:space:]]*display\.rotate\./{print $1; exit}' "${BOOT_CONF}" | tr -d '[:space:]')
-        if [ -n "${specific_key}" ]; then
-            video_rotation=$(/usr/bin/batocera-settings-get -f "${BOOT_CONF}" "${specific_key}")
+    # Check connector-specific settings
+    if [ -n "${effectiveDrmOutput}" ]; then
+        if [ -f "${BOOT_CONF}" ]; then
+            video_rotation=$(/usr/bin/batocera-settings-get -f "${BOOT_CONF}" "display.rotate.${effectiveDrmOutput}")
         fi
-        [ -z "${video_rotation}" ] && \
-            video_rotation=$(/usr/bin/batocera-settings-get -f "${BOOT_CONF}" "display.rotate")
+        if [ -z "${video_rotation}" ] && [ -f "${MODEL_CONF}" ]; then
+            video_rotation=$(grep -iE "^display\.rotate\.${effectiveDrmOutput}=" "${MODEL_CONF}" | head -1 | cut -d'=' -f2)
+        fi
     fi
 
+    # Fall back to generic global settings
     if [ -z "${video_rotation}" ]; then
-        MODEL_CONF="/usr/share/batocera/sysconfigs/batocera.conf.${V_BOARD_MODEL}"
-        if [ -f "${MODEL_CONF}" ]; then
-            # Match the active connector's own rotate key, not the first one.
-            effectiveDrmOutput=$(for GPU in /dev/dri/card*; do batocera-drminfo "${GPU}" "current" 2>/dev/null; done | grep -oP '^[0-9]+\.[0-9]+:\K[^ ]+' | head -1)
-            rotation_line=""
-            if [ -n "${effectiveDrmOutput}" ]; then
-                rotation_line=$(grep -E "^display\.rotate\.${effectiveDrmOutput}=" "${MODEL_CONF}" | head -1)
-            fi
-            if [ -z "${rotation_line}" ]; then
-                rotation_line=$(grep -E '^display\.rotate=' "${MODEL_CONF}" | head -1)
-            fi
-            if [ -n "${rotation_line}" ]; then
-                video_rotation=$(echo "${rotation_line}" | cut -d'=' -f2)
-            fi
+        if [ -f "${BOOT_CONF}" ]; then
+            video_rotation=$(/usr/bin/batocera-settings-get -f "${BOOT_CONF}" "display.rotate")
+        fi
+        if [ -z "${video_rotation}" ] && [ -f "${MODEL_CONF}" ]; then
+            video_rotation=$(grep -iE '^display\.rotate=' "${MODEL_CONF}" | head -1 | cut -d'=' -f2)
         fi
     fi
 
     video_rotation=$(echo "${video_rotation}" | tr -d '[:space:]')
+    echo "Active DRM Output: [${effectiveDrmOutput}]"
     echo "Final Rotation Value: [${video_rotation}]"
-    
+
     # Get the screen's physical dimensions
     if [ -r /sys/class/graphics/fb0/modes ]; then
         if read -r MODE_STR < /sys/class/graphics/fb0/modes; then
@@ -76,7 +73,7 @@ do_start () {
 
         if [ -n "${WIDTH}" ] && [ -n "${HEIGHT}" ]; then
             echo "Resolution detected via modes: ${WIDTH}x${HEIGHT}"
-            
+
             # Determine target size for cropping.
             # If rotated 90 or 270 degrees (1 or 3), swap width and height.
             if [ "${video_rotation}" = "1" ] || [ "${video_rotation}" = "3" ]; then


### PR DESCRIPTION
Ssystem-splash's fallback (used when `batocera-boot.conf` has no `display.rotate` entry yet) grabbed whichever `display.rotate.<connector>` line came first in the sysconfig file, regardless of which connector was active. Boards defining more than one such line (e.g. a secondary panel that needs rotating while the primary doesn't) get whatever the file ordering happens to be - on the ODROID-M1, an HDMI-only boot picked up the DSI panel's rotation and rendered the boot logo sideways.

Fix: detect the active connector (same `batocera-drminfo` approach `S65values4boot` already uses) and match its own `display.rotate.<connector>` key, falling back to a bare `display.rotate=` default, then to the old first-match behavior only if the connector can't be detected yet.

Verified on hardware (HDMI-only, secondary panel disabled): with the fix, rotation resolves to none and the logo renders upright; reverting just the connector-detection block back to the old first-match logic reproduces the sideways logo.
