### PR TITLE
batocera-es-swissknife: respect updates.url override for --update

### DIFF
--- a/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
+++ b/package/batocera/core/batocera-scripts/scripts/batocera-es-swissknife
@@ -117,7 +117,9 @@ case ${1,,} in
           test "${BOARD}" = "rpi4" && BOARD=rpi464 # "temporarily" download on rpi464 for rpi4
 
         if [[ "${1,,}" == "--update" && $ret -eq 0 ]]; then
-            URL="https://updates.batocera.org/$BOARD/$BRANCH/last/batocera.version"
+            UPDATEURL="$(/usr/bin/batocera-settings-get updates.url)"
+            [[ -n "${UPDATEURL}" ]] || UPDATEURL="https://updates.batocera.org"
+            URL="$UPDATEURL/$BOARD/$BRANCH/last/batocera.version"
             NET_VER=$(wget -q -O - "$URL")
             [[ $? -eq 0 ]] || NET_VER="Connection failed!"
             echo "Installed:   $VER"


### PR DESCRIPTION
`batocera-upgrade` already reads `updates.url` with a fallback to `updates.batocera.org`. The `--update` action (what ES's own update notification uses) had that URL hardcoded, so setting `updates.url` did nothing for it.

Confirmed live: with `updates.url` set to a custom manifest, `--update` now checks that URL instead of `updates.batocera.org`.
