### PR TITLE
batocera-upgrade: fix wget exit code check

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-upgrade
@@ -213,7 +213,8 @@ do_version_update() {
 # Upgrade Check, get updated url from ES call
 do_upgradecheck_0() {
     local update_url="${1}"
-    local available=$(wget -qO- ${update_url})
+    local available
+    available=$(wget -qO- ${update_url})
     if [ "$?" != "0" ]; then
         echo "Unable to access the url" >&2
         return 2


### PR DESCRIPTION
`local available=$(wget ...)` masks wget's exit code with `local`'s own (always 0), so a failed request is never caught. `available` stays empty and always compares unequal to the current version, so an unreachable update URL falsely reports "update available" with a blank version in the ES dialog.

Fix: split the declaration and assignment so `$?` reflects wget's actual exit code.
