### PR TITLE
batocera-audio: wait for system D-Bus socket before starting pipewire

### DIFF
--- a/package/batocera/core/batocera-audio/Saudio
+++ b/package/batocera/core/batocera-audio/Saudio
@@ -18,6 +18,17 @@ log() {
 
 start_pipewire() {
     log "info" "Starting audio service sequence..."
+
+    # Wait for the system D-Bus socket before starting PipeWire.
+    N=0
+    while [ ! -S "/run/dbus/system_bus_socket" ] && [ $N -lt 150 ]; do
+        sleep 0.1
+        N=$((N+1))
+    done
+    if [ ! -S "/run/dbus/system_bus_socket" ]; then
+        log "err" "D-Bus system socket still missing after 15s wait, WirePlumber's D-Bus module will likely fail to start"
+    fi
+
     # Cleanup stale locks
     rm -f /var/run/pipewire-0 /var/run/pipewire-0.lock
     # Start the PipeWire daemon


### PR DESCRIPTION
Bluetooth audio sometimes never works for the rest of a boot. Pairing and connection succeed fine at the bluetoothd level, but no sink ever shows up in PipeWire.

**Cause:** `/etc/profile.d/dbus.sh` points the "session" bus address at the same socket as the system bus (`unix:path=/run/dbus/system_bus_socket`), since this is a single-user system with no separate session bus daemon. WirePlumber (PipeWire's session manager) connects to that same socket. If dbus-daemon hasn't created it yet when WirePlumber starts, its `dbus-connection` module fails with `Failed to connect to bus: Could not connect: No such file or directory`, and the `bluez5` monitor script never even loads. No retry, so it stays broken for the whole boot.

Reproduced live by pointing `DBUS_SESSION_BUS_ADDRESS` at a nonexistent socket and starting WirePlumber by hand: the `bluez5` monitor never appears in the logs at all when the socket is missing, but loads and registers all its media endpoints fine as soon as the socket exists.

**Fix:** wait up to 15s for the socket before starting PipeWire. Matches the default `sharewait` timeout other init scripts in this codebase already use for similar waits.
