### PR TITLE
rk3568: fix ODROID-M1S Ethernet by naming the RTL8211F by PHY ID

### DIFF
--- a/board/batocera/rockchip/rk3568/linux_patches/0200-odroid-m1s-rtl8211f-phy-id.patch
+++ b/board/batocera/rockchip/rk3568/linux_patches/0200-odroid-m1s-rtl8211f-phy-id.patch
@@ -1,0 +1,50 @@
+From: Drew <drew@dcyfr.ai>
+Date: Thu, 11 Sep 2026 12:00:00 -0600
+Subject: [PATCH] arm64: dts: rockchip: rk3566-odroid-m1s: identify the
+ RTL8211F by PHY ID
+
+phylib reads the PHY ID over MDIO before it claims the PHY node's
+reset-gpios: fwnode_mdiobus_register_phy() calls get_phy_device() when the
+compatible string carries no ID, while the reset line is only taken later in
+phy_device_register() -> mdiobus_register_gpiod().
+
+The ODROID-M1S holds the RTL8211F in reset at boot, so that first ID read
+finds nothing, of_mdiobus_register() skips the node silently, and the reset
+is never toggled:
+
+  mdio_bus stmmac-0: MDIO device at address 1 is missing.
+  rk_gmac-dwmac fe010000.ethernet eth0: cannot attach to PHY (error: -19)
+
+The RJ45 link LEDs stay dark because the RTL8211F drives them itself.
+
+Naming the ID makes phylib use phy_device_create() instead, so the node's
+20 ms / 100 ms reset sequence runs before anything reads the PHY.
+Documentation/devicetree/bindings/net/ethernet-phy.yaml sanctions exactly
+this case: "the PHY requires a specific initialization sequence (like a
+particular order of clocks, resets, power supplies), in order to be able to
+read the ID registers".
+
+Suggested by Jonas Karlman on linux-rockchip for this board:
+https://lore.kernel.org/all/47d55aca-bee6-810f-379f-9431649fefa6@kwiboo.se/
+
+Batocera 40 instead relied on a U-Boot patch to release the reset, which
+cannot work on a stock M1S: the RK3566 BootROM runs the soldered eMMC's
+Hardkernel U-Boot, which chain-boots the SD card via extlinux, so Batocera's
+own U-Boot never executes.
+---
+ arch/arm64/boot/dts/rockchip/rk3566-odroid-m1s.dts | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3566-odroid-m1s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3566-odroid-m1s.dts
+@@ -471,7 +471,9 @@
+ 
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+-		compatible = "ethernet-phy-ieee802.3-c22";
++		/* RTL8211F: register the PHY from its ID so the reset-gpios toggle happens
++		 * before the first MDIO read (Jonas Karlman, linux-rockchip 2024-07). */
++		compatible = "ethernet-phy-id001c.c916", "ethernet-phy-ieee802.3-c22";
+ 		reg = <1>;
+ 		reset-assert-us = <20000>;
+ 		reset-deassert-us = <100000>;


### PR DESCRIPTION
# rk3568: fix ODROID-M1S Ethernet by naming the RTL8211F by PHY ID

Adds `board/batocera/rockchip/rk3568/linux_patches/0200-odroid-m1s-rtl8211f-phy-id.patch`.

Depends on the config restore in #16444. That PR gets `dwmac-rk` built again for the whole rk3568 target; this one fixes the remaining board-level problem on the ODROID-M1S. Neither works alone.

## Problem

On the ODROID-M1S the MAC initialises but never finds its PHY:

```
rk_gmac-dwmac fe010000.ethernet: init for RGMII_ID
rk_gmac-dwmac fe010000.ethernet: 	DWMAC4/5
rk_gmac-dwmac fe010000.ethernet: Active PHY interface: RGMII (1)
mdio_bus stmmac-0: MDIO device at address 1 is missing.
rk_gmac-dwmac fe010000.ethernet eth0: cannot attach to PHY (error: -19)
```

`eth0` stays `DOWN` and the RJ45 link/activity LEDs are dark with a cable plugged in. The RTL8211F drives those LEDs itself, so dark LEDs are direct evidence the PHY never left reset.

## Root cause

phylib reads the PHY ID over MDIO **before** it claims the PHY node's `reset-gpios`:

- `fwnode_mdiobus_register_phy()` (`drivers/net/mdio/fwnode_mdio.c`) calls `get_phy_device()` — an MDIO read of the ID registers — when the compatible string carries no PHY ID.
- The reset GPIO is only claimed later, inside `phy_device_register()` → `mdiobus_register_gpiod()` (`drivers/net/phy/mdio_device.c:124`, `devm_gpiod_get_optional(…, "reset", GPIOD_OUT_LOW)`).

The M1S holds the RTL8211F in reset at boot, so that first ID read returns nothing. `of_mdiobus_register()` then skips the node silently (`drivers/net/mdio/of_mdio.c:153`, `if (rc && rc != -ENODEV)`), the reset line is never toggled, and `stmmac_open()` → `stmmac_init_phy()` → `phylink_fwnode_phy_connect()` returns `-ENODEV` — the `error: -19` above.

The `reset-assert-us` / `reset-deassert-us` / `reset-gpios` properties in the node are all correct. They are simply never reached.

## Fix

Name the PHY by its ID so phylib takes the `phy_device_create()` path instead of probing the bus:

```diff
 &mdio1 {
 	rgmii_phy1: ethernet-phy@1 {
-		compatible = "ethernet-phy-ieee802.3-c22";
+		compatible = "ethernet-phy-id001c.c916", "ethernet-phy-ieee802.3-c22";
 		reg = <1>;
 		reset-assert-us = <20000>;
```

