### PR TITLE
Add 8BitDo Ultimate 2C Wireless BT mapping

### DIFF
--- a/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
+++ b/package/batocera/emulationstation/batocera-emulationstation/controllers/es_input.cfg
@@ -5551,6 +5551,29 @@
 		<input name="x" type="button" id="3" value="1" code="307" />
 		<input name="y" type="button" id="4" value="1" code="308" />
 	</inputConfig>
+	<inputConfig type="joystick" deviceName="8BitDo Ultimate 2C Wireless" deviceGUID="05000000c82d00001b30000001000000">
+		<input name="a" type="button" id="1" value="1" code="305" />
+		<input name="b" type="button" id="0" value="1" code="304" />
+		<input name="down" type="hat" id="0" value="4" />
+		<input name="hotkey" type="button" id="12" value="1" code="316" />
+		<input name="joystick1left" type="axis" id="0" value="-1" code="0" />
+		<input name="joystick1up" type="axis" id="1" value="-1" code="1" />
+		<input name="joystick2left" type="axis" id="2" value="-1" code="2" />
+		<input name="joystick2up" type="axis" id="3" value="-1" code="5" />
+		<input name="l2" type="axis" id="5" value="1" code="10" />
+		<input name="l3" type="button" id="13" value="1" code="317" />
+		<input name="left" type="hat" id="0" value="8" />
+		<input name="pagedown" type="button" id="7" value="1" code="311" />
+		<input name="pageup" type="button" id="6" value="1" code="310" />
+		<input name="r2" type="axis" id="4" value="1" code="9" />
+		<input name="r3" type="button" id="14" value="1" code="318" />
+		<input name="right" type="hat" id="0" value="2" />
+		<input name="select" type="button" id="10" value="1" code="314" />
+		<input name="start" type="button" id="11" value="1" code="315" />
+		<input name="up" type="hat" id="0" value="1" />
+		<input name="x" type="button" id="4" value="1" code="308" />
+		<input name="y" type="button" id="3" value="1" code="307" />
+	</inputConfig>
 	<inputConfig type="joystick" deviceName="8BitDo Ultimate 2C Wireless Controller" deviceGUID="03000000c82d00000a31000014010000">
 		<input name="a" type="button" id="1" value="1" code="305" />
 		<input name="b" type="button" id="0" value="1" code="304" />


### PR DESCRIPTION
Adding support for the 8BitDo Ultimate 2C Wireless controller via Bluetooth (GUID: 05000000c82d00001b30000001000000).