### PR TITLE
Add more depth to the batocera-steam find step

### DIFF
--- a/package/batocera/utils/batocera-steam/batocera-steam
+++ b/package/batocera/utils/batocera-steam/batocera-steam
@@ -11,7 +11,7 @@ chown -R root:audio /var/run/pulse
 chmod -R g+rwX /var/run/pulse
 
 # remove steam root restriction
-file_path=$(find /userdata/saves/flatpak/binaries -name "bin_steam.sh" 2>/dev/null)
+file_path=$(find /userdata/saves/flatpak/binaries/app -name "bin_steam.sh" 2>/dev/null)
 if [ -n "$file_path" ]; then
     echo "File bin_steam.sh found at: $file_path" > $log
     # Check if the line "# Don't allow running as root" exists in the file


### PR DESCRIPTION
This find command takes like 20-ish seconds on my old HDD the first time it runs. Adding the app directory to the path makes the search almost instant, so it greatly reduces the Steam start time.