### PR TITLE
configs: rk3588: use relative tty names for util-linux agetty

### DIFF
--- a/configs/batocera-rk3588-mainline.board
+++ b/configs/batocera-rk3588-mainline.board
@@ -6,7 +6,7 @@ BR2_cortex_a76_a55=y
 BR2_ARM_FPU_NEON_FP_ARMV8=y
 BR2_PACKAGE_BATOCERA_TARGET_RK3588_MAINLINE=y
 BR2_TARGET_OPTIMIZATION="-pipe -fsigned-char -mtune=cortex-a76"
-BR2_TARGET_GENERIC_GETTY_PORT="/dev/ttyS2"
+BR2_TARGET_GENERIC_GETTY_PORT="ttyS2"
 BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588-mainline/patches"
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588-mainline/fsoverlay"

--- a/configs/batocera-rk3588-sdio.board
+++ b/configs/batocera-rk3588-sdio.board
@@ -10,7 +10,7 @@ BR2_ARM_FPU_NEON_FP_ARMV8=y
 BR2_PACKAGE_BATOCERA_TARGET_RK3588_SDIO=y
 # As of rockchip-linux-5.10-rkr3.6, the vendored kernel does not like -fsigned-char, do NOT add it to BR2_TARGET_OPTIMIZATION=
 BR2_TARGET_OPTIMIZATION="-pipe -fsigned-char -mtune=cortex-a76"
-BR2_TARGET_GENERIC_GETTY_PORT="/dev/ttyFIQ0"
+BR2_TARGET_GENERIC_GETTY_PORT="ttyFIQ0"
 BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588/patches"
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588/fsoverlay"

--- a/configs/batocera-rk3588.board
+++ b/configs/batocera-rk3588.board
@@ -7,7 +7,7 @@ BR2_ARM_FPU_NEON_FP_ARMV8=y
 BR2_PACKAGE_BATOCERA_TARGET_RK3588=y
 # As of rockchip-linux-5.10-rkr3.6, the vendored kernel does not like -fsigned-char, do NOT add it to BR2_TARGET_OPTIMIZATION=
 BR2_TARGET_OPTIMIZATION="-pipe -fsigned-char -mtune=cortex-a76"
-BR2_TARGET_GENERIC_GETTY_PORT="/dev/ttyFIQ0"
+BR2_TARGET_GENERIC_GETTY_PORT="ttyFIQ0"
 BR2_TARGET_GENERIC_GETTY_BAUDRATE_115200=y
 BR2_GLOBAL_PATCH_DIR="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/patches $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588/patches"
 BR2_ROOTFS_OVERLAY="$(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/fsoverlay $(BR2_EXTERNAL_BATOCERA_PATH)/board/batocera/rockchip/rk3588/fsoverlay"


### PR DESCRIPTION
Batocera uses agetty from util-linux 2.41.4 as /sbin/getty. Its term-utils/agetty.c builds the device path with snprintf(..., "/dev/%s", tty), so BR2_TARGET_GENERIC_GETTY_PORT must contain a tty name relative to /dev.

Passing /dev/ttyFIQ0 or /dev/ttyS2 causes agetty to try opening /dev//dev/ttyFIQ0 or /dev//dev/ttyS2, making init report "respawning too fast" and disabling the serial login service.

This behavior is inherited from util-linux and is already present in v2.25; it was not introduced by the current v2.41.4 update.