`0x001cc916` is the RTL8211F, matched by `REALTEK_PHY` via `PHY_ID_MATCH_EXACT(0x001cc916)` (`drivers/net/phy/realtek/realtek_main.c:2216`). With the ID known up front, the device is created without a bus read, `reset-gpios` is claimed, and the 20 ms / 100 ms reset sequence runs before anything talks to the PHY.

This is exactly what the binding documents it for. `Documentation/devicetree/bindings/net/ethernet-phy.yaml`:

> If the PHY reports an incorrect ID, or the PHY requires a specific initialization sequence (like a particular order of clocks, resets, power supplies), in order to be able to read the ID registers, then the compatible list must contain an entry with the correct PHY ID in the above form.

The two-entry form used here is explicitly in that schema's `oneOf`.

Jonas Karlman prescribed this same fix for this same board on linux-rockchip in July 2024: *"this sounds like the typical issue with rtl8211f phy needed to be reset before it can be identified … possible change the Ethernet phy compatible to ethernet-phy-id001c.c916 to help identify the phy"* — https://lore.kernel.org/all/47d55aca-bee6-810f-379f-9431649fefa6@kwiboo.se/

## Precedent

Batocera already carries the identical change for the ODROID-M2, in `board/batocera/rockchip/rk3588-mainline/linux_patches/board-odroidm2-fix-for-ethernet.patch:42`. Mainline 7.0.14 names a PHY by ID in 17 Rockchip DTS files (including `rk3588s-odroid-m2.dts` and `rk3568-radxa-cm3j.dtsi`).

## Why not fix it in U-Boot

v40 carried `uboot/001-fix-ethernet-odroid-m1s.patch`, which brought the PHY up in the bootloader. That patch is gone from master, and on a stock M1S it would not help anyway: the RK3566 BootROM loads the **soldered eMMC's** Hardkernel U-Boot 2017.09, which chain-boots the SD card via extlinux. Batocera's own mainline U-Boot at SD offset 32K never executes, so a bootloader-side fix is unreachable unless the user reflashes the eMMC. Fixing it in the DTS works on an unmodified board.

## Tested

ODROID-M1S (RK3566, 2 GB), kernel 7.0.14, image built from master `02a6263c96` plus the config restore and this patch, booted from SD through the stock Hardkernel eMMC loader.

**The PHY now attaches and the link comes up.** Same board, same image, the only difference being this patch:

```
rk_gmac-dwmac fe010000.ethernet: init for RGMII_ID
rk_gmac-dwmac fe010000.ethernet: Active PHY interface: RGMII (1)
rk_gmac-dwmac fe010000.ethernet eth0: PHY [stmmac-0:01] driver [RTL8211F Gigabit Ethernet] (irq=POLL)
rk_gmac-dwmac fe010000.ethernet eth0: configuring for phy/rgmii-id link mode
rk_gmac-dwmac fe010000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
```

Compare against the unpatched boot quoted at the top: `MDIO device at address 1 is missing.` followed by `cannot attach to PHY (error: -19)`.

**The reset GPIO is actually claimed now**, which is the specific thing that did not happen before. From `/sys/kernel/debug/gpio` on the patched boot:

```
gpiochip3: 32 GPIOs, parent: platform/fe760000.gpio, gpio3:
 gpio-15  (                    |PHY reset           ) out hi ACTIVE LOW
```

`fe760000.gpio` is `gpio3` and offset 15 is `RK_PB7`, matching `reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>` in the node. On the unpatched boot the node was skipped before `mdiobus_register_gpiod()` ran, so nothing claimed that line.

The PHY binds the Realtek driver rather than the generic one, and reports the expected ID:

```
/sys/class/mdio_bus/stmmac-0/stmmac-0:01/phy_id   0x001cc916
stmmac-0:01  driver=RTL8211F Gigabit Ethernet
```

`ethtool eth0`: `Speed: 1000Mb/s`, `Duplex: Full`, `PHYAD: 1`, `Transceiver: external`, autonegotiated against the switch. DHCP lease acquired (`10.0.0.179/24`, default via `10.0.0.1`) and routed traffic works — `ping 1.1.1.1` 2/2, 0% loss, 4.9 ms. Also verified inbound from a second machine on the same LAN across two independent boots (5/5 ICMP, 0.0% loss, 0.628 ms best, SSH reachable).

Built DTB verified to carry the change:

```
compatible: ethernet-phy-id001c.c916 ethernet-phy-ieee802.3-c22
reg: 1     reset-gpios: <phandle 84> 15 1     phy-mode: rgmii-id
reset-assert-us: 20000     reset-deassert-us: 100000
```

Two things in that log that are not defects, in case they raise questions. The PHY attaches at ~25 s rather than at probe because nothing opens the interface until Batocera's `S07network` runs `ifup -a`; `stmmac_open()` is what triggers `phylink_fwnode_phy_connect()`. And `irq=POLL` is expected — the node declares no `interrupts` property, so phylib polls the PHY, which is how this board has always been described upstream.

Unrelated observation while testing, not addressed here: the board has no MAC address in eFuse or DTS, so `stmmac` generates a random locally-administered one on every boot (three distinct addresses observed across three boots), which means a new DHCP lease each time.

## Patch conventions

Numbered `0200-` to sit in the gap between the existing `0101-` and `1011-` entries in that directory. It carries a mail-style `From:` / `Date:` / `Subject:` header so it reads like `0012` / `0015` rather than a bare diff; I left out a synthetic commit SHA since this patch isn't a cherry-pick from a kernel tree. Verified to apply with Buildroot's own flags (`patch -g0 -p1 -E --no-backup-if-mismatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
