### PR TITLE
Fix Wayland bezel overlay blocking pointer input

### DIFF
--- a/python-src/batocera-bezel-overlay/batocera-bezel-overlay.mk
+++ b/python-src/batocera-bezel-overlay/batocera-bezel-overlay.mk
@@ -7,6 +7,6 @@
 BATOCERA_BEZEL_OVERLAY_VERSION=44.0
 BATOCERA_BEZEL_OVERLAY_LICENSE=GPL
 BATOCERA_BEZEL_OVERLAY_SETUP_TYPE=hatch
-BATOCERA_BEZEL_OVERLAY_DEPENDENCIES=python3 python-gobject libgtk3 gtk-layer-shell
+BATOCERA_BEZEL_OVERLAY_DEPENDENCIES=python3 python-pycairo python-gobject libgtk3 gtk-layer-shell
 
 $(eval $(local-python-package))

--- a/python-src/batocera-bezel-overlay/batocera_bezel_overlay/overlay.py
+++ b/python-src/batocera-bezel-overlay/batocera_bezel_overlay/overlay.py
@@ -4,13 +4,14 @@ import logging
 import sys
 from typing import ClassVar
 
+import cairo
 import gi
 
 try:
     gi.require_version('GdkPixbuf', '2.0')
     gi.require_version('Gtk', '3.0')
 
-    from gi.repository import GdkPixbuf, Gtk
+    from gi.repository import GdkPixbuf, GLib, Gtk
 except (ImportError, ValueError) as exc:
     print('Error: Dependencies not met.', exc)
     sys.exit(1)
@@ -104,6 +105,28 @@ class WaylandOverlay(Overlay):
 
     window_type: ClassVar[Gtk.WindowType] = Gtk.WindowType.TOPLEVEL
 
+    def _apply_input_passthrough(self) -> bool:
+        """Make the mapped layer surface ignore pointer and touch input."""
+        if gdk_window := self.get_window():
+            try:
+                gdk_window.input_shape_combine_region(cairo.Region(), 0, 0)
+                # Commit the updated input region after GtkLayerShell has mapped
+                # and configured the Wayland surface.
+                gdk_window.invalidate_rect(None, False)
+                _log.debug('Wayland input pass-through configured successfully.')
+            except Exception:
+                _log.exception('Failed to configure Wayland input pass-through')
+
+        # GLib.idle_add expects False to remove the callback.
+        return False
+
+    def do_map(self) -> None:
+        Gtk.Window.do_map(self)
+
+        # GtkLayerShell configures the wl_surface during mapping. Applying the
+        # empty input region afterwards prevents it from being overwritten.
+        GLib.idle_add(self._apply_input_passthrough)
+
     def setup(self, dimensions: tuple[int, int], /) -> None:
         """Bind window overlay parameters using GtkLayerShell on Wayland."""
 
@@ -122,7 +145,7 @@ class WaylandOverlay(Overlay):
             GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.LEFT, True)
             GtkLayerShell.set_anchor(self, GtkLayerShell.Edge.RIGHT, True)
 
-        except ValueError, ImportError:
+        except (ValueError, ImportError):
             _log.exception(
                 'Wayland GtkLayerShell initialization failed. Falling back to standard positioning.',
             )

--- a/python-src/batocera-bezel-overlay/pyproject.toml
+++ b/python-src/batocera-bezel-overlay/pyproject.toml
@@ -2,6 +2,7 @@
 name = "batocera-bezel-overlay"
 version = '44.0'
 dependencies = [
+    'pycairo',
     'pygobject',
 ]
 


### PR DESCRIPTION
## Problem

On Batocera v44 running under Wayland/labwc, `batocera-bezel-overlay` can prevent mouse/pointer events from reaching the emulator underneath.

The overlay remains visible as expected, but despite calling `Gdk.Window.set_pass_through(True)`, mouse clicks are intercepted by the bezel surface.

This was reproduced with Azahar:

- Bezel enabled: the pointer moves normally, but mouse clicks do not reach the Nintendo 3DS touchscreen.
- Bezel disabled: mouse/touch input works normally.
- Terminating `batocera-bezel-overlay` while the emulator is running immediately restores mouse clicks.

## Fix

Apply an empty GDK/Cairo input region after the Wayland LayerShell surface has been mapped.

This makes the bezel surface transparent to pointer input while keeping the bezel fully visible.

PyCairo is added as a dependency so the input region can be created through the normal GTK/GDK bindings.

## Tested on

- Batocera `44-dev-69b8598c56`
- x86_64-v3
- Wayland
- labwc
- Azahar 2126.0
- Physical mouse
- DualSense touchpad acting as a mouse

## Result

- Bezel remains visible
- Mouse clicks pass through the bezel correctly
- Nintendo 3DS touchscreen input works in Azahar
- DualSense touchpad-as-mouse also works correctly

The issue is likely not specific to Azahar; Azahar simply made it easy to reproduce because its touchscreen uses normal window pointer events.