### PR TITLE
amiberry: pass amiberry.hardfile_path / cd_path for .uae configs

### DIFF
--- a/python-src/batocera-launch/batocera_launch/emulators/amiberry.py
+++ b/python-src/batocera-launch/batocera_launch/emulators/amiberry.py
@@ -381,6 +381,10 @@ class Amiberry(Emulator):
         elif rom_type == 'UAE':
             args.append('-f')
             args.append(self.rom)
+            args.append('-s')
+            args.append(f'amiberry.hardfile_path={self.roms_dir}')
+            args.append('-s')
+            args.append(f'amiberry.cd_path={self.roms_dir}')
         elif rom_type == 'CD':
             args.append('--cdimage')
             args.append(self.rom)


### PR DESCRIPTION

Currently, .uae files can't use relative paths easily as they are related to the current working directory, and looks like:
```
hardfile2=rw,DH0:"../..//userdata/roms/amiga500/game.hdf",32,1,2,512,0,,uae0
```
They are not really portable between different systems, or cross compatible with retrobat/winuae for example

This patch append roms/<system> to amiberry's hardfile and CD search paths:
```
amiberry -f "<rom>.uae" -s "amiberry.hardfile_path=<dir>" -s "amiberry.cd_path=<dir>"
```
allowing to have in the .uae file:
```
hardfile2=rw,DH0:"game.hdf",32,1,2,512,0,,uae0
```
(This is not breaking existing config, as it's appending another search path, not replacing the existing one)