### PR TITLE
refactor(batocera-launch): modernize config and emulators

### DIFF
--- a/python-src/batocera-launch/batocera_launch/__init__.py
+++ b/python-src/batocera-launch/batocera_launch/__init__.py
@@ -8,6 +8,7 @@ from .config.config import (
     UIMode as UIMode,
 )
 from .config.decoration_id import get_decoration_id as get_decoration_id
+from .config.libretro import LibretroConfig as LibretroConfig
 from .devices.controller import (
     Controller as Controller,
     ControllerList as ControllerList,

--- a/python-src/batocera-launch/batocera_launch/config/config.py
+++ b/python-src/batocera-launch/batocera_launch/config/config.py
@@ -172,8 +172,7 @@ class SystemConfig(Config):
     @classmethod
     def load(cls, args: Arguments, /) -> Self:
         # load configuration from batocera.conf
-        user_config = KeyValueConfig()
-        user_config.read(BATOCERA_CONF)
+        user_config = KeyValueConfig(BATOCERA_CONF)
 
         rom = args.rom
 

--- a/python-src/batocera-launch/batocera_launch/config/libretro.py
+++ b/python-src/batocera-launch/batocera_launch/config/libretro.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import InitVar, dataclass, field
+from typing import TYPE_CHECKING
+
+from batocera_common.key_value_config import KeyValueConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .config import Config
+
+
+@dataclass(slots=True)
+class LibretroConfig:
+    path: InitVar[Path]
+    config: Config
+
+    key_value_config: KeyValueConfig = field(init=False)
+
+    def __post_init__(self, path: Path) -> None:
+        self.key_value_config = KeyValueConfig(path, separator=' ')
+
+    def write(self) -> None:
+        self.key_value_config.write()
+
+    def set(self, name: str, value: object, /) -> None:
+        if value is None:
+            value = ''
+        elif isinstance(value, bool):
+            value = 'true' if value else 'false'
+
+        # RetroArch strips quotes for all values (0 is the same as "0") and determines value
+        # type by the internal definition, not whether it is quoted or not. Quoting all
+        # values ensures that RetroArch will always parse our generated files correctly
+        # regardless of the kind of object we pass in.
+        self.key_value_config[name] = f'"{value}"'
+
+    def set_from_config(self, name: str, config_name: str | None = None, /, *, default: object = None) -> None:
+        self.set(name, self.config.get(config_name or name, default))
+
+    def set_bool_from_config(
+        self,
+        name: str,
+        config_name: str | None = None,
+        /,
+        *,
+        default: bool = False,
+        values: tuple[object, object] | None = None,
+    ) -> None:
+        self.set(name, self.config.get_bool(config_name or name, default, return_values=values))
+
+    def set_int_from_config(self, name: str, config_name: str | None = None, /, *, default: int | None = None) -> None:
+        self.set(name, self.config.get_int(config_name or name, default))
+
+    def set_float_from_config(
+        self, name: str, config_name: str | None = None, /, *, default: float | None = None
+    ) -> None:
+        self.set(name, self.config.get_float(config_name or name, default))
+
+    def remove_section(self, section: str, /) -> None:
+        self.key_value_config.remove_section(section)
+
+    def remove_all_starting_with(self, prefix: str, /) -> None:
+        self.key_value_config.remove_all_starting_with(prefix)

--- a/python-src/batocera-launch/batocera_launch/devices/controller.py
+++ b/python-src/batocera-launch/batocera_launch/devices/controller.py
@@ -267,15 +267,16 @@ def generate_sdl_game_controller_config(
 
 def write_sdl_controller_db(
     controllers: Controllers,
-    outputFile: str | Path = '/tmp/gamecontrollerdb.txt',
+    output_file: str | Path = '/tmp/gamecontrollerdb.txt',
     /,
 ) -> Path:
-    outputFile = Path(outputFile)
+    output_file = Path(output_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
 
-    with outputFile.open('w') as text_file:
+    with output_file.open('w') as text_file:
         text_file.write(generate_sdl_game_controller_config(controllers))
 
-    return outputFile
+    return output_file
 
 
 type Controllers = Sequence[Controller]

--- a/python-src/batocera-launch/batocera_launch/emulator.py
+++ b/python-src/batocera-launch/batocera_launch/emulator.py
@@ -66,8 +66,7 @@ _logger: Final = logging.getLogger(__name__)
 @cached_dataclass
 class Emulator(AbstractAsyncContextManager['Emulator', bool | None], ABC):
     needs_sdl_game_controller_config: ClassVar[bool] = False
-    needs_sdl_controller_db: ClassVar[bool] = False
-    sdl_controller_db_path: ClassVar[Path] = Path('/tmp/gamecontrollerdb.txt')
+    needs_sdl_controller_db: ClassVar[bool] = False  # Override sdl_controller_db_path to write to a different path
     sdl_game_controller_config_ignore_buttons: ClassVar[Container[str] | None] = None
 
     config: SystemConfig
@@ -169,6 +168,10 @@ class Emulator(AbstractAsyncContextManager['Emulator', bool | None], ABC):
     @property
     def es_settings(self) -> ESSettings:
         return self.config.es_settings
+
+    @cached_property
+    def sdl_controller_db_path(self) -> Path:
+        return Path('/tmp/gamecontrollerdb.txt')
 
     @cached_property
     @abstractmethod
@@ -688,6 +691,7 @@ class Emulator(AbstractAsyncContextManager['Emulator', bool | None], ABC):
         )
 
     def write_sdl_controller_db(self) -> None:
+        self.sdl_controller_db_path.parent.mkdir(parents=True, exist_ok=True)
         self.sdl_controller_db_path.write_text(self.get_sdl_game_controller_config())
 
     async def run(self) -> int:

--- a/python-src/batocera-launch/batocera_launch/emulators/amiberry.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/amiberry.py
@@ -1,29 +1,30 @@
 from __future__ import annotations
 
-import io
 import logging
 import zipfile
-from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import Final
 
-from batocera_common.configparser import CaseSensitiveConfigParser
 from batocera_common.dataclasses import cached_dataclass, cached_property
+from batocera_common.key_value_config import KeyValueConfig
 from batocera_common.paths import BIOS, CONFIGS, LOGS, SAVES, SCREENSHOTS
-from batocera_launch import BatoceraException, Command, Emulator, HotkeysContext
-from batocera_launch.devices.controller import write_sdl_controller_db
-
-if TYPE_CHECKING:
-    from batocera_launch import Controller, Controllers, Input, SystemConfig
+from batocera_launch import (
+    BatoceraException,
+    Command,
+    Controller,
+    Emulator,
+    HotkeysContext,
+    Input,
+    LibretroConfig,
+)
 
 _logger = logging.getLogger(__name__)
 
 _AMIBERRY_BIN: Final = Path('/usr/bin/amiberry')
 _AMIBERRY_DATA: Final = Path('/usr/share/amiberry/data')
+
 # saves/bios are shared across all amiga500/amiga1200/amigacd32/amigacdtv systems,
 # deliberately not per-system (self.saves_dir / self.bios_dir)
-_SAVES_DIR: Final = SAVES / 'amiga'
-_BIOS_DIR: Final = BIOS / 'amiga'
 _LOG_FILE: Final = LOGS / 'amiberry.log'
 
 # default cpu model for each system
@@ -42,52 +43,13 @@ _ACCELERATORS: Final[dict[str, tuple[str, int, int]]] = {
 }
 
 
-@dataclass(slots=True)
-class _UnixSettings:
-    """Minimal port of the old configgen ``UnixSettings``: a flat, unsectioned
-    ``key = value`` settings file that preserves entries it doesn't manage
-    (amiberry.conf/overlay.cfg both carry state that isn't fully owned by us)."""
-
-    settings_path: InitVar[Path]
-    separator: str = field(default='', kw_only=True)
-    path: Path = field(init=False)
-    _config: CaseSensitiveConfigParser = field(init=False)
-
-    def __post_init__(self, settings_path: Path) -> None:
-        self.path = settings_path
-        self._config = CaseSensitiveConfigParser(interpolation=None, strict=False)
-        try:
-            file = io.StringIO()
-            file.write('[DEFAULT]\n')
-            with self.path.open(encoding='latin1') as f:
-                file.write(f.read())
-            file.seek(0)
-            self._config.read_file(file)
-        except OSError as e:
-            _logger.debug('%s not read: %s', self.path, e)
-
-    def save(self, name: str, value: object) -> None:
-        self._config.set('DEFAULT', name, str(value))
-
-    def disable_all(self, name: str) -> None:
-        for key, _ in list(self._config.items('DEFAULT')):
-            if key[: len(name)] == name:
-                self._config.remove_option('DEFAULT', key)
-
-    def write(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open('w') as fp:
-            for key, value in self._config.items('DEFAULT'):
-                fp.write(f'{key}{self.separator}={self.separator}{value}\n')
-
-
 # --- Retroarch-style controller config, ported from configgen's libretroControllers.py -----
 # Amiberry reads a retroarch-formatted overlay.cfg for its own controller mapping, hence the
 # reuse of the same key names/format used for libretro cores. This is amiberry-specific here
 # (not shared with the still-unmigrated retroarch generator); amiberry always calls this with
 # lightgun support enabled, so (unlike the old generic helper) that's not a parameter here.
 
-_RETROARCH_DIRS: Final = {'up': 'up', 'down': 'down', 'left': 'left', 'right': 'right'}
+_RETROARCH_DIRS: Final = ('up', 'down', 'left', 'right')
 _RETROARCH_JOYSTICKS: Final = {
     'joystick1up': 'l_y',
     'joystick1left': 'l_x',
@@ -135,123 +97,6 @@ def _get_analog_mode(controller: Controller, /) -> str:
         if dirkey in controller.inputs and controller.inputs[dirkey].type in ('button', 'hat'):
             return '1'
     return '0'
-
-
-def _generate_controller_config(controller: Controller, config: SystemConfig, /) -> dict[str, object]:
-    # Map an emulationstation button name to the corresponding retroarch name
-    retroarch_btns = {
-        'a': 'a',
-        'b': 'b',
-        'x': 'x',
-        'y': 'y',
-        'pageup': 'l',
-        'pagedown': 'r',
-        'l2': 'l2',
-        'r2': 'r2',
-        'l3': 'l3',
-        'r3': 'r3',
-        'start': 'start',
-        'select': 'select',
-    }
-    # X Y L1 L2  ---> X Y R1 L1
-    # A B R1 R2  ---> A B R2 L2
-    if config.get('altlayout') == 'fightstick':
-        retroarch_btns['pageup'] = 'l2'
-        retroarch_btns['pagedown'] = 'l'
-        retroarch_btns['l2'] = 'r2'
-        retroarch_btns['r2'] = 'r'
-
-    retroarch_gun_btns = {
-        'a': 'aux_a',
-        'b': 'aux_b',
-        'y': 'aux_c',
-        'pageup': 'offscreen_shot',
-        'pagedown': 'trigger',
-        'start': 'start',
-        'select': 'select',
-    }
-
-    result: dict[str, object] = {}
-    for btnkey, btnvalue in retroarch_btns.items():
-        if btnkey in controller.inputs:
-            input = controller.inputs[btnkey]
-            result[f'input_player{controller.player_number}_{btnvalue}_{_TYPE_TO_NAME[input.type]}'] = (
-                _get_config_value(input)
-            )
-    for btnkey, btnvalue in retroarch_gun_btns.items():
-        if btnkey in controller.inputs:
-            input = controller.inputs[btnkey]
-            result[f'input_player{controller.player_number}_gun_{btnvalue}_{_TYPE_TO_NAME[input.type]}'] = (
-                _get_config_value(input)
-            )
-    for dirkey, dirvalue in _RETROARCH_DIRS.items():
-        if dirkey in controller.inputs:
-            input = controller.inputs[dirkey]
-            result[f'input_player{controller.player_number}_{dirvalue}_{_TYPE_TO_NAME[input.type]}'] = (
-                _get_config_value(input)
-            )
-            result[f'input_player{controller.player_number}_gun_dpad_{dirvalue}_{_TYPE_TO_NAME[input.type]}'] = (
-                _get_config_value(input)
-            )
-    for jskey, jsvalue in _RETROARCH_JOYSTICKS.items():
-        if jskey in controller.inputs:
-            input = controller.inputs[jskey]
-            if input.value == '-1':
-                result[f'input_player{controller.player_number}_{jsvalue}_minus_axis'] = f'-{input.id}'
-                result[f'input_player{controller.player_number}_{jsvalue}_plus_axis'] = f'+{input.id}'
-            else:
-                result[f'input_player{controller.player_number}_{jsvalue}_minus_axis'] = f'+{input.id}'
-                result[f'input_player{controller.player_number}_{jsvalue}_plus_axis'] = f'-{input.id}'
-    # note: the old generic helper skips writing mouse_index when lightgun support is
-    # requested; amiberry always requests it, so mouse_index is never written here either.
-    return result
-
-
-def _write_controller_config(retroconfig: _UnixSettings, controller: Controller, config: SystemConfig, /) -> None:
-    for key, value in _generate_controller_config(controller, config).items():
-        retroconfig.save(key, value)
-    retroconfig.save(f'input_player{controller.player_number}_joypad_index', controller.index)
-    retroconfig.save(f'input_player{controller.player_number}_analog_dpad_mode', _get_analog_mode(controller))
-
-
-def _write_hotkey_config(retroconfig: _UnixSettings, controllers: Controllers, /) -> None:
-    if controllers and 'hotkey' in controllers[0].inputs and controllers[0].inputs['hotkey'].type == 'button':
-        retroconfig.save('input_enable_hotkey_btn', controllers[0].inputs['hotkey'].id)
-
-
-def _clean_controller_config(retroconfig: _UnixSettings, /) -> None:
-    retroconfig.disable_all('input_player')
-    for name in _CLEARED_INPUT_PREFIXES:
-        retroconfig.disable_all(f'input_{name}')
-
-
-def _write_controllers_config(retroconfig: _UnixSettings, config: SystemConfig, controllers: Controllers, /) -> None:
-    _clean_controller_config(retroconfig)
-
-    # hotkeys, forced to match with the hotkeys system
-    retroconfig.save('input_enable_hotkey', '"shift"')
-    retroconfig.save('input_menu_toggle', '"f1"')
-    retroconfig.save('input_fps_toggle', '"f2"')
-    retroconfig.save('input_exit_emulator', '"escape"')
-    retroconfig.save('input_pause_toggle', '"p"')
-    retroconfig.save('input_save_state', '"f3"')
-    retroconfig.save('input_load_state', '"f4"')
-    retroconfig.save('input_state_slot_decrease', '"f5"')
-    retroconfig.save('input_state_slot_increase', '"f6"')
-    retroconfig.save('input_ai_service', '"f9"')
-    retroconfig.save('input_reset', '"f10"')
-    retroconfig.save('input_rewind', '"f11"')
-
-    # See if FF is toggle or hold
-    ff_action = 'toggle_fast_forward' if config.get_bool('toggle_fast_forward') else 'hold_fast_forward'
-    retroconfig.save(f'input_{ff_action}', '"f12"')
-    retroconfig.save('input_screenshot', '"nul"')
-    retroconfig.save('input_audio_mute', '"nul"')
-    retroconfig.save('input_grab_mouse_toggle', '"nul"')
-
-    for controller in controllers:
-        _write_controller_config(retroconfig, controller, config)
-    _write_hotkey_config(retroconfig, controllers)
 
 
 # --- ROM handling, ported verbatim from amiberryGenerator ----------------------------------
@@ -326,6 +171,27 @@ def _floppies_from_rom(rom: Path, /) -> list[Path]:
 @cached_dataclass
 class Amiberry(Emulator):
     needs_sdl_game_controller_config = True
+    needs_sdl_controller_db = True
+
+    @cached_property
+    def sdl_controller_db_path(self) -> Path:
+        return self.retroarch_inputs_dir / 'gamecontrollerdb.txt'
+
+    @cached_property
+    def bios_dir(self) -> Path:
+        return BIOS / 'amiga'
+
+    @cached_property
+    def saves_dir(self) -> Path:
+        return SAVES / 'amiga'
+
+    @cached_property
+    def retroarch_dir(self) -> Path:
+        return self.config_dir / 'retroarch'
+
+    @cached_property
+    def retroarch_inputs_dir(self) -> Path:
+        return self.retroarch_dir / 'inputs'
 
     @cached_property
     def hotkeygen_context(self) -> HotkeysContext:
@@ -338,51 +204,158 @@ class Amiberry(Emulator):
             },
         }
 
+    def _write_controller_config(self, retroconfig: LibretroConfig, controller: Controller, /) -> None:
+        # Map an emulationstation button name to the corresponding retroarch name
+        retroarch_btns = {
+            'a': 'a',
+            'b': 'b',
+            'x': 'x',
+            'y': 'y',
+            'pageup': 'l',
+            'pagedown': 'r',
+            'l2': 'l2',
+            'r2': 'r2',
+            'l3': 'l3',
+            'r3': 'r3',
+            'start': 'start',
+            'select': 'select',
+        }
+        # X Y L1 L2  ---> X Y R1 L1
+        # A B R1 R2  ---> A B R2 L2
+        if self.config.get('altlayout') == 'fightstick':
+            retroarch_btns['pageup'] = 'l2'
+            retroarch_btns['pagedown'] = 'l'
+            retroarch_btns['l2'] = 'r2'
+            retroarch_btns['r2'] = 'r'
+
+        retroarch_gun_btns = {
+            'a': 'aux_a',
+            'b': 'aux_b',
+            'y': 'aux_c',
+            'pageup': 'offscreen_shot',
+            'pagedown': 'trigger',
+            'start': 'start',
+            'select': 'select',
+        }
+
+        for btnkey, btnvalue in retroarch_btns.items():
+            if (input := controller.inputs.get(btnkey)) is not None:
+                retroconfig.set(
+                    f'input_player{controller.player_number}_{btnvalue}_{_TYPE_TO_NAME[input.type]}',
+                    _get_config_value(input),
+                )
+
+        for btnkey, btnvalue in retroarch_gun_btns.items():
+            if (input := controller.inputs.get(btnkey)) is not None:
+                retroconfig.set(
+                    f'input_player{controller.player_number}_gun_{btnvalue}_{_TYPE_TO_NAME[input.type]}',
+                    _get_config_value(input),
+                )
+
+        for direction in _RETROARCH_DIRS:
+            if (input := controller.inputs.get(direction)) is not None:
+                retroconfig.set(
+                    f'input_player{controller.player_number}_{direction}_{_TYPE_TO_NAME[input.type]}',
+                    _get_config_value(input),
+                )
+                retroconfig.set(
+                    f'input_player{controller.player_number}_gun_dpad_{direction}_{_TYPE_TO_NAME[input.type]}',
+                    _get_config_value(input),
+                )
+
+        for jskey, jsvalue in _RETROARCH_JOYSTICKS.items():
+            if (input := controller.inputs.get(jskey)) is not None:
+                if input.value == '-1':
+                    retroconfig.set(f'input_player{controller.player_number}_{jsvalue}_minus_axis', f'-{input.id}')
+                    retroconfig.set(f'input_player{controller.player_number}_{jsvalue}_plus_axis', f'+{input.id}')
+                else:
+                    retroconfig.set(f'input_player{controller.player_number}_{jsvalue}_minus_axis', f'+{input.id}')
+                    retroconfig.set(f'input_player{controller.player_number}_{jsvalue}_plus_axis', f'-{input.id}')
+
+        # note: the old generic helper skips writing mouse_index when lightgun support is
+        # requested; amiberry always requests it, so mouse_index is never written here either.
+        retroconfig.set(f'input_player{controller.player_number}_joypad_index', controller.index)
+        retroconfig.set(f'input_player{controller.player_number}_analog_dpad_mode', _get_analog_mode(controller))
+
+    def _write_controllers_config(self, config_path: Path, /) -> None:
+        retroconfig = LibretroConfig(config_path, self.config)
+
+        # Clean the config
+        retroconfig.remove_all_starting_with('input_player')
+        for name in _CLEARED_INPUT_PREFIXES:
+            retroconfig.remove_all_starting_with(f'input_{name}')
+
+        # hotkeys, forced to match with the hotkeys system
+        retroconfig.set('input_enable_hotkey', 'shift')
+        retroconfig.set('input_menu_toggle', 'f1')
+        retroconfig.set('input_fps_toggle', 'f2')
+        retroconfig.set('input_exit_emulator', 'escape')
+        retroconfig.set('input_pause_toggle', 'p')
+        retroconfig.set('input_save_state', 'f3')
+        retroconfig.set('input_load_state', 'f4')
+        retroconfig.set('input_state_slot_decrease', 'f5')
+        retroconfig.set('input_state_slot_increase', 'f6')
+        retroconfig.set('input_ai_service', 'f9')
+        retroconfig.set('input_reset', 'f10')
+        retroconfig.set('input_rewind', 'f11')
+
+        # See if FF is toggle or hold
+        ff_action = 'toggle_fast_forward' if self.config.get_bool('toggle_fast_forward') else 'hold_fast_forward'
+        retroconfig.set(f'input_{ff_action}', 'f12')
+        retroconfig.set('input_screenshot', 'nul')
+        retroconfig.set('input_audio_mute', 'nul')
+        retroconfig.set('input_grab_mouse_toggle', 'nul')
+
+        for controller in self.controllers:
+            self._write_controller_config(retroconfig, controller)
+
+        if (
+            self.controllers
+            and 'hotkey' in self.controllers[0].inputs
+            and self.controllers[0].inputs['hotkey'].type == 'button'
+        ):
+            # Write the hotkey config for controller 1
+            retroconfig.set('input_enable_hotkey_btn', self.controllers[0].inputs['hotkey'].id)
+
+        retroconfig.write()
+
     async def configure(self) -> Command:
-        retroarch_dir = self.config_dir / 'retroarch'
-        retroarch_custom = retroarch_dir / 'overlay.cfg'
-        retroarch_inputs_dir = retroarch_dir / 'inputs'
+        retroarch_custom = self.retroarch_dir / 'overlay.cfg'
         plugins_dir = self.config_dir / 'plugins'
         whdboot_dir = self.config_dir / 'whdboot'
 
-        retroarch_dir.mkdir(parents=True, exist_ok=True)
         plugins_dir.mkdir(parents=True, exist_ok=True)
 
-        retroconfig = _UnixSettings(retroarch_custom, separator=' ')
-        amiberryconf = _UnixSettings(self.config_dir / 'amiberry.conf', separator=' ')
-        amiberryconf.save('default_quit_key', 'F9')
-        amiberryconf.save('default_open_gui_key', 'F8')
-        amiberryconf.save('saveimage_dir', _SAVES_DIR)
-        amiberryconf.save('savestate_dir', _SAVES_DIR)
-        amiberryconf.save('screenshot_dir', SCREENSHOTS)
-        amiberryconf.save('nvram_dir', _SAVES_DIR / 'nvram')
-        amiberryconf.save('rom_path', _BIOS_DIR)
-        amiberryconf.save('whdboot_path', whdboot_dir)
-        amiberryconf.save('logfile_path', _LOG_FILE)
-        amiberryconf.save('controllers_path', retroarch_inputs_dir)
-        amiberryconf.save('retroarch_config', retroarch_custom)
-        amiberryconf.save(
-            'default_vkbd_enabled', self.config.get_bool('amiberry_virtual_keyboard', return_values=(1, 0))
-        )
+        amiberryconf = KeyValueConfig(self.config_dir / 'amiberry.conf', separator=' ')
+
+        amiberryconf['default_quit_key'] = 'F9'
+        amiberryconf['default_open_gui_key'] = 'F8'
+        amiberryconf['saveimage_dir'] = self.saves_dir
+        amiberryconf['savestate_dir'] = self.saves_dir
+        amiberryconf['screenshot_dir'] = SCREENSHOTS
+        amiberryconf['nvram_dir'] = self.saves_dir / 'nvram'
+        amiberryconf['rom_path'] = self.bios_dir
+        amiberryconf['whdboot_path'] = whdboot_dir
+        amiberryconf['logfile_path'] = _LOG_FILE
+        amiberryconf['controllers_path'] = self.retroarch_inputs_dir
+        amiberryconf['retroarch_config'] = retroarch_custom
+        amiberryconf['default_vkbd_enabled'] = self.config.get_bool('amiberry_virtual_keyboard', return_values=(1, 0))
+
         # NOTE: as of amiberry v8.3.0 upstream treats default_vkbd_hires as a legacy,
         # accepted-but-never-applied key (the bitmap "hi-res keyboard" concept was dropped
         # from the rewritten virtual keyboard) -- amiberry_hires_keyboard is effectively a
         # no-op now. Kept as a harmless write pending a decision on removing the .yml option.
-        amiberryconf.save(
-            'default_vkbd_hires', self.config.get_bool('amiberry_hires_keyboard', return_values=(1, 0))
-        )
-        amiberryconf.save('default_vkbd_transparency', self.config.get_str('amiberry_vkbd_transparency', '60'))
-        amiberryconf.save('default_vkbd_language', self.config.get_str('amiberry_vkbd_language', 'US'))
-        amiberryconf.save('default_vkbd_toggle', 'leftstick')
-        amiberryconf.save('default_fullscreen_mode', '2')
-        amiberryconf.save(
-            'default_auto_crop', self.config.get_bool('amiberry_auto_crop', return_values=('true', 'false'))
-        )
+        amiberryconf['default_vkbd_hires'] = self.config.get_bool('amiberry_hires_keyboard', return_values=(1, 0))
+        amiberryconf['default_vkbd_transparency'] = self.config.get_str('amiberry_vkbd_transparency', '60')
+        amiberryconf['default_vkbd_language'] = self.config.get_str('amiberry_vkbd_language', 'US')
+        amiberryconf['default_vkbd_toggle'] = 'leftstick'
+        amiberryconf['default_fullscreen_mode'] = '2'
+        amiberryconf['default_auto_crop'] = self.config.get_bool('amiberry_auto_crop', return_values=('true', 'false'))
         # NOTE: there is no amiberry.conf "default_keep_aspect" key upstream -- gfx_keep_aspect
         # is a per-config UAE option only, applied on the command line below instead.
-        amiberryconf.save('shader', self.config.get_str('amiberry_shader', 'none'))
+        amiberryconf['shader'] = self.config.get_str('amiberry_shader', 'none')
 
-        amiberryconf.save('write_logfile', 'yes')
+        amiberryconf['write_logfile'] = 'yes'
         amiberryconf.write()
 
         rom_type = _get_rom_type(self.rom)
@@ -421,18 +394,14 @@ class Amiberry(Emulator):
             args.append(f'amiberry.floppy_path={self.rom.parent}')
 
         # controller
-        _write_controllers_config(retroconfig, self.config, self.controllers)
-        retroconfig.write()
-
-        retroarch_inputs_dir.mkdir(parents=True, exist_ok=True)
-        write_sdl_controller_db(self.controllers, retroarch_inputs_dir / 'gamecontrollerdb.txt')
+        self._write_controllers_config(retroarch_custom)
 
         is_player2 = False
         for pad in self.controllers:
             replacements = {f'_player{pad.player_number}_': '_'}
             # amiberry remove / included in pads names like "USB Downlo01.80 PS3/USB Corded Gamepad"
             padfilename = pad.real_name.replace('/', '')
-            player_input_filename = retroarch_inputs_dir / f'{padfilename}.cfg'
+            player_input_filename = self.retroarch_inputs_dir / f'{padfilename}.cfg'
             with retroarch_custom.open() as infile, player_input_filename.open('w') as outfile:
                 for line in infile:
                     for src, target in replacements.items():
@@ -532,7 +501,7 @@ class Amiberry(Emulator):
 
         if amiberry_cpu or wants_z3:
             args.append('-s')
-            args.append(f"cpu_24bit_addressing={'true' if cpu in ('68000', '68010') else 'false'}")
+            args.append(f'cpu_24bit_addressing={"true" if cpu in ("68000", "68010") else "false"}')
 
         # cpu frenquency multiplier
         if amiberry_cpu_multiplier := self.config.get_int('amiberry_cpu_multiplier', default_multiplier):
@@ -543,16 +512,16 @@ class Amiberry(Emulator):
         # instruction timings. Turning it off falls back to 68000 timings scaled down
         # (adjust_cycles), which is *slower* on a big cpu, and is only worth it together with the jit.
         match self.config.get_str('amiberry_cycle_exact'):
-            case 'on':
-                args.append('-s')
-                args.append('cpu_cycle_exact=true')
-                args.append('-s')
-                args.append('blitter_cycle_exact=true')
             case 'off':
                 args.append('-s')
                 args.append('cpu_cycle_exact=false')
                 args.append('-s')
                 args.append('blitter_cycle_exact=false')
+            case _:  # on
+                args.append('-s')
+                args.append('cpu_cycle_exact=true')
+                args.append('-s')
+                args.append('blitter_cycle_exact=true')
 
         # default fastram to 8MB
         args.append('-s')
@@ -570,9 +539,6 @@ class Amiberry(Emulator):
 
         # Scaling method
         match self.config.get_str('amiberry_scalingmethod'):
-            case 'none':
-                args.append('-s')
-                args.append('amiberry.scaling_method=-1')
             case 'pixelated':
                 args.append('-s')
                 args.append('amiberry.scaling_method=0')
@@ -582,6 +548,9 @@ class Amiberry(Emulator):
             case 'integer':
                 args.append('-s')
                 args.append('amiberry.scaling_method=2')
+            case _:  # none
+                args.append('-s')
+                args.append('amiberry.scaling_method=-1')
 
         # display vertical centering
         args.append('-s')

--- a/python-src/batocera-launch/batocera_launch/emulators/cannonball.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/cannonball.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
+from typing import TYPE_CHECKING
 
 from batocera_common.dataclasses import cached_dataclass, cached_property
 from batocera_common.paths import CONFIGS
 from batocera_launch import Command, Emulator, HotkeysContext
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @cached_dataclass
 class Cannonball(Emulator):
     needs_sdl_game_controller_config = True
     needs_sdl_controller_db = True
-    sdl_controller_db_path = CONFIGS / 'cannonball' / 'gamecontrollerdb.txt'
+
+    @cached_property
+    def sdl_controller_db_path(self) -> Path:
+        return self.config_dir / 'gamecontrollerdb.txt'
 
     @cached_property
     def hotkeygen_context(self) -> HotkeysContext:

--- a/python-src/batocera-launch/batocera_launch/emulators/cemu.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/cemu.py
@@ -7,8 +7,6 @@ from os import environ
 from typing import TYPE_CHECKING, Final, cast
 from xml.dom import minidom
 
-import pyudev
-
 from batocera_common import vulkan
 from batocera_common.dataclasses import cached_dataclass, cached_property
 from batocera_common.paths import BIOS, CACHE, CONFIGS, SAVES
@@ -192,15 +190,17 @@ def _lang_from_environment() -> str:
     return 'en_US'
 
 
-def _cemu_lang(lang: str) -> int:
+def _cemu_lang(lang: str, /) -> int:
     return _AVAILABLE_LANGUAGES.get(lang, _AVAILABLE_LANGUAGES['en_US'])
 
 
-def _is_wiimote(pad: Controller) -> bool:
+def _is_wiimote(pad: Controller, /) -> bool:
     return pad.real_name == _WIIMOTE_NAME
 
 
-def _find_wiimote_type(pad: Controller) -> str:
+def _find_wiimote_type(pad: Controller, /) -> str:
+    import pyudev
+
     context = pyudev.Context()
     device = pyudev.Devices.from_device_file(context, pad.device_path)
     names: list[str] = []
@@ -220,7 +220,7 @@ def _find_wiimote_type(pad: Controller) -> str:
     return _WIIMOTE_TYPE_CORE
 
 
-def _xml_root(config: minidom.Document, name: str) -> minidom.Element:
+def _xml_root(config: minidom.Document, name: str, /) -> minidom.Element:
     xml_section = config.getElementsByTagName(name)
 
     if len(xml_section) == 0:
@@ -231,7 +231,7 @@ def _xml_root(config: minidom.Document, name: str) -> minidom.Element:
     return xml_section[0]
 
 
-def _set_xml_value(config: minidom.Document, xml_section: minidom.Element, name: str, value: str) -> None:
+def _set_xml_value(config: minidom.Document, xml_section: minidom.Element, name: str, value: str, /) -> None:
     xml_elt = xml_section.getElementsByTagName(name)
     if len(xml_elt) == 0:
         element = config.createElement(name)
@@ -384,9 +384,7 @@ class Cemu(Emulator):
         # Vsync
         _set_xml_value(config, graphic_root, 'VSync', self.config.get_str('cemu_vsync', '1'))  # 1 = On
         # Upscale Filter
-        _set_xml_value(
-            config, graphic_root, 'UpscaleFilter', self.config.get_str('cemu_upscale', '2')
-        )  # 2 = Hermite
+        _set_xml_value(config, graphic_root, 'UpscaleFilter', self.config.get_str('cemu_upscale', '2'))  # 2 = Hermite
         # Downscale Filter
         _set_xml_value(
             config, graphic_root, 'DownscaleFilter', self.config.get_str('cemu_downscale', '0')
@@ -503,9 +501,10 @@ class Cemu(Emulator):
                     controller_type = _WIIMOTE
                 case '4':
                     controller_type = _CLASSIC
-                case '0' | None:
+                case _:  # '0' or None
                     if nplayer == 0:
                         controller_type = _GAMEPAD
+
             ET.SubElement(root, 'type').text = controller_type
 
             if _is_wiimote(pad):
@@ -519,9 +518,7 @@ class Cemu(Emulator):
             ET.SubElement(controller_node, 'api').text = api
             ET.SubElement(controller_node, 'uuid').text = f'{guid_n[pad.index]}_{pad.guid}'  # controller guid
             ET.SubElement(controller_node, 'display_name').text = pad.real_name  # controller name
-            ET.SubElement(controller_node, 'rumble').text = self.config.get_str(
-                'cemu_rumble', '0'
-            )  # % chosen
+            ET.SubElement(controller_node, 'rumble').text = self.config.get_str('cemu_rumble', '0')  # % chosen
             for name in ('axis', 'rotation', 'trigger'):
                 analog = ET.SubElement(controller_node, name)
                 ET.SubElement(analog, 'deadzone').text = _DEFAULT_DEADZONE

--- a/python-src/batocera-launch/batocera_launch/emulators/gsplus.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/gsplus.py
@@ -109,8 +109,7 @@ class GSplus(Emulator):
         self.config_dir.mkdir(parents=True, exist_ok=True)
         config_file = self.config_dir / 'config.txt'
 
-        config = KeyValueConfig(' ')
-        config.read(config_file)
+        config = KeyValueConfig(config_file, separator=' ')
 
         if self.rom.suffix.lower() in _FLOPPY_SUFFIXES:
             config['s6d1'] = str(self.rom)
@@ -127,6 +126,6 @@ class GSplus(Emulator):
             config[key] = value
 
         config['g_cfg_rom_path'] = str(BIOS / self.config.get_str('gsplus_bios_filename', 'ROM.03'))
-        config.write(config_file)
+        config.write()
 
         return Command(['GSplus', '-fullscreen'])

--- a/python-src/batocera-launch/batocera_launch/emulators/jazz2_native.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/jazz2_native.py
@@ -11,7 +11,10 @@ from batocera_launch import Command, Emulator, HotkeysContext
 class Jazz2_Native(Emulator):
     needs_sdl_game_controller_config = True
     needs_sdl_controller_db = True
-    sdl_controller_db_path = Path('/usr/share/jazz2/gamecontrollerdb.txt')
+
+    @cached_property
+    def sdl_controller_db_path(self) -> Path:
+        return Path('/usr/share/jazz2/gamecontrollerdb.txt')
 
     @cached_property
     def hotkeygen_context(self) -> HotkeysContext:

--- a/python-src/batocera-launch/batocera_launch/emulators/sonic_mania.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/sonic_mania.py
@@ -14,14 +14,16 @@ from batocera_launch import (
 )
 
 _BINARY_SRC: Final = Path('/usr/bin/sonic-mania')
-_ROM_DIR: Final = ROMS / 'sonic-mania'
 
 
 @cached_dataclass
 class SonicMania(Emulator):
     needs_sdl_game_controller_config = True
     needs_sdl_controller_db = True
-    sdl_controller_db_path = _ROM_DIR / 'gamecontrollerdb.txt'
+
+    @cached_property
+    def sdl_controller_db_path(self) -> Path:
+        return self.roms_dir / 'gamecontrollerdb.txt'
 
     @cached_property
     def hotkeygen_context(self) -> HotkeysContext:
@@ -34,16 +36,20 @@ class SonicMania(Emulator):
             },
         }
 
+    @cached_property
+    def roms_dir(self) -> Path:
+        return ROMS / 'sonic-mania'
+
     @property
     def execution_path(self) -> Path | None:
-        return _ROM_DIR
+        return self.roms_dir
 
     @cached_property
     def in_game_ratio(self) -> float:
         return 16 / 9
 
     async def configure(self) -> Command:
-        destination_file = _ROM_DIR / 'sonic-mania'
+        destination_file = self.roms_dir / 'sonic-mania'
         if not destination_file.exists():
             shutil.copy(_BINARY_SRC, destination_file)
 
@@ -75,7 +81,7 @@ class SonicMania(Emulator):
             'sfxVolume': '1.000000',
         }
 
