### PR TITLE
emulationstation-standalone: read global.videooutput2 default via -master too

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
+++ b/package/batocera/emulationstation/batocera-emulationstation/emulationstation-standalone
@@ -187,7 +187,7 @@ while [ -e "${REBOOT_FLAG}" ]; do
     fi
     # If screen2 is empty, take the first one found which is not screen1
     if [ -z "${settings_output2}" ]; then
-        user_output2="$(batocera-settings-get global.videooutput2)"
+        user_output2="$(batocera-settings-get-master global.videooutput2)"
         if [ "${user_output2}" != "none" ]; then
             settings_output2=$(batocera-resolution listOutputs | grep -vE "^${settings_output}$" | head -1)
             if [ -n "${settings_output2}" ]; then


### PR DESCRIPTION
If screen2 is unset, the script auto-picks a second output. It decides this by checking `global.videooutput2` with the plain lookup, but that lookup only sees user overrides in `/userdata/system/batocera.conf`. It doesn't see sysconfig-level board defaults. Every other read of this setting in the script already uses `-master`, which does see those defaults.

So a board default like `global.videooutput2=none` (meaning "don't auto-pick a second output") gets missed here, and the code picks one anyway.

Confirmed live: with the sysconfig default in place and no user override, a second output kept getting auto-selected on every restart.

No board upstream sets `global.videooutput2=none` right now, so this isn't hurting anyone else yet. But any board that wants no second output by default will hit the same problem. Better to fix it now than wait for another board to run into it.

Fix: use `-master` here too, same as every other read of this setting in the script.
