### PR TITLE
batocera-resolution.drm: setOutput must resolve bare connector names, not just "N - NAME"

### DIFF
--- a/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.drm
+++ b/package/batocera/core/batocera-resolution/scripts/resolution/batocera-resolution.drm
@@ -172,7 +172,21 @@ case "${ACTION}" in
 	MODE=$1
 	if test "${MODE}" != ""
 	   then
-	       echo "${MODE}" | sed -e s+"^\([0-9]*\) .*"+"\1"+ > /var/run/drmConn
+	       if echo "${MODE}" | grep -qE '^[0-9]'
+	       then
+		   # numeric, or "N - NAME" format as returned by listOutputs
+		   echo "${MODE}" | sed -e s+"^\([0-9]*\).*"+"\1"+ > /var/run/drmConn
+	       else
+		   NORM_MODE=$(echo "${MODE}" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+		   CONNECTORS=$(for GPU in /dev/dri/card*; do batocera-drminfo "${GPU}" 2>/dev/null; done | sed -e s+"^\([0-9]*\)\.[0-9]*:\([^ ]*\) .*$"+"\1 \2"+ | sort -u)
+		   MATCHED_CONN=$(echo "${CONNECTORS}" | while read -r CONN NAME; do
+		       NORM_NAME=$(echo "${NAME}" | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')
+		       case "${NORM_MODE}" in "${NORM_NAME}"*) echo "${CONN}"; break ;; esac
+		   done)
+		   if [ -n "${MATCHED_CONN}" ]; then
+		       echo "${MATCHED_CONN}" > /var/run/drmConn
+		   fi
+	       fi
 	       echo 0 > /var/run/drmMode # reset the drmMode
 	fi
 	f_checkVals


### PR DESCRIPTION
On a board with more than one display, setting `global.videooutput` to anything other than whichever connector the kernel happens to enumerate first has no effect - the image stays on that first connector regardless of what's selected.

Cause: emulationstation-standalone passes the raw value ("HDMI-A-1", "DSI-1") to `batocera-resolution setOutput`, but setOutput only parsed the "N - NAME" format listOutputs itself emits ("1 - DSI"). A bare name doesn't match that pattern, so `/var/run/drmConn` ends up invalid and `f_checkVals` falls back to connector 0.

Fix resolves a bare name by normalized (alnum-only, lowercased) prefix match against listOutputs' NAME field, since that field ("HDMIA"/"DSI") isn't the same string as the sysfs-style name ("HDMI-A-1"/"DSI-1") batocera.conf stores.

Verified live on a two-connector board (HDMI + DSI): `setOutput DSI-1` set `drmConn=0` (wrong, fell back to HDMI) before the fix and `drmConn=1` (correct) after. `setOutput HDMI-A-1` unaffected either way.

Not the root-cause fix: `batocera-drminfo` doesn't track sysfs-style connector names (type + numeric id) at all, so `listOutputs`/`currentOutput` have no way to emit them either. Fixing that means changing `batocera-drminfo` itself, which has more callers to verify - a bigger change than this workaround.