-        with (_ROM_DIR / 'Settings.ini').open('w') as configfile:
+        with (self.roms_dir / 'Settings.ini').open('w') as configfile:
             config.write(configfile)
 
         return Command(

--- a/python-src/batocera-launch/batocera_launch/launch.py
+++ b/python-src/batocera-launch/batocera_launch/launch.py
@@ -43,10 +43,7 @@ def launch(args: Arguments, profiler: Profiler, /) -> None:
 
     exit_code = 0
     try:
-        config = KeyValueConfig()
-        config.read(BATOCERA_CONF)
-
-        if config.get('configgen') == '1':
+        if KeyValueConfig(BATOCERA_CONF).get('configgen') == '1':
             _logger.debug('Using legacy configgen')
             exit_code = _run_legacy(args, profiler)
         else:

--- a/python-src/batocera-launch/tests/test_libretro_config.py
+++ b/python-src/batocera-launch/tests/test_libretro_config.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+
+from batocera_launch.config.config import Config
+from batocera_launch.config.libretro import LibretroConfig
+
+if TYPE_CHECKING:
+    from pyfakefs.fake_filesystem import FakeFilesystem
+
+pytestmark = pytest.mark.usefixtures('fs')
+
+
+@pytest.fixture
+def config_data(request: pytest.FixtureRequest) -> dict[str, Any]:
+    return getattr(request, 'param', {})
+
+
+@pytest.fixture
+def config(config_data: dict[str, Any]) -> Config:
+    return Config(config_data)
+
+
+@pytest.fixture
+def config_path(request: pytest.FixtureRequest, fs: FakeFilesystem) -> Path:
+    param = getattr(request, 'param', Path('/retroarch/custom.cfg'))
+
+    if isinstance(param, tuple):
+        path, content = cast('tuple[Path, str]', param)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    return Path(param) if isinstance(param, str) else param
+
+
+@pytest.fixture
+def retroconfig(config_path: Path, config: Config) -> LibretroConfig:
+    return LibretroConfig(config_path, config)
+
+
+class TestLibretroConfigSet:
+    def test_quotes_string_values(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('input_enable_hotkey', 'shift')
+
+        assert retroconfig.key_value_config['input_enable_hotkey'] == '"shift"'
+
+    def test_quotes_none_as_empty_string(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('input_screenshot', None)
+
+        assert retroconfig.key_value_config['input_screenshot'] == '""'
+
+    def test_quotes_booleans_as_lowercase_strings(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('run_ahead_enabled', True)
+        retroconfig.set('run_ahead_secondary_instance', False)
+
+        assert retroconfig.key_value_config['run_ahead_enabled'] == '"true"'
+        assert retroconfig.key_value_config['run_ahead_secondary_instance'] == '"false"'
+
+    def test_quotes_numeric_values(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('input_player1_a_btn', 0)
+        retroconfig.set('input_player1_l_y_plus_axis', '+1')
+
+        assert retroconfig.key_value_config['input_player1_a_btn'] == '"0"'
+        assert retroconfig.key_value_config['input_player1_l_y_plus_axis'] == '"+1"'
+
+
+class TestLibretroConfigWrite:
+    def test_writes_space_separated_file(self, retroconfig: LibretroConfig, config_path: Path) -> None:
+        retroconfig.set('stella_console', 'auto')
+        retroconfig.set('input_enable_hotkey', 'shift')
+        retroconfig.write()
+
+        assert (
+            config_path.read_text()
+            == """stella_console = "auto"
+input_enable_hotkey = "shift"
+"""
+        )
+
+    @pytest.mark.parametrize(
+        'config_path',
+        [Path('/userdata/system/configs/amiberry/custom/uae4arm-libretro.cfg')],
+        indirect=True,
+    )
+    def test_creates_parent_directories(self, retroconfig: LibretroConfig, config_path: Path) -> None:
+        retroconfig.set('key', 'value')
+        retroconfig.write()
+
+        assert config_path.is_file()
+        assert config_path.parent.is_dir()
+
+
+class TestLibretroConfigRead:
+    _RETROARCH_CONFIG = """\
+input_enable_hotkey = "shift"
+input_menu_toggle = "f1"
+video_smooth = true
+input_player1_a_btn = "0"
+global.shader = "crt"
+"""
+
+    @pytest.mark.parametrize(
+        'config_path',
+        [(Path('/retroarch/custom.cfg'), _RETROARCH_CONFIG)],
+        indirect=True,
+    )
+    def test_reads_retroarch_config_on_init(self, retroconfig: LibretroConfig) -> None:
+        assert retroconfig.key_value_config['input_enable_hotkey'] == '"shift"'
+        assert retroconfig.key_value_config['input_menu_toggle'] == '"f1"'
+        assert retroconfig.key_value_config['video_smooth'] == 'true'
+        assert retroconfig.key_value_config['input_player1_a_btn'] == '"0"'
+        assert retroconfig.key_value_config['global.shader'] == '"crt"'
+
+    @pytest.mark.parametrize(
+        'config_path',
+        [(Path('/retroarch/custom.cfg'), 'existing = kept\n')],
+        indirect=True,
+    )
+    def test_reads_unquoted_values(self, retroconfig: LibretroConfig) -> None:
+        assert retroconfig.key_value_config['existing'] == 'kept'
+
+    def test_missing_file_on_init_does_not_raise(self, config: Config) -> None:
+        retroconfig = LibretroConfig(Path('/does/not/exist.cfg'), config)
+
+        assert 'anything' not in retroconfig.key_value_config
+
+    def test_write_read_roundtrip(self, retroconfig: LibretroConfig, config_path: Path, config: Config) -> None:
+        retroconfig.set('input_enable_hotkey', 'shift')
+        retroconfig.set('run_ahead_enabled', True)
+        retroconfig.write()
+
+        reloaded = LibretroConfig(config_path, config)
+
+        assert reloaded.key_value_config['input_enable_hotkey'] == '"shift"'
+        assert reloaded.key_value_config['run_ahead_enabled'] == '"true"'
+
+    @pytest.mark.parametrize(
+        'config_path',
+        [(Path('/retroarch/custom.cfg'), 'from_file = "yes"\n')],
+        indirect=True,
+    )
+    def test_preserves_read_keys_when_adding(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('added', 'value')
+
+        assert retroconfig.key_value_config['from_file'] == '"yes"'
+        assert retroconfig.key_value_config['added'] == '"value"'
+
+
+class TestLibretroConfigFromConfig:
+    @pytest.mark.parametrize('config_data', [{'stella_console': 'NTSC'}], indirect=True)
+    def test_set_from_config(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_from_config('stella_console')
+
+        assert retroconfig.key_value_config['stella_console'] == '"NTSC"'
+
+    @pytest.mark.parametrize(
+        'config_data',
+        [{'internal_resolution_desmume': '512x384'}],
+        indirect=True,
+    )
+    def test_set_from_config_with_config_name(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_from_config('desmume_internal_resolution', 'internal_resolution_desmume')
+
+        assert retroconfig.key_value_config['desmume_internal_resolution'] == '"512x384"'
+
+    def test_set_from_config_uses_default(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_from_config('stella_console', default='auto')
+
+        assert retroconfig.key_value_config['stella_console'] == '"auto"'
+
+    @pytest.mark.parametrize('config_data', [{'toggle_fast_forward': '1'}], indirect=True)
+    def test_set_bool_from_config(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_bool_from_config('toggle_fast_forward')
+
+        assert retroconfig.key_value_config['toggle_fast_forward'] == '"true"'
+
+    @pytest.mark.parametrize('config_data', [{'default_vkbd_enabled': '0'}], indirect=True)
+    def test_set_bool_from_config_return_values(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_bool_from_config(
+            'default_vkbd_enabled',
+            values=(1, 0),
+        )
+
+        assert retroconfig.key_value_config['default_vkbd_enabled'] == '"0"'
+
+    @pytest.mark.parametrize('config_data', [{'amiberry_cpu_multiplier': '4'}], indirect=True)
+    def test_set_int_from_config(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_int_from_config('amiberry_cpu_multiplier')
+
+        assert retroconfig.key_value_config['amiberry_cpu_multiplier'] == '"4"'
+
+    @pytest.mark.parametrize('config_data', [{'video_aspect_ratio': '1.333333'}], indirect=True)
+    def test_set_float_from_config(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set_float_from_config('video_aspect_ratio')
+
+        assert retroconfig.key_value_config['video_aspect_ratio'] == '"1.333333"'
+
+
+class TestLibretroConfigRemove:
+    def test_remove_all_starting_with(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.set('input_player1_a_btn', 0)
+        retroconfig.set('input_player2_a_btn', 1)
+        retroconfig.set('input_menu_toggle', 'f1')
+
+        retroconfig.remove_all_starting_with('input_player')
+
+        assert 'input_player1_a_btn' not in retroconfig.key_value_config
+        assert 'input_player2_a_btn' not in retroconfig.key_value_config
+        assert retroconfig.key_value_config['input_menu_toggle'] == '"f1"'
+
+    def test_remove_section(self, retroconfig: LibretroConfig) -> None:
+        retroconfig.key_value_config['global.shader'] = 'crt'
+        retroconfig.key_value_config['global.smooth'] = '1'
+        retroconfig.key_value_config['global_extra'] = '2'
+
+        retroconfig.remove_section('global')
+
+        assert 'global.shader' not in retroconfig.key_value_config
+        assert 'global.smooth' not in retroconfig.key_value_config
+        assert retroconfig.key_value_config['global_extra'] == '2'

--- a/python-src/python-batocera-common/batocera_common/key_value_config.py
+++ b/python-src/python-batocera-common/batocera_common/key_value_config.py
@@ -4,14 +4,14 @@ import logging
 import re
 from configparser import UNNAMED_SECTION
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import TYPE_CHECKING, Final, overload
+from typing_extensions import Sentinel
 
 from .configparser import CaseSensitiveConfigParser
 
 if TYPE_CHECKING:
-    from _typeshed import StrPath
     from collections.abc import Iterator
+    from pathlib import Path
 
 _logger: Final = logging.getLogger(__name__)
 _sub_re: Final = re.compile(r'[^A-Za-z0-9-\.]+')
@@ -25,9 +25,14 @@ def _section_re(section: str, /) -> re.Pattern[str]:
     return re.compile(rf'^{_protect_string(section)}\.(.+)')
 
 
+_MISSING = Sentinel('_MISSING')
+
+
 @dataclass(slots=True)
 class KeyValueConfig:
-    separator: str = field(default='')
+    path: Path | None = None
+    read_encoding: str | None = field(kw_only=True, default='latin1')
+    separator: str = field(kw_only=True, default='')
 
     __config: CaseSensitiveConfigParser = field(init=False)
 
@@ -35,27 +40,45 @@ class KeyValueConfig:
         self.__config = CaseSensitiveConfigParser(interpolation=None, strict=False, allow_unnamed_section=True)
         self.__config.add_section(UNNAMED_SECTION)
 
-    def read(self, path: StrPath, /, *, encoding: str | None = 'latin1') -> None:
-        try:
-            self.__config.read_string(Path(path).read_text(encoding=encoding), source=str(path))
-        except OSError as e:
-            _logger.error(str(e))
+        if self.path is not None:
+            self.read()
 
-    def write(self, path: StrPath, /, *, encoding: str | None = None) -> None:
-        with Path(path).open('w', encoding=encoding) as fp:
+    def read(self, path: Path | None = None, /, *, encoding: str | _MISSING | None = _MISSING) -> None:
+        path = self.path if path is None else path
+
+        if path is None:
+            raise ValueError('path must be provided')
+
+        if encoding is _MISSING:
+            encoding = self.read_encoding
+
+        try:
+            self.__config.read_string(path.read_text(encoding=encoding), source=str(path))
+        except OSError:
+            _logger.exception('error reading %s', path)
+
+    def write(self, path: Path | None = None, /, *, encoding: str | None = None) -> None:
+        path = self.path if path is None else path
+
+        if path is None:
+            raise ValueError('path must be provided')
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        with path.open('w', encoding=encoding) as fp:
             try:
                 for key, value in self.__config.items(UNNAMED_SECTION):
                     fp.write(f'{key}{self.separator}={self.separator}{value!s}\n')
             except Exception:
                 # PSX Mednafen writes beetle_psx_hw_cpu_freq_scale = "100%(native)"
                 # Python 2.7 is EOL and ConfigParser 2.7 takes "%(" as a won't fix error
-                _logger.error('Wrong value detected (after % char maybe?), ignoring.')
+                _logger.exception('Wrong value detected (after % char maybe?), ignoring.')
 
     def __getitem__(self, key: str) -> str:
         return self.__config.get(UNNAMED_SECTION, key)
 
-    def __setitem__(self, key: str, value: str) -> None:
-        self.__config.set(UNNAMED_SECTION, key, value)
+    def __setitem__(self, key: str, value: object) -> None:
+        self.__config.set(UNNAMED_SECTION, key, str(value))
 
     def __delitem__(self, key: str) -> None:
         self.__config.remove_option(UNNAMED_SECTION, key)

--- a/python-src/python-batocera-common/batocera_common/vulkan.py
+++ b/python-src/python-batocera-common/batocera_common/vulkan.py
@@ -144,10 +144,7 @@ def _is_radeon_prime_disabled() -> bool:
     if not _BATOCERA_BOOT_CONF.is_file():
         return False
 
-    config = KeyValueConfig()
-    config.read(_BATOCERA_BOOT_CONF)
-
-    value = config.get('radeon-prime')
+    value = KeyValueConfig(_BATOCERA_BOOT_CONF).get('radeon-prime')
 
     return value is not None and value.strip() == 'false'
 

--- a/python-src/python-batocera-common/tests/test_key_value_config.py
+++ b/python-src/python-batocera-common/tests/test_key_value_config.py
@@ -15,6 +15,13 @@ class TestKeyValueConfigGetSet:
         config['foo'] = 'bar'
         assert config['foo'] == 'bar'
 
+    def test_setitem_coerces_non_string_values(self) -> None:
+        config = KeyValueConfig()
+        config['count'] = 42
+        config['enabled'] = True
+        assert config['count'] == '42'
+        assert config['enabled'] == 'True'
+
     def test_get_with_default(self) -> None:
         config = KeyValueConfig()
         assert config.get('missing') is None
@@ -62,7 +69,7 @@ class TestKeyValueConfigReadWrite:
 
     def test_write_with_separator(self) -> None:
         path = Path('/config.cfg')
-        config = KeyValueConfig(' ')
+        config = KeyValueConfig(separator=' ')
         config['key'] = 'value'
         config.write(path)
 
@@ -70,7 +77,7 @@ class TestKeyValueConfigReadWrite:
 
     def test_read_missing_file_does_not_raise(self) -> None:
         config = KeyValueConfig()
-        config.read('/does/not/exist.cfg')
+        config.read(Path('/does/not/exist.cfg'))
         assert config.get('anything') is None
 
     def test_read_updates_existing_keys(self) -> None:
@@ -93,6 +100,80 @@ class TestKeyValueConfigReadWrite:
         config.read(path)
 
         assert config['name'] == 'café'
+
+    def test_read_without_path_raises(self) -> None:
+        config = KeyValueConfig()
+
+        with pytest.raises(ValueError, match='path must be provided'):
+            config.read()
+
+    def test_write_without_path_raises(self) -> None:
+        config = KeyValueConfig()
+
+        with pytest.raises(ValueError, match='path must be provided'):
+            config.write()
+
+
+class TestKeyValueConfigPathBound:
+    def test_loads_on_init(self) -> None:
+        path = Path('/config.cfg')
+        path.write_text('key=value\n', encoding='latin1')
+
+        config = KeyValueConfig(path)
+
+        assert config['key'] == 'value'
+
+    def test_write_uses_bound_path(self) -> None:
+        path = Path('/nested/dir/config.cfg')
+        config = KeyValueConfig(path)
+        config['key'] = 'value'
+        config.write()
+
+        assert path.read_text() == 'key=value\n'
+        assert path.parent.is_dir()
+
+    def test_read_uses_bound_path(self) -> None:
+        path = Path('/config.cfg')
+        path.write_text('key=value\n', encoding='latin1')
+
+        config = KeyValueConfig(path)
+        config['key'] = 'stale'
+        config.read()
+
+        assert config['key'] == 'value'
+
+    def test_bound_roundtrip_with_separator(self) -> None:
+        path = Path('/configs/amiberry.conf')
+        config = KeyValueConfig(path, separator=' ')
+        config['default_quit_key'] = 'F9'
+        config.write()
+
+        loaded = KeyValueConfig(path, separator=' ')
+        assert loaded['default_quit_key'] == 'F9'
+        assert path.read_text() == 'default_quit_key = F9\n'
+
+    def test_read_encoding_override_on_read(self) -> None:
+        path = Path('/config.cfg')
+        path.write_text('key=café\n', encoding='utf-8')
+
+        config = KeyValueConfig()
+        config.read(path, encoding='utf-8')
+
+        assert config['key'] == 'café'
+
+    def test_read_encoding_from_instance(self) -> None:
+        path = Path('/config.cfg')
+        path.write_bytes(b'name=caf\xe9\n')
+
+        config = KeyValueConfig(read_encoding='latin1')
+        config.read(path)
+
+        assert config['name'] == 'café'
+
+    def test_missing_bound_file_on_init_does_not_raise(self) -> None:
+        config = KeyValueConfig(Path('/does/not/exist.cfg'))
+
+        assert config.get('anything') is None
 
 
 class TestKeyValueConfigSection:


### PR DESCRIPTION
- Add path-bound `KeyValueConfig` that auto-reads on init and writes to its bound path
- Introduce `LibretroConfig` for RetroArch-style configs with quoted values and config helpers
- Refactor Amiberry to drop `_UnixSettings` in favor of `KeyValueConfig` and `LibretroConfig`
- Move `Emulator.sdl_controller_db_path` to a per-instance `@cached_property` and ensure parent dirs are created when writing the SDL controller DB
- Update `GSplus`, `launch`, and `vulkan` call sites for the new `KeyValueConfig` API
- Add unit tests for `KeyValueConfig` path binding and `LibretroConfig` read/write behavior